### PR TITLE
harden(control-plane): trust broker fail-closed on remote input (Copilot #1190 follow-up)

### DIFF
--- a/tools/tests/test_trust_broker.py
+++ b/tools/tests/test_trust_broker.py
@@ -28,7 +28,8 @@ def _signed_manifest(mid="capman-1", *, expiry=FUTURE, revoked=False, signer="ro
         "revocation": {"revoked": revoked},
     }
     payload = tb.canonical_signing_bytes(m, exclude=("signature",))
-    m["signature"] = {"signer": signer, "algorithm": algo, "signature": tb.mac_sign(payload, SECRET), "signed_at": signed_at}
+    sig = tb.mac_sign(tb.signing_input(payload, signed_at), SECRET)
+    m["signature"] = {"signer": signer, "algorithm": algo, "signature": sig, "signed_at": signed_at}
     return m
 
 
@@ -76,7 +77,7 @@ def _signed_catalog(threshold, n_valid, n_invalid=0):
     payload = tb.canonical_signing_bytes(entry, exclude=("signatures",))
     sigs = []
     for i in range(n_valid):
-        sigs.append({"signer": f"s{i}", "algorithm": "hmac-blake2b", "signature": tb.mac_sign(payload, SECRET), "signed_at": NOW})
+        sigs.append({"signer": f"s{i}", "algorithm": "hmac-blake2b", "signature": tb.mac_sign(tb.signing_input(payload, NOW), SECRET), "signed_at": NOW})
     for i in range(n_invalid):
         sigs.append({"signer": f"bad{i}", "algorithm": "hmac-blake2b", "signature": "deadbeef", "signed_at": NOW})
     entry["signatures"] = sigs
@@ -131,13 +132,36 @@ def test_catalog_max_age_enforced():
     entry = {"entry_id": "cat-old", "role": "targets", "version": 1, "targets": ["x"],
              "expiry": FUTURE, "delegation": {"threshold": 2, "keys": ["k"]}}
     payload = tb.canonical_signing_bytes(entry, exclude=("signatures",))
+    old = "2026-07-31T20:00:00+00:00"  # >1h before NOW
     entry["signatures"] = [
-        {"signer": "s0", "algorithm": "hmac-blake2b", "signature": tb.mac_sign(payload, SECRET), "signed_at": "2026-07-31T20:00:00+00:00"},
-        {"signer": "s1", "algorithm": "hmac-blake2b", "signature": tb.mac_sign(payload, SECRET), "signed_at": "2026-07-31T20:00:00+00:00"},
+        {"signer": "s0", "algorithm": "hmac-blake2b", "signature": tb.mac_sign(tb.signing_input(payload, old), SECRET), "signed_at": old},
+        {"signer": "s1", "algorithm": "hmac-blake2b", "signature": tb.mac_sign(tb.signing_input(payload, old), SECRET), "signed_at": old},
     ]
     d = broker.verify_catalog(entry, NOW)
     assert not d.trusted and any("insufficient_signatures" in r for r in d.reasons)
-    # Same catalog, fresh signatures -> trusted.
-    for s in entry["signatures"]:
-        s["signed_at"] = NOW
+    # Fresh signatures (re-signed over NOW, since signed_at is authenticated) -> trusted.
+    entry["signatures"] = [
+        {"signer": "s0", "algorithm": "hmac-blake2b", "signature": tb.mac_sign(tb.signing_input(payload, NOW), SECRET), "signed_at": NOW},
+        {"signer": "s1", "algorithm": "hmac-blake2b", "signature": tb.mac_sign(tb.signing_input(payload, NOW), SECRET), "signed_at": NOW},
+    ]
     assert broker.verify_catalog(entry, NOW).trusted
+
+
+def test_replay_with_edited_signed_at_is_rejected():
+    # signed_at is authenticated: taking an old valid signature and editing
+    # signed_at to NOW must NOT verify (defeats the max-age bypass, Copilot #1190).
+    broker = tb.TrustBroker(_registry("root"), max_age_seconds=3600)
+    m = _signed_manifest(signed_at="2026-07-31T20:00:00+00:00")  # old but validly signed
+    m["signature"]["signed_at"] = NOW  # attacker edits timestamp without re-signing
+    d = broker.verify_manifest(m, NOW)
+    assert not d.trusted and "bad_signature" in d.reasons
+
+
+def test_nonstring_signer_does_not_crash():
+    broker = tb.TrustBroker(_registry("root"))
+    m = {"manifest_id": "m", "kind": "capability", "provider": "p",
+         "capabilities": [{"name": "x"}], "expiry": FUTURE,
+         "signature": {"signer": {"not": "a-string"}, "algorithm": "hmac-blake2b",
+                       "signature": "x", "signed_at": NOW}}
+    d = broker.verify_manifest(m, NOW)  # must not raise (unhashable signer)
+    assert not d.trusted and "malformed_signature" in d.reasons

--- a/tools/tests/test_trust_broker.py
+++ b/tools/tests/test_trust_broker.py
@@ -99,3 +99,45 @@ def test_transparency_log_appends_every_check():
     broker.verify_manifest(_signed_manifest(revoked=True), NOW)
     assert len(broker.transparency_log) == 2
     assert [e["trusted"] for e in broker.transparency_log] == [True, False]
+
+
+# ---- hardening follow-up (Copilot #1190) ----
+
+def test_unknown_algorithm_is_distinct_from_unavailable():
+    broker = tb.TrustBroker(_registry("root"))
+    d = broker.verify_manifest(_signed_manifest(algo="totally-made-up"), NOW)
+    assert "unknown_algorithm" in d.reasons and "verifier_unavailable" not in d.reasons
+
+
+def test_malformed_signature_does_not_crash():
+    broker = tb.TrustBroker(_registry("root"))
+    m = {"manifest_id": "m", "kind": "capability", "provider": "p",
+         "capabilities": [{"name": "x"}], "expiry": FUTURE, "signature": "not-a-dict"}
+    d = broker.verify_manifest(m, NOW)  # must not raise
+    assert not d.trusted and "malformed_signature" in d.reasons
+    assert broker.transparency_log[-1]["subject_id"] == "m"  # still recorded
+
+
+def test_bad_timestamp_fails_closed():
+    broker = tb.TrustBroker(_registry("root"))
+    d = broker.verify_manifest(_signed_manifest(expiry="not-a-date"), NOW)  # attacker-controlled
+    assert not d.trusted and "bad_timestamp" in d.reasons
+
+
+def test_catalog_max_age_enforced():
+    reg = _registry("s0", "s1")
+    broker = tb.TrustBroker(reg, max_age_seconds=3600)
+    # Two valid signatures, but signed >1h before NOW -> none count -> below threshold.
+    entry = {"entry_id": "cat-old", "role": "targets", "version": 1, "targets": ["x"],
+             "expiry": FUTURE, "delegation": {"threshold": 2, "keys": ["k"]}}
+    payload = tb.canonical_signing_bytes(entry, exclude=("signatures",))
+    entry["signatures"] = [
+        {"signer": "s0", "algorithm": "hmac-blake2b", "signature": tb.mac_sign(payload, SECRET), "signed_at": "2026-07-31T20:00:00+00:00"},
+        {"signer": "s1", "algorithm": "hmac-blake2b", "signature": tb.mac_sign(payload, SECRET), "signed_at": "2026-07-31T20:00:00+00:00"},
+    ]
+    d = broker.verify_catalog(entry, NOW)
+    assert not d.trusted and any("insufficient_signatures" in r for r in d.reasons)
+    # Same catalog, fresh signatures -> trusted.
+    for s in entry["signatures"]:
+        s["signed_at"] = NOW
+    assert broker.verify_catalog(entry, NOW).trusted

--- a/tools/trust_broker.py
+++ b/tools/trust_broker.py
@@ -67,24 +67,38 @@ def mac_sign(payload: bytes, secret: bytes) -> str:
 _KNOWN_ASYMMETRIC = {"ed25519", "ecdsa-p256", "sigstore-keyless"}
 
 
+def signing_input(payload: bytes, signed_at: str) -> bytes:
+    """The bytes a signature actually covers.
+
+    `signed_at` is folded in so it is **authenticated** — otherwise it lives
+    outside the signed payload and an attacker could replay an old valid
+    signature with an edited `signed_at` to defeat max-age freshness.
+    """
+    return payload + b"\n:signed_at:" + signed_at.encode("utf-8")
+
+
 def verify_signature(sig_block: dict[str, Any], payload: bytes, registry: KeyRegistry) -> tuple[bool, str]:
     """Verify one signature block against payload. Returns (ok, reason).
 
-    Fail-closed on malformed/attacker-controlled input; distinguishes an
-    *unsupported-in-lab* algorithm from an *unknown/typo* one.
+    Fail-closed on malformed/attacker-controlled input (non-dict block, non-string
+    signer/signature/signed_at); distinguishes an *unsupported-in-lab* algorithm
+    from an *unknown/typo* one. The signature covers `signed_at` (see
+    [`signing_input`]).
     """
     if not isinstance(sig_block, dict):
         return False, "malformed_signature"
     algo = sig_block.get("algorithm")
-    signer = sig_block.get("signer", "")
-    sig = sig_block.get("signature", "")
+    signer = sig_block.get("signer")
+    sig = sig_block.get("signature")
+    signed_at = sig_block.get("signed_at")
+    # signer must be hashable/str (registry lookup), and sig/signed_at present strings.
+    if not isinstance(signer, str) or not isinstance(sig, str) or not sig or not isinstance(signed_at, str):
+        return False, "malformed_signature"
     if algo == "hmac-blake2b":
-        if not isinstance(sig, str) or not sig:
-            return False, "malformed_signature"
         key = registry.get(signer)
         if key is None:
             return False, "unknown_signer"
-        ok = hmac.compare_digest(mac_sign(payload, key), sig)
+        ok = hmac.compare_digest(mac_sign(signing_input(payload, signed_at), key), sig)
         return ok, "ok" if ok else "bad_signature"
     if algo in _KNOWN_ASYMMETRIC:
         # Supported algorithm, but no production verifier wired in the lab stance.

--- a/tools/trust_broker.py
+++ b/tools/trust_broker.py
@@ -29,6 +29,16 @@ def _parse(ts: str) -> datetime:
     return dt
 
 
+def _try_parse(ts: Any) -> Optional[datetime]:
+    """Parse an attacker-controlled timestamp, returning None on anything invalid."""
+    if not isinstance(ts, str):
+        return None
+    try:
+        return _parse(ts)
+    except (ValueError, TypeError):
+        return None
+
+
 def canonical_signing_bytes(obj: dict[str, Any], *, exclude: tuple[str, ...]) -> bytes:
     """Deterministic bytes over an object with the signature field(s) excluded."""
     payload = {k: v for k, v in obj.items() if k not in exclude}
@@ -53,21 +63,34 @@ def mac_sign(payload: bytes, secret: bytes) -> str:
     return hashlib.blake2b(payload, key=secret).hexdigest()
 
 
+# Algorithms with a real (production) verifier interface, pending keys/infra.
+_KNOWN_ASYMMETRIC = {"ed25519", "ecdsa-p256", "sigstore-keyless"}
+
+
 def verify_signature(sig_block: dict[str, Any], payload: bytes, registry: KeyRegistry) -> tuple[bool, str]:
-    """Verify one signature block against payload. Returns (ok, reason)."""
+    """Verify one signature block against payload. Returns (ok, reason).
+
+    Fail-closed on malformed/attacker-controlled input; distinguishes an
+    *unsupported-in-lab* algorithm from an *unknown/typo* one.
+    """
+    if not isinstance(sig_block, dict):
+        return False, "malformed_signature"
     algo = sig_block.get("algorithm")
     signer = sig_block.get("signer", "")
     sig = sig_block.get("signature", "")
     if algo == "hmac-blake2b":
+        if not isinstance(sig, str) or not sig:
+            return False, "malformed_signature"
         key = registry.get(signer)
         if key is None:
             return False, "unknown_signer"
-        expected = mac_sign(payload, key)
-        # Constant-time compare.
-        ok = hmac.compare_digest(expected, sig)
+        ok = hmac.compare_digest(mac_sign(payload, key), sig)
         return ok, "ok" if ok else "bad_signature"
-    # Asymmetric algorithms need production keys/infra.
-    return False, "verifier_unavailable"
+    if algo in _KNOWN_ASYMMETRIC:
+        # Supported algorithm, but no production verifier wired in the lab stance.
+        return False, "verifier_unavailable"
+    # Typos / algorithms outside the declared enum are a distinct, diagnosable error.
+    return False, "unknown_algorithm"
 
 
 @dataclass
@@ -94,12 +117,27 @@ class TrustBroker:
         })
 
     def _fresh(self, expiry: Optional[str], signed_at: Optional[str], now: str, reasons: list[str]) -> None:
-        now_dt = _parse(now)
-        if expiry and _parse(expiry) <= now_dt:
-            reasons.append("expired")
-        if self.max_age_seconds is not None and signed_at:
-            if (now_dt - _parse(signed_at)).total_seconds() > self.max_age_seconds:
+        now_dt = _parse(now)  # our own clock string; trusted format
+        if expiry is not None:
+            e = _try_parse(expiry)
+            if e is None:
+                reasons.append("bad_timestamp")  # fail closed on malformed input
+            elif e <= now_dt:
+                reasons.append("expired")
+        if self.max_age_seconds is not None and signed_at is not None:
+            s = _try_parse(signed_at)
+            if s is None:
+                reasons.append("bad_timestamp")
+            elif (now_dt - s).total_seconds() > self.max_age_seconds:
                 reasons.append("stale")
+
+    def _sig_fresh(self, sig: Any, now_dt: datetime) -> bool:
+        """Whether a single signature is within max_age (fail-closed)."""
+        if self.max_age_seconds is None:
+            return True
+        signed_at = sig.get("signed_at") if isinstance(sig, dict) else None
+        s = _try_parse(signed_at)
+        return s is not None and (now_dt - s).total_seconds() <= self.max_age_seconds
 
     def verify_manifest(self, manifest: dict[str, Any], now: str) -> TrustDecision:
         subject_id = manifest.get("manifest_id", "?")
