### PR TITLE
feat(control-plane): Phase 4 — mirror/live/action rails + attention registry

### DIFF
--- a/.github/workflows/control-plane-rails.yml
+++ b/.github/workflows/control-plane-rails.yml
@@ -1,0 +1,38 @@
+name: control-plane-rails
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'tools/rail_orchestrator.py'
+      - 'tools/attention_registry.py'
+      - 'tools/connector_roots.py'
+      - 'tools/tests/test_rails_attention.py'
+      - 'docs/WORKSPACE_CONTROL_PLANE_PHASE4.md'
+      - '.github/workflows/control-plane-rails.yml'
+  pull_request:
+    paths:
+      - 'tools/rail_orchestrator.py'
+      - 'tools/attention_registry.py'
+      - 'tools/connector_roots.py'
+      - 'tools/tests/test_rails_attention.py'
+      - 'docs/WORKSPACE_CONTROL_PLANE_PHASE4.md'
+      - '.github/workflows/control-plane-rails.yml'
+
+jobs:
+  control-plane-rails:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install jsonschema pytest
+      - name: Rails + attention tests
+        run: pytest -q tools/tests/test_rails_attention.py

--- a/docs/WORKSPACE_CONTROL_PLANE_PHASE4.md
+++ b/docs/WORKSPACE_CONTROL_PLANE_PHASE4.md
@@ -1,0 +1,48 @@
+# Workspace Control Plane — Phase 4 (rails + attention registry)
+
+Implements **Phase 4**: mirror/live/action rail orchestration (D4) and the
+attention registry (D5), on the Phase-1 object model and Phase-3 connectors.
+
+## Rail orchestration (`tools/rail_orchestrator.py`, D4)
+
+`orchestrate(roots, connectors)` runs one pass, routing each root by its
+`sync_mode`:
+
+| Rail | Behavior |
+|---|---|
+| mirror | connector produces indexed `asset.v0` + `event.v0`; cursor advances |
+| live | events only, no cached asset; cursor advances |
+| action | no ingestion — deferred to `workflow-run` (side-effect rail) |
+
+`apply_cursors` persists advanced delta cursors back onto the roots. The
+orchestrator never fetches anything itself; it drives the Phase-3 connectors, so
+the split stays structural rather than one uncontrolled path.
+
+## Attention registry (`tools/attention_registry.py`, D5)
+
+Keeps half-processed work discoverable before deep indexing. `should_surface`
+and `AttentionRegistry` operate over `attention-mark.v0`:
+
+| Mode | Surfaces when |
+|---|---|
+| pin | always |
+| watch | one of its event triggers fires |
+| revisit | a scheduled `at:<iso>` trigger is due, or on an event |
+| incubate | its decay half-life has elapsed, or on a trigger |
+| hold | never (until released to another mode) |
+| forget | never (tombstoned) |
+
+**Suppression wins:** if any of a mark's suppression rules is active, it does not
+surface regardless of mode. `resolve_surfacing` returns due marks in stable order;
+`add`/`release`/`forget` manage lifecycle.
+
+## Validation
+
+`tools/tests/test_rails_attention.py` — 10 tests: rails honored, cursors advance,
+missing-connector raises, mark schema conformance, each mode, suppression, and
+registry transitions. Path-filtered CI: `.github/workflows/control-plane-rails.yml`.
+
+## Next (Phase 5)
+
+Trust broker + signed catalog verification (TUF/Sigstore) over the
+`capability-manifest`/`topic-manifest`/`catalog-entry` schemas already frozen.

