### PR TITLE
fix(observability): promtail write-mode hostPath rejected by GKE Autopilot

### DIFF
--- a/infra/k8s/observability/base/promtail.yaml
+++ b/infra/k8s/observability/base/promtail.yaml
@@ -126,8 +126,13 @@ spec:
           configMap:
             name: promtail-config
         - name: run
-          hostPath:
-            path: /run/promtail
+          # GKE Autopilot's Warden admission webhook rejects ANY write-mode
+          # hostPath outright (autogke-no-write-mode-hostpath) -- confirmed
+          # live, ArgoCD retried 5x and failed to ever create this DaemonSet.
+          # positions.yaml only needs to survive within one pod's lifetime;
+          # losing it on a reschedule just means a few duplicate log lines
+          # get re-shipped, which is the correct tradeoff vs never deploying.
+          emptyDir: {}
         - name: pods
           hostPath:
             path: /var/log/pods


### PR DESCRIPTION
Verified whether Loki ingestion actually recovered after PR #1161 (telemetry-capture-and-liveness) merged. It hadn't — checked live via `kubectl` + the ArgoCD API:

- `kubectl get application observability -n argocd` shows `phase: Failed`, `retryCount: 5`, stuck since the merge synced (~16:31 UTC 2026-08-01).
- The actual error: GKE Autopilot's Warden admission webhook rejects the request outright — `[denied by autogke-no-write-mode-hostpath]: hostPath volume run in container promtail is accessed in write mode; disallowed in Autopilot.`
- `promtail`'s `pods`/`containers` hostPath mounts were already `readOnly: true`; the `run` volume (backing `positions.yaml`) was the one write-mode mount, and it blocked the entire DaemonSet from ever being created — so the whole log-shipping pipeline this PR was meant to bring online has been failing silently since it merged.

**Fix:** `emptyDir: {}` instead of `hostPath` for the `run` volume. positions.yaml only needs to survive within one pod's lifetime — losing it on a reschedule means promtail re-ships a few already-seen log lines on restart (at-least-once duplication), which is the correct tradeoff against the DaemonSet never deploying at all under Autopilot.

No other changes. ArgoCD has `automated: {prune: true, selfHeal: true}` on this Application already, so once this merges it should sync on its own — will re-check `loki_distributor_bytes_received_total` afterward to confirm ingestion actually resumes, since that's the real proof, not just a clean sync.