### PR TITLE
feat(control-plane): Phase 3 — connector roots (contracts + local connector + cloud adapter interface)

### DIFF
--- a/.github/workflows/control-plane-connectors.yml
+++ b/.github/workflows/control-plane-connectors.yml
@@ -1,0 +1,38 @@
+name: control-plane-connectors
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'contracts/workspace-control-plane/**'
+      - 'tools/connector_roots.py'
+      - 'tools/tests/test_connector_roots.py'
+      - 'docs/WORKSPACE_CONTROL_PLANE_PHASE3.md'
+      - '.github/workflows/control-plane-connectors.yml'
+  pull_request:
+    paths:
+      - 'contracts/workspace-control-plane/**'
+      - 'tools/connector_roots.py'
+      - 'tools/tests/test_connector_roots.py'
+      - 'docs/WORKSPACE_CONTROL_PLANE_PHASE3.md'
+      - '.github/workflows/control-plane-connectors.yml'
+
+jobs:
+  control-plane-connectors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install jsonschema pytest
+      - name: Validate contracts (all control-plane schemas + examples)
+        run: python tools/validate_control_plane_contracts.py
+      - name: Connector tests (local ingest + rails + delta + credential-gated cloud)
+        run: pytest -q tools/tests/test_connector_roots.py

--- a/contracts/workspace-control-plane/examples/account.v0.json
+++ b/contracts/workspace-control-plane/examples/account.v0.json
@@ -1,0 +1,1 @@
+{ "account_id": "acct-gdrive-1", "provider": "google", "display_name": "SocioProphet Drive", "auth_ref": "secret://gdrive/oauth-1" }

--- a/contracts/workspace-control-plane/examples/capability-grant.v0.json
+++ b/contracts/workspace-control-plane/examples/capability-grant.v0.json
@@ -1,0 +1,1 @@
+{ "grant_id": "grant-gdrive-1", "account_ref": "acct-gdrive-1", "scopes": ["drive.readonly", "drive.metadata.readonly"], "expiry": "2026-12-31T00:00:00+00:00", "revocation": { "revoked": false } }

--- a/contracts/workspace-control-plane/examples/mount.v0.json
+++ b/contracts/workspace-control-plane/examples/mount.v0.json
@@ -1,0 +1,1 @@
+{ "mount_id": "mount-gdrive-proj", "root_ref": "root-gdrive-primary", "scope": ["/Projects/SocioProphet", "/Investor"], "least_privilege": true }

--- a/contracts/workspace-control-plane/examples/root.v0.json
+++ b/contracts/workspace-control-plane/examples/root.v0.json
@@ -1,0 +1,1 @@
+{ "root_id": "root-gdrive-primary", "account_ref": "acct-gdrive-1", "kind": "drive_folder", "sync_mode": "mirror", "cache_policy": "metadata_only", "allowed_actions": ["read", "list"], "delta_cursor": "startPageToken:98213", "watch": { "enabled": true, "channel_ref": "gdrive://watch/ch-1" } }

--- a/contracts/workspace-control-plane/schemas/account.v0.schema.json
+++ b/contracts/workspace-control-plane/schemas/account.v0.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/workspace-control-plane/account.v0.schema.json",
+  "title": "account.v0",
+  "description": "An external account as a first-class root owner (spec D3). Holds a reference to credentials, never the credentials themselves.",
+  "type": "object", "additionalProperties": false,
+  "required": ["account_id", "provider", "display_name", "auth_ref"],
+  "properties": {
+    "account_id": { "type": "string", "minLength": 4 },
+    "provider": { "enum": ["google", "microsoft", "box", "apple", "local", "imap", "caldav"] },
+    "display_name": { "type": "string" },
+    "auth_ref": { "type": "string", "description": "Opaque reference to a credential in a secret store — NOT the secret." }
+  }
+}

