### PR TITLE
feat(control-plane): Phase 2 — deterministic capability broker + trust gates

### DIFF
--- a/.github/workflows/control-plane-broker.yml
+++ b/.github/workflows/control-plane-broker.yml
@@ -1,0 +1,34 @@
+name: control-plane-broker
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'tools/capability_broker.py'
+      - 'tools/tests/test_capability_broker.py'
+      - 'docs/WORKSPACE_CONTROL_PLANE_PHASE2.md'
+      - '.github/workflows/control-plane-broker.yml'
+  pull_request:
+    paths:
+      - 'tools/capability_broker.py'
+      - 'tools/tests/test_capability_broker.py'
+      - 'docs/WORKSPACE_CONTROL_PLANE_PHASE2.md'
+      - '.github/workflows/control-plane-broker.yml'
+
+jobs:
+  control-plane-broker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install jsonschema pytest
+      - name: Broker tests (deterministic order + trust gates + provenance)
+        run: pytest -q tools/tests/test_capability_broker.py

--- a/docs/WORKSPACE_CONTROL_PLANE_PHASE2.md
+++ b/docs/WORKSPACE_CONTROL_PLANE_PHASE2.md
@@ -1,0 +1,39 @@
+# Workspace Control Plane — Phase 2 (capability broker)
+
+Implements **Phase 2** of the control spec: local capability manifests + MCP
+discovery + a **deterministic capability broker** (spec D7). Gets a controlled
+"go fish" working safely, on top of the Phase-1 frozen schemas, before remote
+overlays exist.
+
+## What it does
+
+`tools/capability_broker.py` resolves a requested capability across sources in a
+**fixed order** — `local_manifest -> local_affordance -> mcp_server ->
+trusted_catalog -> remote_join` — as sequenced by a `discovery-policy.v0`. The
+planner never crawls arbitrarily.
+
+Every candidate passes a **trust gate** derived from the policy's
+`trust_requirements`:
+
+- `require_signed` -> manifest must carry a signature.
+- expiry -> manifest must be unexpired at `now`.
+- `require_revocation_check` -> a revocation field must be present and not revoked.
+- `trusted_catalog` lane -> the manifest id must be listed in a **valid**
+  `catalog-entry.v0` (unexpired, signed, delegation threshold met).
+
+The first trusted match wins, and the broker emits a provenance **`event.v0`**
+(`CapabilityResolved` / `CapabilityUnresolved`) — append-only and object-centric.
+
+## Conformance
+
+Sources are `capability-manifest.v0`, policy is `discovery-policy.v0`, catalogs
+are `catalog-entry.v0`, and emitted events validate against `event.v0` — all
+Phase-1 frozen schemas. Tests: deterministic order, trust rejections
+(unsigned/expired/revoked/missing-revocation), catalog gating, and event
+conformance. Path-filtered CI: `.github/workflows/control-plane-broker.yml`.
+
+## Next (Phase 3)
+
+Connector roots (local files, Google Drive, OneDrive, Box, Apple/iCloud) with
+delta + watch and scoped mounts — producing assets/events against the Phase-1
+object model.

