### PR TITLE
feat(control-plane): Phase 5 — trust broker + signed catalog verification

### DIFF
--- a/.github/workflows/control-plane-trust.yml
+++ b/.github/workflows/control-plane-trust.yml
@@ -1,0 +1,38 @@
+name: control-plane-trust
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'tools/trust_broker.py'
+      - 'tools/tests/test_trust_broker.py'
+      - 'contracts/workspace-control-plane/**'
+      - 'docs/WORKSPACE_CONTROL_PLANE_PHASE5.md'
+      - '.github/workflows/control-plane-trust.yml'
+  pull_request:
+    paths:
+      - 'tools/trust_broker.py'
+      - 'tools/tests/test_trust_broker.py'
+      - 'contracts/workspace-control-plane/**'
+      - 'docs/WORKSPACE_CONTROL_PLANE_PHASE5.md'
+      - '.github/workflows/control-plane-trust.yml'
+
+jobs:
+  control-plane-trust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install jsonschema pytest
+      - name: Validate contracts (enum extension safe)
+        run: python tools/validate_control_plane_contracts.py
+      - name: Trust broker tests
+        run: pytest -q tools/tests/test_trust_broker.py

--- a/contracts/workspace-control-plane/schemas/capability-manifest.v0.schema.json
+++ b/contracts/workspace-control-plane/schemas/capability-manifest.v0.schema.json
@@ -33,6 +33,6 @@
       "required": ["revoked"],
       "properties": { "revoked": { "type": "boolean" }, "reason": { "type": "string" } }
     },
-    "signature": { "type": "object", "additionalProperties": false, "required": ["signer", "algorithm", "signature", "signed_at"], "properties": { "signer": { "type": "string" }, "algorithm": { "enum": ["ed25519", "ecdsa-p256", "sigstore-keyless"] }, "signature": { "type": "string" }, "cert_ref": { "type": "string" }, "signed_at": { "type": "string" } } }
+    "signature": { "type": "object", "additionalProperties": false, "required": ["signer", "algorithm", "signature", "signed_at"], "properties": { "signer": { "type": "string" }, "algorithm": { "enum": ["ed25519", "ecdsa-p256", "sigstore-keyless", "hmac-blake2b"] }, "signature": { "type": "string" }, "cert_ref": { "type": "string" }, "signed_at": { "type": "string" } } }
   }
 }

--- a/contracts/workspace-control-plane/schemas/catalog-entry.v0.schema.json
+++ b/contracts/workspace-control-plane/schemas/catalog-entry.v0.schema.json
@@ -23,7 +23,7 @@
         "required": ["signer", "algorithm", "signature", "signed_at"],
         "properties": {
           "signer": { "type": "string" },
-          "algorithm": { "enum": ["ed25519", "ecdsa-p256", "sigstore-keyless"] },
+          "algorithm": { "enum": ["ed25519", "ecdsa-p256", "sigstore-keyless", "hmac-blake2b"] },
           "signature": { "type": "string" },
           "cert_ref": { "type": "string" },
           "signed_at": { "type": "string" }

--- a/contracts/workspace-control-plane/schemas/topic-manifest.v0.schema.json
+++ b/contracts/workspace-control-plane/schemas/topic-manifest.v0.schema.json
@@ -18,6 +18,6 @@
       "required": ["revoked"],
       "properties": { "revoked": { "type": "boolean" }, "reason": { "type": "string" } }
     },
-    "signature": { "type": "object", "additionalProperties": false, "required": ["signer", "algorithm", "signature", "signed_at"], "properties": { "signer": { "type": "string" }, "algorithm": { "enum": ["ed25519", "ecdsa-p256", "sigstore-keyless"] }, "signature": { "type": "string" }, "cert_ref": { "type": "string" }, "signed_at": { "type": "string" } } }
+    "signature": { "type": "object", "additionalProperties": false, "required": ["signer", "algorithm", "signature", "signed_at"], "properties": { "signer": { "type": "string" }, "algorithm": { "enum": ["ed25519", "ecdsa-p256", "sigstore-keyless", "hmac-blake2b"] }, "signature": { "type": "string" }, "cert_ref": { "type": "string" }, "signed_at": { "type": "string" } } }
   }
 }

