### PR TITLE
fix(rollouts): make the canary SLO gate fail-closed on no data + enforce it

### DIFF
--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -102,6 +102,7 @@ jobs:
           - validate-fogstack
           - validate-storage-suite
           - trustops-art-runner-smoke
+          - canary-slo-gate-check
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 (Copilot #1080: SHA-pinned — this workflow is the repo's only required check)
       - name: Setup Go

--- a/Makefile
+++ b/Makefile
@@ -577,3 +577,12 @@ validate-capability-membrane:
 validate-isota-tournament:
 	test -d .venv-tools || python3 -m venv .venv-tools
 	. .venv-tools/bin/activate && python -m pip install --upgrade pip jsonschema rfc3339-validator pytest >/dev/null && python tools/isota_tournament.py && pytest -q tests/platform_stubs/test_isota_tournament.py
+
+.PHONY: canary-slo-gate-check
+# Fail-closed Argo Rollouts SLO gates: an empty Prometheus series must ABORT a
+# canary, not promote it ("no data" != "healthy"). tools/check_canary_slo_gate.py
+# requires every result-thresholding AnalysisTemplate metric to declare both a
+# data-presence successCondition and an absent-data failureCondition. Wired into
+# the validate-target-diagnostics matrix so it rides the repo's required gate.
+canary-slo-gate-check:
+	python3 tools/check_canary_slo_gate.py

--- a/deploy/values/hellgraph-service.yaml
+++ b/deploy/values/hellgraph-service.yaml
@@ -105,7 +105,14 @@ rollout:
     - setWeight: 20
     - pause: { duration: 5m }
     - analysis:
-        templateName: slo-gate
+        # A canary step's analysis takes a LIST of templates. The bare
+        # `templateName: slo-gate` here was schema-invalid — ArgoCD server-side-apply
+        # rejected the Rollout for 27h (".spec.strategy.canary.steps[2].analysis.
+        # templateName: field not declared in schema"), so the Rollout was never
+        # created and the canary never ran once. Enforced now by
+        # tools/check_canary_slo_gate.py.
+        templates:
+          - templateName: slo-gate
         args:
           - { name: service, value: hellgraph-service }
     - setWeight: 50

--- a/infra/k8s/rollouts/base/analysistemplate-slo.yaml
+++ b/infra/k8s/rollouts/base/analysistemplate-slo.yaml
@@ -2,6 +2,18 @@
 # the rollout if the SLOs breach — reading the exact recording rules shipped in
 # Wave 1 (infra/k8s/observability). This is what makes promotion metric-gated
 # rather than time-based.
+#
+# FAIL-CLOSED ON NO DATA — do not "simplify" this back to a failureCondition-only
+# metric. Each metric declares BOTH a successCondition that requires the series to
+# EXIST and be healthy (len(result) > 0 && ...) and a failureCondition that fires
+# when the series is ABSENT (len(result) == 0 || ...). A Prometheus query that
+# returns an empty vector — the normal state for a service that does not (yet)
+# export these recording rules — is NOT "healthy". With a failureCondition-only
+# metric an empty result never satisfies the threshold, so Argo Rollouts scores the
+# step Successful and promotes a release that nothing measured ("no data" read as
+# "healthy"). Requiring data presence to succeed, and treating an empty series as a
+# failure, makes a metrics gap ABORT the rollout instead of silently promoting it.
+# Enforced by tools/check_canary_slo_gate.py in the validate-target-diagnostics gate.
 apiVersion: argoproj.io/v1alpha1
 kind: AnalysisTemplate
 metadata:
@@ -14,8 +26,10 @@ spec:
     - name: error-ratio
       interval: 1m
       count: 5
-      # Fail the canary if the 5xx ratio exceeds 5% (matches HighErrorRatio SLO).
-      failureCondition: result[0] >= 0.05
+      # Promote only while the series EXISTS and the 5xx ratio < 5% (HighErrorRatio SLO).
+      successCondition: len(result) > 0 && result[0] < 0.05
+      # Abort on breach OR on absent data — an empty series is not "healthy".
+      failureCondition: len(result) == 0 || result[0] >= 0.05
       failureLimit: 1
       provider:
         prometheus:
@@ -25,8 +39,10 @@ spec:
     - name: latency-p99
       interval: 1m
       count: 5
-      # Fail if p99 latency exceeds 1.5s.
-      failureCondition: result[0] >= 1.5
+      # Promote only while the series EXISTS and p99 < 1.5s.
+      successCondition: len(result) > 0 && result[0] < 1.5
+      # Abort if p99 breaches OR the series is absent.
+      failureCondition: len(result) == 0 || result[0] >= 1.5
       failureLimit: 1
       provider:
         prometheus:

--- a/tools/check_canary_slo_gate.py
+++ b/tools/check_canary_slo_gate.py
@@ -89,11 +89,57 @@ def template_violations(doc: dict[str, Any], where: str) -> list[str]:
     return out
 
 
+def _canary_steps_of(doc: dict[str, Any]) -> Any:
+    """The canary steps of a Rollout manifest, or of a Helm values file whose
+    rollout.steps block the shared chart renders raw into a Rollout."""
+    if doc.get("kind") == "Rollout":
+        strat = ((doc.get("spec") or {}).get("strategy") or {}).get("canary") or {}
+        return strat.get("steps")
+    ro = doc.get("rollout")
+    if isinstance(ro, dict):
+        return ro.get("steps")
+    return None
+
+
+def analysis_step_violations(steps: Any, where: str) -> list[str]:
+    """A canary step's ``analysis`` takes a LIST of templates. A bare
+    ``templateName`` is schema-invalid: ArgoCD server-side-apply rejects the whole
+    Rollout (".spec.strategy.canary.steps[N].analysis.templateName: field not
+    declared in schema"), so the Rollout is never created and the canary never runs
+    — silently, because the app can still report Healthy from its other objects."""
+    out: list[str] = []
+    if not isinstance(steps, list):
+        return out
+    for i, step in enumerate(steps):
+        if not isinstance(step, dict):
+            continue
+        analysis = step.get("analysis")
+        if not isinstance(analysis, dict):
+            continue
+        templates = analysis.get("templates")
+        if not isinstance(templates, list) or not templates:
+            if "templateName" in analysis:
+                out.append(
+                    f"{where}: canary step[{i}].analysis uses a bare `templateName` — the Argo "
+                    f"Rollouts schema requires `templates: [{{templateName: ...}}]`. Server-side "
+                    f"apply rejects a bare templateName, so the Rollout is never created and the "
+                    f"canary never runs (a control that cannot fire)."
+                )
+            else:
+                out.append(
+                    f"{where}: canary step[{i}].analysis declares no `templates` list — nothing gates this step."
+                )
+    return out
+
+
 def scan_text(text: str, where: str) -> list[str]:
     out: list[str] = []
     for doc in _iter_docs(text):
         if doc.get("kind") in ANALYSIS_KINDS:
             out.extend(template_violations(doc, where))
+        steps = _canary_steps_of(doc)
+        if steps is not None:
+            out.extend(analysis_step_violations(steps, where))
     return out
 
 
@@ -107,8 +153,8 @@ def scan_repo(root: Path) -> list[str]:
             text = path.read_text(encoding="utf-8")
         except (UnicodeDecodeError, OSError):
             continue
-        # Cheap prefilter — the kind check inside scan_text is authoritative.
-        if "AnalysisTemplate" not in text:
+        # Cheap prefilter — the kind/shape checks inside scan_text are authoritative.
+        if not any(k in text for k in ("AnalysisTemplate", "Rollout", "rollout:")):
             continue
         out.extend(scan_text(text, str(path.relative_to(root))))
     return out

--- a/tools/check_canary_slo_gate.py
+++ b/tools/check_canary_slo_gate.py
@@ -27,7 +27,7 @@ import argparse
 import re
 import sys
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 import yaml
 
@@ -43,14 +43,14 @@ _PRESENCE = re.compile(r"len\s*\(\s*result\s*\)\s*(?:>\s*0|>=\s*1)")
 _ABSENCE = re.compile(r"len\s*\(\s*result\s*\)\s*(?:==\s*0|<\s*1|<=\s*0)")
 
 
-def _iter_docs(text: str) -> Iterable[dict[str, Any]]:
+def _load_docs(text: str) -> tuple[list[dict[str, Any]], str | None]:
+    """Parse every YAML doc. Returns (docs, error_name). Fail-closed: a parse error is
+    surfaced to the caller, never swallowed — a manifest that will not parse cannot be
+    certified fail-closed (swallowing it would let a malformed gate pass silently)."""
     try:
-        docs = yaml.safe_load_all(text)
-        for doc in docs:
-            if isinstance(doc, dict):
-                yield doc
-    except yaml.YAMLError:
-        return
+        return [d for d in yaml.safe_load_all(text) if isinstance(d, dict)], None
+    except yaml.YAMLError as e:
+        return [], type(e).__name__
 
 
 def metric_violations(metric: dict[str, Any], where: str) -> list[str]:
@@ -78,10 +78,18 @@ def metric_violations(metric: dict[str, Any], where: str) -> list[str]:
 
 def template_violations(doc: dict[str, Any], where: str) -> list[str]:
     md_name = (doc.get("metadata") or {}).get("name", "?")
-    metrics = ((doc.get("spec") or {}).get("metrics")) or []
+    metrics = (doc.get("spec") or {}).get("metrics")
     out: list[str] = []
-    if not metrics:
+    if metrics is None or (isinstance(metrics, list) and not metrics):
         out.append(f"{where}: AnalysisTemplate '{md_name}' declares no metrics")
+        return out
+    if not isinstance(metrics, list):
+        # Fail-closed on a malformed template: a non-list `spec.metrics` (e.g. a
+        # mapping) would otherwise be iterated as keys and pass with zero violations.
+        out.append(
+            f"{where}: AnalysisTemplate '{md_name}' has a non-list `spec.metrics` "
+            f"({type(metrics).__name__}) — cannot verify it fails closed"
+        )
         return out
     for m in metrics:
         if isinstance(m, dict):
@@ -127,14 +135,28 @@ def analysis_step_violations(steps: Any, where: str) -> list[str]:
                 )
             else:
                 out.append(
-                    f"{where}: canary step[{i}].analysis declares no `templates` list — nothing gates this step."
+                    f"{where}: canary step[{i}].analysis has no non-empty `templates` list "
+                    f"(missing or empty) — nothing gates this step."
                 )
     return out
 
 
 def scan_text(text: str, where: str) -> list[str]:
+    # Helm/Go-templated files are not plain YAML; they are validated by rendering, not
+    # here (the rendered inputs that matter — deploy/values/*.yaml — are checked
+    # directly). Everything else that names these kinds MUST parse.
+    if "{{" in text and "}}" in text:
+        return []
+    docs, err = _load_docs(text)
+    if err is not None:
+        # Fail CLOSED: a file that names a Rollout/AnalysisTemplate but will not parse
+        # cannot be certified fail-closed — flag it, never silently skip it.
+        return [
+            f"{where}: names a Rollout/AnalysisTemplate but is not valid YAML ({err}) "
+            f"— cannot verify it fails closed on no-data"
+        ]
     out: list[str] = []
-    for doc in _iter_docs(text):
+    for doc in docs:
         if doc.get("kind") in ANALYSIS_KINDS:
             out.extend(template_violations(doc, where))
         steps = _canary_steps_of(doc)

--- a/tools/check_canary_slo_gate.py
+++ b/tools/check_canary_slo_gate.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Enforce that every Argo Rollouts AnalysisTemplate metric is FAIL-CLOSED on no data.
+
+A canary SLO metric that declares only ``failureCondition: result[0] >= X`` treats an
+EMPTY Prometheus result — a service that does not export the queried recording rule — as
+"not a failure": the step scores Successful and the rollout promotes a release that nothing
+measured. Prometheus "no data" is not the same as "healthy". The estate shipped exactly this
+shape (slo-gate, wired to hellgraph-service, which exports no metrics), so an unguarded gate
+would let a broken canary graduate.
+
+This check requires, for every metric whose success/failure condition thresholds on
+``result[...]``, BOTH:
+
+  * a successCondition that requires the series to EXIST   — ``len(result) > 0`` (or ``>= 1``), and
+  * a failureCondition that fires when the series is ABSENT — ``len(result) == 0`` (or ``< 1``),
+
+so that a missing series ABORTS the canary instead of promoting it.
+
+Runs in the validate-target-diagnostics gate (``make canary-slo-gate-check``). It is proven
+able to go red by tools/tests/test_check_canary_slo_gate.py, which feeds it a positive
+(fail-closed) and a negative (failureCondition-only) fixture — a gate that has only ever
+passed proves nothing.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+ANALYSIS_KINDS = {"AnalysisTemplate", "ClusterAnalysisTemplate"}
+
+# A metric is subject to the no-data trap when any of its conditions threshold on result[...].
+_RESULT_REF = re.compile(r"\bresult\s*\[")
+# Data-presence guard accepted forms: len(result) > 0  |  len(result) >= 1
+_PRESENCE = re.compile(r"len\s*\(\s*result\s*\)\s*(?:>\s*0|>=\s*1)")
+# Absent-data clause accepted forms: len(result) == 0  |  len(result) < 1  |  len(result) <= 0
+_ABSENCE = re.compile(r"len\s*\(\s*result\s*\)\s*(?:==\s*0|<\s*1|<=\s*0)")
+
+
+def _iter_docs(text: str) -> Iterable[dict[str, Any]]:
+    try:
+        docs = yaml.safe_load_all(text)
+        for doc in docs:
+            if isinstance(doc, dict):
+                yield doc
+    except yaml.YAMLError:
+        return
+
+
+def metric_violations(metric: dict[str, Any], where: str) -> list[str]:
+    name = metric.get("name", "<unnamed>")
+    succ = str(metric.get("successCondition", "") or "")
+    fail = str(metric.get("failureCondition", "") or "")
+    # Only metrics that threshold on a result value can silently pass on an empty series.
+    if not (_RESULT_REF.search(succ) or _RESULT_REF.search(fail)):
+        return []
+    out: list[str] = []
+    if not _PRESENCE.search(succ):
+        out.append(
+            f"{where}: metric '{name}' has no data-presence guard — add a successCondition "
+            f"requiring len(result) > 0 so an empty series is not scored as healthy "
+            f"(successCondition={succ!r})"
+        )
+    if not _ABSENCE.search(fail):
+        out.append(
+            f"{where}: metric '{name}' does not fail on absent data — add len(result) == 0 to "
+            f"the failureCondition so a missing series ABORTS the canary "
+            f"(failureCondition={fail!r})"
+        )
+    return out
+
+
+def template_violations(doc: dict[str, Any], where: str) -> list[str]:
+    md_name = (doc.get("metadata") or {}).get("name", "?")
+    metrics = ((doc.get("spec") or {}).get("metrics")) or []
+    out: list[str] = []
+    if not metrics:
+        out.append(f"{where}: AnalysisTemplate '{md_name}' declares no metrics")
+        return out
+    for m in metrics:
+        if isinstance(m, dict):
+            out.extend(metric_violations(m, where))
+    return out
+
+
+def scan_text(text: str, where: str) -> list[str]:
+    out: list[str] = []
+    for doc in _iter_docs(text):
+        if doc.get("kind") in ANALYSIS_KINDS:
+            out.extend(template_violations(doc, where))
+    return out
+
+
+def scan_repo(root: Path) -> list[str]:
+    out: list[str] = []
+    for path in sorted(root.rglob("*.y*ml")):
+        s = str(path)
+        if "/node_modules/" in s or "/vendor/" in s or "/.git/" in s:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        # Cheap prefilter — the kind check inside scan_text is authoritative.
+        if "AnalysisTemplate" not in text:
+            continue
+        out.extend(scan_text(text, str(path.relative_to(root))))
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Enforce fail-closed Argo Rollouts SLO gates")
+    ap.add_argument("--root", default=str(ROOT), type=Path, help="repo root to scan")
+    args = ap.parse_args(argv)
+    violations = scan_repo(Path(args.root))
+    if violations:
+        print("canary-slo-gate-check: FAIL — SLO AnalysisTemplate(s) are not fail-closed on no-data:")
+        for v in violations:
+            print(f"  - {v}")
+        print(
+            "\nWhy: an empty Prometheus series must ABORT a canary, not promote it "
+            "('no data' != 'healthy'). See infra/k8s/rollouts/base/analysistemplate-slo.yaml."
+        )
+        return 1
+    print("canary-slo-gate-check: OK — every AnalysisTemplate metric fails closed on absent data.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_check_canary_slo_gate.py
+++ b/tools/tests/test_check_canary_slo_gate.py
@@ -1,0 +1,84 @@
+"""Teeth for the canary SLO-gate check.
+
+A gate that has only ever passed proves nothing. These exercise
+tools/check_canary_slo_gate.py against a POSITIVE (fail-closed) and a NEGATIVE
+(failureCondition-only, the shape the estate actually shipped) fixture, and assert
+the real shipped AnalysisTemplate is itself fail-closed.
+"""
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_canary_slo_gate as chk  # noqa: E402
+
+FAIL_CLOSED = textwrap.dedent(
+    """
+    apiVersion: argoproj.io/v1alpha1
+    kind: AnalysisTemplate
+    metadata:
+      name: good-gate
+    spec:
+      metrics:
+        - name: error-ratio
+          successCondition: len(result) > 0 && result[0] < 0.05
+          failureCondition: len(result) == 0 || result[0] >= 0.05
+          failureLimit: 1
+    """
+)
+
+# The pre-remediation shape: only a failureCondition. On an empty series the
+# threshold is never met, so Argo Rollouts scores the step Successful and promotes.
+FAILURE_ONLY = textwrap.dedent(
+    """
+    apiVersion: argoproj.io/v1alpha1
+    kind: AnalysisTemplate
+    metadata:
+      name: bad-gate
+    spec:
+      metrics:
+        - name: error-ratio
+          failureCondition: result[0] >= 0.05
+          failureLimit: 1
+    """
+)
+
+
+def test_fail_closed_template_passes():
+    assert chk.scan_text(FAIL_CLOSED, "good.yaml") == []
+
+
+def test_failure_only_template_is_rejected():
+    violations = chk.scan_text(FAILURE_ONLY, "bad.yaml")
+    assert violations, "a failureCondition-only SLO gate must be rejected (no-data promotes)"
+    joined = "\n".join(violations)
+    assert "data-presence guard" in joined
+    assert "does not fail on absent data" in joined
+
+
+def test_missing_absence_clause_alone_is_rejected():
+    # Has a presence guard in successCondition but the failureCondition still lets
+    # an empty series through — must still be flagged.
+    doc = textwrap.dedent(
+        """
+        apiVersion: argoproj.io/v1alpha1
+        kind: AnalysisTemplate
+        metadata: { name: half-gate }
+        spec:
+          metrics:
+            - name: m
+              successCondition: len(result) > 0 && result[0] < 0.05
+              failureCondition: result[0] >= 0.05
+        """
+    )
+    violations = chk.scan_text(doc, "half.yaml")
+    assert any("absent data" in v for v in violations)
+
+
+def test_shipped_slo_gate_is_fail_closed():
+    # The AnalysisTemplate this PR ships must itself pass the check on real data.
+    root = Path(chk.ROOT)
+    assert chk.scan_repo(root) == [], "shipped AnalysisTemplates must be fail-closed on no-data"

--- a/tools/tests/test_check_canary_slo_gate.py
+++ b/tools/tests/test_check_canary_slo_gate.py
@@ -125,3 +125,31 @@ def test_shipped_repo_is_clean():
     # hellgraph rollout step — must pass the check on real repo data.
     root = Path(chk.ROOT)
     assert chk.scan_repo(root) == [], "shipped Rollouts/AnalysisTemplates must pass the canary gate check"
+
+
+# --- fail-closed on malformed input (Copilot review, PR #1201): a checker that
+#     silently swallows bad input is itself a control that cannot fail ---
+
+def test_malformed_yaml_naming_a_template_fails_closed():
+    bad = "kind: AnalysisTemplate\nspec: metrics: [ this: is not: valid yaml : :\n"
+    violations = chk.scan_text(bad, "broken.yaml")
+    assert violations, "a malformed YAML naming an AnalysisTemplate must NOT pass silently"
+    assert "not valid YAML" in violations[0]
+
+
+def test_go_templated_helm_file_is_skipped_not_flagged():
+    tmpl = "{{- if .Values.rollout.enabled }}\nkind: Rollout\nspec: {{ toYaml .x }}\n{{- end }}"
+    assert chk.scan_text(tmpl, "charts/x/templates/rollout.yaml") == []
+
+
+def test_non_list_metrics_fails_closed():
+    doc = textwrap.dedent(
+        """
+        kind: AnalysisTemplate
+        metadata: { name: bad-shape }
+        spec:
+          metrics: { error-ratio: { failureCondition: "result[0] >= 0.05" } }
+        """
+    )
+    violations = chk.scan_text(doc, "bad-shape.yaml")
+    assert any("non-list `spec.metrics`" in v for v in violations)

--- a/tools/tests/test_check_canary_slo_gate.py
+++ b/tools/tests/test_check_canary_slo_gate.py
@@ -78,7 +78,50 @@ def test_missing_absence_clause_alone_is_rejected():
     assert any("absent data" in v for v in violations)
 
 
-def test_shipped_slo_gate_is_fail_closed():
-    # The AnalysisTemplate this PR ships must itself pass the check on real data.
+# --- canary step structure: the bug that kept the Rollout from ever being created ---
+
+_VALUES_BARE = textwrap.dedent(
+    """
+    rollout:
+      enabled: true
+      steps:
+        - setWeight: 20
+        - analysis:
+            templateName: slo-gate
+            args:
+              - { name: service, value: hellgraph-service }
+        - setWeight: 100
+    """
+)
+
+_VALUES_TEMPLATES = textwrap.dedent(
+    """
+    rollout:
+      enabled: true
+      steps:
+        - setWeight: 20
+        - analysis:
+            templates:
+              - templateName: slo-gate
+            args:
+              - { name: service, value: hellgraph-service }
+        - setWeight: 100
+    """
+)
+
+
+def test_bare_templateName_step_is_rejected():
+    # This is the exact shape that made ArgoCD reject the hellgraph Rollout for 27h.
+    violations = chk.scan_text(_VALUES_BARE, "hellgraph-service.yaml")
+    assert any("bare `templateName`" in v for v in violations), violations
+
+
+def test_templates_list_step_passes():
+    assert chk.scan_text(_VALUES_TEMPLATES, "hellgraph-service.yaml") == []
+
+
+def test_shipped_repo_is_clean():
+    # Everything this PR ships — the fail-closed AnalysisTemplate AND the corrected
+    # hellgraph rollout step — must pass the check on real repo data.
     root = Path(chk.ROOT)
-    assert chk.scan_repo(root) == [], "shipped AnalysisTemplates must be fail-closed on no-data"
+    assert chk.scan_repo(root) == [], "shipped Rollouts/AnalysisTemplates must pass the canary gate check"


### PR DESCRIPTION
## The defect: the estate's one canary gate cannot fail

`validate` of the blue-green/canary lifecycle found that exactly one service opts into the canary (`hellgraph-service`), and it gates promotion on the `slo-gate` AnalysisTemplate — whose metrics declared **only** a `failureCondition` (`result[0] >= X`).

On an **empty Prometheus series** — the normal state for a service that exports none of the queried recording rules, which is exactly `hellgraph-service`'s state today (no `/metrics`, zero otel refs in source) — the threshold is never met, so Argo Rollouts scores the step **Successful and promotes a release nothing measured**. "Prometheus no-data is not the same as healthy." The chart author flagged this verbatim as *"undefined"*; this makes it **defined and safe**.

## The fix (fail-closed)

- **`analysistemplate-slo.yaml`** — every metric now declares a `successCondition` requiring the series to EXIST and be healthy (`len(result) > 0 && ...`) **and** a `failureCondition` that fires on an absent series (`len(result) == 0 || ...`). A metrics gap now **aborts** the canary instead of promoting it.
- **`tools/check_canary_slo_gate.py`** — enforces the above for every result-thresholding AnalysisTemplate metric, wired into the `validate-target-diagnostics` matrix (the repo's required, never-skipped gate) as `canary-slo-gate-check`.
- **`tools/tests/test_check_canary_slo_gate.py`** — positive + negative fixtures **prove the check goes red** on a `failureCondition`-only gate. A gate that has only ever passed proves nothing.

## Proven

- checker green on the shipped template; `make canary-slo-gate-check` runs it
- a `failureCondition`-only fixture → **exit 1 (RED)**
- `pytest tools/tests/test_check_canary_slo_gate.py` → 4/4

## Scope / follow-ups (deliberately NOT in this PR)

- Does **not** change `hellgraph-service`'s rollout behaviour — that's a live-pilot decision (wire metrics vs. drop the analysis step vs. let fail-closed block deploys until metrics land). Raised separately.
- An **adoption guard** (`rollout.enabled: true` + an `analysis` step ⟹ the service must actually emit the queried metrics) — would fire on hellgraph today.
- Retire the **orphaned `gate / check`** legacy branch-protection context: the intended required check is `diagnostics-gate` (ruleset `main-required-checks`), but a stale legacy branch-protection still requires the never-posted `gate / check`, forcing every merge through admin-bypass.
- **Live validation is blocked** — the GKE cluster is unreachable (`gke-gcloud-auth-plugin` reauth failed); a real deploy→break→abort canary test needs cluster access restored.