@@ -107,6 +145,8 @@ class TrustBroker:
         sig = manifest.get("signature")
         if not sig:
             reasons.append("unsigned")
+        elif not isinstance(sig, dict):
+            reasons.append("malformed_signature")  # remote input; do not crash
         else:
             payload = canonical_signing_bytes(manifest, exclude=("signature",))
             ok, why = verify_signature(sig, payload, self.registry)
@@ -124,10 +164,15 @@ class TrustBroker:
         subject_id = entry.get("entry_id", "?")
         reasons: list[str] = []
         payload = canonical_signing_bytes(entry, exclude=("signatures",))
+        now_dt = _parse(now)
+        sigs = entry.get("signatures", [])
+        if not isinstance(sigs, list):
+            sigs = []
         valid = 0
-        for sig in entry.get("signatures", []):
+        for sig in sigs:
             ok, _ = verify_signature(sig, payload, self.registry)
-            if ok:
+            # A signature counts only if it verifies AND is within max_age.
+            if ok and self._sig_fresh(sig, now_dt):
                 valid += 1
         threshold = (entry.get("delegation") or {}).get("threshold", 1)
         if valid < threshold:


### PR DESCRIPTION
Follow-up hardening for #1190. That PR auto-merged before I evaluated Copilot; Copilot posted 5 valid, security-relevant findings on `trust_broker.py` (attacker-controlled remote inputs). All 5 addressed:

1. **unknown_algorithm** vs **verifier_unavailable** — typos/unknown algos are diagnosable, not masked as infra issues.
2. **Fail-closed timestamps** — malformed ISO `expiry`/`signed_at` yield `bad_timestamp` instead of raising (was a DoS + lost transparency record).
3. **Catalog max_age enforced** — stale signatures no longer count toward the delegation threshold.
4. **Malformed signature guard** — a non-dict `signature` fails closed (recorded), no AttributeError crash.
5. **Regression tests** — stale-catalog, malformed-signature, bad-timestamp, unknown-algorithm.

11 tests green. Process fix: not using `--auto` before Copilot is evaluated again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)