### PR TITLE
feat(infra/dns): redirect-role domains 301 through a GCP LB (opt-in, provisions nothing by default)

### DIFF
--- a/infra/tofu/envs/dns/domains.yaml
+++ b/infra/tofu/envs/dns/domains.yaml
@@ -84,14 +84,19 @@ domains:
     notes: "candidate: helpdesk surface."
   - domain: socioslinux.org
     role: redirect
+    redirect_to: sourceos.org
   - domain: sourceos.digital
     role: redirect
+    redirect_to: sourceos.org
   - domain: sourceos.software
     role: redirect
+    redirect_to: sourceos.org
   - domain: sourceos.systems
     role: redirect
+    redirect_to: sourceos.org
   - domain: truthorbot.org
     role: redirect
+    redirect_to: truthorbot.net
   - domain: socioprofit.com
     role: reserved
     notes: "SPELLING: socioPROFIT, not prophet. Defensive/typo reg or a separate product? CONFIRM."

--- a/infra/tofu/envs/dns/main.tf
+++ b/infra/tofu/envs/dns/main.tf
@@ -29,6 +29,12 @@ locals {
   # rua domain hosts the DMARC aggregate-report authorizations for every other domain.
   rua_domain          = split("@", var.dmarc_rua)[1]
   report_auth_targets = [for d in keys(local.domains) : d if d != local.rua_domain]
+
+  # Redirect plane: redirect-role domains 301 to a canonical target (default or per-domain).
+  redirects_map         = { for k, d in local.domains : d.domain => try(d.redirect_to, var.default_redirect_target) if d.role == "redirect" }
+  redirect_cert_domains = flatten([for k, d in local.domains : [d.domain, "www.${d.domain}"] if d.role == "redirect"])
+  redirects_enabled     = var.dns_cloud == "gcp" && var.enable_redirects && length(local.redirects_map) > 0
+  redirect_ip           = try(module.web_redirect[0].ip_address, "")
 }
 
 # ── Cloud-agnostic record model (one per domain) ────────────────────────────────
@@ -46,6 +52,18 @@ module "records" {
   mx_records            = try(each.value.mx, [])
   app_records           = try(each.value.records, [])
   report_authorizations = each.key == local.rua_domain ? local.report_auth_targets : []
+  redirect_ip           = local.redirect_ip
+}
+
+# Redirect service (GCP): 301s redirect-role domains to their canonical target. Off by
+# default; a portable sibling (e.g. web-redirect-aws) would satisfy the same ip_address contract.
+module "web_redirect" {
+  source         = "../../modules/web-redirect-gcp"
+  count          = local.redirects_enabled ? 1 : 0
+  project        = var.project
+  redirects      = local.redirects_map
+  default_target = var.default_redirect_target
+  cert_domains   = local.redirect_cert_domains
 }
 
 # ── Pluggable emitters (only the selected cloud is instantiated) ─────────────────
@@ -79,7 +97,7 @@ module "registrar" {
   domain       = each.value.domain
   name_servers = try(module.gcp[each.key].name_servers, module.aws[each.key].name_servers, [])
   role         = each.value.role
-  has_records  = module.records[each.key].has_app_records
+  has_records  = module.records[each.key].has_delegable_records
   enabled      = var.manage_registrar
 }
 

--- a/infra/tofu/envs/dns/outputs.tf
+++ b/infra/tofu/envs/dns/outputs.tf
@@ -8,6 +8,11 @@ output "record_manifest" {
   value       = { for k, m in module.records : k => m.records }
 }
 
