### PR TITLE
ci(gate): revive the orphaned `gate / check` required context

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -1,0 +1,63 @@
+# Revives the orphaned `gate / check` status context.
+#
+# The classic branch-protection on `main` requires a status context literally named
+# `gate / check` (app_id 15368 = GitHub Actions) — i.e. a workflow named `gate` with
+# a job named `check`. That workflow has NEVER existed in this repo's history, so the
+# context is permanently "Expected — waiting for status to be reported": every PR
+# reads BLOCKED and merges only via admin bypass. Meanwhile the REAL required check
+# (the `main-required-checks` ruleset) is `diagnostics-gate`, produced by
+# validate-target-diagnostics.yml.
+#
+# Rather than delete the legacy context, this un-orphans it: `gate / check` now
+# reports the SAME verdict as the real gate. It is fail-closed — anything other than
+# a `success` conclusion from validate-target-diagnostics (failure, cancelled,
+# timed_out, or a missing run) fails `gate / check`. It cannot pass on its own; it
+# only mirrors a gate that actually ran and passed. So it is a real check with teeth,
+# not a green rubber stamp.
+#
+# VERIFY LIVE AFTER MERGE (workflow_run check-runs attaching to a PR head as a
+# required context is the one behaviour that cannot be tested off-GitHub): open a
+# throwaway PR, confirm `gate / check` posts and that a passing gate clears BLOCKED
+# without --admin. If it does not surface as the required context, the fallback is to
+# retire the legacy `gate / check` from branch protection (the ruleset's
+# `diagnostics-gate` already enforces the same thing) — but that is a branch-
+# protection change held for explicit sign-off.
+name: gate
+
+on:
+  workflow_run:
+    workflows: ["validate-target-diagnostics"]
+    types: [completed]
+
+# One verdict per head SHA; a newer run supersedes an in-flight mirror.
+concurrency:
+  group: gate-check-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    # Only mirror runs that actually gate a change (PRs and pushes to main).
+    if: >-
+      github.event.workflow_run.event == 'pull_request' ||
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mirror the diagnostics gate verdict onto 'gate / check'
+        env:
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          set -euo pipefail
+          echo "validate-target-diagnostics for ${HEAD_SHA} concluded: ${CONCLUSION}"
+          echo "run: ${RUN_URL}"
+          # Fail-closed: only an explicit success passes. A skipped/cancelled/failed
+          # gate, or a null conclusion, must block — never treat absence as success.
+          if [ "${CONCLUSION}" != "success" ]; then
+            echo "::error::the real diagnostics gate did not pass (${CONCLUSION}); gate/check fails closed"
+            exit 1
+          fi
+          echo "diagnostics gate passed — gate/check is green for ${HEAD_SHA}"


### PR DESCRIPTION
## Why every PR reads `BLOCKED`

`main` carries **two** required-check layers:
- **Ruleset `main-required-checks`** → requires **`diagnostics-gate`** (real — produced by `validate-target-diagnostics.yml`, fail-closed, never-skipped). ✅
- **Legacy classic branch-protection** → requires **`gate / check`** (app_id 15368 = GitHub Actions) — a workflow named `gate`, job `check`, that **has never existed in this repo's history**. So the context is permanently *"Expected — waiting for status to be reported"* → every PR is `BLOCKED` → merges happen only via `gh pr merge --admin`. A required check that trains everyone to bypass it is a control that cannot fail.

## The fix — reuse, don't retire (per request: "deliver it from orphanage")

A new `gate` workflow whose `check` job **mirrors the real gate's verdict**, fail-closed:
- passes **only** when `validate-target-diagnostics` concluded `success` on that head SHA;
- **fails** on `failure` / `cancelled` / `timed_out` / a missing run — absence is never treated as success.

It has teeth (it can and will go red when the real gate is red) and it cannot self-certify — it only reflects a gate that actually ran. Once this is on `main`, `gate / check` posts on every PR and the chronic admin-bypass ends.

## Honest caveat — verify live after merge

`workflow_run` check-runs surfacing as a **required** status context on a PR head is the one behaviour that cannot be tested off-GitHub. **After merge**, open a throwaway PR and confirm `gate / check` posts and that a green gate clears `BLOCKED` **without** `--admin`.

If it does **not** surface as the required context, the documented fallback is to retire the legacy `gate / check` from branch protection (the ruleset's `diagnostics-gate` already enforces the same guarantee) — but that's a branch-protection change held for your explicit sign-off, since you asked me to leave protection alone.

## Bootstrap note

This PR must be admin-merged **once** (the context it creates doesn't exist yet); every PR after it merges through the front door.
