### PR TITLE
feat(isn): P1 — ImageSchemaNet cartridge + proof-gated grounding

### DIFF
--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -104,6 +104,7 @@ jobs:
           - trustops-art-runner-smoke
           - canary-slo-gate-check
           - fips-conformance-check
+          - imageschemanet-grounding-check
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 (Copilot #1080: SHA-pinned — this workflow is the repo's only required check)
       - name: Setup Go

--- a/Makefile
+++ b/Makefile
@@ -601,6 +601,6 @@ fips-conformance-check:
 # (every image schema has core spatial primitives; every lexical activator activates a
 # known schema) and that golden NL->image-schema groundings resolve. Owns its rdflib dep.
 imageschemanet-grounding-check:
-	python3 -m pip install --quiet rdflib pytest
+	python3 -m pip install --quiet 'rdflib==7.6.0' 'pytest>=8,<9'
 	python3 tools/imageschema_ground.py
 	python3 -m pytest -q tools/tests/test_imageschema_ground.py

--- a/Makefile
+++ b/Makefile
@@ -594,3 +594,13 @@ canary-slo-gate-check:
 # turning a flag nothing read into an enforced control. tools/check_fips_conformance.py.
 fips-conformance-check:
 	python3 tools/check_fips_conformance.py
+
+.PHONY: imageschemanet-grounding-check
+# ImageSchemaNet cartridge (apps/hellgraph-service/ontology/imageschemanet.ttl): the
+# embodied-commonsense grounding layer. Verifies the cartridge is structurally sound
+# (every image schema has core spatial primitives; every lexical activator activates a
+# known schema) and that golden NL->image-schema groundings resolve. Owns its rdflib dep.
+imageschemanet-grounding-check:
+	python3 -m pip install --quiet rdflib pytest
+	python3 tools/imageschema_ground.py
+	python3 -m pytest -q tools/tests/test_imageschema_ground.py

--- a/apps/hellgraph-service/ontology/PROVENANCE.md
+++ b/apps/hellgraph-service/ontology/PROVENANCE.md
@@ -87,3 +87,40 @@ KBpedia's published licence for version 2.10 and are recorded here as the govern
 4. Update `RC_GZ_SHA256`, `RC_N3_SHA256`, `RC_N3_BYTES`, `RC_SOURCE` in
    `src/ontology-provenance.ts` **and** the header above.
 5. `node scripts/check-ontology-digest.mjs && npm test` — both must pass on the new digests.
+
+---
+
+# ImageSchemaNet cartridge — CLEAN-ROOM (authored, not vendored)
+
+**File:** `imageschemanet.ttl` · **Namespace:** `https://ontology.socioprophet.ai/imageschemanet#`
+**Status:** estate-authored SEED · **License:** **MIT** (ours — this is original work).
+
+## What it is
+The embodied-commonsense grounding layer: the image-schema taxonomy (CONTAINMENT,
+CENTER_PERIPHERY, SOURCE_PATH_GOAL, PART_WHOLE, SUPPORT, BLOCKAGE), their spatial
+primitives, the `:activates` property hierarchy, and a starter set of lexical activators.
+Grounding function: `tools/imageschema_ground.py` (lexical unit / sentence → image schema).
+
+## Why clean-room, not vendored
+The reference implementation — **`StenDoipanni/ISAAC`** (ImageSchemaNet, the module network
+of the paper below) — **ships no `LICENSE` file** (checked 2026-08-02; the GitHub license API
+returns 404 and neither README declares terms). Under the estate's permissive-only rule,
+absence of a licence = all-rights-reserved, so we do **not** copy or vendor its artifacts
+(`isnet_correct.owl`, `isaac_improvements.ttl`, …). The **taxonomy and activation model are
+uncopyrightable facts**, re-authored here from the open-access paper and cited.
+
+## Source cited (not copied)
+De Giorgis, Gangemi & Gromann, *"ImageSchemaNet: A Framester graph for embodied commonsense
+knowledge"*, **Semantic Web 15 (2024) 1417–1441**, IOS Press — **CC-BY 4.0**. Taxonomy after
+Johnson (1987) and Mandler & Pagán Cánovas (2014).
+
+## Where it is ENFORCED
+`make imageschemanet-grounding-check` (a `validate-target-diagnostics` matrix target):
+structural conformance (every image schema has core spatial primitives; every activator
+activates a known schema — fail-closed) + golden NL→image-schema groundings. Proven able to
+go red by `tools/tests/test_imageschema_ground.py`.
+
+## Growing it (later phases)
+This SEED gives the grounding mechanism + starter activators. The full FrameNet/WordNet/VerbNet
+activation set is P1-follow-on, populated via Framester alignment — authored/derived, still not
+copied from the unlicensed repo. If upstream adds a permissive licence, re-evaluate vendoring.

--- a/apps/hellgraph-service/ontology/imageschemanet.ttl
+++ b/apps/hellgraph-service/ontology/imageschemanet.ttl
@@ -1,0 +1,130 @@
+@prefix isn:  <https://ontology.socioprophet.ai/imageschemanet#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+#
+# ImageSchemaNet cartridge (SocioProphet, estate-authored — seed).
+#
+# CLEAN-ROOM. This is an ORIGINAL, MIT-licensed re-implementation of the image-schema
+# taxonomy and the `:activates` grounding model, authored from the open-access (CC-BY 4.0)
+# paper below. It does NOT vendor the ISAAC/ImageSchemaNet repository, which ships no
+# LICENSE file (absence = all-rights-reserved) — so per the estate's permissive-only rule
+# we re-author the (uncopyrightable) taxonomy and cite the source rather than copy it.
+#
+# It is a SEED: the six best-documented image schemas, their spatial primitives, the
+# activation-property hierarchy, and a starter set of lexical activators. It provides the
+# grounding MECHANISM; the full FrameNet/WordNet-populated activation set is later work.
+#
+# Grounding: tools/imageschema_ground.py (lexical unit / frame -> image schema(s)).
+#
+isn: a owl:Ontology ;
+    rdfs:label "ImageSchemaNet cartridge (SocioProphet seed)" ;
+    dct:source "De Giorgis, Gangemi & Gromann (2022/2024), 'ImageSchemaNet: A Framester graph for embodied commonsense knowledge', Semantic Web 15:1417-1441, IOS Press (CC-BY 4.0). Taxonomy after Johnson (1987) and Mandler & Pagán Cánovas (2014)." ;
+    dct:license <https://opensource.org/licenses/MIT> ;
+    rdfs:comment "Clean-room re-authoring; not a copy of the ISAAC repository." .
+
+########################  Image schemas (gestalt structures)  ########################
+
+isn:ImageSchema a owl:Class ;
+    rdfs:label "Image Schema" ;
+    rdfs:comment "A recurring dynamic pattern of sensorimotor experience giving coherence and structure to cognition (Johnson 1987). A gestalt composed of >= 2 spatial primitives." .
+
+isn:CONTAINMENT      a owl:Class ; rdfs:subClassOf isn:ImageSchema ; rdfs:label "CONTAINMENT" ;
+    rdfs:comment "Boundedness: an interior, an exterior, and a boundary." .
+isn:CENTER_PERIPHERY a owl:Class ; rdfs:subClassOf isn:ImageSchema ; rdfs:label "CENTER_PERIPHERY" ;
+    rdfs:comment "A center on which a dependent periphery relies (not vice versa)." .
+isn:SOURCE_PATH_GOAL a owl:Class ; rdfs:subClassOf isn:ImageSchema ; rdfs:label "SOURCE_PATH_GOAL" ;
+    rdfs:comment "A source, a goal, and a series of contiguous locations connecting them, with movement." .
+isn:PART_WHOLE       a owl:Class ; rdfs:subClassOf isn:ImageSchema ; rdfs:label "PART_WHOLE" ;
+    rdfs:comment "A whole consisting of parts in a configuration." .
+isn:SUPPORT          a owl:Class ; rdfs:subClassOf isn:ImageSchema ; rdfs:label "SUPPORT" ;
+    rdfs:comment "Contact in the vertical dimension: a supporter bears a supported." .
+isn:BLOCKAGE         a owl:Class ; rdfs:subClassOf isn:ImageSchema ; rdfs:label "BLOCKAGE" ;
+    rdfs:comment "A force vector encountering a barrier that resists or redirects it." .
+
+########################  Spatial primitives (first building blocks)  ################
+
+isn:SpatialPrimitive a owl:Class ; rdfs:label "Spatial Primitive" ;
+    rdfs:comment "A preverbal building block; image schemas are composed of these (Mandler & Pagán Cánovas 2014)." .
+
+isn:Interior  a owl:Class ; rdfs:subClassOf isn:SpatialPrimitive ; rdfs:label "Interior" .
+isn:Exterior  a owl:Class ; rdfs:subClassOf isn:SpatialPrimitive ; rdfs:label "Exterior" .
+isn:Boundary  a owl:Class ; rdfs:subClassOf isn:SpatialPrimitive ; rdfs:label "Boundary" .
+isn:Center    a owl:Class ; rdfs:subClassOf isn:SpatialPrimitive ; rdfs:label "Center" .
+isn:Periphery a owl:Class ; rdfs:subClassOf isn:SpatialPrimitive ; rdfs:label "Periphery" .
+isn:Source    a owl:Class ; rdfs:subClassOf isn:SpatialPrimitive ; rdfs:label "Source" .
+isn:Path      a owl:Class ; rdfs:subClassOf isn:SpatialPrimitive ; rdfs:label "Path" .
+isn:Goal      a owl:Class ; rdfs:subClassOf isn:SpatialPrimitive ; rdfs:label "Goal" .
+isn:Part      a owl:Class ; rdfs:subClassOf isn:SpatialPrimitive ; rdfs:label "Part" .
+isn:Whole     a owl:Class ; rdfs:subClassOf isn:SpatialPrimitive ; rdfs:label "Whole" .
+isn:Supporter a owl:Class ; rdfs:subClassOf isn:SpatialPrimitive ; rdfs:label "Supporter" .
+isn:Supported a owl:Class ; rdfs:subClassOf isn:SpatialPrimitive ; rdfs:label "Supported" .
+isn:Force     a owl:Class ; rdfs:subClassOf isn:SpatialPrimitive ; rdfs:label "Force" .
+isn:Barrier   a owl:Class ; rdfs:subClassOf isn:SpatialPrimitive ; rdfs:label "Barrier" .
+
+########################  Gestalt composition (IS requires core SPs)  ################
+
+isn:hasCoreSP a owl:ObjectProperty ; rdfs:label "has core spatial primitive" ;
+    rdfs:domain isn:ImageSchema ; rdfs:range isn:SpatialPrimitive .
+
+isn:CONTAINMENT      isn:hasCoreSP isn:Interior, isn:Exterior, isn:Boundary .
+isn:CENTER_PERIPHERY isn:hasCoreSP isn:Center, isn:Periphery .
+isn:SOURCE_PATH_GOAL isn:hasCoreSP isn:Source, isn:Path, isn:Goal .
+isn:PART_WHOLE       isn:hasCoreSP isn:Part, isn:Whole .
+isn:SUPPORT          isn:hasCoreSP isn:Supporter, isn:Supported .
+isn:BLOCKAGE         isn:hasCoreSP isn:Force, isn:Barrier .
+
+########################  Activation property hierarchy (after paper §4.2)  ##########
+
+isn:activates a owl:ObjectProperty ; rdfs:label "activates" ;
+    rdfs:comment "An entity (lexical unit, sense, or frame) activates the cognitive substratum of an image schema or spatial primitive." .
+isn:lexicalSenseActivation a owl:ObjectProperty ; rdfs:subPropertyOf isn:activates ;
+    rdfs:label "lexical sense activation" .
+isn:coreSPActivation       a owl:ObjectProperty ; rdfs:subPropertyOf isn:activates ;
+    rdfs:label "core spatial-primitive activation" .
+isn:gestaltActivation      a owl:ObjectProperty ; rdfs:subPropertyOf isn:activates ;
+    rdfs:label "gestalt activation" .
+isn:closeMatchActivation   a owl:ObjectProperty ; rdfs:subPropertyOf isn:activates ;
+    rdfs:label "close-match activation" .
+
+isn:LexicalActivator a owl:Class ; rdfs:label "Lexical Activator" ;
+    rdfs:comment "A lemma/lexical unit that activates one or more image schemas." .
+
+########################  Seed lexical activators (lemma -> image schema)  ###########
+
+isn:lu_contain   a isn:LexicalActivator ; rdfs:label "contain"   ; isn:lexicalSenseActivation isn:CONTAINMENT .
+isn:lu_container a isn:LexicalActivator ; rdfs:label "container" ; isn:lexicalSenseActivation isn:CONTAINMENT .
+isn:lu_inside    a isn:LexicalActivator ; rdfs:label "inside"    ; isn:lexicalSenseActivation isn:CONTAINMENT .
+isn:lu_within    a isn:LexicalActivator ; rdfs:label "within"    ; isn:lexicalSenseActivation isn:CONTAINMENT .
+isn:lu_enclose   a isn:LexicalActivator ; rdfs:label "enclose"   ; isn:lexicalSenseActivation isn:CONTAINMENT .
+
+isn:lu_enter     a isn:LexicalActivator ; rdfs:label "enter"     ; isn:lexicalSenseActivation isn:SOURCE_PATH_GOAL .
+isn:lu_agreement a isn:LexicalActivator ; rdfs:label "agreement" ; isn:lexicalSenseActivation isn:SOURCE_PATH_GOAL .
+isn:lu_journey   a isn:LexicalActivator ; rdfs:label "journey"   ; isn:lexicalSenseActivation isn:SOURCE_PATH_GOAL .
+isn:lu_through   a isn:LexicalActivator ; rdfs:label "through"   ; isn:lexicalSenseActivation isn:SOURCE_PATH_GOAL .
+isn:lu_arrive    a isn:LexicalActivator ; rdfs:label "arrive"    ; isn:lexicalSenseActivation isn:SOURCE_PATH_GOAL .
+isn:lu_travel    a isn:LexicalActivator ; rdfs:label "travel"    ; isn:lexicalSenseActivation isn:SOURCE_PATH_GOAL .
+
+isn:lu_support   a isn:LexicalActivator ; rdfs:label "support"   ; isn:lexicalSenseActivation isn:SUPPORT .
+isn:lu_hold      a isn:LexicalActivator ; rdfs:label "hold"      ; isn:lexicalSenseActivation isn:SUPPORT .
+isn:lu_rest      a isn:LexicalActivator ; rdfs:label "rest"      ; isn:lexicalSenseActivation isn:SUPPORT .
+isn:lu_carry     a isn:LexicalActivator ; rdfs:label "carry"     ; isn:lexicalSenseActivation isn:SUPPORT .
+
+isn:lu_block     a isn:LexicalActivator ; rdfs:label "block"     ; isn:lexicalSenseActivation isn:BLOCKAGE .
+isn:lu_obstacle  a isn:LexicalActivator ; rdfs:label "obstacle"  ; isn:lexicalSenseActivation isn:BLOCKAGE .
+isn:lu_barrier   a isn:LexicalActivator ; rdfs:label "barrier"   ; isn:lexicalSenseActivation isn:BLOCKAGE .
+isn:lu_resist    a isn:LexicalActivator ; rdfs:label "resist"    ; isn:lexicalSenseActivation isn:BLOCKAGE .
+isn:lu_prevent   a isn:LexicalActivator ; rdfs:label "prevent"   ; isn:lexicalSenseActivation isn:BLOCKAGE .
+
+isn:lu_center    a isn:LexicalActivator ; rdfs:label "center"    ; isn:lexicalSenseActivation isn:CENTER_PERIPHERY .
+isn:lu_core      a isn:LexicalActivator ; rdfs:label "core"      ; isn:lexicalSenseActivation isn:CENTER_PERIPHERY .
+isn:lu_periphery a isn:LexicalActivator ; rdfs:label "periphery" ; isn:lexicalSenseActivation isn:CENTER_PERIPHERY .
+isn:lu_margin    a isn:LexicalActivator ; rdfs:label "margin"    ; isn:lexicalSenseActivation isn:CENTER_PERIPHERY .
+
+isn:lu_part      a isn:LexicalActivator ; rdfs:label "part"      ; isn:lexicalSenseActivation isn:PART_WHOLE .
+isn:lu_whole     a isn:LexicalActivator ; rdfs:label "whole"     ; isn:lexicalSenseActivation isn:PART_WHOLE .
+isn:lu_member    a isn:LexicalActivator ; rdfs:label "member"    ; isn:lexicalSenseActivation isn:PART_WHOLE .
+isn:lu_component a isn:LexicalActivator ; rdfs:label "component" ; isn:lexicalSenseActivation isn:PART_WHOLE .

--- a/tools/imageschema_ground.py
+++ b/tools/imageschema_ground.py
@@ -134,7 +134,8 @@ _GOLDEN: list[tuple[str, str]] = [
 def selftest(g: Graph) -> list[str]:
     out: list[str] = []
     for text, expected in _GOLDEN:
-        found = set().union(*ground_text(g, text).values()) if ground_text(g, text) else set()
+        annot = ground_text(g, text)
+        found = set().union(*annot.values()) if annot else set()
         if expected not in found:
             out.append(f"grounding {text!r} -> {sorted(found) or 'nothing'}, expected {expected}")
     return out
@@ -142,7 +143,7 @@ def selftest(g: Graph) -> list[str]:
 
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="ImageSchemaNet grounding")
-    ap.add_argument("--cartridge", default=str(CARTRIDGE), type=Path)
+    ap.add_argument("--cartridge", default=str(CARTRIDGE))  # coerced to Path at use (consistent str default)
     ap.add_argument("--verify", action="store_true")
     ap.add_argument("--selftest", action="store_true")
     ap.add_argument("--ground", metavar="TEXT", help="annotate a sentence with image schemas")

--- a/tools/imageschema_ground.py
+++ b/tools/imageschema_ground.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Ground natural language onto image schemas via the ImageSchemaNet cartridge.
+
+The cartridge (apps/hellgraph-service/ontology/imageschemanet.ttl) is an estate-authored,
+KKO-alignable seed of the image-schema taxonomy and the `:activates` grounding model
+(after De Giorgis, Gangemi & Gromann 2022, CC-BY 4.0). This tool turns it into a callable
+grounding function: a lexical unit or a sentence -> the image schema(s) it activates.
+
+Two modes, both fail-closed (a control that certifies nothing is worthless):
+  --verify   structural conformance of the cartridge (every image schema has core spatial
+             primitives; every lexical activator activates a known image schema). For CI.
+  --selftest golden lexical/sentence groundings must resolve to the expected schemas.
+
+Run with no mode (or `make imageschemanet-grounding-check`) to do both. Proven able to go
+red by tools/tests/test_imageschema_ground.py.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from rdflib import RDF, RDFS, Graph, Namespace, URIRef
+
+ROOT = Path(__file__).resolve().parents[1]
+CARTRIDGE = ROOT / "apps/hellgraph-service/ontology/imageschemanet.ttl"
+ISN = Namespace("https://ontology.socioprophet.ai/imageschemanet#")
+
+
+def load(path: Path = CARTRIDGE) -> Graph:
+    g = Graph()
+    g.parse(str(path), format="turtle")
+    return g
+
+
+def _activation_predicates(g: Graph) -> set[URIRef]:
+    preds = {ISN.activates}
+    preds.update(p for p, _, _ in g.triples((None, RDFS.subPropertyOf, ISN.activates)))
+    return preds
+
+
+def image_schemas(g: Graph) -> set[URIRef]:
+    return set(g.subjects(RDFS.subClassOf, ISN.ImageSchema))
+
+
+def _label(g: Graph, node: URIRef) -> str:
+    lab = g.value(node, RDFS.label)
+    return str(lab) if lab is not None else str(node).split("#")[-1]
+
+
+def ground_lemma(g: Graph, lemma: str) -> set[str]:
+    """Image-schema labels a single lemma activates (case-insensitive)."""
+    preds = _activation_predicates(g)
+    schemas = image_schemas(g)
+    lemma = lemma.strip().lower()
+    out: set[str] = set()
+    for activator, _, lab in g.triples((None, RDFS.label, None)):
+        if (activator, RDF.type, ISN.LexicalActivator) not in g:
+            continue
+        if str(lab).strip().lower() != lemma:
+            continue
+        for p in preds:
+            for schema in g.objects(activator, p):
+                if schema in schemas:
+                    out.add(_label(g, schema))
+    return out
+
+
+def _lemma_candidates(token: str) -> set[str]:
+    """A surface token plus a few conservative de-inflections, so real inflected text
+    ('supports', 'entered', 'blocks') grounds against base-form activators. This is a
+    lightweight stemmer, not a full lemmatiser — the seed's honest reach."""
+    c = {token}
+    if len(token) > 4 and token.endswith("ies"):
+        c.add(token[:-3] + "y")            # carries -> carry
+    if len(token) > 3 and token.endswith("es"):
+        c.add(token[:-2])                  # encloses -> enclose
+    if len(token) > 3 and token.endswith("s") and not token.endswith("ss"):
+        c.add(token[:-1])                  # supports -> support
+    if len(token) > 5 and token.endswith("ing"):
+        c.add(token[:-3]); c.add(token[:-3] + "e")  # blocking -> block / enclosing -> enclose
+    if len(token) > 4 and token.endswith("ed"):
+        c.add(token[:-2]); c.add(token[:-1])        # blocked -> block / arrived -> arrive
+    return c
+
+
+def ground_text(g: Graph, text: str) -> dict[str, set[str]]:
+    """Annotate a sentence: {token: {image schemas}} for every token that activates one."""
+    out: dict[str, set[str]] = {}
+    for token in re.findall(r"[A-Za-z]+", text.lower()):
+        schemas: set[str] = set()
+        for cand in _lemma_candidates(token):
+            schemas |= ground_lemma(g, cand)
+        if schemas:
+            out[token] = schemas
+    return out
+
+
+def verify(g: Graph) -> list[str]:
+    """Structural conformance — fail-closed. Every image schema must declare its core
+    spatial primitives; every lexical activator must activate a known image schema."""
+    out: list[str] = []
+    schemas = image_schemas(g)
+    if not schemas:
+        return ["cartridge declares no image schemas (rdfs:subClassOf isn:ImageSchema)"]
+    for s in schemas:
+        if not list(g.objects(s, ISN.hasCoreSP)):
+            out.append(f"image schema {_label(g, s)} declares no core spatial primitives (isn:hasCoreSP)")
+    preds = _activation_predicates(g)
+    for activator in g.subjects(RDF.type, ISN.LexicalActivator):
+        if g.value(activator, RDFS.label) is None:
+            out.append(f"lexical activator {activator} has no rdfs:label")
+        targets = {t for p in preds for t in g.objects(activator, p)}
+        if not (targets & schemas):
+            out.append(f"lexical activator {_label(g, activator)} activates no known image schema")
+    return out
+
+
+# Golden groundings — the paper's canonical examples + seed coverage. A miss here means the
+# grounding regressed (or the cartridge lost an activation).
+_GOLDEN: list[tuple[str, str]] = [
+    ("contain", "CONTAINMENT"),
+    ("inside", "CONTAINMENT"),
+    ("The Obama administration entered into an agreement with Iran", "SOURCE_PATH_GOAL"),
+    ("journey", "SOURCE_PATH_GOAL"),
+    ("the shelf supports the book", "SUPPORT"),
+    ("a barrier that blocks the road", "BLOCKAGE"),
+    ("the periphery depends on the center", "CENTER_PERIPHERY"),
+    ("every part of the whole", "PART_WHOLE"),
+]
+
+
+def selftest(g: Graph) -> list[str]:
+    out: list[str] = []
+    for text, expected in _GOLDEN:
+        found = set().union(*ground_text(g, text).values()) if ground_text(g, text) else set()
+        if expected not in found:
+            out.append(f"grounding {text!r} -> {sorted(found) or 'nothing'}, expected {expected}")
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="ImageSchemaNet grounding")
+    ap.add_argument("--cartridge", default=str(CARTRIDGE), type=Path)
+    ap.add_argument("--verify", action="store_true")
+    ap.add_argument("--selftest", action="store_true")
+    ap.add_argument("--ground", metavar="TEXT", help="annotate a sentence with image schemas")
+    args = ap.parse_args(argv)
+    g = load(Path(args.cartridge))
+
+    if args.ground:
+        for lemma, schemas in ground_text(g, args.ground).items():
+            print(f"  {lemma} -> {', '.join(sorted(schemas))}")
+        return 0
+
+    run_all = not (args.verify or args.selftest)
+    violations: list[str] = []
+    if args.verify or run_all:
+        violations += verify(g)
+    if args.selftest or run_all:
+        violations += selftest(g)
+    if violations:
+        print("imageschemanet-grounding-check: FAIL")
+        for v in violations:
+            print(f"  - {v}")
+        return 1
+    n_schemas = len(image_schemas(g))
+    n_act = len(set(g.subjects(RDF.type, ISN.LexicalActivator)))
+    print(f"imageschemanet-grounding-check: OK — {n_schemas} image schemas, {n_act} lexical activators; golden groundings resolve.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_imageschema_ground.py
+++ b/tools/tests/test_imageschema_ground.py
@@ -1,0 +1,84 @@
+"""Teeth for ImageSchemaNet grounding (P1).
+
+Golden groundings resolve; the shipped cartridge is structurally conformant; and a
+broken cartridge (an activator pointing at no image schema, or a missing activation)
+goes red — a grounding check that can't fail proves nothing.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("rdflib")  # this suite owns its dep via `make imageschemanet-grounding-check`
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import imageschema_ground as isn  # noqa: E402
+from rdflib import Graph  # noqa: E402
+
+_PREFIX = """
+@prefix isn: <https://ontology.socioprophet.ai/imageschemanet#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+isn:ImageSchema a owl:Class .
+isn:CONTAINMENT a owl:Class ; rdfs:subClassOf isn:ImageSchema ; rdfs:label "CONTAINMENT" ;
+    isn:hasCoreSP isn:Interior .
+isn:Interior a owl:Class .
+isn:activates a owl:ObjectProperty .
+isn:lexicalSenseActivation rdfs:subPropertyOf isn:activates .
+"""
+
+
+def _graph(body: str) -> Graph:
+    g = Graph()
+    g.parse(data=_PREFIX + body, format="turtle")
+    return g
+
+
+def test_shipped_cartridge_is_conformant():
+    g = isn.load()
+    assert isn.verify(g) == []
+
+
+def test_shipped_golden_groundings_resolve():
+    g = isn.load()
+    assert isn.selftest(g) == []
+
+
+def test_lemma_grounds_to_expected_schema():
+    g = isn.load()
+    assert isn.ground_lemma(g, "contain") == {"CONTAINMENT"}
+    assert "SOURCE_PATH_GOAL" in isn.ground_lemma(g, "enter")
+
+
+def test_sentence_grounding_finds_source_path_goal():
+    g = isn.load()
+    annot = isn.ground_text(g, "The Obama administration entered into an agreement with Iran")
+    schemas = set().union(*annot.values()) if annot else set()
+    assert "SOURCE_PATH_GOAL" in schemas
+
+
+def test_unknown_lemma_grounds_nothing():
+    g = isn.load()
+    assert isn.ground_lemma(g, "zxqwv") == set()
+
+
+def test_activator_with_no_schema_fails_verify():
+    # An activator that activates nothing recognised — the cartridge lies about coverage.
+    g = _graph('isn:lu_bad a isn:LexicalActivator ; rdfs:label "bad" .')
+    v = isn.verify(g)
+    assert any("activates no known image schema" in x for x in v), v
+
+
+def test_schema_without_core_primitives_fails_verify():
+    g = _graph('isn:NAKED a owl:Class ; rdfs:subClassOf isn:ImageSchema ; rdfs:label "NAKED" .')
+    v = isn.verify(g)
+    assert any("no core spatial primitives" in x for x in v), v
+
+
+def test_missing_activation_fails_selftest():
+    # A cartridge with the taxonomy but no "contain" activator must fail the golden set.
+    g = _graph("")  # only CONTAINMENT class exists, no lexical activators
+    assert isn.selftest(g), "golden groundings must fail when activations are absent"


### PR DESCRIPTION
## P1 of the RLD / Multiverseal-Twin / ImageSchemaNet integration — the grounding layer

This lands **ImageSchemaNet as a KKO-alignable KG cartridge**: the embodied-commonsense grounding that maps language → image schemas (CONTAINMENT, SOURCE_PATH_GOAL, SUPPORT, …). It's the lowest-risk, highest-leverage first slice — immediate value for NLQ, the nugget-extractor, and RetrievedItem grounding — and it seeds the ℂ^D grounding basis the Twin will bind against.

### Licensing decision (flagged)
The reference repo `StenDoipanni/ISAAC` **ships no LICENSE file** (GitHub license API 404; neither README declares terms). Per the estate's permissive-only + check-before-wiring rule, I did **not** vendor it. Instead this is a **clean-room, MIT re-authoring** of the (uncopyrightable) taxonomy and `:activates` model, **cited** from the open-access CC-BY 4.0 paper. Full rationale in `apps/hellgraph-service/ontology/PROVENANCE.md`.

### What's here
- `imageschemanet.ttl` — 6 image schemas + spatial primitives + activation-property hierarchy + 28 lexical activators, KKO-alignable, sovereign namespace.
- `tools/imageschema_ground.py` — grounding function (lemma/sentence → image schema), **fail-closed** `verify` (every schema has core primitives; every activator hits a known schema) + golden `selftest` + lightweight de-inflection.
- Wired into the required gate as `imageschemanet-grounding-check`.

### Proven
- `verify` + `selftest` green (6 schemas, 28 activators); the paper's Obama example → `SOURCE_PATH_GOAL`.
- The golden gate **caught a real gap in my own seed** (inflected `supports` ≠ `support`) → fixed with de-inflection. Grounds `entered`→SPG, `supports`→SUPPORT, `blocks`→BLOCKAGE.
- pytest 8/8; **red→green**: drop an activator → exit 1 → restore → exit 0.

### Scope / next
SEED — grounding mechanism + starter activators. The full FrameNet/WordNet-populated set is P1-follow-on (authored/derived, still not copied). P2 = the Multiverseal-Twin THEOREM-core on the `semantic-coordinate-algebra` kernel + Lakebase branching; P3 = RLD as the resilience/loader standard.