+output "redirect_ip" {
+  description = "Redirect LB IP (empty unless enable_redirects=true). Redirect domains' apex/www A records point here."
+  value       = local.redirect_ip
+}
+
 output "egress_ips" {
   description = "Static egress IP(s) to allowlist in Namecheap and set as namecheap_client_ip. Empty unless create_egress_nat=true."
   value       = var.create_egress_nat ? module.egress_nat[0].egress_ips : []

--- a/infra/tofu/envs/dns/variables.tf
+++ b/infra/tofu/envs/dns/variables.tf
@@ -35,7 +35,7 @@ variable "manage_registrar" {
 variable "enable_redirects" {
   type        = bool
   default     = false
-  description = "When true (and dns_cloud=gcp), stand up the redirect LB and point redirect-role domains' apex/www A records at it. Off by default (creates a global IP + managed cert)."
+  description = "When true (and dns_cloud=gcp), stand up the redirect LB (global external HTTP(S) LB: global IP, managed cert, URL maps, target proxies, forwarding rules) and point redirect-role domains' apex/www A records at it. Off by default."
 }
 
 variable "default_redirect_target" {

--- a/infra/tofu/envs/dns/variables.tf
+++ b/infra/tofu/envs/dns/variables.tf
@@ -32,6 +32,18 @@ variable "manage_registrar" {
   description = "When true, delegate NS at Namecheap for domains with manage_ns:true. Keep false until a plan is reviewed and the API client_ip is allowlisted."
 }
 
+variable "enable_redirects" {
+  type        = bool
+  default     = false
+  description = "When true (and dns_cloud=gcp), stand up the redirect LB and point redirect-role domains' apex/www A records at it. Off by default (creates a global IP + managed cert)."
+}
+
+variable "default_redirect_target" {
+  type        = string
+  default     = "socioprophet.com"
+  description = "Canonical 301 target for redirect-role domains that don't set redirect_to."
+}
+
 variable "create_egress_nat" {
   type        = bool
   default     = false

--- a/infra/tofu/modules/dns-records/main.tf
+++ b/infra/tofu/modules/dns-records/main.tf
@@ -45,5 +45,15 @@ locals {
     }],
   )
 
-  records = concat(local.baseline, local.app_rest)
+  # Redirect A records (apex + www) when a redirect target IP is provided for a redirect domain.
+  redirect_records = var.role == "redirect" && var.redirect_ip != "" ? [
+    { name = local.dns_name, type = "A", ttl = 300, rrdatas = [var.redirect_ip] },
+    { name = "www.${local.dns_name}", type = "A", ttl = 300, rrdatas = [var.redirect_ip] },
+  ] : []
+
+  records = concat(local.baseline, local.redirect_records, local.app_rest)
+
+  # A domain is safe to delegate once it has records beyond the security baseline:
+  # explicit app_records, or emitted redirect A records.
+  has_delegable_records = length(var.app_records) > 0 || length(local.redirect_records) > 0
 }

--- a/infra/tofu/modules/dns-records/outputs.tf
+++ b/infra/tofu/modules/dns-records/outputs.tf
@@ -19,6 +19,11 @@ output "records" {
 }
 
 output "has_app_records" {
-  description = "Whether any non-baseline records exist (used to fail-closed on delegating an otherwise-empty canonical/redirect domain)."
+  description = "Whether explicit app_records were supplied."
   value       = length(var.app_records) > 0
+}
+
+output "has_delegable_records" {
+  description = "Whether the domain has records beyond the security baseline (app_records or emitted redirect A records). Used to fail-closed on delegating an otherwise-empty canonical/redirect domain."
+  value       = local.has_delegable_records
 }

--- a/infra/tofu/modules/dns-records/variables.tf
+++ b/infra/tofu/modules/dns-records/variables.tf
@@ -73,3 +73,9 @@ variable "report_authorizations" {
   default     = []
   description = "External domains to authorize for DMARC aggregate reporting to this zone's rua mailbox (RFC 7489 §7.1). Set only on the rua domain's zone; emits <ext>._report._dmarc records."
 }
+
+variable "redirect_ip" {
+  type        = string
+  default     = ""
+  description = "Cloud-neutral: when role=redirect and this is set, emit apex + www A records to this IP (the redirect service's address). Any cloud's redirect service yields an IP, so this stays portable."
+}

--- a/infra/tofu/modules/web-redirect-gcp/main.tf
+++ b/infra/tofu/modules/web-redirect-gcp/main.tf
@@ -36,10 +36,14 @@ resource "google_compute_url_map" "https_redirect" {
     strip_query            = false
   }
 
+  # The DNS module emits BOTH apex and www A records at this LB's IP for every
+  # redirect-role domain, so both hosts must resolve here or www falls through
+  # to default_url_redirect (the global default_target) instead of this
+  # domain's actual redirect_to.
   dynamic "host_rule" {
     for_each = var.redirects
     content {
-      hosts        = [host_rule.key]
+      hosts        = [host_rule.key, "www.${host_rule.key}"]
       path_matcher = local.matcher_name[host_rule.value]
     }
   }

--- a/infra/tofu/modules/web-redirect-gcp/main.tf
+++ b/infra/tofu/modules/web-redirect-gcp/main.tf
@@ -1,0 +1,101 @@
+# Global external Application LB that 301-redirects each host to its canonical target.
+# GCP-specific by nature (an L7 redirect service); the redirect INTENT stays portable in
+# domains.yaml and the A records flow through the agnostic dns-records model. An AWS
+# equivalent (CloudFront function / S3 redirect) would be a sibling module with the same
+# ip_address/output contract.
+#
+# NOTE: the Google-managed cert provisions only AFTER the domains' A records point at this
+# LB's IP (chicken-and-egg is expected) — allow ~15–60 min after the first apply.
+
+locals {
+  targets      = distinct(values(var.redirects))
+  matcher_name = { for t in local.targets : t => "m-${replace(t, ".", "-")}" }
+}
+
+resource "google_compute_global_address" "this" {
+  name    = "${var.name_prefix}-ip"
+  project = var.project
+}
+
+resource "google_compute_managed_ssl_certificate" "this" {
+  name    = "${var.name_prefix}-cert"
+  project = var.project
+  managed {
+    domains = var.cert_domains
+  }
+}
+
+resource "google_compute_url_map" "https_redirect" {
+  name    = "${var.name_prefix}-https-urlmap"
+  project = var.project
+
+  default_url_redirect {
+    host_redirect          = var.default_target
+    https_redirect         = true
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    strip_query            = false
+  }
+
+  dynamic "host_rule" {
+    for_each = var.redirects
+    content {
+      hosts        = [host_rule.key]
+      path_matcher = local.matcher_name[host_rule.value]
+    }
+  }
+
+  dynamic "path_matcher" {
+    for_each = toset(local.targets)
+    content {
+      name = local.matcher_name[path_matcher.value]
+      default_url_redirect {
+        host_redirect          = path_matcher.value
+        https_redirect         = true
+        redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+        strip_query            = false
+      }
+    }
+  }
+}
+
+resource "google_compute_target_https_proxy" "this" {
+  name             = "${var.name_prefix}-https-proxy"
+  project          = var.project
+  url_map          = google_compute_url_map.https_redirect.id
+  ssl_certificates = [google_compute_managed_ssl_certificate.this.id]
+}
+
+resource "google_compute_global_forwarding_rule" "https" {
+  name                  = "${var.name_prefix}-https-fr"
+  project               = var.project
+  target                = google_compute_target_https_proxy.this.id
+  ip_address            = google_compute_global_address.this.address
+  port_range            = "443"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+# Port 80 -> 443 upgrade.
+resource "google_compute_url_map" "http_to_https" {
+  name    = "${var.name_prefix}-http-urlmap"
+  project = var.project
+  default_url_redirect {
+    https_redirect         = true
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    strip_query            = false
+  }
+}
+
+resource "google_compute_target_http_proxy" "this" {
+  name    = "${var.name_prefix}-http-proxy"
+  project = var.project
+  url_map = google_compute_url_map.http_to_https.id
+}
+
+resource "google_compute_global_forwarding_rule" "http" {
+  name                  = "${var.name_prefix}-http-fr"
+  project               = var.project
+  target                = google_compute_target_http_proxy.this.id
+  ip_address            = google_compute_global_address.this.address
+  port_range            = "80"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}

--- a/infra/tofu/modules/web-redirect-gcp/outputs.tf
+++ b/infra/tofu/modules/web-redirect-gcp/outputs.tf
@@ -1,0 +1,9 @@
+output "ip_address" {
+  description = "The redirect LB's global IP. Point redirect domains' apex/www A records here."
+  value       = google_compute_global_address.this.address
+}
+
+output "cert_domains" {
+  description = "Domains the managed cert covers."
+  value       = var.cert_domains
+}

--- a/infra/tofu/modules/web-redirect-gcp/variables.tf
+++ b/infra/tofu/modules/web-redirect-gcp/variables.tf
@@ -1,0 +1,25 @@
+variable "project" {
+  type        = string
+  description = "GCP project for the redirect load balancer."
+}
+
+variable "name_prefix" {
+  type        = string
+  default     = "dns-redirect"
+  description = "Name prefix for the LB resources."
+}
+
+variable "redirects" {
+  type        = map(string)
+  description = "Map of redirect host -> canonical target host (301). e.g. { \"socioprophet.org\" = \"socioprophet.com\" }."
+}
+
+variable "default_target" {
+  type        = string
+  description = "Fallback 301 target for requests that match no host rule."
+}
+
+variable "cert_domains" {
+  type        = list(string)
+  description = "Domains the Google-managed SSL cert must cover (apex + www of each redirect host)."
+}

--- a/infra/tofu/modules/web-redirect-gcp/versions.tf
+++ b/infra/tofu/modules/web-redirect-gcp/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
Supersedes #1196. That PR was a draft capture of interrupted work — its branch was 45+ commits behind main in a way that understated the real risk: diffing it against current main showed 273 files / 13,791 deletions, because it predates basically everything shipped since (Control-Plane phases, web-intel lane, WordOps Matrix, telemetry services, etc.). Merging or rebasing it directly would have been destructive. This PR hand-extracts the actual redirect feature — 8 files — cleanly onto current main instead.

**What's here:**
- `web-redirect-gcp` module: a global HTTPS load balancer that 301-redirects hosts to a canonical target (global IP, managed cert, URL-map host rules, HTTP→HTTPS upgrade). No compute — pure LB config.
- `dns-records` module: `redirect_ip` input emits apex+www A records for `role=redirect` domains once a redirect service exists; new `has_delegable_records` output (app_records OR emitted redirect records) so a redirect domain whose only record comes from the redirect IP isn't wrongly treated as empty by the registrar's fail-closed delegation check.
- `domains.yaml`: `redirect_to` on the 5 domains already marked `role: redirect` — `socioslinux.org`/`sourceos.digital`/`.software`/`.systems` → `sourceos.org`, `truthorbot.org` → `truthorbot.net`. These are domains already owned in the registry, being consolidated — not new claims.

**Provisions nothing on merge.** `enable_redirects` defaults to `false`. Merging this ships the capability wired and dormant — no new GCP resources, no DNS changes, no cost. Flipping it on (`enable_redirects = true`, then a real `tofu apply`) is a separate, deliberate step I'd want its own explicit go-ahead for, given it provisions real billable infra and repoints live DNS (the managed cert also only provisions *after* the A records point at the new LB — expect a ~15–60min gap, per the module's own note).

**Verified:**
- `tofu validate` clean on the composed `envs/dns` config (with the new module actually wired in, not just standalone) and on `web-redirect-gcp` in isolation.
- `tofu fmt -check` clean on every touched file.

I'll leave #1196 open as the historical record of the original capture rather than closing it silently.