--- a/tools/capability_broker.py
+++ b/tools/capability_broker.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Deterministic capability broker (Workspace Control Plane, Phase 2 / D7).
+
+Resolves a requested capability across sources in a FIXED order — local
+manifests -> local affordances -> MCP servers -> trusted catalogs -> remote
+joins — applying trust gates (signed, unexpired, unrevoked, catalog-listed) from
+a DiscoveryPolicy, and emitting a provenance `event.v0` for every resolution.
+
+This is a controlled 'go fish': the planner never crawls arbitrarily. Sources,
+policy, and catalogs all conform to the Phase-1 frozen schemas.
+"""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+# The deterministic lane order the policy may sequence over.
+LANES = ["local_manifest", "local_affordance", "mcp_server", "trusted_catalog", "remote_join"]
+
+
+@dataclass
+class Source:
+    """A discovery source: a lane label plus a capability manifest."""
+
+    lane: str
+    manifest: dict[str, Any]
+
+
+@dataclass
+class ResolutionResult:
+    """Outcome of a resolve() call."""
+
+    resolved: bool
+    capability: str
+    lane: Optional[str] = None
+    provider: Optional[str] = None
+    manifest_id: Optional[str] = None
+    rejected: list[dict[str, str]] = field(default_factory=list)
+    event: dict[str, Any] = field(default_factory=dict)
+
+
+def _parse(ts: str) -> datetime:
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def trust_reason(manifest: dict[str, Any], policy: dict[str, Any], now: str,
+                 trusted_ids: Optional[set[str]] = None, lane: str = "") -> Optional[str]:
+    """Return a rejection reason if the manifest fails the trust gate, else None."""
+    req = policy.get("trust_requirements", {})
+    if req.get("require_signed") and not manifest.get("signature"):
+        return "unsigned"
+    expiry = manifest.get("expiry")
+    if expiry and _parse(expiry) <= _parse(now):
+        return "expired"
+    revocation = manifest.get("revocation")
+    if req.get("require_revocation_check"):
+        if revocation is None:
+            return "no_revocation_field"
+        if revocation.get("revoked"):
+            return "revoked"
+    elif revocation and revocation.get("revoked"):
+        return "revoked"
+    # Catalog gating: a manifest surfaced via a trusted catalog must be listed.
+    if lane == "trusted_catalog" and trusted_ids is not None:
+        if manifest.get("manifest_id") not in trusted_ids:
+            return "not_in_trusted_catalog"
+    return None
+
+
+def _catalog_trusted_ids(catalogs: list[dict[str, Any]], now: str) -> set[str]:
+    """The set of manifest ids trusted via valid catalog entries."""
+    ids: set[str] = set()
+    for entry in catalogs:
+        exp = entry.get("expiry")
+        if exp and _parse(exp) <= _parse(now):
+            continue
+        if not entry.get("signatures"):
+            continue
+        deleg = entry.get("delegation") or {}
+        threshold = deleg.get("threshold")
+        if threshold is not None and len(entry.get("signatures", [])) < threshold:
+            continue
+        ids.update(entry.get("targets", []))
+    return ids
+
+
+def _provides(manifest: dict[str, Any], capability: str) -> bool:
+    return any(c.get("name") == capability for c in manifest.get("capabilities", []))
+
+
+def resolve(
+    capability: str,
+    sources: list[Source],
+    policy: dict[str, Any],
+    *,
+    catalogs: Optional[list[dict[str, Any]]] = None,
+    now: Optional[str] = None,
+) -> ResolutionResult:
+    """Resolve `capability` deterministically per `policy.resolution_order`."""
+    now = now or datetime.now(timezone.utc).isoformat()
+    catalogs = catalogs or []
+    trusted_ids = _catalog_trusted_ids(catalogs, now)
+    rejected: list[dict[str, str]] = []
+
+    for lane in policy.get("resolution_order", []):
+        for src in sources:
+            if src.lane != lane:
+                continue
+            if not _provides(src.manifest, capability):
+                continue
+            reason = trust_reason(src.manifest, policy, now, trusted_ids, lane)
+            if reason is not None:
+                rejected.append({"manifest_id": src.manifest.get("manifest_id", "?"), "lane": lane, "reason": reason})
+                continue
+            provider = src.manifest.get("provider", "")
+            mid = src.manifest.get("manifest_id", "")
+            return ResolutionResult(
+                resolved=True, capability=capability, lane=lane, provider=provider,
+                manifest_id=mid, rejected=rejected,
+                event=_event("CapabilityResolved", capability, now,
+                             object_refs=[mid], outputs={"lane": lane, "provider": provider}),
+            )
+
+    return ResolutionResult(
+        resolved=False, capability=capability, rejected=rejected,
+        event=_event("CapabilityUnresolved", capability, now, object_refs=[],
+                     outputs={"rejected": rejected}),
+    )
+
+
+def _event(activity: str, capability: str, now: str, *, object_refs: list[str],
+           outputs: dict[str, Any]) -> dict[str, Any]:
+    """A provenance event.v0 for a resolution (append-only, object-centric)."""
+    return {
+        "event_id": f"evt-{uuid.uuid4().hex[:12]}",
+        "ts": now,
+        "case_id": f"capability-resolution/{capability}",
+        "activity": activity,
+        "actor": "capability-broker",
+        "object_refs": object_refs,
+        "inputs": {"capability": capability},
+        "outputs": outputs,
+        "prov": {"activity": activity, "agent": "capability-broker"},
+    }

--- a/tools/tests/test_capability_broker.py
+++ b/tools/tests/test_capability_broker.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+TOOLS = Path(__file__).resolve().parents[1]
+ROOT = TOOLS.parent
+sys.path.insert(0, str(TOOLS))
+
+import capability_broker as cb  # type: ignore
+
+LANE = ROOT / "contracts" / "workspace-control-plane"
+EVENT_SCHEMA = json.loads((LANE / "schemas" / "event.v0.schema.json").read_text())
+POLICY = json.loads((LANE / "examples" / "discovery-policy.v0.json").read_text())
+
+NOW = "2026-08-01T00:00:00+00:00"
+FUTURE = "2026-12-31T00:00:00+00:00"
+PAST = "2025-01-01T00:00:00+00:00"
+
+
+def capman(mid, cap, *, provider="p", expiry=FUTURE, signed=True, revoked=False, revocation=True):
+    m = {
+        "manifest_id": mid,
+        "kind": "capability",
+        "provider": provider,
+        "capabilities": [{"name": cap, "transport": "mcp"}],
+        "expiry": expiry,
+    }
+    if signed:
+        m["signature"] = {"signer": "root", "algorithm": "ed25519", "signature": "s", "signed_at": NOW}
+    if revocation:
+        m["revocation"] = {"revoked": revoked}
+    return m
+
+
+def _valid_event(ev):
+    return list(Draft202012Validator(EVENT_SCHEMA).iter_errors(ev)) == []
+
+
+def test_deterministic_order_local_beats_mcp():
+    sources = [
+        cb.Source("mcp_server", capman("m-mcp", "drive.search")),
+        cb.Source("local_manifest", capman("m-local", "drive.search")),
+    ]
+    r = cb.resolve("drive.search", sources, POLICY, now=NOW)
+    assert r.resolved
+    assert r.lane == "local_manifest"  # earlier lane wins regardless of source order
+    assert r.manifest_id == "m-local"
+    assert _valid_event(r.event)
+    assert r.event["activity"] == "CapabilityResolved"
+
+
+def test_expired_is_rejected_and_falls_through():
+    sources = [
+        cb.Source("local_manifest", capman("m-exp", "drive.search", expiry=PAST)),
+        cb.Source("mcp_server", capman("m-mcp", "drive.search")),
+    ]
+    r = cb.resolve("drive.search", sources, POLICY, now=NOW)
+    assert r.resolved and r.lane == "mcp_server"
+    assert any(x["reason"] == "expired" for x in r.rejected)
+
+
+def test_unsigned_rejected_when_policy_requires_signed():
+    assert POLICY["trust_requirements"]["require_signed"] is True
+    sources = [cb.Source("local_manifest", capman("m", "drive.search", signed=False))]
+    r = cb.resolve("drive.search", sources, POLICY, now=NOW)
+    assert not r.resolved
+    assert any(x["reason"] == "unsigned" for x in r.rejected)
+
+
+def test_revoked_and_missing_revocation_field_rejected():
+    r1 = cb.resolve("x", [cb.Source("local_manifest", capman("m1", "x", revoked=True))], POLICY, now=NOW)
+    assert not r1.resolved and any(x["reason"] == "revoked" for x in r1.rejected)
+    # require_revocation_check is on -> a manifest with no revocation field is rejected
+    r2 = cb.resolve("x", [cb.Source("local_manifest", capman("m2", "x", revocation=False))], POLICY, now=NOW)
+    assert not r2.resolved and any(x["reason"] == "no_revocation_field" for x in r2.rejected)
+
+
+def test_catalog_gating():
+    man = capman("m-cat", "remote.tool")
+    sources = [cb.Source("trusted_catalog", man)]
+    # No catalog -> not trusted.
+    r_none = cb.resolve("remote.tool", sources, POLICY, now=NOW)
+    assert not r_none.resolved
+    assert any(x["reason"] == "not_in_trusted_catalog" for x in r_none.rejected)
+    # A valid catalog entry listing the manifest -> trusted.
+    catalog = [{
+        "entry_id": "cat-1", "role": "targets", "version": 1, "targets": ["m-cat"],
+        "expiry": FUTURE, "delegation": {"threshold": 1, "keys": ["k"]},
+        "signatures": [{"signer": "k", "algorithm": "ed25519", "signature": "s", "signed_at": NOW}],
+    }]
+    r_ok = cb.resolve("remote.tool", sources, POLICY, catalogs=catalog, now=NOW)
+    assert r_ok.resolved and r_ok.lane == "trusted_catalog"
+
+
+def test_unresolved_emits_conformant_event():
+    r = cb.resolve("nope", [], POLICY, now=NOW)
+    assert not r.resolved
+    assert r.event["activity"] == "CapabilityUnresolved"
+    assert _valid_event(r.event)


### PR DESCRIPTION
Implements **Phase 2** (spec D7): local capability manifests + MCP discovery + a **deterministic capability broker** on the Phase-1 frozen schemas. Controlled 'go fish' — no arbitrary crawling.

Resolves a capability in FIXED order (local_manifest → local_affordance → mcp_server → trusted_catalog → remote_join) per `discovery-policy.v0`, with trust gates (require_signed, expiry, require_revocation_check, and catalog gating against a valid `catalog-entry.v0`). First trusted match wins; every resolution emits a provenance `event.v0` (append-only, object-centric).

Conforms to Phase-1 schemas. 6 tests (deterministic order, trust rejections, catalog gating, event conformance). Path-filtered CI (permissions: contents:read). Copilot eval / adversarial review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)