--- a/docs/WORKSPACE_CONTROL_PLANE_PHASE5.md
+++ b/docs/WORKSPACE_CONTROL_PLANE_PHASE5.md
@@ -1,0 +1,46 @@
+# Workspace Control Plane — Phase 5 (trust broker)
+
+Implements **Phase 5** of the control spec: remote discovery must not precede
+signed manifests and revocation semantics (D9), under a staged security stance
+(D16). Verifies over the `capability-manifest` / `topic-manifest` / `catalog-entry`
+schemas frozen in Phase 1.
+
+## What it verifies (`tools/trust_broker.py`)
+
+- **Signature** — the manifest/catalog signature verifies under the configured verifier.
+- **Freshness** — not past `expiry`, and (optionally) signed within `max_age_seconds`.
+- **Revocation** — `revocation.revoked` must be false.
+- **Delegation threshold** (catalogs) — at least `delegation.threshold` signatures
+  must verify (TUF-style).
+- **Transparency** — every verification (trusted or not, with reasons) is appended
+  to an in-memory transparency log.
+
+## Pluggable, staged crypto (D16)
+
+Signature verification is an interface. The **lab default** implements a real
+keyed MAC — `hmac-blake2b`, stdlib only, no heavy dependency — so trust is
+genuinely enforced in the trusted-lab stance. **Asymmetric** algorithms
+(`ed25519`, `ecdsa-p256`, `sigstore-keyless`) require production keys/infra and
+report `verifier_unavailable` rather than pretending to verify. Swap in a
+production verifier behind the same interface for the hardened stance.
+
+`hmac-blake2b` was added to the three manifest algorithm enums as a deliberate,
+additive extension (existing values unchanged).
+
+## Relationship to the capability broker (Phase 2)
+
+The Phase-2 capability broker gates `trusted_catalog` resolution on structural
+catalog validity; the trust broker is the deeper verifier a hardened deployment
+routes those checks through.
+
+## Validation
+
+`tools/tests/test_trust_broker.py` — 7 tests: valid→trusted, tamper→bad_signature,
+expired/revoked/unsigned, unknown-signer + asymmetric-unavailable, stale via
+max_age, catalog delegation threshold, transparency log. Path-filtered CI:
+`.github/workflows/control-plane-trust.yml`.
+
+## Next (Phase 6)
+
+Hypercore/Hyperswarm/Autobase overlay for approved private topics — needs the
+Hyper stack deps; scaffold-first (topic-manifest transport already frozen).

