### PR TITLE
feat(control-plane): Phase 6 — overlay transport broker (scaffold-first)

### DIFF
--- a/.github/workflows/control-plane-overlay.yml
+++ b/.github/workflows/control-plane-overlay.yml
@@ -1,0 +1,36 @@
+name: control-plane-overlay
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'tools/overlay_transport.py'
+      - 'tools/tests/test_overlay_transport.py'
+      - 'contracts/workspace-control-plane/**'
+      - 'docs/WORKSPACE_CONTROL_PLANE_PHASE6.md'
+      - '.github/workflows/control-plane-overlay.yml'
+  pull_request:
+    paths:
+      - 'tools/overlay_transport.py'
+      - 'tools/tests/test_overlay_transport.py'
+      - 'contracts/workspace-control-plane/**'
+      - 'docs/WORKSPACE_CONTROL_PLANE_PHASE6.md'
+      - '.github/workflows/control-plane-overlay.yml'
+
+jobs:
+  control-plane-overlay:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install jsonschema pytest
+      - name: Overlay transport tests
+        run: pytest -q tools/tests/test_overlay_transport.py

--- a/docs/WORKSPACE_CONTROL_PLANE_PHASE6.md
+++ b/docs/WORKSPACE_CONTROL_PLANE_PHASE6.md
@@ -1,0 +1,36 @@
+# Workspace Control Plane — Phase 6 (overlay transport)
+
+Implements **Phase 6**: a private-mesh overlay for approved topics (D8/D10),
+scaffold-first. The durable Hypercore/Autobase **semantics** are implemented
+in-process with **no network / no Hyper-stack dependency**; the real stack swaps
+in behind the same `OverlayBroker` interface later.
+
+## Pattern registry semantics (§5)
+
+- **AppendLog** — single-writer, append-only, blake2b **hash-chained** log
+  (Hypercore); `verify()` is tamper-evident.
+- **sparse_fetch** — lazy subset fetch by index (`seed_sparse`).
+- **linearize** — merge multiple writer logs into one **causal, deterministic**
+  view by `(lamport clock, writer, seq)`, so peers converge (`linearize_multiwriter`,
+  Autobase).
+- **OverlayBroker.join** — `join_topic_or_peer`: a topic is joined **only after a
+  trust decision** (D9). Refuses `untrusted` / `revoked` / `expired` /
+  `unknown_transport`; append/fetch/linearize are gated on membership.
+
+## Trust wiring
+
+`join(manifest, trusted=..., now=...)` takes the trust verdict as an explicit
+argument — the caller passes `TrustBroker.verify_manifest(...).trusted` (Phase 5),
+keeping the discovery, trust, and transport planes separate (D8).
+
+## Validation
+
+`tools/tests/test_overlay_transport.py` — 7 tests: chain + tamper, sparse subset,
+causal linearization (order-independent), the four join refusals, join →
+append/fetch/linearize, unjoined refused, and topic-manifest conformance.
+Path-filtered CI: `.github/workflows/control-plane-overlay.yml`.
+
+## Next (Phase 7)
+
+Temporal outbox + approvals + workflow replay over `workflow-run.v0` (needs
+Temporal infra → scaffold-first: durable outbox state machine + approval gate).

--- a/tools/overlay_transport.py
+++ b/tools/overlay_transport.py
@@ -20,8 +20,14 @@ from typing import Iterable, Optional
 KNOWN_TRANSPORTS = {"hypercore", "hyperswarm", "autobase", "hyperdrive"}
 
 