--- a/contracts/workspace-control-plane/schemas/capability-grant.v0.schema.json
+++ b/contracts/workspace-control-plane/schemas/capability-grant.v0.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/workspace-control-plane/capability-grant.v0.schema.json",
+  "title": "capability-grant.v0",
+  "description": "A per-account access grant (spec D3): the scopes an account has authorized, with expiry and revocation. Distinct from capability-manifest (which describes tools).",
+  "type": "object", "additionalProperties": false,
+  "required": ["grant_id", "account_ref", "scopes", "expiry", "revocation"],
+  "properties": {
+    "grant_id": { "type": "string", "minLength": 8 },
+    "account_ref": { "type": "string" },
+    "scopes": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+    "expiry": { "type": "string" },
+    "revocation": { "type": "object", "additionalProperties": false, "required": ["revoked"], "properties": { "revoked": { "type": "boolean" }, "reason": { "type": "string" } } }
+  }
+}

--- a/contracts/workspace-control-plane/schemas/mount.v0.schema.json
+++ b/contracts/workspace-control-plane/schemas/mount.v0.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/workspace-control-plane/mount.v0.schema.json",
+  "title": "mount.v0",
+  "description": "A least-privilege, user-selected mount over a root (spec D3). Scoped to picker-selected paths rather than ambient account-wide access.",
+  "type": "object", "additionalProperties": false,
+  "required": ["mount_id", "root_ref", "scope", "least_privilege"],
+  "properties": {
+    "mount_id": { "type": "string", "minLength": 8 },
+    "root_ref": { "type": "string" },
+    "scope": { "type": "array", "items": { "type": "string" }, "description": "Explicitly selected paths/ids (least authority)." },
+    "least_privilege": { "type": "boolean" }
+  }
+}

--- a/contracts/workspace-control-plane/schemas/root.v0.schema.json
+++ b/contracts/workspace-control-plane/schemas/root.v0.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/workspace-control-plane/root.v0.schema.json",
+  "title": "root.v0",
+  "description": "A mounted root with per-root policy and rail configuration (spec D3/D4). Each root declares its sync mode, cache policy, and allowed actions independently.",
+  "type": "object", "additionalProperties": false,
+  "required": ["root_id", "account_ref", "kind", "sync_mode", "cache_policy", "allowed_actions"],
+  "properties": {
+    "root_id": { "type": "string", "minLength": 4 },
+    "account_ref": { "type": "string" },
+    "kind": { "enum": ["local_dir", "drive_folder", "mailbox", "calendar", "box_folder", "onedrive_folder", "icloud_documents"] },
+    "sync_mode": { "enum": ["mirror", "live", "action"], "description": "D4: mirror rail (indexed copy) | live rail (just-in-time) | action rail (side effects)." },
+    "cache_policy": { "enum": ["none", "metadata_only", "full"] },
+    "allowed_actions": { "type": "array", "items": { "type": "string" } },
+    "delta_cursor": { "type": ["string", "null"], "description": "Opaque provider delta token / mtime watermark for incremental sync." },
+    "watch": { "type": "object", "additionalProperties": false, "properties": { "enabled": { "type": "boolean" }, "channel_ref": { "type": "string" } } }
+  }
+}