--- a/tools/tests/test_trust_broker.py
+++ b/tools/tests/test_trust_broker.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+TOOLS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOLS))
+
+import trust_broker as tb  # type: ignore
+
+NOW = "2026-08-01T00:00:00+00:00"
+FUTURE = "2026-12-31T00:00:00+00:00"
+PAST = "2025-01-01T00:00:00+00:00"
+SECRET = b"lab-secret-key"
+
+
+def _registry(*signers):
+    r = tb.KeyRegistry()
+    for s in signers:
+        r.add(s, SECRET)
+    return r
+
+
+def _signed_manifest(mid="capman-1", *, expiry=FUTURE, revoked=False, signer="root", signed_at=NOW, algo="hmac-blake2b"):
+    m = {
+        "manifest_id": mid, "kind": "capability", "provider": "mcp://x",
+        "capabilities": [{"name": "drive.search"}], "expiry": expiry,
+        "revocation": {"revoked": revoked},
+    }
+    payload = tb.canonical_signing_bytes(m, exclude=("signature",))
+    m["signature"] = {"signer": signer, "algorithm": algo, "signature": tb.mac_sign(payload, SECRET), "signed_at": signed_at}
+    return m
+
+
+def test_valid_manifest_is_trusted():
+    broker = tb.TrustBroker(_registry("root"))
+    d = broker.verify_manifest(_signed_manifest(), NOW)
+    assert d.trusted and d.reasons == []
+    assert broker.transparency_log[-1]["trusted"] is True
+
+
+def test_tamper_breaks_signature():
+    broker = tb.TrustBroker(_registry("root"))
+    m = _signed_manifest()
+    m["provider"] = "mcp://evil"  # tamper after signing
+    d = broker.verify_manifest(m, NOW)
+    assert not d.trusted and "bad_signature" in d.reasons
+
+
+def test_expired_and_revoked_and_unsigned():
+    broker = tb.TrustBroker(_registry("root"))
+    assert "expired" in broker.verify_manifest(_signed_manifest(expiry=PAST), NOW).reasons
+    assert "revoked" in broker.verify_manifest(_signed_manifest(revoked=True), NOW).reasons
+    unsigned = {"manifest_id": "m", "kind": "capability", "provider": "p", "capabilities": [{"name": "x"}], "expiry": FUTURE}
+    assert "unsigned" in broker.verify_manifest(unsigned, NOW).reasons
+
+
+def test_unknown_signer_and_asymmetric_unavailable():
+    broker = tb.TrustBroker(tb.KeyRegistry())  # no keys registered
+    assert "unknown_signer" in broker.verify_manifest(_signed_manifest(), NOW).reasons
+    d = broker.verify_manifest(_signed_manifest(algo="ed25519"), NOW)
+    assert "verifier_unavailable" in d.reasons
+
+
+def test_stale_via_max_age():
+    broker = tb.TrustBroker(_registry("root"), max_age_seconds=3600)
+    old = _signed_manifest(signed_at="2026-07-31T20:00:00+00:00")  # >1h before NOW
+    assert "stale" in broker.verify_manifest(old, NOW).reasons
+
+
+def _signed_catalog(threshold, n_valid, n_invalid=0):
+    entry = {
+        "entry_id": "cat-1", "role": "targets", "version": 1, "targets": ["capman-1"],
+        "expiry": FUTURE, "delegation": {"threshold": threshold, "keys": ["k"]},
+    }
+    payload = tb.canonical_signing_bytes(entry, exclude=("signatures",))
+    sigs = []
+    for i in range(n_valid):
+        sigs.append({"signer": f"s{i}", "algorithm": "hmac-blake2b", "signature": tb.mac_sign(payload, SECRET), "signed_at": NOW})
+    for i in range(n_invalid):
+        sigs.append({"signer": f"bad{i}", "algorithm": "hmac-blake2b", "signature": "deadbeef", "signed_at": NOW})
+    entry["signatures"] = sigs
+    return entry
+
+
+def test_catalog_delegation_threshold():
+    reg = _registry("s0", "s1", "bad0")
+    broker = tb.TrustBroker(reg)
+    # 2 valid signatures, threshold 2 -> trusted
+    assert broker.verify_catalog(_signed_catalog(2, n_valid=2), NOW).trusted
+    # 1 valid + 1 invalid, threshold 2 -> not trusted
+    d = broker.verify_catalog(_signed_catalog(2, n_valid=1, n_invalid=1), NOW)
+    assert not d.trusted and any("insufficient_signatures" in r for r in d.reasons)
+
+
+def test_transparency_log_appends_every_check():
+    broker = tb.TrustBroker(_registry("root"))
+    broker.verify_manifest(_signed_manifest(), NOW)
+    broker.verify_manifest(_signed_manifest(revoked=True), NOW)
+    assert len(broker.transparency_log) == 2
+    assert [e["trusted"] for e in broker.transparency_log] == [True, False]