-def _parse(ts: str) -> datetime:
-    dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+def _try_parse(ts: object) -> Optional[datetime]:
+    """Parse an attacker-controlled timestamp, returning None on anything invalid."""
+    if not isinstance(ts, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     return dt
@@ -61,10 +67,15 @@ class AppendLog:
         return e
 
     def verify(self) -> bool:
-        """True iff the hash chain is intact (tamper-evident)."""
+        """True iff the hash chain is intact AND single-writer (tamper-evident).
+
+        Enforces `e.writer == self.writer` for every entry: without it a
+        cross-writer entry could validate as long as its internal chain is
+        consistent, since the hash is recomputed from the (tamperable) `e.writer`.
+        """
         prev = ""
         for i, e in enumerate(self.entries):
-            if e.seq != i or e.prev_hash != prev:
+            if e.writer != self.writer or e.seq != i or e.prev_hash != prev:
                 return False
             if e.entry_hash != _entry_hash(prev, e.writer, e.seq, e.clock, e.data):
                 return False
@@ -125,11 +136,24 @@ class OverlayBroker:
         rev = manifest.get("revocation") or {}
         if rev.get("revoked"):
             reasons.append("revoked")
+        # Fail closed on malformed (attacker-controlled) timestamps.
+        now_dt = _try_parse(now)
+        if now_dt is None:
+            reasons.append("bad_timestamp")
         expiry = manifest.get("expiry")
-        if expiry and _parse(expiry) <= _parse(now):
-            reasons.append("expired")
+        if expiry is not None:
+            exp_dt = _try_parse(expiry)
+            if exp_dt is None:
+                reasons.append("bad_timestamp")
+            elif now_dt is not None and exp_dt <= now_dt:
+                reasons.append("expired")
         if reasons:
             raise OverlayRefused(reasons)
+        # Re-joining an already-joined topic returns the existing handle so its
+        # logs are preserved (do not reset/discard on re-join).
+        existing = self.joined.get(manifest["topic"])
+        if existing is not None:
+            return existing
         topic = Topic(manifest["topic"])
         self.joined[manifest["topic"]] = topic
         return topic

--- a/tools/overlay_transport.py
+++ b/tools/overlay_transport.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Overlay transport broker (Workspace Control Plane, Phase 6 / D8, D10).
+
+Scaffold-first: the durable Hypercore/Autobase *semantics* — an append-only,
+hash-chained log; sparse (lazy subset) fetch; and multiwriter linearization into
+one causally-ordered view — implemented in-process with **no network / no Hyper
+stack dependency**. Topics are joined only *after* a trust decision
+(join-after-trust, D9), conformant to the frozen `topic-manifest.v0`.
+
+When the real Hyper stack is added, swap the local transport behind the same
+`OverlayBroker` interface; the pattern registry semantics (§5) do not change.
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Optional
+
+KNOWN_TRANSPORTS = {"hypercore", "hyperswarm", "autobase", "hyperdrive"}
+
+
+def _parse(ts: str) -> datetime:
+    dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _entry_hash(prev_hash: str, writer: str, seq: int, clock: int, data: str) -> str:
+    h = hashlib.blake2b(digest_size=32)
+    h.update(f"{prev_hash}|{writer}|{seq}|{clock}|".encode("utf-8"))
+    h.update(data.encode("utf-8"))
+    return h.hexdigest()
+
+
+@dataclass
+class LogEntry:
+    """One append-only entry; `entry_hash` chains it to its predecessor."""
+
+    writer: str
+    seq: int
+    clock: int  # lamport-style logical clock for causal linearization
+    data: str
+    prev_hash: str
+    entry_hash: str
+
+
+class AppendLog:
+    """A single-writer append-only, hash-chained log (Hypercore semantics)."""
+
+    def __init__(self, writer: str) -> None:
+        self.writer = writer
+        self.entries: list[LogEntry] = []
+
+    def append(self, data: str, clock: int) -> LogEntry:
+        seq = len(self.entries)
+        prev = self.entries[-1].entry_hash if self.entries else ""
+        e = LogEntry(self.writer, seq, clock, data, prev, _entry_hash(prev, self.writer, seq, clock, data))
+        self.entries.append(e)
+        return e
+
+    def verify(self) -> bool:
+        """True iff the hash chain is intact (tamper-evident)."""
+        prev = ""
+        for i, e in enumerate(self.entries):
+            if e.seq != i or e.prev_hash != prev:
+                return False
+            if e.entry_hash != _entry_hash(prev, e.writer, e.seq, e.clock, e.data):
+                return False
+            prev = e.entry_hash
+        return True
+
+
+def sparse_fetch(log: AppendLog, indices: Iterable[int]) -> list[LogEntry]:
+    """Fetch only the requested entries (seed_sparse): lazy subset, in order."""
+    want = sorted({i for i in indices if 0 <= i < len(log.entries)})
+    return [log.entries[i] for i in want]
+
+
+def linearize(logs: Iterable[AppendLog]) -> list[LogEntry]:
+    """Merge multiple writer logs into one causally-ordered view (Autobase).
+
+    Deterministic total order: (clock, writer, seq) — lamport clock first, ties
+    broken by writer id then per-writer sequence, so all peers converge.
+    """
+    all_entries: list[LogEntry] = []
+    for log in logs:
+        all_entries.extend(log.entries)
+    return sorted(all_entries, key=lambda e: (e.clock, e.writer, e.seq))
+
+
+class OverlayRefused(Exception):
+    """Raised when a join/operation is refused; carries structured reasons."""
+
+    def __init__(self, reasons: list[str]) -> None:
+        super().__init__(", ".join(reasons))
+        self.reasons = reasons
+
+
+@dataclass
+class Topic:
+    """A joined topic: a set of writer logs sharing a linearized view."""
+
+    name: str
+    logs: dict[str, AppendLog] = field(default_factory=dict)
+
+    def writer_log(self, writer: str) -> AppendLog:
+        return self.logs.setdefault(writer, AppendLog(writer))
+
+
+class OverlayBroker:
+    """Joins topics after a trust decision and brokers append/fetch/linearize."""
+
+    def __init__(self) -> None:
+        self.joined: dict[str, Topic] = {}
+
+    def join(self, manifest: dict, *, trusted: bool, now: str) -> Topic:
+        """Join a topic only if trusted, unrevoked, unexpired, known transport."""
+        reasons: list[str] = []
+        if not trusted:
+            reasons.append("untrusted")  # join-after-trust (D9): caller supplies the verdict
+        if manifest.get("transport") not in KNOWN_TRANSPORTS:
+            reasons.append("unknown_transport")
+        rev = manifest.get("revocation") or {}
+        if rev.get("revoked"):
+            reasons.append("revoked")
+        expiry = manifest.get("expiry")
+        if expiry and _parse(expiry) <= _parse(now):
+            reasons.append("expired")
+        if reasons:
+            raise OverlayRefused(reasons)
+        topic = Topic(manifest["topic"])
+        self.joined[manifest["topic"]] = topic
+        return topic
+
+    def _require(self, topic: str) -> Topic:
+        t = self.joined.get(topic)
+        if t is None:
+            raise OverlayRefused(["not_joined"])
+        return t
+
+    def append(self, topic: str, writer: str, data: str, clock: int) -> LogEntry:
+        return self._require(topic).writer_log(writer).append(data, clock)
+
+    def fetch(self, topic: str, writer: str, indices: Iterable[int]) -> list[LogEntry]:
+        t = self._require(topic)
+        log = t.logs.get(writer)
+        return sparse_fetch(log, indices) if log is not None else []
+
+    def linearized_view(self, topic: str) -> list[LogEntry]:
+        return linearize(self._require(topic).logs.values())

--- a/tools/tests/test_overlay_transport.py
+++ b/tools/tests/test_overlay_transport.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+TOOLS = Path(__file__).resolve().parents[1]
+ROOT = TOOLS.parent
+sys.path.insert(0, str(TOOLS))
+
+import overlay_transport as ov  # type: ignore
+
+LANE = ROOT / "contracts" / "workspace-control-plane"
+TOPIC_SCHEMA = json.loads((LANE / "schemas" / "topic-manifest.v0.schema.json").read_text())
+
+NOW = "2026-08-01T00:00:00+00:00"
+FUTURE = "2026-12-31T00:00:00+00:00"
+PAST = "2025-01-01T00:00:00+00:00"
+
+
+def manifest(topic="socioprophet/intel", transport="hypercore", revoked=False, expiry=FUTURE):
+    return {
+        "manifest_id": "topman-1", "kind": "data_topic", "topic": topic, "transport": transport,
+        "discovery_key": "hc:abc", "expiry": expiry, "revocation": {"revoked": revoked},
+        "signature": {"signer": "root", "algorithm": "ed25519", "signature": "s", "signed_at": NOW},
+    }
+
+
+# ---- append-only log (Hypercore semantics) ----
+
+def test_append_log_chain_and_tamper():
+    log = ov.AppendLog("w1")
+    log.append("a", 1)
+    log.append("b", 2)
+    assert log.verify()
+    # tamper with a committed entry -> chain breaks.
+    log.entries[0].data = "evil"
+    assert not log.verify()
+
+
+def test_sparse_fetch_returns_only_requested():
+    log = ov.AppendLog("w1")
+    for i in range(5):
+        log.append(f"d{i}", i)
+    got = ov.sparse_fetch(log, [3, 1, 1, 99, -1])  # dedup, in order, ignore OOB
+    assert [e.data for e in got] == ["d1", "d3"]
+
+
+def test_linearize_multiwriter_is_causal_and_deterministic():
+    a = ov.AppendLog("A")
+    a.append("a1", 1)
+    a.append("a2", 3)
+    b = ov.AppendLog("B")
+    b.append("b1", 2)
+    view = ov.linearize([a, b])
+    assert [e.data for e in view] == ["a1", "b1", "a2"]  # by (clock, writer, seq)
+    # order is independent of the input order of logs.
+    assert [e.data for e in ov.linearize([b, a])] == ["a1", "b1", "a2"]
+
+
+# ---- broker: join-after-trust ----
+
+def test_join_refused_without_trust_or_when_invalid():
+    broker = ov.OverlayBroker()
+    with pytest.raises(ov.OverlayRefused) as e:
+        broker.join(manifest(), trusted=False, now=NOW)
+    assert "untrusted" in e.value.reasons
+
+    for bad, reason in [
+        (manifest(transport="carrier-pigeon"), "unknown_transport"),
+        (manifest(revoked=True), "revoked"),
+        (manifest(expiry=PAST), "expired"),
+    ]:
+        with pytest.raises(ov.OverlayRefused) as e2:
+            broker.join(bad, trusted=True, now=NOW)
+        assert reason in e2.value.reasons
+
+
+def test_join_then_append_fetch_linearize():
+    broker = ov.OverlayBroker()
+    topic = broker.join(manifest(), trusted=True, now=NOW).name
+    broker.append(topic, "A", "a1", 1)
+    broker.append(topic, "B", "b1", 2)
+    broker.append(topic, "A", "a2", 3)
+    assert [e.data for e in broker.linearized_view(topic)] == ["a1", "b1", "a2"]
+    assert [e.data for e in broker.fetch(topic, "A", [0, 1])] == ["a1", "a2"]
+
+
+def test_ops_on_unjoined_topic_refused():
+    broker = ov.OverlayBroker()
+    with pytest.raises(ov.OverlayRefused) as e:
+        broker.append("never-joined", "A", "x", 1)
+    assert "not_joined" in e.value.reasons
+
+
+def test_join_manifest_conforms_to_frozen_schema():
+    assert list(Draft202012Validator(TOPIC_SCHEMA).iter_errors(manifest())) == []

--- a/tools/tests/test_overlay_transport.py
+++ b/tools/tests/test_overlay_transport.py
@@ -98,3 +98,34 @@ def test_ops_on_unjoined_topic_refused():
 
 def test_join_manifest_conforms_to_frozen_schema():
     assert list(Draft202012Validator(TOPIC_SCHEMA).iter_errors(manifest())) == []
+
+
+# ---- hardening (Copilot #1195) ----
+
+def test_rejoin_preserves_existing_logs():
+    broker = ov.OverlayBroker()
+    topic = broker.join(manifest(), trusted=True, now=NOW).name
+    broker.append(topic, "A", "a1", 1)
+    # Re-join the same topic: must NOT reset/discard the existing log.
+    again = broker.join(manifest(), trusted=True, now=NOW)
+    assert [e.data for e in again.writer_log("A").entries] == ["a1"]
+
+
+def test_malformed_timestamp_refused_not_raised():
+    broker = ov.OverlayBroker()
+    with pytest.raises(ov.OverlayRefused) as e:
+        broker.join(manifest(expiry="not-a-date"), trusted=True, now=NOW)
+    assert "bad_timestamp" in e.value.reasons
+    with pytest.raises(ov.OverlayRefused) as e2:
+        broker.join(manifest(), trusted=True, now="also-bad")
+    assert "bad_timestamp" in e2.value.reasons
+
+
+def test_verify_enforces_single_writer():
+    log = ov.AppendLog("A")
+    log.append("a1", 1)
+    assert log.verify()
+    # A cross-writer entry (even with a self-consistent hash) must not validate.
+    log.entries[0].writer = "B"
+    log.entries[0].entry_hash = ov._entry_hash("", "B", 0, 1, "a1")  # re-hash under forged writer
+    assert not log.verify()


### PR DESCRIPTION
Implements **Phase 6** (D8/D10) scaffold-first: Hypercore/Autobase **semantics** in-process, no network/Hyper dep — swap the real stack behind `OverlayBroker` later.

- **AppendLog** — append-only, blake2b hash-chained, tamper-evident.
- **sparse_fetch** — lazy subset by index (seed_sparse).
- **linearize** — multiwriter → one causal deterministic view by (clock, writer, seq) (Autobase); order-independent.
- **OverlayBroker.join** — join-after-trust (D9): refuses untrusted/revoked/expired/unknown-transport; ops gated on membership; conformant to frozen `topic-manifest.v0`.

7 tests. Path-filtered CI (permissions: contents:read). Merge after CI green **and Copilot evaluated** (no --auto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)