--- a/tools/attention_registry.py
+++ b/tools/attention_registry.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Attention registry (Workspace Control Plane, Phase 4 / D5).
+
+Keeps half-processed work discoverable before it is deeply indexed. Each
+`attention-mark.v0` carries a mode, resurfacing triggers, a decay policy, and
+suppression rules; this module decides which marks should surface *now*.
+
+Mode semantics:
+* **pin**      — always surfaces.
+* **watch**    — surfaces when one of its event triggers fires.
+* **revisit**  — surfaces at a scheduled time (`at:<iso>` trigger) or on an event.
+* **incubate** — surfaces once its decay half-life has elapsed, or on a trigger.
+* **hold**     — never surfaces until explicitly released (mode changed).
+* **forget**   — never surfaces (tombstoned).
+
+Suppression always wins: if any of a mark's suppression rules is active, it does
+not surface regardless of mode.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+
+def _parse(ts: str) -> datetime:
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def should_surface(
+    mark: dict[str, Any],
+    now: str,
+    active_events: Optional[set[str]] = None,
+    active_suppressions: Optional[set[str]] = None,
+) -> bool:
+    """Decide whether a single mark should surface at `now`."""
+    active_events = active_events or set()
+    active_suppressions = active_suppressions or set()
+
+    mode = mark.get("mode")
+    if mode in ("forget", "hold"):
+        return False
+
+    # Suppression wins over everything else.
+    rules = set(mark.get("suppression", {}).get("rules", []))
+    if rules & active_suppressions:
+        return False
+
+    if mode == "pin":
+        return True
+
+    now_dt = _parse(now)
+    triggers = mark.get("resurfacing_triggers", [])
+    time_due = any(t.startswith("at:") and _parse(t[3:]) <= now_dt for t in triggers)
+    event_due = any((not t.startswith("at:")) and t in active_events for t in triggers)
+
+    if mode == "watch":
+        return event_due
+    if mode == "revisit":
+        return time_due or event_due
+    if mode == "incubate":
+        decay = mark.get("decay", {})
+        half_life = decay.get("half_life_seconds")
+        if half_life is not None:
+            elapsed = (now_dt - _parse(mark["created_at"])).total_seconds()
+            if elapsed >= half_life:
+                return True
+        return time_due or event_due
+    return False
+
+
+class AttentionRegistry:
+    """An in-memory registry of attention marks with resurfacing resolution."""
+
+    def __init__(self) -> None:
+        self._marks: dict[str, dict[str, Any]] = {}
+
+    def add(self, mark: dict[str, Any]) -> None:
+        self._marks[mark["mark_id"]] = mark
+
+    def release(self, mark_id: str, new_mode: str) -> None:
+        """Transition a mark's mode (e.g. release a hold to watch/revisit)."""
+        if mark_id in self._marks:
+            self._marks[mark_id]["mode"] = new_mode
+
+    def forget(self, mark_id: str) -> None:
+        if mark_id in self._marks:
+            self._marks[mark_id]["mode"] = "forget"
+
+    def marks(self) -> list[dict[str, Any]]:
+        return list(self._marks.values())
+
+    def resolve_surfacing(
+        self,
+        now: str,
+        active_events: Optional[set[str]] = None,
+        active_suppressions: Optional[set[str]] = None,
+    ) -> list[dict[str, Any]]:
+        """Marks that should surface now, in stable (mark_id) order."""
+        return [
+            m
+            for _id, m in sorted(self._marks.items())
+            if should_surface(m, now, active_events, active_suppressions)
+        ]

--- a/tools/attention_registry.py
+++ b/tools/attention_registry.py
@@ -18,12 +18,17 @@ not surface regardless of mode.
 """
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 
 def _parse(ts: str) -> datetime:
-    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    # Always return an aware datetime (assume UTC when no offset is present) so
+    # comparisons never mix naive and aware and raise TypeError.
+    dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
 
 
 def should_surface(

--- a/tools/rail_orchestrator.py
+++ b/tools/rail_orchestrator.py
@@ -32,11 +32,12 @@ class RailResult:
     deferred_to_workflow: bool = False
 
 
+VALID_RAILS = ("mirror", "live", "action")
+
+
 def orchestrate(
     roots: list[dict[str, Any]],
     connectors: dict[str, RootConnector],
-    *,
-    now: str | None = None,
 ) -> list[RailResult]:
     """Run one orchestration pass across roots, honoring each root's rail.
 