--- a/tools/trust_broker.py
+++ b/tools/trust_broker.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Trust broker (Workspace Control Plane, Phase 5 / D9, D16).
+
+Verifies signed manifests and catalogs before remote discovery is allowed:
+signature validity, freshness (expiry + optional max age), revocation, and — for
+catalogs — the TUF-style delegation threshold. Every verification is recorded in
+an append-only transparency log.
+
+Signature verification is pluggable. The lab default (D16: trusted-lab stance)
+implements a real keyed MAC (`hmac-blake2b`, stdlib only — no heavy deps).
+Asymmetric algorithms (ed25519 / ecdsa-p256 / sigstore-keyless) require keys and
+infrastructure; in the lab they report `verifier_unavailable` rather than
+pretending to verify. Swap in a production verifier behind the same interface.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+
+def _parse(ts: str) -> datetime:
+    dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def canonical_signing_bytes(obj: dict[str, Any], *, exclude: tuple[str, ...]) -> bytes:
+    """Deterministic bytes over an object with the signature field(s) excluded."""
+    payload = {k: v for k, v in obj.items() if k not in exclude}
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+class KeyRegistry:
+    """Maps a signer id to its lab MAC secret (bytes)."""
+
+    def __init__(self) -> None:
+        self._keys: dict[str, bytes] = {}
+
+    def add(self, signer: str, secret: bytes) -> None:
+        self._keys[signer] = secret
+
+    def get(self, signer: str) -> Optional[bytes]:
+        return self._keys.get(signer)
+
+
+def mac_sign(payload: bytes, secret: bytes) -> str:
+    """Lab signature: keyed blake2b MAC, hex."""
+    return hashlib.blake2b(payload, key=secret).hexdigest()
+
+
+def verify_signature(sig_block: dict[str, Any], payload: bytes, registry: KeyRegistry) -> tuple[bool, str]:
+    """Verify one signature block against payload. Returns (ok, reason)."""
+    algo = sig_block.get("algorithm")
+    signer = sig_block.get("signer", "")
+    sig = sig_block.get("signature", "")
+    if algo == "hmac-blake2b":
+        key = registry.get(signer)
+        if key is None:
+            return False, "unknown_signer"
+        expected = mac_sign(payload, key)
+        # Constant-time compare.
+        ok = hmac.compare_digest(expected, sig)
+        return ok, "ok" if ok else "bad_signature"
+    # Asymmetric algorithms need production keys/infra.
+    return False, "verifier_unavailable"
+
+
+@dataclass
+class TrustDecision:
+    subject_id: str
+    trusted: bool
+    reasons: list[str] = field(default_factory=list)
+
+
+class TrustBroker:
+    """Verifies manifests/catalogs and records a transparency log."""
+
+    def __init__(self, registry: KeyRegistry, *, max_age_seconds: Optional[int] = None) -> None:
+        self.registry = registry
+        self.max_age_seconds = max_age_seconds
+        self.transparency_log: list[dict[str, Any]] = []
+
+    def _record(self, decision: TrustDecision, now: str) -> None:
+        self.transparency_log.append({
+            "ts": now,
+            "subject_id": decision.subject_id,
+            "trusted": decision.trusted,
+            "reasons": list(decision.reasons),
+        })
+
+    def _fresh(self, expiry: Optional[str], signed_at: Optional[str], now: str, reasons: list[str]) -> None:
+        now_dt = _parse(now)
+        if expiry and _parse(expiry) <= now_dt:
+            reasons.append("expired")
+        if self.max_age_seconds is not None and signed_at:
+            if (now_dt - _parse(signed_at)).total_seconds() > self.max_age_seconds:
+                reasons.append("stale")
+
+    def verify_manifest(self, manifest: dict[str, Any], now: str) -> TrustDecision:
+        subject_id = manifest.get("manifest_id", "?")
+        reasons: list[str] = []
+        sig = manifest.get("signature")
+        if not sig:
+            reasons.append("unsigned")
+        else:
+            payload = canonical_signing_bytes(manifest, exclude=("signature",))
+            ok, why = verify_signature(sig, payload, self.registry)
+            if not ok:
+                reasons.append(why)
+            self._fresh(manifest.get("expiry"), sig.get("signed_at"), now, reasons)
+        rev = manifest.get("revocation") or {}
+        if rev.get("revoked"):
+            reasons.append("revoked")
+        decision = TrustDecision(subject_id, not reasons, reasons)
+        self._record(decision, now)
+        return decision
+
+    def verify_catalog(self, entry: dict[str, Any], now: str) -> TrustDecision:
+        subject_id = entry.get("entry_id", "?")
+        reasons: list[str] = []
+        payload = canonical_signing_bytes(entry, exclude=("signatures",))
+        valid = 0
+        for sig in entry.get("signatures", []):
+            ok, _ = verify_signature(sig, payload, self.registry)
+            if ok:
+                valid += 1
+        threshold = (entry.get("delegation") or {}).get("threshold", 1)
+        if valid < threshold:
+            reasons.append(f"insufficient_signatures:{valid}<{threshold}")
+        self._fresh(entry.get("expiry"), None, now, reasons)
+        decision = TrustDecision(subject_id, not reasons, reasons)
+        self._record(decision, now)
+        return decision


### PR DESCRIPTION
Implements **Phase 5** (D9/D16) over the Phase-1 frozen manifest/catalog schemas.

`tools/trust_broker.py` verifies signed manifests + catalogs before remote discovery: signature validity, freshness (expiry + optional max_age), revocation, and TUF-style delegation threshold for catalogs — recording every check in an append-only transparency log.

**Staged crypto (D16):** pluggable verifier; lab default is a real keyed MAC (`hmac-blake2b`, stdlib only — no heavy dep); asymmetric algos report `verifier_unavailable` until production keys/infra (no pretending). Additive enum extension adds `hmac-blake2b` to the 3 algorithm enums (existing values unchanged; 13 schemas still validate).

7 tests (valid/tamper/expired/revoked/unsigned/unknown-signer/asymmetric-unavailable/stale/delegation-threshold/transparency). Path-filtered CI (permissions: contents:read). Copilot eval / adversarial review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)