--- a/docs/WORKSPACE_CONTROL_PLANE_PHASE3.md
+++ b/docs/WORKSPACE_CONTROL_PLANE_PHASE3.md
@@ -1,0 +1,48 @@
+# Workspace Control Plane — Phase 3 (connector roots)
+
+Implements **Phase 3** of the control spec: connector roots with per-root policy,
+delta/incremental sync, scoped mounts, and the mirror/live/action rails (D3/D4),
+on the Phase-1 object model. The local-files connector is fully working and
+credential-free; cloud connectors declare their delta+watch mechanism and are
+gated behind credentials.
+
+## Contracts (frozen, `contracts/workspace-control-plane/schemas`)
+
+- `account.v0` (D3) — external account; holds a credential **reference**, never the secret.
+- `capability-grant.v0` (D3) — per-account scopes with expiry + revocation.
+- `root.v0` (D3/D4) — per-root `sync_mode` (mirror | live | action), `cache_policy`,
+  `allowed_actions`, `delta_cursor`, `watch`.
+- `mount.v0` (D3) — least-privilege, user-selected scope over a root.
+
+## Rails (D4)
+
+| Rail | Behavior |
+|---|---|
+| **mirror** | Produce indexed asset copies (`asset.v0`) + events. |
+| **live** | Just-in-time: emit events only, no cached asset. |
+| **action** | Side effects only — handled by `workflow-run`, not ingestion. |
+
+## Connectors (`tools/connector_roots.py`)
+
+- **LocalFilesConnector** — fully implemented: walks a local dir, emits governed
+  `asset.v0` + `event.v0`, content-addressed (sha256), incremental via an mtime
+  delta cursor. Honors the rail.
+- **Cloud connectors** (credential-gated; `sync`/`watch` raise until wired, naming
+  the mechanism):
+  - Google Drive — `changes.getStartPageToken + changes.list`; `changes.watch` push.
+  - OneDrive/SharePoint — Graph `delta`/`deltaLink` (deleted facet); Graph subscriptions.
+  - Box — events/`stream_position`; Box webhooks.
+  - Apple iCloud — `NSMetadataQuery` over the ubiquitous-documents scope;
+    security-scoped bookmarks for restart-safe access.
+
+## Validation
+
+New schemas + examples are validated by the existing control-plane contract
+validator; `tools/tests/test_connector_roots.py` proves the local connector emits
+schema-valid assets/events, the delta cursor is incremental, each rail behaves,
+and cloud connectors are credential-gated. Path-filtered CI:
+`.github/workflows/control-plane-connectors.yml`.
+
+## Next (Phase 4)
+
+Mirror/live/action rail orchestration + the attention registry (`attention-mark.v0`).

