### PR TITLE
feat(semantic): compositional coordinate-address algebra + 23×6 bridge

### DIFF
--- a/contracts/AgentCoordinateVector.v0.1.json
+++ b/contracts/AgentCoordinateVector.v0.1.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/contracts/AgentCoordinateVector.v0.1.json",
+  "title": "AgentCoordinateVector v0.1",
+  "description": "The eleven axes every agent declares itself on, so that 'what kind of work is this' is a typed value rather than a convention. Exactly eleven coordinates; an agent with ten or twelve is ill-formed by construction. Exactly one coordinate is the agent's primary. The middle-column axes (chesed/gevurah/tiferet) name the two dual operators and the meet that reconciles them.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "kind", "agentId", "coordinates"],
+  "properties": {
+    "schemaVersion": { "const": "v0.1" },
+    "kind": { "const": "AgentCoordinateVector" },
+    "agentId": { "type": "string", "minLength": 1 },
+    "coordinates": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Exactly the eleven named axes — no more, no fewer.",
+      "required": [
+        "keter", "chochmah", "binah", "daat", "chesed", "gevurah",
+        "tiferet", "netzach", "hod", "yesod", "malchut"
+      ],
+      "properties": {
+        "keter":    { "$ref": "#/$defs/axis" },
+        "chochmah": { "$ref": "#/$defs/axis" },
+        "binah":    { "$ref": "#/$defs/axis" },
+        "daat":     { "$ref": "#/$defs/axis" },
+        "chesed":   { "$ref": "#/$defs/axis" },
+        "gevurah":  { "$ref": "#/$defs/axis" },
+        "tiferet":  { "$ref": "#/$defs/axis" },
+        "netzach":  { "$ref": "#/$defs/axis" },
+        "hod":      { "$ref": "#/$defs/axis" },
+        "yesod":    { "$ref": "#/$defs/axis" },
+        "malchut":  { "$ref": "#/$defs/axis" }
+      }
+    }
+  },
+  "$defs": {
+    "axis": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["primary"],
+      "properties": {
+        "primary": {
+          "type": "boolean",
+          "description": "True on exactly one axis across the vector — the agent's home coordinate."
+        },
+        "operator": {
+          "type": "string",
+          "description": "The library operator this axis is realised by, where it is an operator axis.",
+          "enum": ["pushout", "pullback", "meet", "none"]
+        },
+        "binding": {
+          "type": "string",
+          "description": "Optional reference to the contract or service that implements this coordinate."
+        }
+      }
+    }
+  }
+}

--- a/contracts/BoundaryTransition.v0.2.json
+++ b/contracts/BoundaryTransition.v0.2.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.socioprophet.org/contracts/BoundaryTransition.v0.2.json",
+  "title": "BoundaryTransition v0.2",
+  "description": "v0.1 plus a complete, non-redundant governed-action frame: the nine actantial roles (who, to what, for whom, by what and why, when, where, to what purpose, how). Additive over v0.1 — every v0.1 field is retained. The actantial frame is universal linguistics (Tesnière's actants + standard case grammar), not any third party's IP, and it replaces the ad-hoc field sets in v0.1 with one closed role inventory. A USL is language-independent, so the frame's structure can be transmitted while the natural-language surface is withheld — the concrete lever for linkability (G2) and twin de-identification.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "kind",
+    "transitionId",
+    "timestamp",
+    "sourceComponent",
+    "targetComponent",
+    "boundaryType",
+    "initiator",
+    "userVisible",
+    "actants"
+  ],
+  "properties": {
+    "schemaVersion": { "const": "v0.2" },
+    "kind": { "const": "BoundaryTransition" },
+    "transitionId": { "type": "string", "minLength": 1 },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "sourceComponent": { "type": "string", "minLength": 1 },
+    "targetComponent": { "type": "string", "minLength": 1 },
+    "boundaryType": {
+      "type": "string",
+      "enum": [
+        "embedded_engine_initialization",
+        "network_open",
+        "file_open",
+        "credential_request",
+        "ai_invocation",
+        "shell_execution",
+        "automation_bridge_use",
+        "diagnostic_export",
+        "policy_gate",
+        "renderer_spawn",
+        "worker_spawn"
+      ]
+    },
+    "initiator": {
+      "type": "string",
+      "enum": [
+        "local_user_action",
+        "system_startup",
+        "feature_rollout",
+        "agent_action",
+        "remote_event",
+        "scheduled_task",
+        "unknown"
+      ]
+    },
+    "userVisible": { "type": "boolean" },
+    "userActionRef": { "type": "string" },
+    "policyDecisionRef": { "type": "string" },
+    "engineManifestRef": { "type": "string" },
+    "networkDelta": { "type": "string", "enum": ["none", "opened", "denied", "closed", "unknown"] },
+    "fileAccessDelta": { "type": "string", "enum": ["none", "opened", "denied", "closed", "unknown"] },
+    "credentialAccessDelta": { "type": "string", "enum": ["none", "requested", "denied", "granted", "unknown"] },
+    "aiAccessDelta": { "type": "string", "enum": ["none", "requested", "denied", "granted", "unknown"] },
+    "operatorExplanation": { "type": "string" },
+    "evidenceRefs": { "type": "array", "items": { "type": "string" } },
+    "actants": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The nine syntagmatic roles of the crossing. `root` (the process) and `initiator` (actant-1) are required; the rest are declared when they apply. This inventory is closed: an unlisted role is rejected.",
+      "required": ["root", "initiator"],
+      "properties": {
+        "root":        { "type": "string", "minLength": 1, "description": "the process / predicate — what is being done" },
+        "initiator":   { "type": "string", "minLength": 1, "description": "actant-1 — who acts" },
+        "interactant": { "type": "string", "description": "actant-2 — what is acted upon" },
+        "recipient":   { "type": "string", "description": "actant-3 — for or to whom" },
+        "cause":       { "type": "string", "description": "by what and why" },
+        "time":        { "type": "string", "description": "when" },
+        "place":       { "type": "string", "description": "where" },
+        "intention":   { "type": "string", "description": "to what purpose" },
+        "manner":      { "type": "string", "description": "how" }
+      }
+    }
+  }
+}

--- a/contracts/examples/agent-coordinate-vector-michael-agent.example.json
+++ b/contracts/examples/agent-coordinate-vector-michael-agent.example.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "v0.1",
+  "kind": "AgentCoordinateVector",
+  "agentId": "michael-agent",
+  "coordinates": {
+    "keter":    { "primary": false },
+    "chochmah": { "primary": false },
+    "binah":    { "primary": false },
+    "daat":     { "primary": false, "binding": "contracts/InternalModelState.v0.1.json" },
+    "chesed":   { "primary": false, "operator": "pushout" },
+    "gevurah":  { "primary": false, "operator": "pullback" },
+    "tiferet":  { "primary": true,  "operator": "meet", "binding": "Truth = Law x Evidence" },
+    "netzach":  { "primary": false },
+    "hod":      { "primary": false },
+    "yesod":    { "primary": false },
+    "malchut":  { "primary": false }
+  }
+}

--- a/contracts/examples/boundary-transition-v0.2-ai-invocation.example.json
+++ b/contracts/examples/boundary-transition-v0.2-ai-invocation.example.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "v0.2",
+  "kind": "BoundaryTransition",
+  "transitionId": "bt-2026-08-01-0007",
+  "timestamp": "2026-08-01T18:45:00Z",
+  "sourceComponent": "prophet-mesh/research-agent",
+  "targetComponent": "agent-machine/ai-invocation-boundary",
+  "boundaryType": "ai_invocation",
+  "initiator": "agent_action",
+  "userVisible": true,
+  "aiAccessDelta": "granted",
+  "policyDecisionRef": "membrane://decision/9f2c",
+  "operatorExplanation": "research-agent asked the model to summarize a capital-markets filing for the analyst",
+  "evidenceRefs": ["evidence://receipt/bt-2026-08-01-0007"],
+  "actants": {
+    "root": "summarize",
+    "initiator": "prophet-mesh/research-agent",
+    "interactant": "capital-markets/filing/ASX-GYG-2026Q2",
+    "recipient": "analyst/charles.peterson",
+    "cause": "analyst requested a briefing ahead of the earnings call",
+    "time": "2026-08-01T18:45:00Z",
+    "place": "agent-machine/ai-invocation-boundary",
+    "intention": "produce a decision-ready briefing",
+    "manner": "extractive summary with source spans, no external network"
+  }
+}

--- a/docs/SEMANTIC_COORDINATE_ALGEBRA.md
+++ b/docs/SEMANTIC_COORDINATE_ALGEBRA.md
@@ -1,0 +1,59 @@
+# Semantic Coordinate Algebra — provenance register & conformance
+
+Status: v0.1 · stdlib-only kernel in `tools/semantic_algebra.py`
+
+This document is the **provenance register** the module docstring points at. It
+doubles as the clean-room warrant: every generating element of the algebra traces
+to a public-domain source, so the *system* is unencumbered and owes no attribution
+to any third-party formal language. (A formal language and its algebra are a
+*system*; systems are not copyrightable — CJEU C-406/10 *SAS v WPL*; 17 U.S.C.
+§102(b); *Baker v. Selden*.) The register is the evidence for that claim.
+
+## 1. Generating set — one row per element
+
+| Element | Role in the algebra | Public-domain source | Citation |
+|---|---|---|---|
+| `NIL` | neutral element; axis marker in a role | algebraic necessity | a monoid needs an identity — not anyone's invention |
+| `POT` / `ACT` | the binary symmetry (potentiality / actuality) | Aristotle, *Metaphysics* Θ | δύναμις / ἐνέργεια — matter/form, → `kko:Matter` / `kko:Forms` |
+| `FST` / `SND` / `TRD` | the ternary symmetry (Firstness / Secondness / Thirdness) | C. S. Peirce, 1890s | the phenomenological categories — already the KKO spine |
+| roles `ground` / `differentia` / `mode` | the three positions of the ternary product | Aristotle (genus + differentia) + Spinoza (mode) | *Categories*; *Ethics* Pt I def. 5 |
+
+Nothing in the generating set is taken from, or requires permission of, any
+third-party metalanguage. The comparison to IEML lives in the internal design
+register (`SP-DES-*`), **not** in this repo or its public README, and no element
+above was derived from IEML's dictionary, definitions, or grammar prose.
+
+## 2. Why an algebra (the measured failure it fixes)
+
+The keyed-vec topic space was flat: an intro-physics query matched a graduate-QFT
+topic — 94.9% vocab hit, topic max-cos only 0.38–0.54. Abstraction level was not
+*representable*, so it could not be *enforced*. Here `layer` is a **syntactic**
+property of an address: a cross-layer match is not discouraged by a threshold, it
+is structurally impossible. See `bind_tiered` and its rejection test.
+
+## 3. Conformance (what the tests pin, both ways)
+
+* Terms are immutable, hashable; equality is structural.
+* `add` is commutative and normalised — no two formally different expressions
+  denote the same set.
+* `mul` is **non-commutative** and raises on mixed-layer operands; layer
+  discipline is enforced at construction, not checked after the fact.
+* `pullback` (limit/restrict) and `pushout` (colimit/glue) are duals and the only
+  two ways to combine knowledge; `meet` reconciles them. **One** `meet`
+  implementation serves both this kernel and `Truth = Law × Evidence`.
+* Every guard is exercised on its refusal path too: a guard only ever seen to
+  allow is not evidence of a guard.
+
+## 4. Layering (the abstraction bar)
+
+`MAX_LAYER = 4`. `distance` is undefined across layers and raises; `bind_tiered`
+grounds general-first and admits a lower-tier candidate **only** if its `ground`
+role is the upper anchor actually landed on. That structural rule — not a tunable
+cosine threshold — is the abstraction-level bar, and it is what the S5 gate
+(`tools/abstraction_level_gate.py`) measures.
+
+## 5. Attribution posture
+
+Legally owed: none, provided no third-party protected expression is used.
+Publicly cited: **Peirce, Spinoza, Aristotle, Tesnière** — the actual provenance.
+Marks of third parties are not used to name anything in this system.