@@ -48,6 +49,9 @@ def orchestrate(
     for root in roots:
         root_id = root["root_id"]
         rail = root.get("sync_mode", "mirror")
+        if rail not in VALID_RAILS:
+            # Keep the mirror/live/action split structural: reject unknown rails.
+            raise ValueError(f"unknown sync_mode {rail!r} for root {root_id!r}; expected one of {VALID_RAILS}")
         conn = connectors.get(root_id)
         if conn is None:
             raise KeyError(f"no connector registered for root {root_id!r}")

--- a/tools/rail_orchestrator.py
+++ b/tools/rail_orchestrator.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Rail orchestrator (Workspace Control Plane, Phase 4 / D4).
+
+Routes each root through its declared rail and aggregates governed output:
+
+* **mirror** — connector produces indexed assets + events; the root's
+  `delta_cursor` is advanced (incremental).
+* **live**   — events only, no cached assets; cursor advances.
+* **action** — no ingestion here (side effects run through `workflow-run`).
+
+The orchestrator does not fetch anything itself — it drives the Phase-3
+connectors, so the mirror/live/action split is enforced structurally rather than
+mixed into one uncontrolled access path.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from connector_roots import RootConnector
+
+
+@dataclass
+class RailResult:
+    """Per-root outcome of an orchestration pass."""
+
+    root_id: str
+    rail: str
+    assets: list[dict[str, Any]] = field(default_factory=list)
+    events: list[dict[str, Any]] = field(default_factory=list)
+    new_cursor: Any = None
+    deferred_to_workflow: bool = False
+
+
+def orchestrate(
+    roots: list[dict[str, Any]],
+    connectors: dict[str, RootConnector],
+    *,
+    now: str | None = None,
+) -> list[RailResult]:
+    """Run one orchestration pass across roots, honoring each root's rail.
+
+    `connectors` maps `root_id -> RootConnector`. Returns a `RailResult` per root
+    with its (possibly advanced) delta cursor; the caller persists cursors back
+    onto the roots.
+    """
+    results: list[RailResult] = []
+    for root in roots:
+        root_id = root["root_id"]
+        rail = root.get("sync_mode", "mirror")
+        conn = connectors.get(root_id)
+        if conn is None:
+            raise KeyError(f"no connector registered for root {root_id!r}")
+
+        if rail == "action":
+            # The action rail performs side effects via workflow-run, not ingestion.
+            results.append(RailResult(root_id=root_id, rail=rail, new_cursor=root.get("delta_cursor"),
+                                      deferred_to_workflow=True))
+            continue
+
+        assets, events, cursor = conn.sync(root, root.get("delta_cursor"))
+        results.append(RailResult(root_id=root_id, rail=rail, assets=assets, events=events, new_cursor=cursor))
+    return results
+
+
+def apply_cursors(roots: list[dict[str, Any]], results: list[RailResult]) -> None:
+    """Persist advanced delta cursors back onto the root records (in place)."""
+    by_id = {r["root_id"]: r for r in roots}
+    for res in results:
+        if res.root_id in by_id:
+            by_id[res.root_id]["delta_cursor"] = res.new_cursor

--- a/tools/tests/test_rails_attention.py
+++ b/tools/tests/test_rails_attention.py
@@ -34,7 +34,7 @@ def test_orchestrate_honors_rails(tmp_path):
     roots = [_root("mirror"), _root("live"), _root("action")]
     connectors = {r["root_id"]: conn for r in roots}
 
-    results = {res.root_id: res for res in ro.orchestrate(roots, connectors, now=NOW)}
+    results = {res.root_id: res for res in ro.orchestrate(roots, connectors)}
     assert len(results["root-mirror"].assets) == 1 and len(results["root-mirror"].events) == 1
     assert results["root-live"].assets == [] and len(results["root-live"].events) == 1
     assert results["root-action"].deferred_to_workflow and results["root-action"].events == []
@@ -44,14 +44,20 @@ def test_apply_cursors_advances_root(tmp_path):
     (tmp_path / "f.txt").write_text("hi")
     conn = cr.LocalFilesConnector(str(tmp_path))
     roots = [_root("mirror")]
-    results = ro.orchestrate(roots, {roots[0]["root_id"]: conn}, now=NOW)
+    results = ro.orchestrate(roots, {roots[0]["root_id"]: conn})
     ro.apply_cursors(roots, results)
     assert roots[0]["delta_cursor"] is not None
 
 
 def test_missing_connector_raises():
     with pytest.raises(KeyError):
-        ro.orchestrate([_root("mirror")], {}, now=NOW)
+        ro.orchestrate([_root("mirror")], {})
+
+
+def test_unknown_rail_rejected():
+    bad = _root("teleport")  # not mirror/live/action
+    with pytest.raises(ValueError):
+        ro.orchestrate([bad], {bad["root_id"]: cr.LocalFilesConnector("/tmp")})
 
 
 # ---- attention registry ----

--- a/tools/tests/test_rails_attention.py
+++ b/tools/tests/test_rails_attention.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+TOOLS = Path(__file__).resolve().parents[1]
+ROOT = TOOLS.parent
+sys.path.insert(0, str(TOOLS))
+
+import attention_registry as ar  # type: ignore
+import connector_roots as cr  # type: ignore
+import rail_orchestrator as ro  # type: ignore
+
+LANE = ROOT / "contracts" / "workspace-control-plane"
+MARK_SCHEMA = json.loads((LANE / "schemas" / "attention-mark.v0.schema.json").read_text())
+
+NOW = "2026-08-01T00:00:00+00:00"
+
+
+def _root(mode):
+    return {"root_id": f"root-{mode}", "account_ref": "a", "kind": "local_dir",
+            "sync_mode": mode, "cache_policy": "full", "allowed_actions": ["read"], "delta_cursor": None}
+
+
+# ---- rail orchestrator ----
+
+def test_orchestrate_honors_rails(tmp_path):
+    (tmp_path / "f.txt").write_text("hi")
+    conn = cr.LocalFilesConnector(str(tmp_path))
+    roots = [_root("mirror"), _root("live"), _root("action")]
+    connectors = {r["root_id"]: conn for r in roots}
+
+    results = {res.root_id: res for res in ro.orchestrate(roots, connectors, now=NOW)}
+    assert len(results["root-mirror"].assets) == 1 and len(results["root-mirror"].events) == 1
+    assert results["root-live"].assets == [] and len(results["root-live"].events) == 1
+    assert results["root-action"].deferred_to_workflow and results["root-action"].events == []
+
+
+def test_apply_cursors_advances_root(tmp_path):
+    (tmp_path / "f.txt").write_text("hi")
+    conn = cr.LocalFilesConnector(str(tmp_path))
+    roots = [_root("mirror")]
+    results = ro.orchestrate(roots, {roots[0]["root_id"]: conn}, now=NOW)
+    ro.apply_cursors(roots, results)
+    assert roots[0]["delta_cursor"] is not None
+
+
+def test_missing_connector_raises():
+    with pytest.raises(KeyError):
+        ro.orchestrate([_root("mirror")], {}, now=NOW)
+
+
+# ---- attention registry ----
+
+def mark(mark_id, mode, *, triggers=None, half_life=None, suppress=None, created_at="2026-07-01T00:00:00+00:00"):
+    m = {"mark_id": mark_id, "target_ref": "asset://x", "mode": mode, "created_at": created_at}
+    if triggers is not None:
+        m["resurfacing_triggers"] = triggers
+    if half_life is not None:
+        m["decay"] = {"policy": "exponential", "half_life_seconds": half_life}
+    if suppress is not None:
+        m["suppression"] = {"rules": suppress}
+    return m
+
+
+def test_marks_conform_to_schema():
+    for m in (mark("mark-0001", "pin"), mark("mark-0002", "watch", triggers=["related_asset_ingested"]),
+              mark("mark-0003", "incubate", half_life=3600, suppress=["focus_mode"])):
+        assert list(Draft202012Validator(MARK_SCHEMA).iter_errors(m)) == [], m
+
+
+def test_pin_always_and_forget_hold_never():
+    assert ar.should_surface(mark("m", "pin"), NOW)
+    assert not ar.should_surface(mark("m", "forget"), NOW)
+    assert not ar.should_surface(mark("m", "hold", triggers=["e"]), NOW, active_events={"e"})
+
+
+def test_watch_needs_event():
+    m = mark("m", "watch", triggers=["related_asset_ingested"])
+    assert not ar.should_surface(m, NOW)
+    assert ar.should_surface(m, NOW, active_events={"related_asset_ingested"})
+
+
+def test_revisit_time_trigger():
+    m = mark("m", "revisit", triggers=["at:2026-07-15T00:00:00+00:00"])
+    assert ar.should_surface(m, NOW)  # now is after the scheduled time
+    future = mark("m", "revisit", triggers=["at:2026-12-01T00:00:00+00:00"])
+    assert not ar.should_surface(future, NOW)
+
+
+def test_incubate_surfaces_after_half_life():
+    # created 2026-07-01, half-life 1 day -> due by 2026-08-01.
+    due = mark("m", "incubate", half_life=86400, created_at="2026-07-01T00:00:00+00:00")
+    assert ar.should_surface(due, NOW)
+    not_due = mark("m", "incubate", half_life=86400, created_at="2026-07-31T23:00:00+00:00")
+    assert not ar.should_surface(not_due, NOW)
+
+
+def test_suppression_wins():
+    m = mark("m", "pin", suppress=["focus_mode"])
+    assert not ar.should_surface(m, NOW, active_suppressions={"focus_mode"})
+
+
+def test_registry_resolves_and_transitions():
+    reg = ar.AttentionRegistry()
+    reg.add(mark("a-pin", "pin"))
+    reg.add(mark("b-hold", "hold", triggers=["e"]))
+    reg.add(mark("c-watch", "watch", triggers=["e"]))
+    surfaced = [m["mark_id"] for m in reg.resolve_surfacing(NOW, active_events={"e"})]
+    assert surfaced == ["a-pin", "c-watch"]  # hold stays down; stable order
+
+    reg.release("b-hold", "watch")  # release the hold
+    surfaced2 = [m["mark_id"] for m in reg.resolve_surfacing(NOW, active_events={"e"})]
+    assert "b-hold" in surfaced2
+
+    reg.forget("a-pin")
+    assert "a-pin" not in [m["mark_id"] for m in reg.resolve_surfacing(NOW, active_events={"e"})]


### PR DESCRIPTION
Implements **Phase 4** (D4/D5) on the Phase-1 object model + Phase-3 connectors.

**Rails (D4):** `rail_orchestrator.py` routes each root by sync_mode — mirror (assets+events+cursor), live (events only), action (deferred to workflow-run) — driving the Phase-3 connectors so the split is structural. `apply_cursors` advances delta cursors.

**Attention (D5):** `attention_registry.py` over `attention-mark.v0` — pin/watch/revisit/incubate/hold/forget with decay half-life and suppression-wins; add/release/forget + stable resolve_surfacing.

10 tests. Path-filtered CI (permissions: contents:read). Copilot eval / adversarial review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)