--- a/tools/connector_roots.py
+++ b/tools/connector_roots.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Connector roots (Workspace Control Plane, Phase 3 / D3, D4).
+
+A root connector turns an external estate into governed assets + events against
+the Phase-1 object model. Every root declares a rail (spec D4):
+
+* **mirror** — produce indexed asset copies + events;
+* **live**   — just-in-time: produce events only, no cached asset;
+* **action** — side effects only (handled by workflow-run, not ingestion).
+
+The local-files connector is fully implemented and credential-free. Cloud
+connectors (Drive/OneDrive/Box/Apple) declare their delta+watch mechanism and
+are gated behind credentials — their `sync` raises until wired, so the contract
+is explicit without pretending to have access.
+"""
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _iso(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+class RootConnector:
+    """Base connector. `sync` returns (assets, events, new_cursor)."""
+
+    provider = "base"
+
+    def sync(self, root: dict[str, Any], since_cursor: Optional[str] = None):
+        raise NotImplementedError
+
+    def watch(self, root: dict[str, Any]) -> dict[str, Any]:
+        raise NotImplementedError
+
+
+class LocalFilesConnector(RootConnector):
+    """Fully-working connector over a local directory root."""
+
+    provider = "local"
+
+    def __init__(self, base_dir: str) -> None:
+        self.base_dir = Path(base_dir)
+
+    def sync(self, root: dict[str, Any], since_cursor: Optional[str] = None):
+        """Incrementally ingest files modified after `since_cursor` (an ISO mtime)."""
+        rail = root.get("sync_mode", "mirror")
+        if rail == "action":
+            # The action rail performs side effects via workflow-run, not ingestion.
+            return [], [], since_cursor
+
+        since = datetime.fromisoformat(since_cursor) if since_cursor else None
+        root_id = root.get("root_id", "root-local")
+        assets: list[dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
+        max_mtime = since
+
+        for path in sorted(p for p in self.base_dir.rglob("*") if p.is_file()):
+            st = path.stat()
+            mtime = datetime.fromtimestamp(st.st_mtime, tz=timezone.utc)
+            if since is not None and mtime <= since:
+                continue  # incremental: skip unchanged
+            if max_mtime is None or mtime > max_mtime:
+                max_mtime = mtime
+
+            rel = str(path.relative_to(self.base_dir))
+            data = path.read_bytes()
+            content_hash = f"sha256:{_sha256_hex(data)}"
+            asset_id = f"asset://{root_id}/{rel}"
+            version_id = content_hash[7:19]
+
+            if rail == "mirror":
+                assets.append({
+                    "asset_id": asset_id,
+                    "kind": "file",
+                    "root_ref": root_id,
+                    "current_version": {
+                        "version_id": version_id,
+                        "content_hash": content_hash,
+                        "size_bytes": st.st_size,
+                        "modified_at": _iso(st.st_mtime),
+                    },
+                    "prior_versions": [],
+                    "created_at": _iso(st.st_ctime),
+                })
+            # Both mirror and live emit an event (live carries no cached asset copy).
+            events.append({
+                "event_id": f"evt-{_sha256_hex((asset_id + version_id).encode())[:12]}",
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "case_id": f"root-sync/{root_id}",
+                "activity": "AssetIngested",
+                "actor": f"connector://{self.provider}",
+                "object_refs": [asset_id],
+                "inputs": {"root_ref": root_id, "rail": rail},
+                "outputs": {"content_hash": content_hash},
+                "prov": {"entity": asset_id, "activity": "AssetIngested", "agent": f"connector://{self.provider}"},
+            })
+
+        new_cursor = max_mtime.isoformat() if max_mtime is not None else since_cursor
+        return assets, events, new_cursor
+
+
+class _CredentialGatedCloudConnector(RootConnector):
+    """Base for cloud connectors whose delta+watch requires OAuth credentials."""
+
+    delta_mechanism = ""
+    watch_mechanism = ""
+
+    def sync(self, root: dict[str, Any], since_cursor: Optional[str] = None):
+        raise NotImplementedError(
+            f"{self.provider} sync requires OAuth credentials; delta mechanism: {self.delta_mechanism}"
+        )
+
+    def watch(self, root: dict[str, Any]) -> dict[str, Any]:
+        raise NotImplementedError(
+            f"{self.provider} watch requires OAuth credentials; watch mechanism: {self.watch_mechanism}"
+        )
+
+
+class GoogleDriveConnector(_CredentialGatedCloudConnector):
+    provider = "google"
+    delta_mechanism = "changes.getStartPageToken + changes.list(pageToken)"
+    watch_mechanism = "changes.watch (push channel)"
+
+
+class OneDriveConnector(_CredentialGatedCloudConnector):
+    provider = "microsoft"
+    delta_mechanism = "driveItem delta / deltaLink (deleted facet for tombstones)"
+    watch_mechanism = "Microsoft Graph change notifications (subscriptions)"
+
+
+class BoxConnector(_CredentialGatedCloudConnector):
+    provider = "box"
+    delta_mechanism = "events endpoint / stream_position"
+    watch_mechanism = "Box webhooks (file/folder events)"
+
+
+class AppleICloudConnector(_CredentialGatedCloudConnector):
+    provider = "apple"
+    delta_mechanism = "NSMetadataQuery over ubiquitous documents scope"
+    watch_mechanism = "NSMetadataQuery live updates + security-scoped bookmarks"
+
+
+CLOUD_CONNECTORS = {
+    "google": GoogleDriveConnector,
+    "microsoft": OneDriveConnector,
+    "box": BoxConnector,
+    "apple": AppleICloudConnector,
+}

--- a/tools/tests/test_connector_roots.py
+++ b/tools/tests/test_connector_roots.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+TOOLS = Path(__file__).resolve().parents[1]
+ROOT = TOOLS.parent
+sys.path.insert(0, str(TOOLS))
+
+import connector_roots as cr  # type: ignore
+
+LANE = ROOT / "contracts" / "workspace-control-plane"
+ASSET_SCHEMA = json.loads((LANE / "schemas" / "asset.v0.schema.json").read_text())
+EVENT_SCHEMA = json.loads((LANE / "schemas" / "event.v0.schema.json").read_text())
+
+
+def _valid(schema, obj):
+    return list(Draft202012Validator(schema).iter_errors(obj)) == []
+
+
+def _root(tmp, mode="mirror"):
+    return {"root_id": "root-local-test", "account_ref": "acct-local", "kind": "local_dir",
+            "sync_mode": mode, "cache_policy": "full", "allowed_actions": ["read"], "delta_cursor": None}
+
+
+def test_local_mirror_produces_valid_assets_and_events(tmp_path):
+    (tmp_path / "a.txt").write_text("hello")
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "b.txt").write_text("world")
+
+    conn = cr.LocalFilesConnector(str(tmp_path))
+    assets, events, cursor = conn.sync(_root(tmp_path, "mirror"))
+
+    assert len(assets) == 2 and len(events) == 2
+    for a in assets:
+        assert _valid(ASSET_SCHEMA, a), a
+        assert a["current_version"]["content_hash"].startswith("sha256:")
+    for e in events:
+        assert _valid(EVENT_SCHEMA, e), e
+        assert e["activity"] == "AssetIngested"
+    assert cursor is not None
+
+
+def test_incremental_cursor_skips_unchanged(tmp_path):
+    (tmp_path / "a.txt").write_text("hello")
+    conn = cr.LocalFilesConnector(str(tmp_path))
+    _, _, cursor = conn.sync(_root(tmp_path))
+    # Second sync from the returned cursor: nothing changed -> nothing ingested.
+    assets2, events2, cursor2 = conn.sync(_root(tmp_path), since_cursor=cursor)
+    assert assets2 == [] and events2 == []
+
+
+def test_live_rail_emits_events_without_cached_assets(tmp_path):
+    (tmp_path / "a.txt").write_text("hi")
+    conn = cr.LocalFilesConnector(str(tmp_path))
+    assets, events, _ = conn.sync(_root(tmp_path, "live"))
+    assert assets == [] and len(events) == 1  # live = just-in-time, no cached copy
+
+
+def test_action_rail_does_not_ingest(tmp_path):
+    (tmp_path / "a.txt").write_text("hi")
+    conn = cr.LocalFilesConnector(str(tmp_path))
+    assets, events, _ = conn.sync(_root(tmp_path, "action"))
+    assert assets == [] and events == []
+
+
+def test_cloud_connectors_are_credential_gated():
+    for provider, cls in cr.CLOUD_CONNECTORS.items():
+        conn = cls()
+        with pytest.raises(NotImplementedError) as exc:
+            conn.sync({"root_id": "r"})
+        # The delta mechanism is named even though it is not wired.
+        assert conn.delta_mechanism and conn.delta_mechanism in str(exc.value)


### PR DESCRIPTION
Implements **Phase 3** (spec D3/D4) on the Phase-1/2 base. Scaffold path — buildable + mergeable without credentials.

**Contracts (frozen):** `account.v0` (credential ref, not secret), `capability-grant.v0` (scopes+expiry+revocation), `root.v0` (per-root sync_mode mirror|live|action + cache_policy + allowed_actions + delta_cursor + watch), `mount.v0` (least-privilege scope).

**Connectors:** `LocalFilesConnector` fully working (sha256 content-address, incremental mtime delta cursor, honors rails), emitting governed `asset.v0` + `event.v0`. Cloud connectors (Drive/OneDrive/Box/Apple) declare their delta+watch mechanism and are **credential-gated** (sync/watch raise until wired) — contract explicit without pretending access.

5 connector tests + all 13 control-plane schemas validate. Path-filtered CI (permissions: contents:read). Copilot eval / adversarial review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)