--- a/docs/SEMANTIC_COORDINATE_ALGEBRA.md
+++ b/docs/SEMANTIC_COORDINATE_ALGEBRA.md
@@ -19,9 +19,11 @@ to any third-party formal language. (A formal language and its algebra are a
 | roles `ground` / `differentia` / `mode` | the three positions of the ternary product | Aristotle (genus + differentia) + Spinoza (mode) | *Categories*; *Ethics* Pt I def. 5 |
 
 Nothing in the generating set is taken from, or requires permission of, any
-third-party metalanguage. The comparison to IEML lives in the internal design
-register (`SP-DES-*`), **not** in this repo or its public README, and no element
-above was derived from IEML's dictionary, definitions, or grammar prose.
+third-party formal language or metalanguage. Any such comparison lives only in the
+internal design register (`SP-DES-*`), **never** in this repo or its public README,
+and no element above was derived from a third party's dictionary, definitions, or
+grammar prose. (This constraint is enforced, not merely asserted — see
+`tools/check_cleanroom.py`.)
 
 ## 2. Why an algebra (the measured failure it fixes)
 

--- a/docs/SEMANTIC_LAYER_ADJUNCTION.md
+++ b/docs/SEMANTIC_LAYER_ADJUNCTION.md
@@ -1,0 +1,101 @@
+# Design note — the layer adjunction: `lift ⊣ ground`
+
+Status: DESIGN (code to follow) · Scope: an addition to `tools/semantic_algebra.py`
+Motivation: Kant's schematism, made plural and principled. This note is spec + proof
+obligations; it deliberately does not ship code, because an adjunction earns its keep
+only with a both-ways proof and that deserves its own change.
+
+---
+
+## 1 · The problem
+
+`distance` **raises** across layers, and `bind_tiered` is the single bridge between an
+upper and a lower tier. That is safe — it makes the intro-physics → graduate-QFT
+mismatch structurally impossible — but it is *only prohibitive*: the algebra can forbid
+a cross-abstraction relation, never *express* one. And there is exactly one schema
+(tier-anchoring). Kant's schematism is plural: many rules mediate concept and intuition.
+We want the same — cross-layer relation that is **possible but only through a named,
+warranted morphism**, with room for more than one such morphism.
+
+## 2 · The morphisms
+
+For each layer `n` introduce a pair of maps to/from `n+1`:
+
+- **`lift : L_n → L_{n+1}`** — generalize: place a term one layer up.
+- **`ground : L_{n+1} → L_n`** — specialize: recover the layer-`n` term a lifted term
+  stands on.
+
+Order the terms of a layer by **refinement**: `a ⊑ b` means "a is at least as specific
+as b" (a pins at least the roles b pins, to at least the same specificity). `NIL`-heavy
+terms are more general (higher); fully-pinned products are more specific (lower).
+
+## 3 · The recommended construction (makes the proofs cheap)
+
+- `lift(t) = mul(t, NEUTRAL@n, NEUTRAL@n)` — wrap `t` as the `ground` role of an
+  otherwise-neutral product one layer up. (`NEUTRAL@n` is `_neutral_at(n)`.)
+- `ground(p) = p.roles()["ground"]` for a product `p`; **undefined (⊥) on a leaf**, and
+  undefined across the wrong layer.
+
+With this construction the two composites are not merely adjoint, they are a
+**section/retraction with a closure**:
+
+1. `ground ∘ lift = id` on `L_n` — lifting then grounding returns the original exactly.
+2. `p ⊑ lift(ground(p))` for every product `p` — grounding then lifting *forgets* the
+   `differentia` and `mode`, yielding a **generalization** of `p`; `p` refines its own
+   re-generalization. This is the closure/coreflection property.
+
+That is a **coreflection** `L_n ↪ L_{n+1}`: `lift` is a full embedding, `ground` its
+retraction, and `lift ∘ ground` is idempotent‑up‑to‑refinement (a closure operator on
+`L_{n+1}`). The Galois form we require:
+
+> **`ground(y) ⊑ x   ⟺   y ⊑ lift(x)`**   (the adjunction/Galois condition)
+
+## 4 · Proof obligations — the tests that must pass, both ways
+
+A one-directional guard is not a guard, so each law is pinned on its failure path too:
+
+| # | Law | Refusal-path test |
+|---|---|---|
+| P1 | `lift(t).layer == t.layer + 1`; `ground(lift(t)).layer == t.layer` | lifting a layer-`MAX_LAYER` term **raises** (`LayerError`) |
+| P2 | `ground(lift(t)) == t` (section) | `ground` of a **leaf** is ⊥ (BOTTOM), not a guess |
+| P3 | `p ⊑ lift(ground(p))` (closure / inflationary in generality) | a term that is **not** a refinement of `lift(ground(p))` fails the ⊑ check |
+| P4 | monotonicity: `a ⊑ b ⇒ lift(a) ⊑ lift(b)` and `ground` likewise | a non-monotone counterexample is rejected |
+| P5 | Galois: `ground(y) ⊑ x ⟺ y ⊑ lift(x)` | a pair that satisfies one side but not the other **fails** |
+| P6 | `distance_bridged(a@n, b@{n+1}) := distance(lift(a), b)` is defined and symmetric to `distance(a, ground(b))` **only through the morphism** | a raw cross-layer `distance(a, b)` still **raises** — the bridge is the *only* legal crossing |
+
+P6 is the point: cross-layer comparison stops being forbidden and becomes *warranted* —
+you may compare across a tier, but only by naming the morphism you crossed on, which is
+recorded like any other warrant.
+
+## 5 · Why this subsumes `bind_tiered` (and makes schematism plural)
+
+`bind_tiered` becomes a special case: admit a lower candidate `c` under an anchor `A`
+iff `c ⊑ ground(A)` — i.e. `c` injects through the grounded anchor. The current
+implementation is exactly this with the projection construction of §3.
+
+Plural schematism falls out by allowing **more than one** `(lift, ground)` pair with
+different bridging semantics — e.g. a *taxonomic* schema (genus/species, the §3
+construction) and a *mereological* schema (part/whole, where `ground` selects a
+component role rather than the genus). Each is a named morphism; each carries its own
+warrant; the raw `distance` raise remains the default for any crossing not licensed by
+a schema. One kernel, several schematisms, no un-typed leaps.
+
+## 6 · API sketch (for the follow-up change)
+
+```python
+def lift(t: Term) -> Term: ...                  # raises LayerError at MAX_LAYER
+def ground(p: Term) -> "Term | Abstain": ...    # BOTTOM on a leaf
+def refines(a: Term, b: Term) -> bool: ...       # the ⊑ relation, same-layer
+def distance_bridged(lo: Term, hi: Term) -> int: ...  # the only legal cross-layer compare
+```
+
+No change to existing signatures; `bind_tiered` may later be re-expressed in terms of
+`ground` + `refines` once P1–P6 are green.
+
+## 7 · Open
+
+- The refinement relation `⊑` must itself be pinned by test (both a positive and a
+  non-refinement pair), since P3–P5 all lean on it.
+- Whether `distance_bridged` should compose across more than one layer (n → n+2) or be
+  restricted to adjacent layers; recommend adjacent-only until a use forces otherwise
+  (economy — Mach).

--- a/tools/abstraction_level_gate.py
+++ b/tools/abstraction_level_gate.py
@@ -1,0 +1,119 @@
+"""Abstraction-level gate (S5 instrument) — measure the mismatch the board never did.
+
+The KKO tiered-grounding arm came back inert: grounding fired on 345/350 rows and
+moved the score +0.3pp (noise). The lesson was not "grounding is useless" — it was
+that nobody measured the quantity grounding was supposed to fix: the
+**abstraction-level mismatch rate**, the rate at which an intro-level query is bound
+to a graduate-level topic.
+
+This gate measures exactly that over `bind_tiered`, and it has teeth in BOTH
+directions, because a one-sided control is not a control:
+
+  * it FAILS if the binder admits a cross-abstraction match (`mismatch_rate` too high);
+  * it FAILS as **vacuous** if the binder never admits a correct same-tier match, or
+    never abstains on a trap — a binder that abstains on everything scores a perfect
+    zero mismatch and is worthless. A control that has only ever passed, or only ever
+    fired, is suspect.
+  * it FAILS if run below `min_n` — an unfalsifiable sample is not evidence.
+
+`bind_fn` is a parameter so the gate can be pointed at a deliberately broken binder
+and shown to catch it; that is the gate's own teeth-both-ways evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Sequence
+
+from tools.semantic_algebra import Term, TermSet, bind_tiered
+
+BindFn = Callable[[Term, TermSet, TermSet], Optional[Term]]
+
+
+@dataclass(frozen=True)
+class Case:
+    """One grounding trial.
+
+    `gold` is the term the binder SHOULD admit, or None when the correct
+    behaviour is to abstain (the query has no same-anchor candidate — the trap
+    that produced the measured failure).
+    """
+
+    name: str
+    query: Term
+    upper: TermSet
+    lower: TermSet
+    gold: Optional[Term]
+
+    @property
+    def should_admit(self) -> bool:
+        return self.gold is not None
+
+
+@dataclass(frozen=True)
+class GateResult:
+    n: int
+    correct_admits: int
+    correct_abstains: int
+    mismatches: int          # admitted a term other than gold — the dangerous outcome
+    over_abstains: int       # abstained when it should have admitted — a cost, not a danger
+    mismatch_rate: float
+    admit_rate: float
+    passed: bool
+    reasons: Sequence[str]
+
+
+def run_gate(
+    cases: Sequence[Case],
+    bind_fn: BindFn = bind_tiered,
+    *,
+    min_n: int = 30,
+    max_mismatch_rate: float = 0.0,
+) -> GateResult:
+    n = len(cases)
+    correct_admits = correct_abstains = mismatches = over_abstains = 0
+
+    for case in cases:
+        pred = bind_fn(case.query, case.upper, case.lower)
+        if pred == case.gold:
+            if case.gold is None:
+                correct_abstains += 1
+            else:
+                correct_admits += 1
+        elif pred is not None:
+            # admitted a binding other than the gold one: bound across the
+            # abstraction anchor. This is THE failure being measured.
+            mismatches += 1
+        else:
+            # gold was a term, binder abstained: over-cautious, not unsafe.
+            over_abstains += 1
+
+    mismatch_rate = mismatches / n if n else 1.0
+    admits = correct_admits + mismatches
+    admit_rate = admits / n if n else 0.0
+
+    reasons: List[str] = []
+    if n < min_n:
+        reasons.append(f"n={n} below min_n={min_n}: sample too small to be evidence")
+    if mismatch_rate > max_mismatch_rate:
+        reasons.append(
+            f"mismatch_rate={mismatch_rate:.3f} exceeds max={max_mismatch_rate:.3f}: "
+            f"binder crossed the abstraction anchor {mismatches} time(s)"
+        )
+    if correct_admits == 0:
+        reasons.append("vacuous: binder never admitted a correct same-tier match")
+    if correct_abstains == 0:
+        reasons.append("vacuous: binder never abstained on a trap — the reject path never fired")
+
+    passed = not reasons
+    return GateResult(
+        n=n,
+        correct_admits=correct_admits,
+        correct_abstains=correct_abstains,
+        mismatches=mismatches,
+        over_abstains=over_abstains,
+        mismatch_rate=mismatch_rate,
+        admit_rate=admit_rate,
+        passed=passed,
+        reasons=tuple(reasons),
+    )

--- a/tools/abstraction_level_gate.py
+++ b/tools/abstraction_level_gate.py
@@ -25,16 +25,22 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, List, Optional, Sequence
 
-from tools.semantic_algebra import Term, TermSet, bind_tiered
+from tools.semantic_algebra import BOTTOM, Term, TermSet, bind_tiered
 
-BindFn = Callable[[Term, TermSet, TermSet], Optional[Term]]
+
+def _abstained(x: object) -> bool:
+    """True for a first-class abstention (BOTTOM) or a legacy ``None``."""
+    return x is None or x is BOTTOM
+
+
+BindFn = Callable[[Term, TermSet, TermSet], object]
 
 
 @dataclass(frozen=True)
 class Case:
     """One grounding trial.
 
-    `gold` is the term the binder SHOULD admit, or None when the correct
+    `gold` is the term the binder SHOULD admit, or BOTTOM when the correct
     behaviour is to abstain (the query has no same-anchor candidate — the trap
     that produced the measured failure).
     """
@@ -43,11 +49,11 @@ class Case:
     query: Term
     upper: TermSet
     lower: TermSet
-    gold: Optional[Term]
+    gold: "Term | object"  # a Term, or BOTTOM for an expected abstain
 
     @property
     def should_admit(self) -> bool:
-        return self.gold is not None
+        return not _abstained(self.gold)
 
 
 @dataclass(frozen=True)
@@ -75,18 +81,18 @@ def run_gate(
 
     for case in cases:
         pred = bind_fn(case.query, case.upper, case.lower)
-        if pred == case.gold:
-            if case.gold is None:
+        if _abstained(pred):
+            if _abstained(case.gold):
                 correct_abstains += 1
             else:
-                correct_admits += 1
-        elif pred is not None:
+                # gold was a term, binder abstained: over-cautious, not unsafe.
+                over_abstains += 1
+        elif pred == case.gold:
+            correct_admits += 1
+        else:
             # admitted a binding other than the gold one: bound across the
             # abstraction anchor. This is THE failure being measured.
             mismatches += 1
-        else:
-            # gold was a term, binder abstained: over-cautious, not unsafe.
-            over_abstains += 1
 
     mismatch_rate = mismatches / n if n else 1.0
     admits = correct_admits + mismatches

--- a/tools/agent_coordinate_vector.py
+++ b/tools/agent_coordinate_vector.py
@@ -1,0 +1,149 @@
+"""AgentCoordinateVector (S0) — the eleven axes, validated with teeth both ways.
+
+Every agent declares itself on eleven named axes. The point is falsifiability:
+a vector with ten or twelve coordinates is REJECTED structurally, not by
+convention, and exactly one axis is the agent's `primary`. The three
+middle-column axes name the two dual operators of the algebra and the meet that
+reconciles them, so an agent that claims `tiferet` realised by anything other
+than `meet` — or claims to *glue* on the restrictive axis — is caught here.
+
+Pure stdlib, matching the kernel: this runs in the admission path and must not
+take a round-trip. The JSON Schema in `contracts/AgentCoordinateVector.v0.1.json`
+is the registry face; this module is the enforcement face, and it checks the two
+cross-field rules JSON Schema cannot express cleanly (exactly-eleven,
+exactly-one-primary) plus operator-axis coherence.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Dict, List
+
+SCHEMA_VERSION = "v0.1"
+KIND = "AgentCoordinateVector"
+
+#: The eleven axes, in canonical order. Ten sefirot plus Da'at — the internal
+#: model that ShELL Challenge 1 showed is the missing organ.
+AXES: tuple = (
+    "keter",     # charter / mandate — given, not computed
+    "chochmah",  # hypothesis generation
+    "binah",     # elaboration -> typed plan
+    "daat",      # internal model + 5C/5G disposition balance
+    "chesed",    # expansive operator = pushout
+    "gevurah",   # restrictive operator = pullback
+    "tiferet",   # the meet
+    "netzach",   # continuity / durability
+    "hod",       # measurement, when to stop
+    "yesod",     # the single serialization channel
+    "malchut",   # world-effect + receipt
+)
+
+#: The axes that MUST be realised by a specific library operator when they name
+#: one. This is what stops the middle column being reimplemented ad hoc.
+OPERATOR_AXES: Dict[str, str] = {
+    "chesed": "pushout",
+    "gevurah": "pullback",
+    "tiferet": "meet",
+}
+
+ALLOWED_OPERATORS = frozenset({"pushout", "pullback", "meet", "none"})
+
+
+def validate(doc: object) -> List[str]:
+    """Return a list of human-readable errors. Empty list == valid.
+
+    Never raises on shape: a malformed document is a validation failure to be
+    reported, not an exception to be caught by the caller.
+    """
+    errors: List[str] = []
+
+    if not isinstance(doc, dict):
+        return [f"document must be an object, got {type(doc).__name__}"]
+
+    if doc.get("schemaVersion") != SCHEMA_VERSION:
+        errors.append(f"schemaVersion must be {SCHEMA_VERSION!r}, got {doc.get('schemaVersion')!r}")
+    if doc.get("kind") != KIND:
+        errors.append(f"kind must be {KIND!r}, got {doc.get('kind')!r}")
+
+    agent_id = doc.get("agentId")
+    if not isinstance(agent_id, str) or not agent_id:
+        errors.append("agentId must be a non-empty string")
+
+    coords = doc.get("coordinates")
+    if not isinstance(coords, dict):
+        errors.append("coordinates must be an object")
+        return errors
+
+    # -- exactly eleven, by name: this is the "10 or 12 is rejected" rule ----- #
+    present = set(coords)
+    missing = [a for a in AXES if a not in present]
+    extra = sorted(present - set(AXES))
+    if missing:
+        errors.append(f"missing coordinate axes: {missing}")
+    if extra:
+        errors.append(f"unknown coordinate axes (a vector is exactly the eleven): {extra}")
+
+    # -- each axis well-formed; collect primaries; check operator coherence --- #
+    primaries: List[str] = []
+    for axis in AXES:
+        cell = coords.get(axis)
+        if cell is None:
+            continue  # already reported as missing
+        if not isinstance(cell, dict):
+            errors.append(f"axis {axis!r} must be an object")
+            continue
+        primary = cell.get("primary")
+        if not isinstance(primary, bool):
+            errors.append(f"axis {axis!r} must declare boolean 'primary'")
+        elif primary:
+            primaries.append(axis)
+
+        operator = cell.get("operator")
+        if operator is not None:
+            if operator not in ALLOWED_OPERATORS:
+                errors.append(f"axis {axis!r} has unknown operator {operator!r}")
+            elif axis in OPERATOR_AXES and operator not in ("none", OPERATOR_AXES[axis]):
+                errors.append(
+                    f"axis {axis!r} must be realised by {OPERATOR_AXES[axis]!r}, "
+                    f"not {operator!r}"
+                )
+            elif axis not in OPERATOR_AXES and operator != "none":
+                errors.append(
+                    f"axis {axis!r} is not an operator axis but claims operator {operator!r}"
+                )
+
+    # -- exactly one primary: rejects zero and rejects two ------------------- #
+    if len(primaries) == 0:
+        errors.append("no primary axis declared; exactly one is required")
+    elif len(primaries) > 1:
+        errors.append(f"exactly one primary axis is required, got {len(primaries)}: {primaries}")
+
+    return errors
+
+
+def is_valid(doc: object) -> bool:
+    return not validate(doc)
+
+
+def _main(argv: List[str]) -> int:
+    if not argv:
+        print("usage: agent_coordinate_vector.py <vector.json> [...]", file=sys.stderr)
+        return 2
+    failed = 0
+    for path in argv:
+        with open(path, "r", encoding="utf-8") as fh:
+            doc = json.load(fh)
+        errs = validate(doc)
+        if errs:
+            failed += 1
+            print(f"FAIL {path}")
+            for e in errs:
+                print(f"  - {e}")
+        else:
+            print(f"OK   {path}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI glue
+    raise SystemExit(_main(sys.argv[1:]))

--- a/tools/boundary_transition_actants.py
+++ b/tools/boundary_transition_actants.py
@@ -1,0 +1,88 @@
+"""BoundaryTransition v0.2 — the nine actantial roles, validated.
+
+The actantial frame (Tesnière's actants + case grammar) is a complete,
+non-redundant frame for a governed action: who, to what, for whom, by what and
+why, when, where, to what purpose, how. It is universal linguistics, not any
+third party's IP, and it replaces the ad-hoc field sets of v0.1 with one closed
+role inventory.
+
+`skeleton()` returns the frame's STRUCTURE with the natural-language surface of
+every role dropped. Structure travels; surface does not — that is the mechanism
+for transmitting event shape to a counterparty while withholding the descriptor
+(the linkability / de-identification lever).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+SCHEMA_VERSION = "v0.2"
+
+#: The closed inventory, in canonical order. `root` and `initiator` are required.
+ROLES: tuple = (
+    "root",         # the process / predicate
+    "initiator",    # actant-1 — who acts
+    "interactant",  # actant-2 — what is acted upon
+    "recipient",    # actant-3 — for or to whom
+    "cause",        # by what and why
+    "time",         # when
+    "place",        # where
+    "intention",    # to what purpose
+    "manner",       # how
+)
+
+REQUIRED_ROLES = ("root", "initiator")
+
+
+def validate_actants(actants: object) -> List[str]:
+    """Validate the actantial frame. Empty list == valid."""
+    errors: List[str] = []
+    if not isinstance(actants, dict):
+        return [f"actants must be an object, got {type(actants).__name__}"]
+
+    for role in REQUIRED_ROLES:
+        value = actants.get(role)
+        if not isinstance(value, str) or not value:
+            errors.append(f"actant {role!r} is required and must be a non-empty string")
+
+    extra = sorted(set(actants) - set(ROLES))
+    if extra:
+        errors.append(f"unknown actant role(s) (the inventory is closed): {extra}")
+
+    for role, value in actants.items():
+        if role in ROLES and role not in REQUIRED_ROLES:
+            if value is not None and not isinstance(value, str):
+                errors.append(f"actant {role!r} must be a string when present")
+
+    return errors
+
+
+def skeleton(actants: Dict[str, str]) -> Dict[str, bool]:
+    """Which roles are populated, with all surface text dropped.
+
+    A counterparty can see that a crossing had, say, a recipient and a purpose,
+    and compute against that shape, without ever receiving who or what.
+    """
+    return {role: bool(actants.get(role)) for role in ROLES}
+
+
+def validate_boundary_transition(doc: object) -> List[str]:
+    """Validate the v0.2 envelope's actantial obligation.
+
+    Scoped to what v0.2 ADDS over v0.1 (the actantial frame). The full v0.1
+    envelope shape is validated by the JSON Schema in the contracts registry.
+    """
+    errors: List[str] = []
+    if not isinstance(doc, dict):
+        return [f"document must be an object, got {type(doc).__name__}"]
+    if doc.get("schemaVersion") != SCHEMA_VERSION:
+        errors.append(f"schemaVersion must be {SCHEMA_VERSION!r}, got {doc.get('schemaVersion')!r}")
+    if "actants" not in doc:
+        errors.append("v0.2 requires an 'actants' frame")
+    else:
+        errors.extend(validate_actants(doc["actants"]))
+    return errors
+
+
+def is_valid(doc: object) -> bool:
+    return not validate_boundary_transition(doc)

--- a/tools/check_cleanroom.py
+++ b/tools/check_cleanroom.py
@@ -1,0 +1,83 @@
+"""Clean-room guard — fail the build if a framework artifact names a third-party
+metalanguage or its author.
+
+The clean-room posture ("take the algebra, leave the lexicon; keep the comparison in
+the internal register, never in this repo") was, until now, a prose promise. A control
+that is only asserted is not a control. This mechanizes it: run it in CI over the
+framework's own files and it exits non-zero on any leak.
+
+Self-exclusion: this file and its test necessarily contain the forbidden tokens (the
+patterns they scan for, and the fixtures that prove they bite), so they are never
+scanned. A scanner that flags itself is broken — see the estate rule that a
+self-validating checker must exclude itself.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import List, Sequence, Tuple
+
+REPO = Path(__file__).resolve().parents[1]
+
+#: Third-party marks/systems that must not appear in shipped framework artifacts. The
+#: algebra is an unprotectable system traced to public-domain sources; naming a specific
+#: third-party metalanguage in the repo establishes access with no offsetting benefit.
+FORBIDDEN: Tuple[re.Pattern, ...] = tuple(
+    re.compile(p, re.IGNORECASE) for p in (r"\bieml\b", r"\bintlekt\b", r"\bl[eé]vy\b")
+)
+
+#: The framework's own artifacts — the surface the clean-room covers. This file and its
+#: test are deliberately absent (self-exclusion).
+FRAMEWORK_FILES: Tuple[str, ...] = (
+    "tools/semantic_algebra.py",
+    "tools/agent_coordinate_vector.py",
+    "tools/boundary_transition_actants.py",
+    "tools/abstraction_level_gate.py",
+    "tools/intent_address.py",
+    "docs/SEMANTIC_COORDINATE_ALGEBRA.md",
+    "docs/SEMANTIC_LAYER_ADJUNCTION.md",
+    "contracts/AgentCoordinateVector.v0.1.json",
+    "contracts/BoundaryTransition.v0.2.json",
+    "contracts/examples/agent-coordinate-vector-michael-agent.example.json",
+    "contracts/examples/boundary-transition-v0.2-ai-invocation.example.json",
+)
+
+_SELF = Path(__file__).name  # never scan self, whatever the caller passes
+
+
+def scan_paths(paths: Sequence[str]) -> List[Tuple[str, int, str]]:
+    """Return (file, line, token) for every forbidden hit. Empty == clean."""
+    hits: List[Tuple[str, int, str]] = []
+    for p in paths:
+        path = Path(p)
+        if not path.exists() or path.name == _SELF:
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            for pattern in FORBIDDEN:
+                match = pattern.search(line)
+                if match:
+                    hits.append((str(path), lineno, match.group(0)))
+    return hits
+
+
+def framework_files() -> List[str]:
+    return [str(REPO / rel) for rel in FRAMEWORK_FILES]
+
+
+def main(argv: Sequence[str]) -> int:
+    targets = list(argv) or framework_files()
+    hits = scan_paths(targets)
+    if hits:
+        print("CLEAN-ROOM VIOLATION — third-party mark in a framework artifact:")
+        for f, ln, tok in hits:
+            print(f"  {f}:{ln}: {tok!r}")
+        return 1
+    print(f"clean-room OK: {len(targets)} file(s) scanned, no third-party marks")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI glue
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/check_cleanroom.py
+++ b/tools/check_cleanroom.py
@@ -36,6 +36,7 @@ FRAMEWORK_FILES: Tuple[str, ...] = (
     "tools/boundary_transition_actants.py",
     "tools/abstraction_level_gate.py",
     "tools/intent_address.py",
+    "tools/spectral_grounding.py",
     "docs/SEMANTIC_COORDINATE_ALGEBRA.md",
     "docs/SEMANTIC_LAYER_ADJUNCTION.md",
     "contracts/AgentCoordinateVector.v0.1.json",

--- a/tools/intent_address.py
+++ b/tools/intent_address.py
@@ -1,0 +1,185 @@
+"""The bridge: the 23x6 intent grid as a slice of the coordinate algebra.
+
+The intent grid (Noetica `agent-machine/lib/intent-grid.ts`) is a derived, grounded,
+falsifiable capability matrix — but it is *flat*: it has no metric on its rows (which
+intents are near?) and no abstraction ordering. This module lifts each intent row into
+a `SemanticAddress`, so the grid inherits exactly the two properties it lacked and the
+kernel already has:
+
+  * a computed metric — intents that do the same kind of work (share a column) cluster
+    at distance 1; intents in different columns sit at distance 2. Nothing learned,
+    nothing curated per pair.
+  * a layer — the meta row `conversation_objective` is *second-order* (its operand is
+    an action, not a topic), so its address is built one layer up, out of an action
+    address. The self-referential row is a genuine fixed point in the grading.
+
+And it makes the grid's headline finding structural: `sense` (world:read) is the
+estate's thinnest column. Route a world:read query when the sense intents are absent
+and `bind_tiered` returns BOTTOM — the wiring gap becomes an honest abstention, not a
+silent mis-route.
+
+The column algebra, made explicit: a column = a polarity (read=pullback / write=pushout)
+over a substrate, and the three substrates are Peircean — held=Firstness (the present
+working register), world=Secondness (brute external fact), store=Thirdness (the
+persisted, mediating law). Six columns = two dual operators x three substrates.
+
+This is a demonstration/bridge in the algebra's own repo; it encodes the intent roster
+as data (the canon lives in Noetica) and does not import from Noetica.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+from tools.semantic_algebra import (
+    ACT,
+    BOTTOM,
+    FST,
+    NIL,
+    POT,
+    PRIMITIVES,
+    SND,
+    TRD,
+    SemanticAddress,
+    Term,
+    TermSet,
+    add,
+    bind_tiered,
+    distance,
+    mul,
+    prim,
+)
+
+# --------------------------------------------------------------------------- #
+# The six columns = {read: pullback, write: pushout} x {held, world, store}
+# --------------------------------------------------------------------------- #
+
+#: Substrate -> Peircean primitive. held=Firstness, world=Secondness, store=Thirdness.
+SUBSTRATE_PRIM: Dict[str, str] = {"held": FST, "world": SND, "store": TRD}
+
+#: Polarity -> primitive marker. read is receptive (potentiality), write effective (act).
+POLARITY_PRIM: Dict[str, str] = {"read": POT, "write": ACT}
+
+#: The six ACTION_SIGNATURE columns, each as (substrate, polarity).
+COLUMNS: Dict[str, Tuple[str, str]] = {
+    "sense":     ("world", "read"),
+    "execute":   ("world", "write"),
+    "retrieve":  ("store", "read"),
+    "create":    ("store", "write"),
+    "evaluate":  ("held", "read"),
+    "transform": ("held", "write"),
+}
+
+
+def column_anchor(column: str) -> Term:
+    """The layer-1 anchor for a column: substrate primitive x polarity marker."""
+    substrate, polarity = COLUMNS[column]
+    return mul(prim(SUBSTRATE_PRIM[substrate]), prim(POLARITY_PRIM[polarity]))
+
+
+# --------------------------------------------------------------------------- #
+# The 23 rows, by primary column (Noetica intent-router INTENT_ACTION grouping)
+# --------------------------------------------------------------------------- #
+
+#: Intent -> its primary action-column. `everyday` is retained here but its action
+#: profile is a STRICT subset of explain_teach, so the canon collapses it under
+#: minimality; the canonical grid is 22 topics + 1 meta = 23 x 6 = 138 (pinned in
+#: intent-grid.ts, not re-derived here).
+INTENT_PRIMARY: Dict[str, str] = {
+    # retrieve (store:read)
+    "qa_over_doc": "retrieve", "research_lookup": "retrieve", "summarize_doc": "retrieve",
+    "self_identity": "retrieve", "meta_capability": "retrieve", "file_ops": "retrieve",
+    "everyday": "retrieve",
+    # evaluate (held:read)
+    "review_audit": "evaluate", "compare_benchmark": "evaluate", "code_review": "evaluate",
+    "status_check": "evaluate",
+    # create (store:write)
+    "build_implement": "create", "preferences_memory": "create",
+    # transform (held:write)
+    "fix_debug": "transform", "explain_teach": "transform", "write_draft": "transform",
+    "compute_math": "transform", "prove_reason": "transform",
+    # sense (world:read) -- the thinnest column
+    "file_ingest": "sense",
+    # execute (world:write)
+    "configure_ops": "execute",
+    # second-order intents (the meta/embedding group)
+    "plan_nextsteps": "meta", "converse_smalltalk": "meta", "confirm_steer": "meta",
+}
+
+#: The +1 meta row — second-order: its operand is an action, not a topic.
+META_ROW = "conversation_objective"
+
+#: Distinct layer-1 disambiguators (one per intent), so same-column intents are
+#: neighbours differing only in their differentia — the role whose very meaning is
+#: "what distinguishes this within its genus".
+_DISAMBIGUATORS: List[Term] = [mul(prim(a), prim(b)) for a in PRIMITIVES for b in PRIMITIVES]
+
+#: A layer-1 anchor for the meta-action group, deliberately NIL-grounded so it is
+#: distinct from all six column anchors (which ground on FST/SND/TRD) — these rows must
+#: never be mis-counted under, or mis-routed to, a real column.
+_META_COLUMN_ANCHOR = mul(prim(NIL), prim(TRD))
+
+
+def build_intent_addresses() -> Dict[str, SemanticAddress]:
+    """Address every intent row. Topic intents at layer 2; the meta row at layer 3.
+
+    Same-column intents land at distance 1; cross-column at distance 2. The meta row
+    is built out of an action address, so it sits one layer up — the second-order
+    row is a fixed point in the grading, comparable only to other second-order rows.
+    """
+    addrs: Dict[str, SemanticAddress] = {}
+    for i, (name, column) in enumerate(sorted(INTENT_PRIMARY.items())):
+        ground = _META_COLUMN_ANCHOR if column == "meta" else column_anchor(column)
+        term = mul(ground, _DISAMBIGUATORS[i])
+        addrs[name] = SemanticAddress(
+            term=term, iri=f"intent://{name}", inference="asserted", mood="assert"
+        )
+    # the meta row's operand IS an action address -> one layer up
+    action_term = addrs["plan_nextsteps"].term  # a layer-2 action address
+    addrs[META_ROW] = SemanticAddress(
+        term=mul(action_term, action_term),
+        iri=f"intent://{META_ROW}",
+        inference="abduced",
+        mood="assert",
+    )
+    return addrs
+
+
+# --------------------------------------------------------------------------- #
+# What the flat grid could not do
+# --------------------------------------------------------------------------- #
+
+
+def intent_distance(a: SemanticAddress, b: SemanticAddress) -> int:
+    """Structural distance between two intent addresses (same layer only)."""
+    return distance(a.term, b.term)
+
+
+def route(query_column: str, addresses: Dict[str, SemanticAddress]) -> "Term | object":
+    """Ground a by-column query to an intent under that column, or abstain.
+
+    Returns the admitted intent's term, or BOTTOM when the column has no intent in
+    `addresses` — which is exactly what makes the `sense` wiring gap show up as an
+    honest abstention rather than a mis-route.
+    """
+    topic_terms = [
+        addr.term for name, addr in addresses.items()
+        if name != META_ROW and addr.term.layer == 2  # layer-2 topic rows
+    ]
+    upper = add(*[column_anchor(c) for c in COLUMNS])
+    lower = add(*topic_terms)
+    return bind_tiered(column_anchor(query_column), upper, lower)
+
+
+def column_fill(addresses: Dict[str, SemanticAddress]) -> Dict[str, int]:
+    """How many intents sit under each column (their primary), by address ground."""
+    fill = {c: 0 for c in COLUMNS}
+    anchors = {column_anchor(c).code(): c for c in COLUMNS}
+    for name, addr in addresses.items():
+        if name == META_ROW or addr.term.layer != 2:
+            continue
+        ground = addr.term.roles()["ground"]
+        col = anchors.get(ground.code())
+        if col is not None:
+            fill[col] += 1
+    return fill

--- a/tools/semantic_algebra.py
+++ b/tools/semantic_algebra.py
@@ -1,0 +1,540 @@
+"""Compositional semantic algebra — the coordinate kernel (S0-S2).
+
+A graded, non-commutative algebra for *addressing meaning by structure*, so that
+semantic distance is COMPUTED from form rather than learned from a corpus. It is
+the substrate for two things the estate already needs and does not have:
+
+  1. AgentCoordinateVector — the eleven axes every agent declares itself on, so
+     that "what kind of work is this" is a typed value instead of a convention.
+  2. SemanticAddress       — a concept address carrying BOTH its intension (how
+     it decomposes) and its extension (what it refers to: a KKO/KBpedia IRI),
+     plus the warrant for believing it.
+
+Why an algebra at all
+---------------------
+The measured failure this exists to fix: the keyed-vec topic space is flat, so
+an intro-physics query matched a graduate QFT topic — 94.9% vocab hit but topic
+max-cos only 0.38-0.54. Abstraction level was not representable, so it could not
+be enforced. Here `layer` is a SYNTACTIC property of the address: a cross-layer
+match is not discouraged by a threshold, it is structurally impossible (see
+`bind_tiered` and its rejection test). That is the whole point.
+
+Primitives and their provenance
+-------------------------------
+The generating set is forced by the mathematics, not chosen for flavour: to
+generate a lattice by symmetry you need a neutral element, one binary symmetry,
+and one ternary symmetry. We take ours from the public-domain sources this
+estate is ALREADY aligned to, which is why the algebra lands natively on KKO:
+
+  NIL         neutral element                       (algebraic necessity)
+  POT / ACT   potentiality / actuality              (Aristotle) -> kko:Matter/Forms
+  FST/SND/TRD Firstness / Secondness / Thirdness    (Peirce, 1890s) -> KKO spine
+
+The ternary product's three roles are `ground` (what it stands on), `differentia`
+(what distinguishes it) and `mode` (how it is qualified) — Aristotelian
+genus/differentia plus the Spinozan mode. See docs/SEMANTIC_COORDINATE_ALGEBRA.md
+for the full provenance register; every element traces to a public-domain source.
+
+Pure and local-first: stdlib only, no network. An addressing kernel in the hot
+path of every retrieval and every boundary crossing must not take a round-trip.
+
+Conformance notes
+-----------------
+* Terms are immutable and hashable; equality is structural.
+* `add` is commutative and normalised (sorted canonical form), so no two
+  formally different expressions denote the same set.
+* `mul` is NON-commutative and raises on mixed-layer operands — layer discipline
+  is enforced at construction, not checked afterwards.
+* `pullback` (limit / restrict) and `pushout` (colimit / glue) are duals and are
+  the only two ways to combine knowledge. `meet` reconciles them. One meet
+  implementation serves both this kernel and Truth = Law x Evidence.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Dict, FrozenSet, Iterable, Optional, Sequence, Tuple
+
+SPEC_VERSION = "0.1.0"
+
+MAX_LAYER = 4
+
+# --------------------------------------------------------------------------- #
+# 1. Primitives — the generating set (see provenance register in the docs)
+# --------------------------------------------------------------------------- #
+
+NIL = "NIL"  # neutral element; also marks an axis of symmetry when in a role
+POT = "POT"  # potentiality  — the virtual, the not-yet-actual
+ACT = "ACT"  # actuality     — the effective, the concrete
+FST = "FST"  # Firstness     — quality, possibility, monadic
+SND = "SND"  # Secondness    — fact, reaction, dyadic
+TRD = "TRD"  # Thirdness     — law, mediation, triadic
+
+PRIMITIVES: Tuple[str, ...] = (NIL, POT, ACT, FST, SND, TRD)
+
+#: The two irreducible symmetries. Named sets, not new primitives — a paradigm
+#: variable in a role ranges over one of these.
+DYAD: Tuple[str, ...] = (POT, ACT)
+TRIAD: Tuple[str, ...] = (FST, SND, TRD)
+PENTAD: Tuple[str, ...] = DYAD + TRIAD
+
+ROLES: Tuple[str, ...] = ("ground", "differentia", "mode")
+
+
+# --------------------------------------------------------------------------- #
+# 2. Terms — the graded algebra
+# --------------------------------------------------------------------------- #
+
+
+class LayerError(ValueError):
+    """Raised when an operation would cross or exceed the layer grading.
+
+    Layer discipline is the mechanism that bars the abstraction-level mismatch
+    the tiered-ontology work was built to fix. It fails loudly on purpose.
+    """
+
+
+@dataclass(frozen=True)
+class Term:
+    """A point in the algebra: either a primitive (layer 0) or a product.
+
+    A product holds exactly three sub-terms, one per role, all at layer n-1;
+    the product itself is at layer n. `mode` defaults to the neutral element,
+    which is how most words are formed.
+    """
+
+    primitive: Optional[str] = None
+    ground: Optional["Term"] = None
+    differentia: Optional["Term"] = None
+    mode: Optional["Term"] = None
+
+    def __post_init__(self) -> None:
+        is_leaf = self.primitive is not None
+        is_product = self.ground is not None
+        if is_leaf == is_product:
+            raise ValueError("a Term is either a primitive or a product, not both/neither")
+        if is_leaf and self.primitive not in PRIMITIVES:
+            raise ValueError(f"unknown primitive {self.primitive!r}")
+
+    # -- grading ---------------------------------------------------------- #
+
+    @property
+    def layer(self) -> int:
+        if self.primitive is not None:
+            return 0
+        return self.ground.layer + 1  # type: ignore[union-attr]
+
+    @property
+    def is_leaf(self) -> bool:
+        return self.primitive is not None
+
+    def roles(self) -> Dict[str, "Term"]:
+        if self.is_leaf:
+            return {}
+        return {
+            "ground": self.ground,  # type: ignore[dict-item]
+            "differentia": self.differentia,  # type: ignore[dict-item]
+            "mode": self.mode,  # type: ignore[dict-item]
+        }
+
+    # -- canonical form --------------------------------------------------- #
+
+    def code(self) -> str:
+        """Canonical string form. Layer is readable off the bracket depth."""
+        if self.is_leaf:
+            return str(self.primitive)
+        return (
+            f"({self.ground.code()}"  # type: ignore[union-attr]
+            f" {self.differentia.code()}"  # type: ignore[union-attr]
+            f" {self.mode.code()})"  # type: ignore[union-attr]
+        )
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.code()
+
+
+def prim(symbol: str) -> Term:
+    """Lift a primitive symbol to a layer-0 term."""
+    return Term(primitive=symbol)
+
+
+NIL_TERM = prim(NIL)
+
+
+def mul(ground: Term, differentia: Term, mode: Optional[Term] = None) -> Term:
+    """The ternary, NON-commutative product. Elides `mode` to the neutral element.
+
+    All three operands must sit at the same layer; the product lands one layer
+    up. Crossing layers raises rather than coercing — a silent coercion here is
+    exactly how an intro-level concept ends up matching a graduate-level one.
+    """
+    mode_term = mode if mode is not None else _neutral_at(ground.layer)
+    operands = (ground, differentia, mode_term)
+    layers = {t.layer for t in operands}
+    if len(layers) != 1:
+        raise LayerError(
+            f"mul requires operands at one layer, got {sorted(layers)}"
+        )
+    layer = layers.pop()
+    if layer + 1 > MAX_LAYER:
+        raise LayerError(f"product would reach layer {layer + 1}, max is {MAX_LAYER}")
+    return Term(ground=ground, differentia=differentia, mode=mode_term)
+
+
+def _neutral_at(layer: int) -> Term:
+    """The neutral element lifted to `layer` — NIL, NIL*NIL, and so on."""
+    term = NIL_TERM
+    for _ in range(layer):
+        term = Term(ground=term, differentia=term, mode=term)
+    return term
+
+
+@dataclass(frozen=True)
+class TermSet:
+    """A normalised union of same-layer terms — the additive side of the ring.
+
+    This is what a paradigm variable ranges over. Commutative and idempotent;
+    the canonical ordering guarantees no two formally different expressions
+    denote the same set.
+    """
+
+    terms: FrozenSet[Term]
+
+    def __post_init__(self) -> None:
+        if not self.terms:
+            raise ValueError("a TermSet must be non-empty")
+        layers = {t.layer for t in self.terms}
+        if len(layers) != 1:
+            raise LayerError(f"a TermSet is single-layer, got {sorted(layers)}")
+
+    @property
+    def layer(self) -> int:
+        return next(iter(self.terms)).layer
+
+    def code(self) -> str:
+        return " + ".join(sorted(t.code() for t in self.terms))
+
+    def __iter__(self):
+        return iter(sorted(self.terms, key=lambda t: t.code()))
+
+    def __len__(self) -> int:
+        return len(self.terms)
+
+
+def add(*terms: Term) -> TermSet:
+    """Commutative, normalised union of same-layer terms."""
+    return TermSet(frozenset(terms))
+
+
+def distribute(
+    ground: "Term | TermSet",
+    differentia: "Term | TermSet",
+    mode: "Term | TermSet | None" = None,
+) -> TermSet:
+    """Multiplication distributed over addition — this is how a paradigm is generated.
+
+    A root paradigm is exactly this call with one to three roles filled by a
+    TermSet (the variable roles) and the rest by a Term (the invariants). The
+    result is the paradigm's cells.
+    """
+
+    def _as_set(x: "Term | TermSet | None", layer_hint: int) -> TermSet:
+        if x is None:
+            return TermSet(frozenset({_neutral_at(layer_hint)}))
+        if isinstance(x, TermSet):
+            return x
+        return TermSet(frozenset({x}))
+
+    g_layer = ground.layer
+    g, d = _as_set(ground, g_layer), _as_set(differentia, g_layer)
+    m = _as_set(mode, g_layer)
+    cells = {mul(gi, di, mi) for gi in g for di in d for mi in m}
+    return TermSet(frozenset(cells))
+
+
+# --------------------------------------------------------------------------- #
+# 3. Distance — semantic distance IS structural distance
+# --------------------------------------------------------------------------- #
+
+
+def distance(a: Term, b: Term) -> int:
+    """Structural edit distance between two terms at the same layer.
+
+    Zero iff identical. Terms differing in one role are at distance 1, which is
+    what makes a paradigm row/column a genuine neighbourhood: nothing is learned
+    and nothing is curated per pair.
+
+    Raises on cross-layer comparison — see `bind_tiered` for why.
+    """
+    if a.layer != b.layer:
+        raise LayerError(
+            f"distance is undefined across layers ({a.layer} vs {b.layer}); "
+            "compare within a layer or ground through the tier bridge"
+        )
+    if a == b:
+        return 0
+    if a.is_leaf or b.is_leaf:
+        return 1
+    return sum(
+        distance(a.roles()[r], b.roles()[r]) > 0 and 1 or 0 for r in ROLES
+    ) or 1
+
+
+def neighbours(target: Term, candidates: Iterable[Term], radius: int = 1) -> Tuple[Term, ...]:
+    """Candidates within `radius` of `target`, nearest first. Cross-layer skipped."""
+    scored = []
+    for c in candidates:
+        if c.layer != target.layer:
+            continue
+        d = distance(target, c)
+        if d <= radius:
+            scored.append((d, c.code(), c))
+    return tuple(c for _, _, c in sorted(scored))
+
+
+# --------------------------------------------------------------------------- #
+# 4. The two dual operators, and the meet that reconciles them
+# --------------------------------------------------------------------------- #
+
+
+def pullback(candidates: TermSet, constraint: Dict[str, Term]) -> Optional[TermSet]:
+    """LIMIT / restrict — keep only the cells agreeing with `constraint` on each role.
+
+    The restrictive operator. Returns None when the restriction is total, which
+    callers must treat as a refusal rather than as an empty-but-fine result.
+    """
+    kept = set()
+    for cell in candidates.terms:
+        if cell.is_leaf:
+            continue
+        if all(cell.roles()[role] == want for role, want in constraint.items()):
+            kept.add(cell)
+    return TermSet(frozenset(kept)) if kept else None
+
+
+def pushout(a: Term, b: Term, along: str) -> Term:
+    """COLIMIT / glue — combine two terms that agree on the shared role `along`.
+
+    The expansive operator. Refuses to glue along a role where the two disagree:
+    gluing over a disagreement is how contradictory knowledge silently merges.
+    """
+    if along not in ROLES:
+        raise ValueError(f"unknown role {along!r}")
+    if a.is_leaf or b.is_leaf:
+        raise ValueError("pushout requires products, not primitives")
+    if a.layer != b.layer:
+        raise LayerError(f"pushout across layers ({a.layer} vs {b.layer})")
+    if a.roles()[along] != b.roles()[along]:
+        raise ValueError(
+            f"cannot glue along {along!r}: {a.roles()[along].code()} "
+            f"!= {b.roles()[along].code()}"
+        )
+    merged = {}
+    for role in ROLES:
+        av, bv = a.roles()[role], b.roles()[role]
+        merged[role] = av if av == bv else _neutral_at(av.layer)
+    return mul(merged["ground"], merged["differentia"], merged["mode"])
+
+
+#: The verdict lattice, weakest to strongest. `meet` takes the minimum, which is
+#: the same operation Truth = Law x Evidence uses. One implementation, two call
+#: sites — a second copy of this ordering is how the two drift apart.
+VERDICT_ORDER: Tuple[str, ...] = ("refuse", "quarantine", "weak", "probable", "sealed")
+
+
+def meet(*verdicts: str) -> str:
+    """Reconcile verdicts by taking the lattice minimum.
+
+    The middle-column operation: an expansive signal never carries a decision on
+    its own, because the meet with a restrictive signal cannot exceed it.
+    """
+    if not verdicts:
+        raise ValueError("meet requires at least one verdict")
+    unknown = [v for v in verdicts if v not in VERDICT_ORDER]
+    if unknown:
+        raise ValueError(f"unknown verdict(s): {unknown}")
+    return min(verdicts, key=VERDICT_ORDER.index)
+
+
+# --------------------------------------------------------------------------- #
+# 5. Tiered binding — the abstraction-level bar, structural not thresholded
+# --------------------------------------------------------------------------- #
+
+
+def bind_tiered(query: Term, upper: TermSet, lower: TermSet) -> Optional[Term]:
+    """Ground a query general-first: anchor in `upper`, then descend to `lower`.
+
+    A lower-tier candidate is admitted ONLY if it is a product whose `ground`
+    role is the upper anchor we actually landed on. That is what bars an
+    intro-level query from matching a graduate-level topic: the bar is a
+    structural property of the address, not a cosine threshold that can be
+    tuned until it stops complaining.
+
+    Returns None when nothing injects through the anchor — an honest abstain.
+    """
+    if query.layer != upper.layer:
+        raise LayerError(
+            f"query is at layer {query.layer}, upper tier at {upper.layer}"
+        )
+    anchors = neighbours(query, upper.terms, radius=1)
+    if not anchors:
+        return None
+    anchor = anchors[0]
+    admitted = [
+        cell
+        for cell in lower.terms
+        if not cell.is_leaf and cell.roles()["ground"] == anchor
+    ]
+    if not admitted:
+        return None
+    return sorted(admitted, key=lambda t: t.code())[0]
+
+
+# --------------------------------------------------------------------------- #
+# 6. SemanticAddress — intension + extension + warrant
+# --------------------------------------------------------------------------- #
+
+INFERENCE_TYPES: Tuple[str, ...] = ("induced", "deduced", "abduced", "asserted")
+MOODS: Tuple[str, ...] = ("assert", "quote", "negate", "ask")
+
+
+@dataclass(frozen=True)
+class SemanticAddress:
+    """A concept address that carries how it composes, what it refers to, and why.
+
+    `term` is the intension — the algebraic decomposition, from which distance
+    to any other address is computed. `iri` is the extension — a KKO/KBpedia
+    reference concept, itself resolvable to a Wikidata entity. Neither face is
+    sufficient alone: structure without reference cannot be grounded, reference
+    without structure cannot be reasoned about compositionally.
+
+    The remaining fields are the warrant. An address whose validity has lapsed
+    or whose evidence has been revoked is still a well-formed address; it is the
+    warrant, not the addressing, that goes stale.
+    """
+
+    term: Term
+    iri: Optional[str] = None
+    inference: str = "asserted"
+    mood: str = "assert"
+    confidence: Optional[float] = None
+    evidence_ref: Optional[str] = None
+    valid_from: Optional[str] = None
+    valid_until: Optional[str] = None
+    revocation_ref: Optional[str] = None
+    lexicon: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.inference not in INFERENCE_TYPES:
+            raise ValueError(f"unknown inference type {self.inference!r}")
+        if self.mood not in MOODS:
+            raise ValueError(f"unknown mood {self.mood!r}")
+        if self.confidence is not None and not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be in [0, 1]")
+
+    @property
+    def layer(self) -> int:
+        return self.term.layer
+
+    @property
+    def is_grounded(self) -> bool:
+        """True when the address has an extensional anchor, not only structure."""
+        return bool(self.iri)
+
+    def skeleton(self) -> Dict[str, object]:
+        """The address stripped of everything that could identify its subject.
+
+        Structure travels; surface does not. This is the mechanism behind the
+        withhold-on-linkability rule: a counterparty can compute distance
+        against our skeleton without ever receiving the descriptor or the
+        evidence pointer.
+        """
+        return {
+            "code": self.term.code(),
+            "layer": self.layer,
+            "inference": self.inference,
+            "mood": self.mood,
+        }
+
+    def to_json(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "specVersion": SPEC_VERSION,
+            "code": self.term.code(),
+            "layer": self.layer,
+            "inference": self.inference,
+            "mood": self.mood,
+        }
+        for key, value in (
+            ("iri", self.iri),
+            ("confidence", self.confidence),
+            ("evidenceRef", self.evidence_ref),
+            ("validFrom", self.valid_from),
+            ("validUntil", self.valid_until),
+            ("revocationRef", self.revocation_ref),
+            ("lexicon", self.lexicon),
+        ):
+            if value is not None:
+                payload[key] = value
+        return payload
+
+
+def address_distance(a: SemanticAddress, b: SemanticAddress) -> int:
+    """Distance between addresses — structural, and only within a layer."""
+    return distance(a.term, b.term)
+
+
+# --------------------------------------------------------------------------- #
+# 7. Lexicons — a parameter, never a canon
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Lexicon:
+    """A named, versioned binding of terms to labels.
+
+    Many lexicons bind to one algebra. This is deliberate: a single canonical
+    word list is a coverage ceiling (one domain, one language, one author) and a
+    licensing chokepoint. Domains that need their own vocabulary bring their own
+    lexicon and still share every structural operation.
+    """
+
+    name: str
+    version: str
+    labels: Dict[str, str] = field(default_factory=dict)
+    license: str = "unspecified"
+
+    def label(self, term: Term) -> Optional[str]:
+        return self.labels.get(term.code())
+
+    def covers(self, term: Term) -> bool:
+        return term.code() in self.labels
+
+
+class LexiconRegistry:
+    """Resolution across lexicons, in declared priority order."""
+
+    def __init__(self, lexicons: Sequence[Lexicon] = ()) -> None:
+        self._lexicons: list[Lexicon] = list(lexicons)
+
+    def register(self, lexicon: Lexicon) -> None:
+        self._lexicons.append(lexicon)
+
+    def resolve(self, term: Term) -> Optional[Tuple[str, Lexicon]]:
+        for lex in self._lexicons:
+            label = lex.label(term)
+            if label is not None:
+                return label, lex
+        return None
+
+    def coverage(self, terms: Iterable[Term]) -> float:
+        terms = list(terms)
+        if not terms:
+            return 0.0
+        hit = sum(1 for t in terms if self.resolve(t) is not None)
+        return hit / len(terms)
+
+
+def canonical_json(payload: object) -> str:
+    """JCS-style canonical form, matching the rest of the contracts tooling."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)

--- a/tools/semantic_algebra.py
+++ b/tools/semantic_algebra.py
@@ -48,6 +48,13 @@ Conformance notes
 * `pullback` (limit / restrict) and `pushout` (colimit / glue) are duals and are
   the only two ways to combine knowledge. `meet` reconciles them. One meet
   implementation serves both this kernel and Truth = Law x Evidence.
+* Abstention is a first-class value, `BOTTOM`, not `None`: `bind_tiered` and
+  `pullback` return it, `meet` absorbs it, and its position is undefined under
+  `distance`. Incompleteness makes abstention structural, so it is carried, not
+  smuggled through the control flow.
+* The verdict lattice is DERIVED from `VERDICT_CLEARS` (what each verdict clears)
+  by `derive_verdict_order`, not hand-authored; it raises unless the verdicts form
+  a chain. There is no second copy of the ordering to drift from its meaning.
 """
 
 from __future__ import annotations
@@ -56,7 +63,7 @@ import json
 from dataclasses import dataclass, field
 from typing import Dict, FrozenSet, Iterable, Optional, Sequence, Tuple
 
-SPEC_VERSION = "0.1.0"
+SPEC_VERSION = "0.2.0"
 
 MAX_LAYER = 4
 
@@ -162,6 +169,37 @@ def prim(symbol: str) -> Term:
 NIL_TERM = prim(NIL)
 
 
+# --------------------------------------------------------------------------- #
+# 2b. BOTTOM — abstention as a first-class value (Gödel)
+# --------------------------------------------------------------------------- #
+
+
+class Abstain:
+    """The honest-ignorance element: "not decidable from within this system".
+
+    Incompleteness makes abstention *structural*, not incidental — so it is a value
+    the algebra carries, never an out-of-band ``None`` the control flow smuggles.
+    ``BOTTOM`` composes: it is absorbing under ``meet`` and its position is undefined
+    under ``distance``, so a computation that passed through an undecidable point
+    cannot quietly forget it. Singleton; identity comparison (``is BOTTOM``) is the
+    intended test.
+    """
+
+    _instance: "Optional[Abstain]" = None
+
+    def __new__(cls) -> "Abstain":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return "BOTTOM"
+
+
+#: The single abstention value. Grounding operators return this, not ``None``.
+BOTTOM = Abstain()
+
+
 def mul(ground: Term, differentia: Term, mode: Optional[Term] = None) -> Term:
     """The ternary, NON-commutative product. Elides `mode` to the neutral element.
 
@@ -265,8 +303,11 @@ def distance(a: Term, b: Term) -> int:
     what makes a paradigm row/column a genuine neighbourhood: nothing is learned
     and nothing is curated per pair.
 
-    Raises on cross-layer comparison — see `bind_tiered` for why.
+    Raises on cross-layer comparison — see `bind_tiered` for why. Undefined for
+    BOTTOM: abstention has no position, so distance to it is not a number.
     """
+    if a is BOTTOM or b is BOTTOM:
+        raise LayerError("distance is undefined for BOTTOM (abstention has no position)")
     if a.layer != b.layer:
         raise LayerError(
             f"distance is undefined across layers ({a.layer} vs {b.layer}); "
@@ -298,11 +339,12 @@ def neighbours(target: Term, candidates: Iterable[Term], radius: int = 1) -> Tup
 # --------------------------------------------------------------------------- #
 
 
-def pullback(candidates: TermSet, constraint: Dict[str, Term]) -> Optional[TermSet]:
+def pullback(candidates: TermSet, constraint: Dict[str, Term]) -> "TermSet | Abstain":
     """LIMIT / restrict — keep only the cells agreeing with `constraint` on each role.
 
-    The restrictive operator. Returns None when the restriction is total, which
-    callers must treat as a refusal rather than as an empty-but-fine result.
+    The restrictive operator. Returns BOTTOM when the restriction is total: a
+    first-class abstention the caller must reconcile, not an empty-but-fine result
+    and not a smuggled ``None``.
     """
     kept = set()
     for cell in candidates.terms:
@@ -310,7 +352,7 @@ def pullback(candidates: TermSet, constraint: Dict[str, Term]) -> Optional[TermS
             continue
         if all(cell.roles()[role] == want for role, want in constraint.items()):
             kept.add(cell)
-    return TermSet(frozenset(kept)) if kept else None
+    return TermSet(frozenset(kept)) if kept else BOTTOM
 
 
 def pushout(a: Term, b: Term, along: str) -> Term:
@@ -337,20 +379,59 @@ def pushout(a: Term, b: Term, along: str) -> Term:
     return mul(merged["ground"], merged["differentia"], merged["mode"])
 
 
-#: The verdict lattice, weakest to strongest. `meet` takes the minimum, which is
-#: the same operation Truth = Law x Evidence uses. One implementation, two call
-#: sites — a second copy of this ordering is how the two drift apart.
-VERDICT_ORDER: Tuple[str, ...] = ("refuse", "quarantine", "weak", "probable", "sealed")
+#: What each verdict CLEARS. This is the ground the order is DERIVED from, not an
+#: authored ranking — a stronger verdict clears a superset, and the lattice order is
+#: the subset relation over these sets. This was the one hand-authored canon in the
+#: kernel; deriving it removes the second copy of the ordering that could drift from
+#: its meaning, the same discipline the 23x6 grid applies to its cells. (Mach:
+#: economy — keep no ungrounded posit.)
+VERDICT_CLEARS: Dict[str, FrozenSet[str]] = {
+    "refuse":     frozenset(),
+    "quarantine": frozenset({"observe_isolated"}),
+    "weak":       frozenset({"observe_isolated", "cite"}),
+    "probable":   frozenset({"observe_isolated", "cite", "act_reversible"}),
+    "sealed":     frozenset({"observe_isolated", "cite", "act_reversible", "act_irreversible"}),
+}
 
 
-def meet(*verdicts: str) -> str:
-    """Reconcile verdicts by taking the lattice minimum.
+def derive_verdict_order(clears: Dict[str, FrozenSet[str]]) -> Tuple[str, ...]:
+    """Derive the verdict lattice from what each verdict clears — weakest first.
 
-    The middle-column operation: an expansive signal never carries a decision on
-    its own, because the meet with a restrictive signal cannot exceed it.
+    The order is the subset relation over the cleared-capability sets, computed, not
+    written down twice. Raises if the verdicts do not form a chain (a pair whose sets
+    are incomparable): `meet` needs a total order, and an un-derivable one is a defect
+    to surface, not paper over — the same stance as `buildCanonicalGrid` throwing
+    unless the count is exact. Adding a properly-nested verdict extends the order with
+    no second edit.
+    """
+    verdicts = sorted(clears, key=lambda v: (len(clears[v]), v))
+    for weaker, stronger in zip(verdicts, verdicts[1:]):
+        if not clears[weaker] <= clears[stronger]:
+            raise ValueError(
+                f"verdicts {weaker!r} and {stronger!r} are incomparable: "
+                f"{set(clears[weaker])} vs {set(clears[stronger])} — not a chain"
+            )
+    return tuple(verdicts)
+
+
+#: The verdict lattice, weakest to strongest — DERIVED from VERDICT_CLEARS, checked
+#: not claimed. `meet` takes the minimum, the same operation Truth = Law x Evidence
+#: uses. One implementation, one derived order, no authored second copy.
+VERDICT_ORDER: Tuple[str, ...] = derive_verdict_order(VERDICT_CLEARS)
+
+
+def meet(*verdicts: "str | Abstain") -> "str | Abstain":
+    """Reconcile verdicts by the lattice minimum; BOTTOM is absorbing.
+
+    The middle-column operation: an expansive signal never carries a decision on its
+    own, because the meet with a restrictive signal cannot exceed it. If any arm is
+    BOTTOM (undecidable), the reconciliation is BOTTOM — you cannot seal on an arm you
+    could not decide.
     """
     if not verdicts:
         raise ValueError("meet requires at least one verdict")
+    if any(v is BOTTOM for v in verdicts):
+        return BOTTOM
     unknown = [v for v in verdicts if v not in VERDICT_ORDER]
     if unknown:
         raise ValueError(f"unknown verdict(s): {unknown}")
@@ -362,7 +443,7 @@ def meet(*verdicts: str) -> str:
 # --------------------------------------------------------------------------- #
 
 
-def bind_tiered(query: Term, upper: TermSet, lower: TermSet) -> Optional[Term]:
+def bind_tiered(query: Term, upper: TermSet, lower: TermSet) -> "Term | Abstain":
     """Ground a query general-first: anchor in `upper`, then descend to `lower`.
 
     A lower-tier candidate is admitted ONLY if it is a product whose `ground`
@@ -371,7 +452,8 @@ def bind_tiered(query: Term, upper: TermSet, lower: TermSet) -> Optional[Term]:
     structural property of the address, not a cosine threshold that can be
     tuned until it stops complaining.
 
-    Returns None when nothing injects through the anchor — an honest abstain.
+    Returns BOTTOM when nothing injects through the anchor — an honest abstain, as
+    a first-class value the caller must reconcile, not a smuggled ``None``.
     """
     if query.layer != upper.layer:
         raise LayerError(
@@ -379,7 +461,7 @@ def bind_tiered(query: Term, upper: TermSet, lower: TermSet) -> Optional[Term]:
         )
     anchors = neighbours(query, upper.terms, radius=1)
     if not anchors:
-        return None
+        return BOTTOM
     anchor = anchors[0]
     admitted = [
         cell
@@ -387,7 +469,7 @@ def bind_tiered(query: Term, upper: TermSet, lower: TermSet) -> Optional[Term]:
         if not cell.is_leaf and cell.roles()["ground"] == anchor
     ]
     if not admitted:
-        return None
+        return BOTTOM
     return sorted(admitted, key=lambda t: t.code())[0]
 
 
@@ -414,7 +496,7 @@ class SemanticAddress:
     warrant, not the addressing, that goes stale.
     """
 
-    term: Term
+    term: "Term | Abstain"
     iri: Optional[str] = None
     inference: str = "asserted"
     mood: str = "assert"
@@ -434,12 +516,25 @@ class SemanticAddress:
             raise ValueError("confidence must be in [0, 1]")
 
     @property
+    def abstains(self) -> bool:
+        """True when this address is the honest 'could not ground' — term is BOTTOM."""
+        return self.term is BOTTOM
+
+    @property
     def layer(self) -> int:
+        if self.term is BOTTOM:
+            raise LayerError("an abstaining address has no layer")
         return self.term.layer
 
     @property
     def is_grounded(self) -> bool:
-        """True when the address has an extensional anchor, not only structure."""
+        """True when the address has an extensional anchor, not only structure.
+
+        An abstaining address is never grounded, whatever its `iri` — you cannot
+        ground what you declined to decide.
+        """
+        if self.term is BOTTOM:
+            return False
         return bool(self.iri)
 
     def skeleton(self) -> Dict[str, object]:
@@ -451,8 +546,9 @@ class SemanticAddress:
         evidence pointer.
         """
         return {
-            "code": self.term.code(),
-            "layer": self.layer,
+            "code": "BOTTOM" if self.abstains else self.term.code(),
+            "layer": None if self.abstains else self.layer,
+            "abstains": self.abstains,
             "inference": self.inference,
             "mood": self.mood,
         }
@@ -460,8 +556,9 @@ class SemanticAddress:
     def to_json(self) -> Dict[str, object]:
         payload: Dict[str, object] = {
             "specVersion": SPEC_VERSION,
-            "code": self.term.code(),
-            "layer": self.layer,
+            "code": "BOTTOM" if self.abstains else self.term.code(),
+            "layer": None if self.abstains else self.layer,
+            "abstains": self.abstains,
             "inference": self.inference,
             "mood": self.mood,
         }

--- a/tools/semantic_algebra.py
+++ b/tools/semantic_algebra.py
@@ -635,3 +635,71 @@ class LexiconRegistry:
 def canonical_json(payload: object) -> str:
     """JCS-style canonical form, matching the rest of the contracts tooling."""
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+# --------------------------------------------------------------------------- #
+# 8. The layer adjunction — lift ⊣ ground (Kant's schematism, made plural)
+# --------------------------------------------------------------------------- #
+#
+# `distance` forbids cross-layer comparison; that is safe but only prohibitive. This
+# pair makes a crossing POSSIBLE but only through a named morphism. See
+# docs/SEMANTIC_LAYER_ADJUNCTION.md for the proof obligations (P1-P6). It is a
+# coreflection: `lift` is a full embedding, `ground` its retraction, with
+# `ground(lift(t)) == t` exactly and `refines(p, lift(ground(p)))` always.
+
+
+def lift(t: Term) -> Term:
+    """Generalize: place `t` one layer up as the ground of an otherwise-neutral product.
+
+    Raises (via `mul`) at `MAX_LAYER` — the crossing is typed, not unbounded.
+    """
+    if t is BOTTOM:  # type: ignore[comparison-overlap]
+        raise LayerError("cannot lift BOTTOM (abstention has no layer)")
+    neutral = _neutral_at(t.layer)
+    return mul(t, neutral, neutral)
+
+
+def ground(p: Term) -> "Term | Abstain":
+    """Specialize: recover the layer-n term a lifted term stands on.
+
+    BOTTOM on a leaf — a primitive stands on nothing, so grounding it is an honest
+    abstention, not a guess.
+    """
+    if p is BOTTOM:  # type: ignore[comparison-overlap]
+        return BOTTOM
+    if p.is_leaf:
+        return BOTTOM
+    return p.roles()["ground"]
+
+
+def refines(a: Term, b: Term) -> bool:
+    """The refinement relation ⊑: `a` is at least as specific as `b` (same layer).
+
+    The neutral element is the top (most general); `a ⊑ b` when `b` is neutral wherever
+    `a` carries content. Raises across layers — refinement is a within-layer order.
+    """
+    if a is BOTTOM or b is BOTTOM:  # type: ignore[comparison-overlap]
+        raise LayerError("refinement is undefined for BOTTOM")
+    if a.layer != b.layer:
+        raise LayerError(f"refinement is within a layer ({a.layer} vs {b.layer})")
+    if b == _neutral_at(b.layer):
+        return True  # everything refines the top
+    if a.is_leaf or b.is_leaf:
+        return a == b
+    return all(refines(a.roles()[r], b.roles()[r]) for r in ROLES)
+
+
+def distance_bridged(lo: Term, hi: Term) -> int:
+    """The ONLY legal cross-layer comparison: `lo` at layer n, `hi` at layer n+1.
+
+    Computed by lifting `lo` through the morphism and comparing within `hi`'s layer.
+    Raw cross-layer `distance` still raises; this is the warranted crossing, and it is
+    adjacent-only (no n -> n+2 leaps) by economy.
+    """
+    if lo is BOTTOM or hi is BOTTOM:  # type: ignore[comparison-overlap]
+        raise LayerError("distance_bridged is undefined for BOTTOM")
+    if hi.layer != lo.layer + 1:
+        raise LayerError(
+            f"distance_bridged bridges adjacent layers low->high, got {lo.layer} and {hi.layer}"
+        )
+    return distance(lift(lo), hi)

--- a/tools/spectral_grounding.py
+++ b/tools/spectral_grounding.py
@@ -1,0 +1,103 @@
+"""Grounding the algebra in the constrained-spectral field theory — the tight links, in code.
+
+The doctrine note (superconscious) claims two correspondences are *identical*, not analogous:
+
+  1. Edgeworth supermodularity (manuscript eq 21) IS the lattice condition our `meet` lives on.
+  2. The per-cell clipping projection (manuscript eq 57) IS a `pullback` onto a constraint half-space.
+
+Prose is cheap; this module makes both falsifiable. A 2x2 cell of knot values is the atomic unit on
+which supermodularity is enforced. We show the manuscript's cross-difference equals the standard
+lattice supermodularity slack `g(a∨b)+g(a∧b) − g(a) − g(b)` with `∧=min` — the very operation
+`semantic_algebra.meet` implements — and that the closed-form projection restricts the cell to the
+supermodular half-space by the smallest L2 move, which is exactly what `pullback` does abstractly.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+from tools.semantic_algebra import VERDICT_ORDER, meet
+
+#: A 2x2 cell: value at each corner of the unit square in the (t, u) index lattice.
+Corner = Tuple[int, int]
+Cell = Dict[Corner, float]
+
+CORNERS: Tuple[Corner, ...] = ((0, 0), (1, 0), (0, 1), (1, 1))
+
+
+# --------------------------------------------------------------------------- #
+# 1. Supermodularity IS the meet-lattice condition
+# --------------------------------------------------------------------------- #
+
+
+def join(a: Corner, b: Corner) -> Corner:
+    """Lattice join ∨ = coordinatewise max."""
+    return (max(a[0], b[0]), max(a[1], b[1]))
+
+
+def meet_idx(a: Corner, b: Corner) -> Corner:
+    """Lattice meet ∧ = coordinatewise min — the same min-on-a-chain that `meet` uses."""
+    return (min(a[0], b[0]), min(a[1], b[1]))
+
+
+def cross_difference(cell: Cell) -> float:
+    """The manuscript's Edgeworth cross-difference (eq 21): supermodular iff >= 0."""
+    return cell[(1, 1)] - cell[(1, 0)] - cell[(0, 1)] + cell[(0, 0)]
+
+
+def lattice_supermodular_slack(cell: Cell) -> float:
+    """The standard lattice slack g(a∨b)+g(a∧b) − g(a) − g(b), with a=(1,0), b=(0,1).
+
+    a∨b = (1,1), a∧b = (0,0); so this is g(1,1)+g(0,0) − g(1,0) − g(0,1). It is *equal* to
+    `cross_difference` by construction — that equality is the proof that Edgeworth
+    complementarity and the meet lattice are one condition (Topkis 1998, Milgrom-Roberts 1990).
+    """
+    a, b = (1, 0), (0, 1)
+    return cell[join(a, b)] + cell[meet_idx(a, b)] - cell[a] - cell[b]
+
+
+def is_supermodular(cell: Cell) -> bool:
+    return cross_difference(cell) >= 0
+
+
+def is_submodular(cell: Cell) -> bool:
+    """Substitutability: the reversed inequality (manuscript eq 23)."""
+    return cross_difference(cell) <= 0
+
+
+def meet_on_chain(x: str, y: str) -> str:
+    """The verdict-lattice meet — exposed here to show it is the same min-on-a-chain as ∧."""
+    return meet(x, y)  # type: ignore[return-value]
+
+
+# --------------------------------------------------------------------------- #
+# 2. The per-cell clipping projection IS a half-space pullback
+# --------------------------------------------------------------------------- #
+
+# The supermodularity constraint is aᵀθ ≥ 0 with θ the four corner values and `a` the stencil
+# (+1 at (1,1) and (0,0); −1 at (1,0) and (0,1)). Note aᵀθ == cross_difference(θ), and ‖a‖² = 4.
+_STENCIL: Dict[Corner, float] = {(1, 1): +1.0, (0, 0): +1.0, (1, 0): -1.0, (0, 1): -1.0}
+_STENCIL_NORM2 = sum(v * v for v in _STENCIL.values())  # = 4.0
+
+
+def project_supermodular(cell: Cell) -> Cell:
+    """Project a cell onto the supermodular half-space by the smallest L2 move (eq 57).
+
+    `θ ↦ θ + max(0, −aᵀθ)·a / ‖a‖²`. Idempotent on feasible cells (a `pullback` that admits
+    everything already inside), and it lands an infeasible cell exactly on the boundary
+    (cross_difference == 0) — the restrictive operator, realised metrically.
+    """
+    slack = cross_difference(cell)  # = aᵀθ
+    step = max(0.0, -slack) / _STENCIL_NORM2
+    if step == 0.0:
+        return dict(cell)
+    return {c: cell[c] + step * _STENCIL[c] for c in CORNERS}
+
+
+def project_submodular(cell: Cell) -> Cell:
+    """Dual projection onto the SUBmodular half-space (substitutability, eq 23)."""
+    slack = cross_difference(cell)
+    step = max(0.0, slack) / _STENCIL_NORM2
+    if step == 0.0:
+        return dict(cell)
+    return {c: cell[c] - step * _STENCIL[c] for c in CORNERS}

--- a/tools/tests/test_abstraction_level_gate.py
+++ b/tools/tests/test_abstraction_level_gate.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import List, Optional
 
 from tools.semantic_algebra import (
+    BOTTOM,
     PRIMITIVES,
     Term,
     TermSet,
@@ -62,7 +63,7 @@ def _pair_cases() -> List[Case]:
                     query=grad_anchor,
                     upper=upper,
                     lower=add(c_intro),  # no candidate under the grad anchor
-                    gold=None,
+                    gold=BOTTOM,
                 )
             )
     return cases
@@ -99,8 +100,8 @@ def test_naive_binder_fails_on_mismatch():
 # -- a binder that abstains on everything is CAUGHT as vacuous --------------- #
 
 
-def _lazy_bind(query: Term, upper: TermSet, lower: TermSet) -> Optional[Term]:
-    return None
+def _lazy_bind(query: Term, upper: TermSet, lower: TermSet):
+    return BOTTOM
 
 
 def test_lazy_binder_fails_as_vacuous():
@@ -131,6 +132,6 @@ def test_intro_query_never_binds_to_graduate_topic():
 
     # An intro-level query finds no topic under its own anchor -> abstains,
     # rather than matching the graduate topic (the 0.38-0.54 cosine failure).
-    assert bind_tiered(mechanics, upper, lower) is None
+    assert bind_tiered(mechanics, upper, lower) is BOTTOM
     # ...whereas a binder that ignored the anchor would wrongly bind it:
     assert _naive_bind(mechanics, upper, lower) == qft_topic

--- a/tools/tests/test_abstraction_level_gate.py
+++ b/tools/tests/test_abstraction_level_gate.py
@@ -1,0 +1,136 @@
+"""Tests for the abstraction-level gate.
+
+The gate must PASS the real structural binder and FAIL two broken ones — a
+naive binder that ignores the abstraction anchor, and a lazy binder that
+abstains on everything. Proving both is the gate's own teeth-both-ways evidence:
+a gate that only ever passes is not measuring anything.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from tools.semantic_algebra import (
+    PRIMITIVES,
+    Term,
+    TermSet,
+    add,
+    bind_tiered,
+    mul,
+    prim,
+)
+from tools.abstraction_level_gate import Case, run_gate
+
+
+def _pair_cases() -> List[Case]:
+    """Reproduce the intro->graduate trap across >=30 distinct anchor pairs.
+
+    For each ordered pair of distinct grounds (a, c):
+      intro_anchor = a . FST      grad_anchor = c . FST
+      C_intro = intro_anchor squared   (a layer-2 topic UNDER the intro anchor)
+      C_grad  = grad_anchor squared    (a layer-2 topic UNDER the grad anchor)
+
+    * admit case  — query at the intro anchor, both topics offered; the correct
+      binding is C_intro, never C_grad.
+    * abstain case — query at the grad anchor, only the intro topic offered; the
+      correct behaviour is to abstain rather than bind a grad query to an
+      intro topic. This is the trap that produced the measured failure.
+    """
+    b = prim("FST")
+    cases: List[Case] = []
+    for a in PRIMITIVES:
+        for c in PRIMITIVES:
+            if a == c:
+                continue
+            intro_anchor = mul(prim(a), b)
+            grad_anchor = mul(prim(c), b)
+            c_intro = mul(intro_anchor, intro_anchor)
+            c_grad = mul(grad_anchor, grad_anchor)
+            upper = add(intro_anchor, grad_anchor)
+            cases.append(
+                Case(
+                    name=f"admit:{a}->intro",
+                    query=intro_anchor,
+                    upper=upper,
+                    lower=add(c_intro, c_grad),
+                    gold=c_intro,
+                )
+            )
+            cases.append(
+                Case(
+                    name=f"abstain:{c}-grad-vs-intro-only",
+                    query=grad_anchor,
+                    upper=upper,
+                    lower=add(c_intro),  # no candidate under the grad anchor
+                    gold=None,
+                )
+            )
+    return cases
+
+
+# -- the real binder passes at n >= 30 -------------------------------------- #
+
+
+def test_real_binder_passes():
+    cases = _pair_cases()
+    assert len(cases) >= 30
+    result = run_gate(cases, bind_fn=bind_tiered)
+    assert result.passed, result.reasons
+    assert result.mismatch_rate == 0.0
+    assert result.correct_admits > 0
+    assert result.correct_abstains > 0
+
+
+# -- a binder that ignores the anchor is CAUGHT (dangerous direction) -------- #
+
+
+def _naive_bind(query: Term, upper: TermSet, lower: TermSet) -> Optional[Term]:
+    """Ignores the abstraction anchor entirely — always returns some lower term."""
+    return sorted(lower.terms, key=lambda t: t.code())[0]
+
+
+def test_naive_binder_fails_on_mismatch():
+    result = run_gate(_pair_cases(), bind_fn=_naive_bind)
+    assert not result.passed
+    assert result.mismatches > 0
+    assert any("mismatch_rate" in r for r in result.reasons)
+
+
+# -- a binder that abstains on everything is CAUGHT as vacuous --------------- #
+
+
+def _lazy_bind(query: Term, upper: TermSet, lower: TermSet) -> Optional[Term]:
+    return None
+
+
+def test_lazy_binder_fails_as_vacuous():
+    result = run_gate(_pair_cases(), bind_fn=_lazy_bind)
+    assert not result.passed
+    assert result.mismatches == 0  # it never admits anything...
+    assert any("vacuous" in r for r in result.reasons)  # ...which is exactly the failure
+
+
+# -- an under-sized run is not evidence ------------------------------------- #
+
+
+def test_below_min_n_fails():
+    result = run_gate(_pair_cases()[:5], bind_fn=bind_tiered, min_n=30)
+    assert not result.passed
+    assert any("below min_n" in r for r in result.reasons)
+
+
+# -- the named intro-physics / graduate-QFT trap, spelled out --------------- #
+
+
+def test_intro_query_never_binds_to_graduate_topic():
+    mechanics = mul(prim("ACT"), prim("FST"))   # intro anchor
+    qft = mul(prim("TRD"), prim("FST"))         # graduate anchor
+    qft_topic = mul(qft, qft)                   # a topic under the graduate anchor
+    upper = add(mechanics, qft)
+    lower = add(qft_topic)                       # only a graduate topic on offer
+
+    # An intro-level query finds no topic under its own anchor -> abstains,
+    # rather than matching the graduate topic (the 0.38-0.54 cosine failure).
+    assert bind_tiered(mechanics, upper, lower) is None
+    # ...whereas a binder that ignored the anchor would wrongly bind it:
+    assert _naive_bind(mechanics, upper, lower) == qft_topic

--- a/tools/tests/test_agent_coordinate_vector.py
+++ b/tools/tests/test_agent_coordinate_vector.py
@@ -1,0 +1,171 @@
+"""Tests for AgentCoordinateVector (S0).
+
+Every gate is exercised BOTH ways. The headline rule — 'an agent with ten or
+twelve coordinates is REJECTED' — is pinned by an explicit drop-one and add-one
+test, not merely by a happy-path pass.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import pathlib
+
+import pytest
+
+from tools.agent_coordinate_vector import (
+    AXES,
+    OPERATOR_AXES,
+    is_valid,
+    validate,
+)
+
+
+def _valid_vector() -> dict:
+    coords = {axis: {"primary": False, "operator": "none"} for axis in AXES}
+    coords["tiferet"] = {"primary": True, "operator": "meet"}
+    coords["chesed"]["operator"] = "pushout"
+    coords["gevurah"]["operator"] = "pullback"
+    return {
+        "schemaVersion": "v0.1",
+        "kind": "AgentCoordinateVector",
+        "agentId": "michael-agent",
+        "coordinates": coords,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# The pass path
+# --------------------------------------------------------------------------- #
+
+
+def test_canonical_vector_is_valid():
+    assert validate(_valid_vector()) == []
+    assert is_valid(_valid_vector())
+
+
+def test_exactly_eleven_axes_present():
+    assert len(AXES) == 11
+
+
+# --------------------------------------------------------------------------- #
+# 'ten or twelve is rejected' — the headline, both directions
+# --------------------------------------------------------------------------- #
+
+
+def test_ten_coordinates_rejected():
+    doc = _valid_vector()
+    del doc["coordinates"]["hod"]  # now ten
+    errs = validate(doc)
+    assert any("missing coordinate axes" in e and "hod" in e for e in errs)
+    assert not is_valid(doc)
+
+
+def test_twelve_coordinates_rejected():
+    doc = _valid_vector()
+    doc["coordinates"]["shadow"] = {"primary": False}  # now twelve
+    errs = validate(doc)
+    assert any("unknown coordinate axes" in e and "shadow" in e for e in errs)
+    assert not is_valid(doc)
+
+
+# --------------------------------------------------------------------------- #
+# exactly one primary — rejects zero and two
+# --------------------------------------------------------------------------- #
+
+
+def test_zero_primaries_rejected():
+    doc = _valid_vector()
+    doc["coordinates"]["tiferet"]["primary"] = False
+    assert any("no primary axis" in e for e in validate(doc))
+
+
+def test_two_primaries_rejected():
+    doc = _valid_vector()
+    doc["coordinates"]["malchut"]["primary"] = True  # tiferet already primary
+    errs = validate(doc)
+    assert any("exactly one primary" in e for e in errs)
+
+
+def test_non_boolean_primary_rejected():
+    doc = _valid_vector()
+    doc["coordinates"]["binah"]["primary"] = "yes"
+    assert any("boolean 'primary'" in e for e in validate(doc))
+
+
+# --------------------------------------------------------------------------- #
+# operator-axis coherence — the middle column cannot be miswired
+# --------------------------------------------------------------------------- #
+
+
+def test_tiferet_must_be_meet():
+    doc = _valid_vector()
+    doc["coordinates"]["tiferet"]["operator"] = "pushout"
+    errs = validate(doc)
+    assert any("must be realised by 'meet'" in e for e in errs)
+
+
+def test_gevurah_cannot_glue():
+    doc = _valid_vector()
+    doc["coordinates"]["gevurah"]["operator"] = "pushout"  # restrictive axis gluing
+    errs = validate(doc)
+    assert any("gevurah" in e and "pullback" in e for e in errs)
+
+
+def test_non_operator_axis_claiming_operator_rejected():
+    doc = _valid_vector()
+    doc["coordinates"]["netzach"]["operator"] = "meet"
+    assert any("not an operator axis" in e for e in validate(doc))
+
+
+def test_unknown_operator_rejected():
+    doc = _valid_vector()
+    doc["coordinates"]["chesed"]["operator"] = "colimit"
+    assert any("unknown operator" in e for e in validate(doc))
+
+
+def test_operator_axes_have_expected_operators():
+    assert OPERATOR_AXES == {"chesed": "pushout", "gevurah": "pullback", "tiferet": "meet"}
+
+
+# --------------------------------------------------------------------------- #
+# envelope
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("field,bad", [("schemaVersion", "v9"), ("kind", "Nope")])
+def test_envelope_constants_enforced(field, bad):
+    doc = _valid_vector()
+    doc[field] = bad
+    assert not is_valid(doc)
+
+
+def test_missing_agent_id_rejected():
+    doc = _valid_vector()
+    doc["agentId"] = ""
+    assert any("agentId" in e for e in validate(doc))
+
+
+def test_coordinates_must_be_object():
+    doc = _valid_vector()
+    doc["coordinates"] = []
+    assert any("coordinates must be an object" in e for e in validate(doc))
+
+
+def test_non_object_document_rejected():
+    assert validate("not a dict")
+    assert validate(None)
+
+
+# --------------------------------------------------------------------------- #
+# the shipped example validates
+# --------------------------------------------------------------------------- #
+
+
+def test_shipped_example_is_valid():
+    example = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "contracts" / "examples" / "agent-coordinate-vector-michael-agent.example.json"
+    )
+    doc = json.loads(example.read_text(encoding="utf-8"))
+    assert validate(doc) == []

--- a/tools/tests/test_boundary_transition_actants.py
+++ b/tools/tests/test_boundary_transition_actants.py
@@ -1,0 +1,128 @@
+"""Tests for BoundaryTransition v0.2 actantial frame — both ways.
+
+The frame is only worth adding if it is enforced: a crossing that omits who or
+what is doing the acting must be REFUSED, and the closed inventory must reject an
+invented role. The skeleton must drop surface while keeping shape.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+from tools.boundary_transition_actants import (
+    REQUIRED_ROLES,
+    ROLES,
+    is_valid,
+    skeleton,
+    validate_actants,
+    validate_boundary_transition,
+)
+
+
+def _full_actants() -> dict:
+    return {
+        "root": "summarize",
+        "initiator": "prophet-mesh/research-agent",
+        "interactant": "filing/ASX-GYG",
+        "recipient": "analyst",
+        "cause": "requested briefing",
+        "time": "2026-08-01T18:45:00Z",
+        "place": "ai-invocation-boundary",
+        "intention": "decision-ready briefing",
+        "manner": "extractive, no network",
+    }
+
+
+# -- pass path -------------------------------------------------------------- #
+
+
+def test_nine_roles_defined():
+    assert len(ROLES) == 9
+    assert REQUIRED_ROLES == ("root", "initiator")
+
+
+def test_full_frame_valid():
+    assert validate_actants(_full_actants()) == []
+
+
+def test_minimal_frame_valid():
+    assert validate_actants({"root": "open", "initiator": "user"}) == []
+
+
+# -- refusal paths ---------------------------------------------------------- #
+
+
+def test_missing_root_refused():
+    a = _full_actants()
+    del a["root"]
+    assert any("'root'" in e for e in validate_actants(a))
+
+
+def test_missing_initiator_refused():
+    a = _full_actants()
+    del a["initiator"]
+    assert any("'initiator'" in e for e in validate_actants(a))
+
+
+def test_empty_required_role_refused():
+    a = _full_actants()
+    a["initiator"] = ""
+    assert any("'initiator'" in e for e in validate_actants(a))
+
+
+def test_unknown_role_refused():
+    a = _full_actants()
+    a["vibe"] = "good"
+    assert any("unknown actant role" in e and "vibe" in e for e in validate_actants(a))
+
+
+def test_non_string_optional_role_refused():
+    a = _full_actants()
+    a["manner"] = 42
+    assert any("'manner'" in e for e in validate_actants(a))
+
+
+def test_actants_must_be_object():
+    assert validate_actants(["root", "initiator"])
+
+
+# -- envelope-level obligation ---------------------------------------------- #
+
+
+def test_v02_requires_actants():
+    doc = {"schemaVersion": "v0.2", "kind": "BoundaryTransition"}
+    assert any("requires an 'actants' frame" in e for e in validate_boundary_transition(doc))
+
+
+def test_v01_schemaversion_refused_on_v02_validator():
+    doc = {"schemaVersion": "v0.1", "actants": {"root": "x", "initiator": "y"}}
+    assert not is_valid(doc)
+
+
+# -- de-identification lever ------------------------------------------------ #
+
+
+def test_skeleton_drops_surface_keeps_shape():
+    sk = skeleton(_full_actants())
+    assert sk == {role: True for role in ROLES}
+    # every value is a plain boolean — no descriptor text survives
+    assert all(isinstance(v, bool) for v in sk.values())
+
+
+def test_skeleton_marks_absent_roles_false():
+    sk = skeleton({"root": "open", "initiator": "user"})
+    assert sk["root"] is True and sk["initiator"] is True
+    assert sk["recipient"] is False and sk["intention"] is False
+
+
+# -- shipped example -------------------------------------------------------- #
+
+
+def test_shipped_example_valid():
+    example = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "contracts" / "examples" / "boundary-transition-v0.2-ai-invocation.example.json"
+    )
+    doc = json.loads(example.read_text(encoding="utf-8"))
+    assert validate_boundary_transition(doc) == []

--- a/tools/tests/test_check_cleanroom.py
+++ b/tools/tests/test_check_cleanroom.py
@@ -1,0 +1,49 @@
+"""Tests for the clean-room guard — both ways.
+
+The guard must (a) pass on the actual framework files as shipped, (b) BITE on a real
+leak, and (c) exclude itself. A guard only ever seen to pass is not a guard.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.check_cleanroom import (
+    FRAMEWORK_FILES,
+    framework_files,
+    scan_paths,
+)
+
+
+def test_the_shipped_framework_is_clean():
+    # the real surface, as committed, must have no third-party marks
+    assert scan_paths(framework_files()) == []
+
+
+def test_the_guard_bites_on_a_real_leak(tmp_path: Path):
+    leak = tmp_path / "leaky.py"
+    # the exact class of leak the review caught: naming the third-party metalanguage
+    leak.write_text("# derived from the IEML dictionary\nx = 1\n", encoding="utf-8")
+    hits = scan_paths([str(leak)])
+    assert len(hits) == 1
+    assert hits[0][1] == 1  # line number
+    assert hits[0][2].lower() == "ieml"
+
+
+def test_the_guard_catches_each_forbidden_mark(tmp_path: Path):
+    for token in ("IEML", "INTLEKT", "Lévy", "Levy"):
+        f = tmp_path / f"{token}.md"
+        f.write_text(f"see {token} for background\n", encoding="utf-8")
+        assert scan_paths([str(f)]), f"{token} should have been flagged"
+
+
+def test_the_guard_excludes_itself(tmp_path: Path):
+    # even if the checker is explicitly passed to itself, it must not flag its own
+    # forbidden-pattern source — a scanner that flags itself is broken.
+    self_path = Path(__file__).resolve().parents[1] / "check_cleanroom.py"
+    assert scan_paths([str(self_path)]) == []
+
+
+def test_framework_manifest_excludes_the_guard_and_its_test():
+    # self-exclusion by construction: the manifest must not list the guard/its test.
+    assert not any("check_cleanroom" in rel for rel in FRAMEWORK_FILES)

--- a/tools/tests/test_contract_schemas.py
+++ b/tools/tests/test_contract_schemas.py
@@ -1,0 +1,78 @@
+"""Make the JSON-Schema contracts load-bearing, not decorative — both ways.
+
+The review caught that the .json contracts were shipped but never exercised: nothing
+checked they were well-formed, that the shipped examples conform, or that they REJECT a
+malformed document. This closes that: each schema is validated as a Draft 2020-12 schema,
+each example must conform, and a deliberately broken document must fail AT THE SCHEMA
+(not only at the Python validator).
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import pathlib
+
+import pytest
+
+jsonschema = pytest.importorskip("jsonschema")
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+PAIRS = [
+    (
+        "contracts/AgentCoordinateVector.v0.1.json",
+        "contracts/examples/agent-coordinate-vector-michael-agent.example.json",
+    ),
+    (
+        "contracts/BoundaryTransition.v0.2.json",
+        "contracts/examples/boundary-transition-v0.2-ai-invocation.example.json",
+    ),
+]
+
+
+def _load(rel: str) -> dict:
+    return json.loads((ROOT / rel).read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("schema_rel,example_rel", PAIRS)
+def test_schema_wellformed_and_example_conforms(schema_rel, example_rel):
+    schema = _load(schema_rel)
+    jsonschema.Draft202012Validator.check_schema(schema)  # the schema itself is valid
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = list(validator.iter_errors(_load(example_rel)))
+    assert errors == [], [e.message for e in errors]
+
+
+def test_agent_coordinate_vector_schema_bites():
+    schema = _load("contracts/AgentCoordinateVector.v0.1.json")
+    v = jsonschema.Draft202012Validator(schema)
+    good = _load("contracts/examples/agent-coordinate-vector-michael-agent.example.json")
+    assert list(v.iter_errors(good)) == []
+    # ten coordinates -> rejected by the SCHEMA (required), not only by the py validator
+    ten = copy.deepcopy(good)
+    del ten["coordinates"]["hod"]
+    with pytest.raises(jsonschema.ValidationError):
+        v.validate(ten)
+    # twelve coordinates -> rejected (additionalProperties: false)
+    twelve = copy.deepcopy(good)
+    twelve["coordinates"]["shadow"] = {"primary": False}
+    with pytest.raises(jsonschema.ValidationError):
+        v.validate(twelve)
+
+
+def test_boundary_transition_schema_bites():
+    schema = _load("contracts/BoundaryTransition.v0.2.json")
+    v = jsonschema.Draft202012Validator(schema)
+    good = _load("contracts/examples/boundary-transition-v0.2-ai-invocation.example.json")
+    assert list(v.iter_errors(good)) == []
+    # v0.2 requires the actantial frame
+    no_actants = copy.deepcopy(good)
+    del no_actants["actants"]
+    with pytest.raises(jsonschema.ValidationError):
+        v.validate(no_actants)
+    # an out-of-enum boundaryType is rejected
+    bad_enum = copy.deepcopy(good)
+    bad_enum["boundaryType"] = "telepathy"
+    with pytest.raises(jsonschema.ValidationError):
+        v.validate(bad_enum)

--- a/tools/tests/test_intent_address.py
+++ b/tools/tests/test_intent_address.py
@@ -1,0 +1,94 @@
+"""Tests for the 23x6 -> coordinate-algebra bridge.
+
+Proves the flat grid gains exactly what it lacked: a metric on its rows, an
+abstraction layer (the meta row is genuinely second-order), and — the payoff — the
+`sense` wiring gap surfacing as a first-class abstention instead of a mis-route.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.semantic_algebra import BOTTOM, LayerError
+from tools.intent_address import (
+    COLUMNS,
+    INTENT_PRIMARY,
+    META_ROW,
+    build_intent_addresses,
+    column_fill,
+    intent_distance,
+    route,
+)
+
+
+def _addrs():
+    return build_intent_addresses()
+
+
+# -- coverage & shape ------------------------------------------------------- #
+
+
+def test_every_row_addressed_and_distinct():
+    addrs = _addrs()
+    assert len(addrs) == len(INTENT_PRIMARY) + 1  # topics + the meta row
+    terms = [a.term for a in addrs.values()]
+    assert len({t.code() for t in terms}) == len(terms)  # all distinct
+
+
+def test_topic_rows_are_layer_2_meta_is_layer_3():
+    addrs = _addrs()
+    for name, addr in addrs.items():
+        if name == META_ROW:
+            assert addr.term.layer == 3  # second-order: operand is an action
+        else:
+            assert addr.term.layer == 2
+
+
+# -- the metric the flat grid did not have ---------------------------------- #
+
+
+def test_same_column_intents_are_nearer_than_cross_column():
+    addrs = _addrs()
+    same = intent_distance(addrs["qa_over_doc"], addrs["research_lookup"])  # both retrieve
+    cross = intent_distance(addrs["qa_over_doc"], addrs["file_ingest"])      # retrieve vs sense
+    assert same == 1
+    assert cross == 2
+    assert same < cross
+
+
+# -- the meta row is second-order, comparable only to its own order --------- #
+
+
+def test_meta_row_is_not_comparable_to_a_topic_row():
+    addrs = _addrs()
+    with pytest.raises(LayerError):
+        intent_distance(addrs[META_ROW], addrs["qa_over_doc"])  # layer 3 vs 2
+
+
+# -- tiered routing, and the sense gap as abstention ------------------------ #
+
+
+def test_route_grounds_a_column_query_to_an_intent_in_that_column():
+    addrs = _addrs()
+    assert route("sense", addrs) == addrs["file_ingest"].term
+    assert route("transform", addrs) is not BOTTOM  # transform is well-populated
+
+
+def test_sense_gap_becomes_a_first_class_abstention():
+    addrs = _addrs()
+    without_sense = {k: v for k, v in addrs.items() if k != "file_ingest"}
+    # with the one sense intent removed, a world:read query cannot route -> BOTTOM,
+    # not a silent mis-route to some other column.
+    assert route("sense", without_sense) is BOTTOM
+
+
+# -- the column asymmetry finding, reproduced structurally ------------------ #
+
+
+def test_sense_is_the_thinnest_column():
+    fill = column_fill(_addrs())
+    assert fill["sense"] == 1
+    assert fill["sense"] == min(fill.values())
+    # every column admits at least one intent — no dead columns
+    assert all(count >= 1 for count in fill.values())
+    assert set(fill) == set(COLUMNS)

--- a/tools/tests/test_semantic_algebra.py
+++ b/tools/tests/test_semantic_algebra.py
@@ -1,0 +1,385 @@
+"""Tests for the compositional semantic algebra.
+
+Every gate here is exercised BOTH ways — the pass path and the refusal path.
+A guard that has only ever been seen to allow is not evidence of a guard.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.semantic_algebra import (
+    ACT,
+    DYAD,
+    FST,
+    MAX_LAYER,
+    POT,
+    PRIMITIVES,
+    SND,
+    TRD,
+    TRIAD,
+    Lexicon,
+    LexiconRegistry,
+    LayerError,
+    SemanticAddress,
+    Term,
+    add,
+    address_distance,
+    bind_tiered,
+    canonical_json,
+    distance,
+    distribute,
+    meet,
+    mul,
+    neighbours,
+    prim,
+    pullback,
+    pushout,
+)
+
+# --------------------------------------------------------------------------- #
+# Primitives and construction
+# --------------------------------------------------------------------------- #
+
+
+def test_generating_set_is_one_neutral_one_dyad_one_triad():
+    assert len(PRIMITIVES) == 6
+    assert set(DYAD) == {POT, ACT}
+    assert set(TRIAD) == {FST, SND, TRD}
+    assert set(DYAD) & set(TRIAD) == set()
+
+
+def test_term_must_be_leaf_or_product_not_both():
+    with pytest.raises(ValueError):
+        Term(primitive=POT, ground=prim(ACT))
+    with pytest.raises(ValueError):
+        Term()
+
+
+def test_unknown_primitive_refused():
+    with pytest.raises(ValueError):
+        prim("KETER")
+
+
+# --------------------------------------------------------------------------- #
+# The product: non-commutative, layer-graded
+# --------------------------------------------------------------------------- #
+
+
+def test_product_is_non_commutative():
+    a, b = prim(POT), prim(ACT)
+    assert mul(a, b) != mul(b, a)
+    assert mul(a, b).code() != mul(b, a).code()
+
+
+def test_product_lifts_exactly_one_layer():
+    a = mul(prim(POT), prim(ACT))
+    assert prim(POT).layer == 0
+    assert a.layer == 1
+    assert mul(a, a).layer == 2
+
+
+def test_mixed_layer_product_refused():
+    """Layer discipline is enforced at construction, not audited afterwards."""
+    low = prim(POT)
+    high = mul(prim(POT), prim(ACT))
+    with pytest.raises(LayerError):
+        mul(low, high)
+
+
+def test_product_beyond_max_layer_refused():
+    term = mul(prim(POT), prim(ACT))
+    while term.layer < MAX_LAYER:
+        term = mul(term, term)
+    assert term.layer == MAX_LAYER
+    with pytest.raises(LayerError):
+        mul(term, term)
+
+
+def test_mode_elides_to_neutral_element():
+    explicit = mul(prim(POT), prim(ACT), prim("NIL"))
+    elided = mul(prim(POT), prim(ACT))
+    assert explicit == elided
+
+
+# --------------------------------------------------------------------------- #
+# Addition and distribution — how a paradigm is generated
+# --------------------------------------------------------------------------- #
+
+
+def test_addition_is_commutative_and_normalised():
+    a, b = prim(POT), prim(ACT)
+    assert add(a, b) == add(b, a)
+    assert add(a, b).code() == add(b, a).code()
+
+
+def test_addition_is_idempotent():
+    a = prim(POT)
+    assert len(add(a, a)) == 1
+
+
+def test_addition_across_layers_refused():
+    with pytest.raises(LayerError):
+        add(prim(POT), mul(prim(POT), prim(ACT)))
+
+
+def test_paradigm_is_the_product_of_its_variable_roles():
+    """A 2x3 root paradigm has exactly six cells — the symmetry group, generated."""
+    paradigm = distribute(add(*[prim(p) for p in DYAD]), add(*[prim(p) for p in TRIAD]))
+    assert len(paradigm) == 6
+    assert all(cell.layer == 1 for cell in paradigm)
+
+
+def test_distribution_over_addition_holds():
+    left = distribute(prim(POT), add(prim(FST), prim(SND)))
+    manual = add(mul(prim(POT), prim(FST)), mul(prim(POT), prim(SND)))
+    assert left == manual
+
+
+# --------------------------------------------------------------------------- #
+# Distance — computed from form, never learned
+# --------------------------------------------------------------------------- #
+
+
+def test_identical_terms_are_at_distance_zero():
+    a = mul(prim(POT), prim(FST))
+    assert distance(a, a) == 0
+
+
+def test_one_role_apart_is_distance_one():
+    a = mul(prim(POT), prim(FST))
+    b = mul(prim(POT), prim(SND))
+    assert distance(a, b) == 1
+
+
+def test_two_roles_apart_is_farther_than_one():
+    base = mul(prim(POT), prim(FST))
+    near = mul(prim(POT), prim(SND))
+    far = mul(prim(ACT), prim(SND))
+    assert distance(base, far) > distance(base, near)
+
+
+def test_cross_layer_distance_refused():
+    with pytest.raises(LayerError):
+        distance(prim(POT), mul(prim(POT), prim(ACT)))
+
+
+def test_neighbours_skips_other_layers_instead_of_coercing():
+    target = mul(prim(POT), prim(FST))
+    same_layer = mul(prim(POT), prim(SND))
+    other_layer = mul(target, target)
+    found = neighbours(target, [same_layer, other_layer], radius=1)
+    assert same_layer in found
+    assert other_layer not in found
+
+
+# --------------------------------------------------------------------------- #
+# The dual operators
+# --------------------------------------------------------------------------- #
+
+
+def test_pullback_restricts_to_matching_cells():
+    paradigm = distribute(add(*[prim(p) for p in DYAD]), add(*[prim(p) for p in TRIAD]))
+    restricted = pullback(paradigm, {"ground": prim(POT)})
+    assert restricted is not None
+    assert len(restricted) == 3
+    assert all(cell.roles()["ground"] == prim(POT) for cell in restricted)
+
+
+def test_pullback_returns_none_on_total_restriction():
+    """A restriction that admits nothing is a refusal, not an empty success."""
+    paradigm = distribute(prim(POT), add(prim(FST), prim(SND)))
+    assert pullback(paradigm, {"ground": prim(ACT)}) is None
+
+
+def test_pushout_glues_along_a_shared_role():
+    a = mul(prim(POT), prim(FST))
+    b = mul(prim(POT), prim(SND))
+    glued = pushout(a, b, along="ground")
+    assert glued.roles()["ground"] == prim(POT)
+
+
+def test_pushout_refuses_to_glue_over_a_disagreement():
+    """Gluing across a disagreement is how contradictory knowledge merges silently."""
+    a = mul(prim(POT), prim(FST))
+    b = mul(prim(ACT), prim(FST))
+    with pytest.raises(ValueError):
+        pushout(a, b, along="ground")
+
+
+def test_pushout_across_layers_refused():
+    a = mul(prim(POT), prim(FST))
+    b = mul(a, a)
+    with pytest.raises(LayerError):
+        pushout(a, b, along="ground")
+
+
+def test_pushout_drops_roles_that_disagree_rather_than_picking_one():
+    a = mul(prim(POT), prim(FST))
+    b = mul(prim(POT), prim(SND))
+    glued = pushout(a, b, along="ground")
+    assert glued.roles()["differentia"] not in (prim(FST), prim(SND))
+
+
+# --------------------------------------------------------------------------- #
+# The meet
+# --------------------------------------------------------------------------- #
+
+
+def test_meet_takes_the_weaker_verdict():
+    assert meet("sealed", "weak") == "weak"
+    assert meet("probable", "refuse") == "refuse"
+
+
+def test_meet_never_exceeds_either_arm():
+    """The property that makes an expansive signal unable to decide on its own."""
+    for law in ("refuse", "quarantine", "weak", "probable", "sealed"):
+        for evidence in ("refuse", "quarantine", "weak", "probable", "sealed"):
+            result = meet(law, evidence)
+            assert result in (law, evidence)
+            assert result == min((law, evidence), key=("refuse", "quarantine", "weak", "probable", "sealed").index)
+
+
+def test_meet_is_order_independent():
+    assert meet("sealed", "weak") == meet("weak", "sealed")
+
+
+def test_meet_refuses_unknown_verdicts():
+    with pytest.raises(ValueError):
+        meet("sealed", "definitely-fine")
+
+
+# --------------------------------------------------------------------------- #
+# Tiered binding — the recorded failure, barred structurally
+# --------------------------------------------------------------------------- #
+
+
+def _tiers():
+    """Two anchors with one specific topic injected under each.
+
+    `intro` and `advanced` differ only in their ground anchor, which is exactly
+    the situation where a flat vector space picked the wrong abstraction level.
+    """
+    intro_anchor = mul(prim(POT), prim(FST))
+    advanced_anchor = mul(prim(ACT), prim(FST))
+    upper = add(intro_anchor, advanced_anchor)
+    intro_topic = mul(intro_anchor, mul(prim(POT), prim(SND)))
+    advanced_topic = mul(advanced_anchor, mul(prim(ACT), prim(SND)))
+    lower = add(intro_topic, advanced_topic)
+    return intro_anchor, advanced_anchor, intro_topic, advanced_topic, upper, lower
+
+
+def test_tiered_binding_descends_through_the_right_anchor():
+    intro_anchor, _, intro_topic, _, upper, lower = _tiers()
+    assert bind_tiered(intro_anchor, upper, lower) == intro_topic
+
+
+def test_tiered_binding_bars_the_wrong_abstraction_level():
+    """The intro query must NOT reach the advanced topic. This is the whole point."""
+    intro_anchor, _, _, advanced_topic, upper, lower = _tiers()
+    assert bind_tiered(intro_anchor, upper, lower) != advanced_topic
+
+
+def test_tiered_binding_abstains_when_nothing_injects():
+    intro_anchor, advanced_anchor, _, advanced_topic, upper, _ = _tiers()
+    lower_without_intro = add(advanced_topic)
+    assert bind_tiered(intro_anchor, upper, lower_without_intro) is None
+
+
+def test_tiered_binding_refuses_a_query_from_the_wrong_layer():
+    _, _, _, _, upper, lower = _tiers()
+    with pytest.raises(LayerError):
+        bind_tiered(prim(POT), upper, lower)
+
+
+# --------------------------------------------------------------------------- #
+# SemanticAddress — intension, extension, warrant
+# --------------------------------------------------------------------------- #
+
+
+def test_address_is_ungrounded_without_an_iri():
+    addr = SemanticAddress(term=mul(prim(POT), prim(FST)))
+    assert not addr.is_grounded
+
+
+def test_address_is_grounded_with_an_iri():
+    addr = SemanticAddress(term=mul(prim(POT), prim(FST)), iri="kko:Methodeutic")
+    assert addr.is_grounded
+
+
+def test_address_refuses_unknown_inference_type():
+    with pytest.raises(ValueError):
+        SemanticAddress(term=prim(POT), inference="vibes")
+
+
+def test_address_refuses_unknown_mood():
+    with pytest.raises(ValueError):
+        SemanticAddress(term=prim(POT), mood="insinuate")
+
+
+def test_address_refuses_out_of_range_confidence():
+    with pytest.raises(ValueError):
+        SemanticAddress(term=prim(POT), confidence=1.5)
+
+
+def test_skeleton_carries_structure_and_withholds_surface():
+    """Structure travels, surface does not — the linkability withhold mechanism."""
+    addr = SemanticAddress(
+        term=mul(prim(POT), prim(FST)),
+        iri="kko:SomeSensitiveConcept",
+        evidence_ref="evidence://patient-42",
+        confidence=0.9,
+    )
+    skeleton = addr.skeleton()
+    serialised = canonical_json(skeleton)
+    assert "code" in skeleton and "layer" in skeleton
+    assert "patient-42" not in serialised
+    assert "kko:SomeSensitiveConcept" not in serialised
+
+
+def test_skeleton_still_supports_distance():
+    a = SemanticAddress(term=mul(prim(POT), prim(FST)), evidence_ref="secret")
+    b = SemanticAddress(term=mul(prim(POT), prim(SND)), evidence_ref="also-secret")
+    assert address_distance(a, b) == 1
+
+
+def test_address_json_omits_absent_warrant_fields():
+    addr = SemanticAddress(term=mul(prim(POT), prim(FST)))
+    payload = addr.to_json()
+    assert "evidenceRef" not in payload
+    assert payload["inference"] == "asserted"
+
+
+# --------------------------------------------------------------------------- #
+# Lexicons — a parameter, not a canon
+# --------------------------------------------------------------------------- #
+
+
+def test_registry_resolves_in_priority_order():
+    term = mul(prim(POT), prim(FST))
+    first = Lexicon("primary", "1.0", {term.code(): "orientation"}, license="Apache-2.0")
+    second = Lexicon("fallback", "1.0", {term.code(): "something else"})
+    registry = LexiconRegistry([first, second])
+    label, source = registry.resolve(term)
+    assert label == "orientation"
+    assert source.name == "primary"
+
+
+def test_registry_returns_none_for_uncovered_terms():
+    registry = LexiconRegistry([Lexicon("sparse", "1.0", {})])
+    assert registry.resolve(mul(prim(POT), prim(FST))) is None
+
+
+def test_algebra_operates_with_no_lexicon_at_all():
+    """Structure is independent of vocabulary — no lexicon is a licensing chokepoint."""
+    registry = LexiconRegistry([])
+    a = mul(prim(POT), prim(FST))
+    b = mul(prim(POT), prim(SND))
+    assert registry.resolve(a) is None
+    assert distance(a, b) == 1
+
+
+def test_coverage_is_reported_not_assumed():
+    a, b = mul(prim(POT), prim(FST)), mul(prim(POT), prim(SND))
+    registry = LexiconRegistry([Lexicon("half", "1.0", {a.code(): "one"})])
+    assert registry.coverage([a, b]) == 0.5

--- a/tools/tests/test_semantic_algebra.py
+++ b/tools/tests/test_semantic_algebra.py
@@ -10,6 +10,7 @@ import pytest
 
 from tools.semantic_algebra import (
     ACT,
+    BOTTOM,
     DYAD,
     FST,
     MAX_LAYER,
@@ -186,10 +187,10 @@ def test_pullback_restricts_to_matching_cells():
     assert all(cell.roles()["ground"] == prim(POT) for cell in restricted)
 
 
-def test_pullback_returns_none_on_total_restriction():
-    """A restriction that admits nothing is a refusal, not an empty success."""
+def test_pullback_abstains_on_total_restriction():
+    """A restriction that admits nothing is a first-class abstention, not None."""
     paradigm = distribute(prim(POT), add(prim(FST), prim(SND)))
-    assert pullback(paradigm, {"ground": prim(ACT)}) is None
+    assert pullback(paradigm, {"ground": prim(ACT)}) is BOTTOM
 
 
 def test_pushout_glues_along_a_shared_role():
@@ -283,7 +284,7 @@ def test_tiered_binding_bars_the_wrong_abstraction_level():
 def test_tiered_binding_abstains_when_nothing_injects():
     intro_anchor, advanced_anchor, _, advanced_topic, upper, _ = _tiers()
     lower_without_intro = add(advanced_topic)
-    assert bind_tiered(intro_anchor, upper, lower_without_intro) is None
+    assert bind_tiered(intro_anchor, upper, lower_without_intro) is BOTTOM
 
 
 def test_tiered_binding_refuses_a_query_from_the_wrong_layer():

--- a/tools/tests/test_semantic_algebra_adjunction.py
+++ b/tools/tests/test_semantic_algebra_adjunction.py
@@ -1,0 +1,135 @@
+"""Proof obligations P1-P6 for the layer adjunction lift ⊣ ground — both ways.
+
+Each law is pinned on its refusal path too: a coreflection asserted but never shown to
+reject is not a coreflection. See docs/SEMANTIC_LAYER_ADJUNCTION.md.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.semantic_algebra import (
+    BOTTOM,
+    FST,
+    MAX_LAYER,
+    POT,
+    SND,
+    LayerError,
+    _neutral_at,
+    distance,
+    distance_bridged,
+    ground,
+    lift,
+    mul,
+    prim,
+    refines,
+)
+
+
+def _l1():
+    return mul(prim(POT), prim(FST))  # a layer-1 term
+
+
+def _l1b():
+    return mul(prim(POT), prim(SND))  # a different layer-1 term
+
+
+# -- P1: layers move by exactly one; lifting past MAX_LAYER is refused --------- #
+
+
+def test_p1_layers_and_the_ceiling():
+    t = _l1()
+    assert lift(t).layer == t.layer + 1
+    assert ground(lift(t)).layer == t.layer
+    # refusal: lifting a top-layer term would exceed the ceiling
+    top = t
+    while top.layer < MAX_LAYER:
+        top = lift(top)
+    with pytest.raises(LayerError):
+        lift(top)
+
+
+# -- P2: ground ∘ lift = id (section); ground of a leaf abstains --------------- #
+
+
+def test_p2_section_and_leaf_abstains():
+    for t in (prim(POT), _l1(), lift(_l1())):
+        assert ground(lift(t)) == t
+    # refusal: a primitive stands on nothing
+    assert ground(prim(FST)) is BOTTOM
+
+
+# -- P3: p ⊑ lift(ground(p)) (closure); a non-refinement is rejected ---------- #
+
+
+def test_p3_closure_and_its_refusal():
+    p = mul(_l1(), _l1b())  # layer 2, ground = _l1()
+    assert refines(p, lift(ground(p)))
+    # refusal: a term on a different ground does NOT refine lift(ground(p))
+    other = mul(_l1b(), _l1b())
+    assert not refines(other, lift(ground(p)))
+
+
+# -- P4: monotonicity, both a passing and a failing premise ------------------- #
+
+
+def test_p4_monotonicity():
+    a = mul(prim(POT), prim(FST))
+    b = mul(prim(POT), _neutral_at(0))  # more general: differentia neutralized
+    assert refines(a, b)  # a ⊑ b
+    assert refines(lift(a), lift(b))  # ...so lift preserves it
+    # refusal: distinct pinned differentiae are NOT a refinement either way
+    c = mul(prim(POT), prim(SND))
+    assert not refines(a, c)
+    assert not refines(c, a)
+
+
+# -- P5: the Galois condition ground(y) ⊑ x ⟺ y ⊑ lift(x) --------------------- #
+
+
+def test_p5_galois_equivalence():
+    x = _l1()
+    lift_x = lift(x)
+    candidates = [
+        mul(x, _l1b()),        # ground = x  -> both sides True
+        mul(_l1b(), _l1b()),   # ground != x -> both sides False
+        mul(x, x),             # ground = x  -> both sides True
+    ]
+    for y in candidates:
+        left = refines(ground(y), x)
+        right = refines(y, lift_x)
+        assert left == right, y.code()
+
+
+# -- P6: the bridge is the ONLY legal crossing -------------------------------- #
+
+
+def test_p6_bridge_is_the_only_crossing():
+    lo = _l1()
+    hi = mul(lo, _l1b())  # layer 2, adjacent
+    # the warranted crossing is defined and non-negative
+    d = distance_bridged(lo, hi)
+    assert isinstance(d, int) and d >= 0
+    # raw cross-layer distance still raises — the bridge did not weaken the bar
+    with pytest.raises(LayerError):
+        distance(lo, hi)
+    # same-layer is not a bridge
+    with pytest.raises(LayerError):
+        distance_bridged(lo, _l1b())
+    # non-adjacent (n -> n+2) is refused
+    hi2 = mul(hi, hi)  # layer 3
+    with pytest.raises(LayerError):
+        distance_bridged(lo, hi2)
+
+
+# -- the refinement relation itself is pinned both ways ----------------------- #
+
+
+def test_refinement_relation_positive_and_negative():
+    a = mul(prim(POT), prim(FST))
+    top = _neutral_at(1)
+    assert refines(a, top)          # everything refines the top
+    assert refines(a, a)            # reflexive
+    assert not refines(top, a)      # the top refines nothing below it
+    with pytest.raises(LayerError):
+        refines(prim(POT), a)       # cross-layer is undefined

--- a/tools/tests/test_semantic_algebra_deltas.py
+++ b/tools/tests/test_semantic_algebra_deltas.py
@@ -1,0 +1,124 @@
+"""Tests for two algebra deltas — both ways.
+
+Delta 1 (Gödel): abstention is a first-class value, BOTTOM, not an out-of-band None.
+Delta 3 (Mach + our own discipline): the verdict lattice is DERIVED from what each
+verdict clears, not hand-authored — and an un-derivable order is a hard failure.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.semantic_algebra import (
+    ACT,
+    BOTTOM,
+    FST,
+    POT,
+    SND,
+    Abstain,
+    LayerError,
+    SemanticAddress,
+    VERDICT_CLEARS,
+    VERDICT_ORDER,
+    add,
+    bind_tiered,
+    derive_verdict_order,
+    distance,
+    distribute,
+    meet,
+    mul,
+    prim,
+    pullback,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Delta 1 — BOTTOM as a first-class abstention
+# --------------------------------------------------------------------------- #
+
+
+def test_bottom_is_a_singleton():
+    assert Abstain() is BOTTOM
+    assert repr(BOTTOM) == "BOTTOM"
+
+
+def test_grounding_operators_return_bottom_not_none():
+    # pullback under a total restriction
+    paradigm = distribute(prim(POT), add(prim(FST), prim(SND)))
+    assert pullback(paradigm, {"ground": prim(ACT)}) is BOTTOM
+    # bind_tiered with no candidate under the anchor
+    anchor = mul(prim(POT), prim(FST))
+    other = mul(prim(ACT), prim(FST))
+    lower = add(mul(other, other))  # sits under `other`, not `anchor`
+    assert bind_tiered(anchor, add(anchor, other), lower) is BOTTOM
+
+
+def test_distance_to_bottom_is_undefined_both_orders():
+    t = mul(prim(POT), prim(FST))
+    with pytest.raises(LayerError):
+        distance(t, BOTTOM)
+    with pytest.raises(LayerError):
+        distance(BOTTOM, t)
+
+
+def test_meet_is_absorbing_on_bottom():
+    # the ordinary lattice min still holds...
+    assert meet("sealed", "weak") == "weak"
+    # ...but any undecidable arm makes the reconciliation undecidable
+    assert meet("sealed", BOTTOM) is BOTTOM
+    assert meet(BOTTOM, "refuse") is BOTTOM
+    assert meet(BOTTOM) is BOTTOM
+
+
+def test_abstaining_address_is_wellformed_but_never_grounded():
+    addr = SemanticAddress(term=BOTTOM, iri="kko:Something", inference="abduced")
+    assert addr.abstains is True
+    # grounded is False EVEN WITH an iri — you cannot ground what you declined to decide
+    assert addr.is_grounded is False
+    with pytest.raises(LayerError):
+        _ = addr.layer
+    payload = addr.to_json()
+    assert payload["abstains"] is True
+    assert payload["code"] == "BOTTOM"
+    assert payload["layer"] is None
+    assert addr.skeleton()["abstains"] is True
+
+
+def test_ordinary_address_does_not_abstain():
+    addr = SemanticAddress(term=mul(prim(POT), prim(FST)), iri="kko:Thing")
+    assert addr.abstains is False
+    assert addr.is_grounded is True
+    assert addr.layer == 1
+
+
+# --------------------------------------------------------------------------- #
+# Delta 3 — the verdict lattice is derived, not authored
+# --------------------------------------------------------------------------- #
+
+
+def test_derived_order_matches_the_capability_nesting():
+    assert VERDICT_ORDER == ("refuse", "quarantine", "weak", "probable", "sealed")
+
+
+def test_clears_sets_are_strictly_nested():
+    for weaker, stronger in zip(VERDICT_ORDER, VERDICT_ORDER[1:]):
+        assert VERDICT_CLEARS[weaker] < VERDICT_CLEARS[stronger]  # proper subset
+
+
+def test_incomparable_verdicts_are_rejected():
+    """An un-derivable order is a defect to surface, not to paper over."""
+    bad = {
+        "a": frozenset(),
+        "b": frozenset({"x"}),
+        "c": frozenset({"y"}),  # same size as b, incomparable to it
+    }
+    with pytest.raises(ValueError):
+        derive_verdict_order(bad)
+
+
+def test_a_nested_verdict_extends_the_order_with_no_second_edit():
+    extended = dict(VERDICT_CLEARS)
+    extended["notarized"] = VERDICT_CLEARS["sealed"] | {"broadcast"}
+    order = derive_verdict_order(extended)
+    assert order[-1] == "notarized"
+    assert order[:-1] == VERDICT_ORDER  # the existing chain is preserved, not rewritten

--- a/tools/tests/test_spectral_grounding.py
+++ b/tools/tests/test_spectral_grounding.py
@@ -1,0 +1,99 @@
+"""Tests that ground the algebra in the constrained-spectral field theory — both ways.
+
+The point is falsifiability: the doctrine claims supermodularity IS the meet lattice and the
+per-cell clipping IS a pullback. These tests make those claims fail if they were ever untrue.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from tools.semantic_algebra import VERDICT_ORDER, meet
+from tools.spectral_grounding import (
+    CORNERS,
+    cross_difference,
+    is_submodular,
+    is_supermodular,
+    lattice_supermodular_slack,
+    meet_idx,
+    project_submodular,
+    project_supermodular,
+)
+
+
+def _cell(v00, v10, v01, v11):
+    return {(0, 0): v00, (1, 0): v10, (0, 1): v01, (1, 1): v11}
+
+
+# -- 1. supermodularity IS the lattice condition (the identity) -------------- #
+
+
+@pytest.mark.parametrize(
+    "cell",
+    [
+        _cell(0, 1, 1, 3),     # supermodular: cross-diff = +1
+        _cell(0, 2, 2, 3),     # submodular:   cross-diff = -1
+        _cell(1, 1, 1, 1),     # modular:      cross-diff = 0
+        _cell(-2, 0.5, 4, -7), # arbitrary
+    ],
+)
+def test_cross_difference_equals_lattice_slack(cell):
+    # Edgeworth cross-difference == g(a∨b)+g(a∧b) − g(a) − g(b). This equality is the proof.
+    assert math.isclose(cross_difference(cell), lattice_supermodular_slack(cell))
+
+
+def test_the_meet_used_is_the_min_on_a_chain():
+    # the lattice ∧ on the index chain {0<1} is min...
+    assert meet_idx((1, 0), (0, 1)) == (0, 0)
+    # ...and the verdict `meet` is the same min-on-a-chain: weaker of the two wins.
+    assert meet(VERDICT_ORDER[3], VERDICT_ORDER[1]) == VERDICT_ORDER[1]
+    assert meet(VERDICT_ORDER[0], VERDICT_ORDER[4]) == VERDICT_ORDER[0]
+
+
+def test_supermodular_and_submodular_classification():
+    assert is_supermodular(_cell(0, 1, 1, 3)) and not is_submodular(_cell(0, 1, 1, 3))
+    assert is_submodular(_cell(0, 2, 2, 3)) and not is_supermodular(_cell(0, 2, 2, 3))
+    modular = _cell(1, 1, 1, 1)
+    assert is_supermodular(modular) and is_submodular(modular)  # the shared boundary
+
+
+# -- 2. the per-cell clipping IS a half-space pullback ----------------------- #
+
+
+def test_projection_is_a_noop_on_feasible_cells():
+    cell = _cell(0, 1, 1, 3)  # already supermodular
+    assert project_supermodular(cell) == cell
+
+
+def test_projection_lands_an_infeasible_cell_exactly_on_the_boundary():
+    cell = _cell(0, 2, 2, 3)  # cross-diff = -1, infeasible
+    projected = project_supermodular(cell)
+    # the restrictive operator makes it exactly feasible (boundary), not over-corrected
+    assert math.isclose(cross_difference(projected), 0.0, abs_tol=1e-12)
+
+
+def test_projection_is_the_minimal_l2_move():
+    cell = _cell(0, 2, 2, 3)
+    projected = project_supermodular(cell)
+    slack = cross_difference(cell)  # = -1
+    # closed form: each corner moves by |slack|/4 along the stencil sign
+    moved = sum((projected[c] - cell[c]) ** 2 for c in CORNERS)
+    assert math.isclose(moved, slack * slack / 4.0)  # = ‖max(0,−aᵀθ)·a/‖a‖²‖²
+
+
+def test_projection_idempotent():
+    cell = _cell(0, 3, 3, 1)  # strongly submodular
+    once = project_supermodular(cell)
+    twice = project_supermodular(once)
+    assert once == twice  # a pullback applied to its own output is a no-op
+
+
+def test_submodular_projection_is_the_dual():
+    cell = _cell(0, 1, 1, 5)  # supermodular; project onto the SUBmodular half-space
+    projected = project_submodular(cell)
+    assert math.isclose(cross_difference(projected), 0.0, abs_tol=1e-12)
+    # a modular cell is fixed by both projections (the shared face)
+    modular = _cell(1, 1, 1, 1)
+    assert project_supermodular(modular) == modular == project_submodular(modular)


### PR DESCRIPTION
## What

A graded, non-commutative **semantic-address algebra** so that semantic distance is *computed from structure* rather than learned from a corpus — plus the first contracts and the bridge that put it to work. Every primitive traces to a public-domain source (Aristotle's potentiality/actuality, Peirce's Firstness/Secondness/Thirdness); the provenance register in `docs/SEMANTIC_COORDINATE_ALGEBRA.md` is the warrant.

## Commits

| | |
|---|---|
| kernel (S0–S2) | `Term`/`add`/`mul`/`distance`, `pushout`/`pullback` + one shared `meet`, `bind_tiered`, `SemanticAddress` (intension + extension + warrant), pluralistic `Lexicon`s |
| S0 `AgentCoordinateVector.v0.1` | the eleven axes; **10 or 12 is rejected**, exactly one primary, middle column = pushout/pullback/meet |
| S4 `BoundaryTransition.v0.2` | the nine actantial roles (universal linguistics) + `skeleton()` de-identification lever |
| S5 abstraction-level gate | measures the intro→graduate mismatch rate; fails on a cross-tier match **and** fails vacuous |
| BOTTOM + derived verdict lattice | abstention as a first-class value; `VERDICT_ORDER` derived from `VERDICT_CLEARS`, not authored |
| bridge | the 23×6 intent grid lifted into the algebra — a metric + a layer on the flat grid; the `sense` gap becomes a first-class ⊥ |
| adjunction design note | `lift ⊣ ground` spec (code to follow) |

## Why it's trustworthy

- **98 tests, every guard exercised on its refusal path.** A control only ever seen to pass is not a control.
- The abstraction gate is proven against deliberately broken binders (naive + lazy), from the outside.
- Layer discipline makes a cross-abstraction match *structurally impossible*, not threshold-discouraged — the fix for the measured intro-physics → graduate-QFT failure.
- Stdlib-only, local-first: the addressing kernel sits in the hot path of retrieval and every boundary crossing, so it takes no round-trip.

## Scope / notes

- Pure library + contracts + one bridge module. No service wiring in this PR.
- Encodes the intent roster as data; the 23×6 canon stays in Noetica.
- Unbuilt phases (S1, S3, S6–S8) and the `lift ⊣ ground` implementation are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)