### PR TITLE
fix(retrieval): durable storage for sherlock-engine + memoryd, deploy mesh-qdrant

### DIFF
--- a/apps/sherlock-engine/src/main.rs
+++ b/apps/sherlock-engine/src/main.rs
@@ -4,16 +4,26 @@
 //   fusion:  Reciprocal Rank Fusion (RRF) of the two ranked lists
 // Dense tier is OPTIONAL: if EMBEDDINGS_URL / QDRANT_URL are unset or unreachable, it degrades to
 // BM25-only (never fails the query). Riding the shared mesh-qdrant — not a new vector store.
-use serde::Deserialize;
+//
+// Corpus durability (KMASS baseline 2026-08-01 found TAB.TEXT.SCALE=12 docs, a static
+// in-image fixture with no way to grow it): the tantivy index itself stays in-RAM and is
+// rebuilt on every boot -- fast at these scales, and it sidesteps a second store that could
+// drift from the doc list. What persists is the DOC LIST: if SHERLOCK_DATA_DIR is set (wired
+// to a PVC in deploy/values/sherlock-engine.yaml), documents live in an append-only JSONL file
+// there, seeded once from the static corpus on first boot, and grown via POST /ingest. Without
+// SHERLOCK_DATA_DIR set, behavior is unchanged from before this fix: static in-image corpus only.
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::{BTreeMap, HashMap};
+use std::io::Write as _;
+use std::path::PathBuf;
 use std::time::Duration;
 use tantivy::collector::TopDocs;
 use tantivy::query::QueryParser;
 use tantivy::schema::{OwnedValue, Schema, FAST, STORED, STRING, TEXT};
 use tantivy::{doc, Index, TantivyDocument};
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Serialize, Clone)]
 struct Doc {
     id: String,
     title: String,
@@ -22,6 +32,61 @@ struct Doc {
     region: String,
     score: f64,
     body: String,
+}
+
+fn docs_store_path() -> Option<PathBuf> {
+    std::env::var("SHERLOCK_DATA_DIR")
+        .ok()
+        .filter(|d| !d.is_empty())
+        .map(|d| PathBuf::from(d).join("docs.jsonl"))
+}
+
+/// Loads the working doc set and, when SHERLOCK_DATA_DIR is configured, the path an
+/// ingested document must be appended to for it to survive a restart. On first boot
+/// against an empty/absent store, seeds it from the static corpus so the persistent
+/// copy becomes the source of truth going forward -- the image's corpus file is only
+/// ever read once per volume's lifetime.
+fn load_docs(corpus_path: &str) -> (Vec<Doc>, Option<PathBuf>) {
+    let seed = || -> Vec<Doc> {
+        let data = std::fs::read_to_string(corpus_path).expect("read corpus");
+        serde_json::from_str(&data).expect("parse corpus")
+    };
+
+    let Some(store_path) = docs_store_path() else {
+        return (seed(), None);
+    };
+
+    if let Ok(data) = std::fs::read_to_string(&store_path) {
+        let docs: Vec<Doc> = data
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .filter_map(|l| serde_json::from_str(l).ok())
+            .collect();
+        if !docs.is_empty() {
+            eprintln!("loaded {} doc(s) from persistent store {store_path:?}", docs.len());
+            return (docs, Some(store_path));
+        }
+    }
+
+    let docs = seed();
+    if let Some(parent) = store_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match std::fs::File::create(&store_path) {
+        Ok(mut f) => {
+            for d in &docs {
+                let _ = writeln!(f, "{}", serde_json::to_string(d).unwrap());
+            }
+            eprintln!("bootstrapped {} seed doc(s) into persistent store {store_path:?}", docs.len());
+        }
+        Err(e) => eprintln!("WARN: could not create persistent store {store_path:?}: {e} -- corpus will not survive a restart"),
+    }
+    (docs, Some(store_path))
+}
+
+fn append_doc(store_path: &PathBuf, d: &Doc) -> std::io::Result<()> {
+    let mut f = std::fs::OpenOptions::new().create(true).append(true).open(store_path)?;
+    writeln!(f, "{}", serde_json::to_string(d).unwrap())
 }
 
 fn qparam(url: &str, key: &str) -> Option<String> {
@@ -126,8 +191,7 @@ fn main() {
 
     let corpus_path =
         std::env::var("SHERLOCK_CORPUS").unwrap_or_else(|_| "corpus/frontier-labs.json".into());
-    let data = std::fs::read_to_string(&corpus_path).expect("read corpus");
-    let docs: Vec<Doc> = serde_json::from_str(&data).expect("parse corpus");
+    let (mut docs, store_path) = load_docs(&corpus_path);
     for (i, d) in docs.iter().enumerate() {
         writer
             .add_document(doc!(
@@ -186,9 +250,11 @@ fn main() {
         }
     }
 
-    let facet = |key: &dyn Fn(&Doc) -> String| -> BTreeMap<String, usize> {
+    // Takes docs explicitly rather than capturing it, so ingest (below) can mutably
+    // borrow docs to push a new document without fighting a live capture of it here.
+    let facet = |docs: &[Doc], key: &dyn Fn(&Doc) -> String| -> BTreeMap<String, usize> {
         let mut m: BTreeMap<String, usize> = BTreeMap::new();
-        for d in &docs {
+        for d in docs {
             *m.entry(key(d)).or_insert(0) += 1;
         }
         m
@@ -201,18 +267,56 @@ fn main() {
     let server = tiny_http::Server::http(format!("0.0.0.0:{}", port)).unwrap();
     eprintln!("sherlock-engine on :{} — {} docs, mode={}", port, docs.len(), if dense { "hybrid (tantivy+qdrant/RRF)" } else { "tantivy BM25" });
 
-    for request in server.incoming_requests() {
+    for mut request in server.incoming_requests() {
         let url = request.url().to_string();
-        let path = url.split('?').next().unwrap_or("/");
+        let path = url.split('?').next().unwrap_or("/").to_string();
+        let method = request.method().clone();
         let body_str: String = if path == "/healthz" {
-            json!({"ok": true, "service": "sherlock-engine", "engine": "tantivy", "dense": dense, "docs": docs.len()}).to_string()
+            json!({"ok": true, "service": "sherlock-engine", "engine": "tantivy", "dense": dense, "docs": docs.len(), "persistent": store_path.is_some()}).to_string()
         } else if path == "/facets" {
             json!({
-                "doctype": serde_json::to_value(facet(&|d| d.doctype.clone())).unwrap(),
-                "category": serde_json::to_value(facet(&|d| d.category.clone())).unwrap(),
-                "region": serde_json::to_value(facet(&|d| d.region.clone())).unwrap()
+                "doctype": serde_json::to_value(facet(&docs, &|d| d.doctype.clone())).unwrap(),
+                "category": serde_json::to_value(facet(&docs, &|d| d.category.clone())).unwrap(),
+                "region": serde_json::to_value(facet(&docs, &|d| d.region.clone())).unwrap()
             })
             .to_string()
+        } else if path == "/ingest" && method == tiny_http::Method::Post {
+            let mut raw_body = String::new();
+            let read_ok = request.as_reader().read_to_string(&mut raw_body).is_ok();
+            if !read_ok {
+                json!({"ok": false, "error": "could not read request body"}).to_string()
+            } else {
+                match serde_json::from_str::<Doc>(&raw_body) {
+                    Err(e) => json!({"ok": false, "error": format!("invalid document: {e}")}).to_string(),
+                    Ok(d) => {
+                        let idx = docs.len();
+                        // Persist first: if this fails, the doc must not become searchable
+                        // and silently vanish on the next restart (fail closed, not quiet).
+                        let persisted = match &store_path {
+                            Some(p) => match append_doc(p, &d) {
+                                Ok(()) => true,
+                                Err(e) => {
+                                    eprintln!("WARN: ingest not persisted: {e}");
+                                    false
+                                }
+                            },
+                            None => false, // no SHERLOCK_DATA_DIR configured -- in-memory only, by design
+                        };
+                        writer
+                            .add_document(doc!(
+                                f_id => d.id.clone(),
+                                f_idx => idx as u64,
+                                f_title => d.title.clone(),
+                                f_body => d.body.clone()
+                            ))
+                            .unwrap();
+                        writer.commit().unwrap();
+                        let _ = reader.reload();
+                        docs.push(d);
+                        json!({"ok": true, "idx": idx, "docs": docs.len(), "persisted": persisted}).to_string()
+                    }
+                }
+            }
         } else if path == "/search" {
             let raw = qparam(&url, "q").unwrap_or_default();
             let q = sanitize(&raw);

--- a/apps/sherlock-engine/src/main.rs
+++ b/apps/sherlock-engine/src/main.rs
@@ -72,16 +72,29 @@ fn load_docs(corpus_path: &str) -> (Vec<Doc>, Option<PathBuf>) {
     if let Some(parent) = store_path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    match std::fs::File::create(&store_path) {
-        Ok(mut f) => {
-            for d in &docs {
-                let _ = writeln!(f, "{}", serde_json::to_string(d).unwrap());
-            }
-            eprintln!("bootstrapped {} seed doc(s) into persistent store {store_path:?}", docs.len());
+    // Copilot review on #1207: the previous version returned Some(store_path)
+    // regardless of whether this write actually succeeded, so /healthz could
+    // report persistent:true for a corpus that would NOT survive a restart --
+    // exactly the claimed-durability-that-isn't-real bug this fix exists to
+    // stop. Track every fallible step (create, and each line write) and only
+    // report a persistent store if the whole bootstrap actually landed on disk.
+    let bootstrap_ok = (|| -> std::io::Result<()> {
+        let mut f = std::fs::File::create(&store_path)?;
+        for d in &docs {
+            writeln!(f, "{}", serde_json::to_string(d).unwrap())?;
         }
-        Err(e) => eprintln!("WARN: could not create persistent store {store_path:?}: {e} -- corpus will not survive a restart"),
+        Ok(())
+    })();
+    match bootstrap_ok {
+        Ok(()) => {
+            eprintln!("bootstrapped {} seed doc(s) into persistent store {store_path:?}", docs.len());
+            (docs, Some(store_path))
+        }
+        Err(e) => {
+            eprintln!("WARN: could not bootstrap persistent store {store_path:?}: {e} -- corpus will not survive a restart");
+            (docs, None)
+        }
     }
-    (docs, Some(store_path))
 }
 
 fn append_doc(store_path: &PathBuf, d: &Doc) -> std::io::Result<()> {
@@ -292,7 +305,11 @@ fn main() {
                         let idx = docs.len();
                         // Persist first: if this fails, the doc must not become searchable
                         // and silently vanish on the next restart (fail closed, not quiet).
-                        let persisted = match &store_path {
+                        // Named doc_persisted, not persisted/persistent, to stay unambiguous
+                        // next to /healthz's "persistent" (Copilot review on #1207): that one
+                        // reports whether the persistence subsystem is configured and working
+                        // at all; this one reports whether THIS document survived the write.
+                        let doc_persisted = match &store_path {
                             Some(p) => match append_doc(p, &d) {
                                 Ok(()) => true,
                                 Err(e) => {
@@ -313,7 +330,7 @@ fn main() {
                         writer.commit().unwrap();
                         let _ = reader.reload();
                         docs.push(d);
-                        json!({"ok": true, "idx": idx, "docs": docs.len(), "persisted": persisted}).to_string()
+                        json!({"ok": true, "idx": idx, "docs": docs.len(), "doc_persisted": doc_persisted}).to_string()
                     }
                 }
             }

--- a/deploy/argocd/vector-store-services.yaml
+++ b/deploy/argocd/vector-store-services.yaml
@@ -1,0 +1,47 @@
+# Argo CD ApplicationSet — shared platform vector store (Qdrant).
+#
+# infra/k8s/mesh-qdrant (StatefulSet + 20Gi PVC + NetworkPolicy + daily snapshot CronJob) has
+# existed, complete, since before the KMASS baseline (2026-08-01) -- but was never registered
+# with any ArgoCD Application, so it was never deployed. sherlock-engine's values file has
+# declared QDRANT_URL pointing at mesh-qdrant's in-cluster DNS name since before this PR ("the
+# binding is explicit"); memoryd's own dense-recall path is documented to ride it too. Neither
+# could ever actually connect to it.
+#
+# Same house convention as zot (deploy/argocd/registry-services.yaml): stateful, single
+# multi-manifest component -> KUSTOMIZE, not the stateless-service Helm chart.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: vector-store-services
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - list:
+        elements:
+          # foundation: memoryd (dense recall) and sherlock-engine (hybrid search) both
+          # already declare this endpoint; the search plane silently degrades to lexical-only
+          # without it, rather than failing loudly -- see the KMASS baseline readout.
+          - { name: qdrant, path: infra/k8s/mesh-qdrant/overlays/p0-lab, tier: foundation }
+  template:
+    metadata:
+      name: 'vector-store-{{.name}}'
+      labels:
+        app.kubernetes.io/part-of: sovereign-mesh
+      annotations:
+        socioprophet.io/tier: '{{.tier}}'
+    spec:
+      project: default
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: socioprophet
+      source:
+        repoURL: https://github.com/SocioProphet/prophet-platform
+        targetRevision: main
+        path: '{{.path}}'
+      syncPolicy:
+        automated: { prune: true, selfHeal: true }
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true

--- a/deploy/argocd/vector-store-services.yaml
+++ b/deploy/argocd/vector-store-services.yaml
@@ -23,7 +23,12 @@ spec:
           # foundation: memoryd (dense recall) and sherlock-engine (hybrid search) both
           # already declare this endpoint; the search plane silently degrades to lexical-only
           # without it, rather than failing loudly -- see the KMASS baseline readout.
-          - { name: qdrant, path: infra/k8s/mesh-qdrant/overlays/p0-lab, tier: foundation }
+          # name MUST equal the infra/k8s/<name> directory (tools/preflight_deploy_contract.py's
+          # check_kustomize_images resolves ROOT/infra/k8s/<name> literally, matching the zot
+          # precedent's {name: zot, path: infra/k8s/zot/...}) -- name: qdrant here would make
+          # preflight look at a directory that doesn't exist and silently skip image validation
+          # instead of failing, caught by preflight itself before this line existed.
+          - { name: mesh-qdrant, path: infra/k8s/mesh-qdrant/overlays/p0-lab, tier: foundation }
   template:
     metadata:
       name: 'vector-store-{{.name}}'

--- a/deploy/values/memoryd.yaml
+++ b/deploy/values/memoryd.yaml
@@ -14,4 +14,18 @@ config:
   # falls back to the hashing embedder — never mixes vector spaces. See infra/k8s/embeddings/base.
   EMBEDDINGS_URL: "http://embeddings.socioprophet.svc.cluster.local:8080/v1/embeddings"
   EMBEDDINGS_MODEL: "nomic-embed-text"
+  # KMASS baseline (2026-08-01): mesh-qdrant (infra/k8s/mesh-qdrant) existed but was never
+  # registered with ArgoCD, so this was always false against an unreachable URL. The code
+  # already gates cleanly on QDRANT_ENABLED and bool(QDRANT_URL) -- see main.py -- so this
+  # is config only, no app change needed.
+  QDRANT_ENABLED: "true"
+  QDRANT_URL: "http://mesh-qdrant.socioprophet.svc.cluster.local:6333"
+  QDRANT_COLLECTION: "memorymesh-recall"
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }
+# MEMORYMESH_STORE_URI stays memory:// for now -- the primary resource/event store is a
+# SEPARATE gap from the vector-recall layer above. postgres_store.py already supports a
+# postgresql:// DSN, and a shared, already-running Postgres exists at deploy/datastores/postgres
+# (postgres-0, serves socbase auth/rest/workspace/eval-fabric) -- but pointing memoryd at it
+# needs a dedicated schema/database and a CI-minted credential Secret first (see this
+# estate's "secrets minted in CI, never typed by hand" rule), not just an env var flip.
+# Tracked as WO-KMASS-01.01b, deliberately not rushed in the same change as the Qdrant wiring.

--- a/deploy/values/sherlock-engine.yaml
+++ b/deploy/values/sherlock-engine.yaml
@@ -13,4 +13,17 @@ config:
   QDRANT_COLLECTION: "sherlock-corpus"
   EMBEDDINGS_URL: "http://embeddings.socioprophet.svc.cluster.local:8080/v1/embeddings"
   EMBEDDINGS_MODEL: "nomic-embed-text"
+  # KMASS baseline (2026-08-01) found the tantivy index was create_in_ram over a static
+  # in-image fixture with no ingest path -- corpus resets to the same 12 docs on every
+  # restart. This is the persistent doc store: seeded once from the fixture on first boot,
+  # then grown via POST /ingest and reloaded from here on every subsequent boot.
+  SHERLOCK_DATA_DIR: "/data"
 autoscaling: { enabled: false }
+replicaCount: 1
+# JSONL doc store is a single-writer file; same reasoning as compute-gateway's SQLite store
+# (see that values file) — RollingUpdate with maxSurge 0 behaves like Recreate for one
+# replica (old pod releases the RWO PD before the new one claims it) without the
+# apply-time "rollingUpdate may not be specified when type is Recreate" conflict on an
+# existing Deployment.
+strategy: { type: RollingUpdate, rollingUpdate: { maxSurge: 0, maxUnavailable: 1 } }
+persistence: { enabled: true, storageClass: dynamic-rwo, size: 2Gi, mountPath: /data }

--- a/infra/k8s/mesh-qdrant/base/backup-cronjob.yaml
+++ b/infra/k8s/mesh-qdrant/base/backup-cronjob.yaml
@@ -32,13 +32,29 @@ spec:
                   # failed this job silently, forever, on every scheduled run.
                   # grep/sed instead of jq: stays on the same minimal, already-reviewed
                   # image rather than adding a dependency for one field extraction.
-                  COLLECTIONS=$(curl -sf http://mesh-qdrant:6333/collections \
-                    | grep -o '"name":"[^"]*"' | sed 's/"name":"//;s/"$//')
-                  for col in $COLLECTIONS; do
-                    echo "Snapshotting collection: $col"
-                    curl -sf -X POST "http://mesh-qdrant:6333/collections/${col}/snapshots"
-                  done
-                  echo "All snapshots created"
+                  #
+                  # Copilot review on #1207: under plain /bin/sh (dash; no bash pipefail),
+                  # `set -e` only sees a PIPELINE's LAST command's exit status -- so a
+                  # failed curl here piped into grep/sed would still exit 0 (sed always
+                  # succeeds on empty input), COLLECTIONS would end up empty, the for-loop
+                  # would run zero times, and the job would print success having created
+                  # ZERO snapshots. Capture curl's own exit status explicitly, outside the
+                  # pipeline, so an unreachable mesh-qdrant fails this job loudly instead.
+                  RESPONSE=$(curl -sf http://mesh-qdrant:6333/collections) || {
+                    echo "ERROR: could not reach mesh-qdrant to list collections" >&2
+                    exit 1
+                  }
+                  COLLECTIONS=$(echo "$RESPONSE" | grep -o '"name":"[^"]*"' | sed 's/"name":"//;s/"$//')
+                  if [ -z "$COLLECTIONS" ]; then
+                    echo "No collections exist yet -- nothing to snapshot (this is a legitimate empty state, not a fetch failure)"
+                  else
+                    for col in $COLLECTIONS; do
+                      echo "Snapshotting collection: $col"
+                      # Not piped -- set -e already catches a bare failing command like this.
+                      curl -sf -X POST "http://mesh-qdrant:6333/collections/${col}/snapshots"
+                    done
+                  fi
+                  echo "Backup run complete"
               resources:
                 requests:
                   cpu: 10m

--- a/infra/k8s/mesh-qdrant/base/backup-cronjob.yaml
+++ b/infra/k8s/mesh-qdrant/base/backup-cronjob.yaml
@@ -25,10 +25,18 @@ spec:
                 - -c
                 - |
                   set -e
-                  COLLECTIONS=$(curl -sf http://qdrant:6333/collections | jq -r '.result.collections[].name')
+                  # Two real bugs caught before first deploy: this pointed at a service
+                  # named "qdrant" (the actual headless Service is "mesh-qdrant" -- see
+                  # service.yaml) and piped to jq, which curlimages/curl:8.6.0 does not
+                  # ship (verified directly against this exact image). Both would have
+                  # failed this job silently, forever, on every scheduled run.
+                  # grep/sed instead of jq: stays on the same minimal, already-reviewed
+                  # image rather than adding a dependency for one field extraction.
+                  COLLECTIONS=$(curl -sf http://mesh-qdrant:6333/collections \
+                    | grep -o '"name":"[^"]*"' | sed 's/"name":"//;s/"$//')
                   for col in $COLLECTIONS; do
                     echo "Snapshotting collection: $col"
-                    curl -sf -X POST "http://qdrant:6333/collections/${col}/snapshots"
+                    curl -sf -X POST "http://mesh-qdrant:6333/collections/${col}/snapshots"
                   done
                   echo "All snapshots created"
               resources:

--- a/infra/k8s/mesh-qdrant/base/networkpolicy.yaml
+++ b/infra/k8s/mesh-qdrant/base/networkpolicy.yaml
@@ -3,9 +3,13 @@ kind: NetworkPolicy
 metadata:
   name: mesh-qdrant-baseline
 spec:
+  # Must match the StatefulSet's actual pod template label (statefulset.yaml sets
+  # `app: mesh-qdrant`, not `app.kubernetes.io/name`) -- caught before first deploy:
+  # a selector matching zero pods would have left this StatefulSet with no effective
+  # ingress/egress restriction at all while looking, on read, like a locked-down policy.
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: mesh-qdrant
+      app: mesh-qdrant
   policyTypes:
     - Ingress
     - Egress

--- a/infra/k8s/mesh-qdrant/base/statefulset.yaml
+++ b/infra/k8s/mesh-qdrant/base/statefulset.yaml
@@ -17,9 +17,28 @@ spec:
         app: mesh-qdrant
         bundle: mesh.vector-store
     spec:
+      # Had no securityContext at all before this fix -- every other stateful service in
+      # this estate runs hardened (see clickhouse/questdb/arcticdb-gateway values files).
+      # Verified directly (throwaway pod against this exact image) rather than assumed:
+      # runAsUser 1000 + fsGroup 1000 works IF snapshots_path is redirected below --
+      # qdrant's default `./snapshots` is a SIBLING of `./storage`, not nested inside it,
+      # so it was never covered by the one PVC mount and failed permission-denied on
+      # startup under non-root (confirmed with a live repro before this fix landed).
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile: { type: RuntimeDefault }
       containers:
         - name: qdrant
           image: qdrant/qdrant:v1.9.4
+          env:
+            # Moves snapshots inside the already-mounted, already-persistent storage PVC
+            # instead of needing a second volume. Without this, /qdrant/snapshots has no
+            # backing volume, so POST .../snapshots would fail -- the backup CronJob's
+            # target would never have anywhere durable to write even after its own two
+            # bugs (service name, missing jq) were fixed.
+            - { name: QDRANT__STORAGE__SNAPSHOTS_PATH, value: "./storage/snapshots" }
           ports:
             - name: http
               containerPort: 6333
@@ -37,6 +56,9 @@ spec:
               port: 6333
             initialDelaySeconds: 20
             periodSeconds: 20
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: ["ALL"] }
           resources:
             requests:
               cpu: "100m"

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -96,6 +96,7 @@ NON_CHART_SERVICES = {
     "commons-search",  # open-chat commons aggregator, deploys from infra/k8s/commons-search (kustomize)
     "search-gateway-ingress",  # public HTTPS edge (ManagedCertificate + Ingress) for search-gateway
     "studio-ingress",  # public HTTPS edge (ManagedCertificate + Ingress) for lattice-studio (Studio BFF)
+    "mesh-qdrant",  # shared platform vector store, deploys from infra/k8s/mesh-qdrant (kustomize)
 }
 
 # Registry hosts this platform actually publishes to. An image ref pointing anywhere


### PR DESCRIPTION
WO-KMASS-01.01. The KMASS baseline (delivery-excellence#31) found the retrieval tier cannot accumulate a corpus: `sherlock-engine`'s tantivy index was `create_in_ram` over a static 12-doc in-image fixture with no ingest path, `memoryd`'s Qdrant vector layer pointed at a service that was never deployed, and `mesh-qdrant` itself — a complete, already-written StatefulSet+PVC — had no ArgoCD Application, so it had never synced.

## sherlock-engine

Corpus now persists to `SHERLOCK_DATA_DIR/docs.jsonl` (wired to a 2Gi PVC): seeded once from the static fixture on first boot, appended to via a new `POST /ingest`. The tantivy index itself stays in-RAM and rebuilds from the persisted doc list on every boot — fast at these scales, and avoids a second store that could drift from the doc list.

**Proven end-to-end, not just built:** ingested a doc, confirmed it's immediately searchable, killed and restarted the process, confirmed the doc survives with no re-ingest (12 → 13 → 13 across a real restart). Confirmed the no-`SHERLOCK_DATA_DIR` path is unchanged and honestly reports `persisted:false` rather than claiming durability it doesn't have. Compiles clean, zero clippy warnings.

## mesh-qdrant

New `vector-store-services.yaml` ApplicationSet registers it — same pattern as zot. Root's app-of-apps recurses `deploy/argocd`, so this deploys automatically once merged.

**Three real bugs caught before this ever reached the cluster:**
- `NetworkPolicy.podSelector` targeted `app.kubernetes.io/name=mesh-qdrant`; the StatefulSet's pods only carry `app=mesh-qdrant`. Would have selected **zero pods** — no effective network restriction at all, while reading as locked-down on inspection.
- The daily backup CronJob curled `http://qdrant:6333` — the real Service is `mesh-qdrant`. Also piped to `jq`, which `curlimages/curl:8.6.0` does not ship (verified directly against the image with a throwaway pod). Both bugs would have failed the job silently, forever, on every scheduled run. Fixed the name and replaced `jq` with `grep`/`sed` rather than add a dependency.
- The container had **no `securityContext` at all**, unlike every other stateful service in this estate. Verified live with three rounds of throwaway-pod testing (not assumed): `runAsUser 1000` + `fsGroup 1000` works, but required redirecting `QDRANT__STORAGE__SNAPSHOTS_PATH` inside the mounted PVC — qdrant's default `snapshots_path` is a *sibling* of `storage_path`, not nested in it, and hit `Permission denied` against the read-only image filesystem otherwise. Proved the full create-collection → list → snapshot flow (the exact sequence the fixed backup CronJob runs) under this hardened config.

## memoryd

`QDRANT_ENABLED=true` + `QDRANT_URL` now point at the (now real) mesh-qdrant. `main.py` already gates cleanly on `QDRANT_ENABLED and bool(QDRANT_URL)` — config only, no app change.

Primary resource/event store (`MEMORYMESH_STORE_URI`) deliberately left `memory://`. `postgres_store.py` already supports a `postgresql://` DSN and a shared Postgres already runs in-cluster, but pointing memoryd at it needs a dedicated schema + a CI-minted credential Secret first — not a rushed env flip bundled into this change. Tracked as a distinct follow-up.