### PR TITLE
fix(search-orchestrator): default scope was silently disabling retrieval AND the policy gate

### DIFF
--- a/services/search-orchestrator/app/main.py
+++ b/services/search-orchestrator/app/main.py
@@ -60,8 +60,10 @@ def _actions_for(item) -> SearchResultActions:
 def search_query(body: SearchRequest) -> dict[str, object]:
     increment("search_query_total")
     results: list[dict[str, object]] = []
-    scope = body.scope or None
-    enabled = scope is not None and scope.cloud_workspace
+    # body.scope is never None (SearchRequest.scope defaults to SearchScope()) --
+    # simplified from the old `scope is not None and scope.cloud_workspace`, which
+    # was live dead code once scope stopped being Optional.
+    enabled = body.scope.cloud_workspace
 
     for item in query_platform_workspace(text=body.text, enabled=enabled):
         result = SearchResult(

--- a/services/search-orchestrator/app/models.py
+++ b/services/search-orchestrator/app/models.py
@@ -17,7 +17,16 @@ class SearchRequest(BaseModel):
     limit: int
     workspace_id: str | None = None
     jurisdiction_id: str | None = None
-    scope: SearchScope | None = None
+    # KMASS baseline (2026-08-01): defaulted to None, and main.py reads
+    # `scope is not None and scope.cloud_workspace` -- so a caller that omits
+    # scope entirely (every baseline probe did; nothing in the API surface
+    # signals it's required) got zero results from every query path, silently,
+    # with no error. SearchScope's OWN fields already default cloud_workspace
+    # to True; a request with no scope object should behave identically to
+    # one with an empty scope object, not to one that explicitly disabled
+    # everything. This was invisible to the existing test suite because every
+    # test happens to send scope explicitly (see test_academy_visibility.py).
+    scope: SearchScope = Field(default_factory=SearchScope)
 
 
 class SearchResultScore(BaseModel):

--- a/services/search-orchestrator/tests/test_debug_metrics.py
+++ b/services/search-orchestrator/tests/test_debug_metrics.py
@@ -1,9 +1,14 @@
 from fastapi.testclient import TestClient
 
+from app.backends import reset_academy_records
 from app.metrics import reset
 from app.main import app
 
 client = TestClient(app)
+
+
+def setup_function() -> None:
+    reset_academy_records()
 
 
 def academy_record() -> dict[str, object]:
@@ -51,3 +56,65 @@ def test_debug_metrics_reports_counters_without_sensitive_values() -> None:
     assert "http://" not in text
     assert "https://" not in text
     assert "/tmp/" not in text
+
+
+def restricted_academy_record() -> dict[str, object]:
+    return {
+        "header": {
+            "object_id": "lsr_policy_gate_0001",
+            "object_type": "LearningSearchRecord",
+            "policy_tags": ["learning-loop", "search"],
+        },
+        "source": "ALEXANDRIAN_ACADEMY",
+        "entity_type": "LEARNING_ACTION_EXPLANATION",
+        "title": "Policy gate regression fixture",
+        "text": "Policy gate deny-path evidence explanation.",
+        "target_ref": "llr_policy_gate_0001",
+        "visibility": {
+            "allowed_actor_ids": ["allowed-user"],
+            "allowed_workspace_ids": [],
+            "allowed_jurisdiction_ids": [],
+        },
+        "final_score": 1.0,
+    }
+
+
+def _query(actor_id: str, query_id: str) -> None:
+    response = client.post(
+        "/v0/search/query",
+        json={
+            "query_id": query_id,
+            "actor_id": actor_id,
+            "text": "policy gate deny",
+            "mode": "HYBRID",
+            "limit": 10,
+        },
+    )
+    assert response.status_code == 200
+
+
+def test_policy_gate_fires_on_the_request_path_both_ways() -> None:
+    # KMASS baseline (2026-08-01): all five policy_decision_* counters read 0
+    # before AND after 30 real queries. The evaluator code (app/policy.py) was
+    # correct and unit-tested in isolation, but nothing in the request path ever
+    # reached it -- query_academy_records() returned [] before its internal
+    # academy_record_visible() call (the one that actually invokes
+    # academy_policy_evaluator.decide()) because SearchRequest.scope defaulted
+    # to a value that disabled retrieval entirely. Fixing the scope default
+    # (test_query_endpoint_omitting_scope_is_not_silently_disabled in
+    # test_service_smoke.py) is what lets this evaluator run at all; this test
+    # is the "prove teeth both ways" proof that it now does, for both verdicts.
+    reset()
+    assert client.post("/v1/search/ingest/academy", json=restricted_academy_record()).status_code == 200
+
+    _query(actor_id="allowed-user", query_id="q-allow")
+    allowed_metrics = client.get("/v1/search/debug/metrics").json()["metrics"]
+    assert allowed_metrics["policy_decision_allow_total"] == 1
+    assert allowed_metrics["policy_decision_deny_total"] == 0
+    assert allowed_metrics["policy_decision_local_total"] == 1
+
+    _query(actor_id="other-user", query_id="q-deny")
+    denied_metrics = client.get("/v1/search/debug/metrics").json()["metrics"]
+    assert denied_metrics["policy_decision_allow_total"] == 1
+    assert denied_metrics["policy_decision_deny_total"] == 1
+    assert denied_metrics["policy_decision_local_total"] == 2

--- a/services/search-orchestrator/tests/test_debug_metrics.py
+++ b/services/search-orchestrator/tests/test_debug_metrics.py
@@ -107,14 +107,19 @@ def test_policy_gate_fires_on_the_request_path_both_ways() -> None:
     reset()
     assert client.post("/v1/search/ingest/academy", json=restricted_academy_record()).status_code == 200
 
+    # Copilot review on #1208: asserting policy_decision_local_total specifically
+    # couples this test to which evaluator happens to run (LocalVisibilityPolicyEvaluator
+    # vs HttpPolicyFabricEvaluator, selected by whether
+    # SEARCH_ORCHESTRATOR_POLICY_FABRIC_ENDPOINT is set in the environment this test
+    # runs in). debug_config() explicitly documents both as valid modes. What this
+    # test needs to prove is evaluator-independent: the gate reaches a verdict at all,
+    # and distinguishes allow from deny -- not which code path served it.
     _query(actor_id="allowed-user", query_id="q-allow")
     allowed_metrics = client.get("/v1/search/debug/metrics").json()["metrics"]
     assert allowed_metrics["policy_decision_allow_total"] == 1
     assert allowed_metrics["policy_decision_deny_total"] == 0
-    assert allowed_metrics["policy_decision_local_total"] == 1
 
     _query(actor_id="other-user", query_id="q-deny")
     denied_metrics = client.get("/v1/search/debug/metrics").json()["metrics"]
     assert denied_metrics["policy_decision_allow_total"] == 1
     assert denied_metrics["policy_decision_deny_total"] == 1
-    assert denied_metrics["policy_decision_local_total"] == 2

--- a/services/search-orchestrator/tests/test_service_smoke.py
+++ b/services/search-orchestrator/tests/test_service_smoke.py
@@ -43,9 +43,14 @@ def test_query_endpoint_returns_normalized_response_shape() -> None:
     assert payload['query_id'] == 'q1'
     assert payload['actor_id'] == 'user-1'
     assert payload['mode'] == 'HYBRID'
-    assert len(payload['results']) == 1
-    assert payload['results'][0]['source'] == 'PLATFORM'
-    assert payload['results'][0]['path_or_uri'] == 'workspace://documents/budget'
+    # Copilot review on #1208: asserting an exact result count would make this
+    # test brittle against any future change that enables an additional source
+    # by default. What this test needs to prove is narrower and more durable:
+    # the platform-workspace placeholder specifically fires (it did not, before
+    # this PR's fix, for a request with no scope field).
+    platform_results = [r for r in payload['results'] if r['source'] == 'PLATFORM']
+    assert len(platform_results) == 1
+    assert platform_results[0]['path_or_uri'] == 'workspace://documents/budget'
 
 
 def test_query_endpoint_omitting_scope_is_not_silently_disabled() -> None:

--- a/services/search-orchestrator/tests/test_service_smoke.py
+++ b/services/search-orchestrator/tests/test_service_smoke.py
@@ -1,9 +1,14 @@
 from fastapi.testclient import TestClient
 
+from app.backends import reset_academy_records
 from app.main import app
 
 
 client = TestClient(app)
+
+
+def setup_function() -> None:
+    reset_academy_records()
 
 
 def test_health_endpoint() -> None:
@@ -12,7 +17,17 @@ def test_health_endpoint() -> None:
     assert response.json()['service'] == 'search-orchestrator'
 
 
-def test_query_endpoint_returns_normalized_empty_results() -> None:
+def test_query_endpoint_returns_normalized_response_shape() -> None:
+    # Renamed from test_query_endpoint_returns_normalized_empty_results: that name and
+    # its results==[] assertion codified a real defect (KMASS baseline, 2026-08-01) --
+    # SearchRequest.scope defaulted to None, and main.py read
+    # `scope is not None and scope.cloud_workspace`, so a request with no scope field
+    # at all silently returned nothing from every source, with no error. This exact
+    # request shape (no scope) is what every KMASS baseline probe sent. Now that
+    # SearchRequest.scope defaults to an enabled SearchScope(), the platform-workspace
+    # source's placeholder stub (app/backends.py::query_platform_workspace -- it
+    # deliberately echoes the query text back as a fake match, see its own docstring)
+    # correctly fires, and this asserts that real behavior instead of the old bug.
     response = client.post(
         '/v0/search/query',
         json={
@@ -28,4 +43,43 @@ def test_query_endpoint_returns_normalized_empty_results() -> None:
     assert payload['query_id'] == 'q1'
     assert payload['actor_id'] == 'user-1'
     assert payload['mode'] == 'HYBRID'
-    assert payload['results'] == []
+    assert len(payload['results']) == 1
+    assert payload['results'][0]['source'] == 'PLATFORM'
+    assert payload['results'][0]['path_or_uri'] == 'workspace://documents/budget'
+
+
+def test_query_endpoint_omitting_scope_is_not_silently_disabled() -> None:
+    # The specific regression this defect needs: a query that matches a REAL,
+    # non-placeholder, ingested record must return it even when the caller sends no
+    # scope field -- not just the platform-workspace stub above. Exercises the same
+    # academy path the KMASS baseline's 30 probe queries went through and found
+    # permanently empty.
+    record = {
+        'header': {
+            'object_id': 'lsr_default_scope_regression',
+            'object_type': 'LearningSearchRecord',
+            'policy_tags': ['learning-loop', 'search'],
+        },
+        'source': 'ALEXANDRIAN_ACADEMY',
+        'entity_type': 'LEARNING_ACTION_EXPLANATION',
+        'title': 'Default-scope regression fixture',
+        'text': 'evidence about defaulting the search scope correctly',
+        'target_ref': 'llr_default_scope_regression',
+        'final_score': 1.0,
+    }
+    assert client.post('/v1/search/ingest/academy', json=record).status_code == 200
+    response = client.post(
+        '/v0/search/query',
+        json={
+            'query_id': 'q2',
+            'actor_id': 'user-1',
+            'text': 'evidence defaulting scope',
+            'mode': 'HYBRID',
+            'limit': 5,
+            # no scope field -- this must not mean "disabled"
+        },
+    )
+    assert response.status_code == 200
+    academy_hits = [r for r in response.json()['results'] if r['source'] == 'ALEXANDRIAN_ACADEMY']
+    assert len(academy_hits) == 1
+    assert academy_hits[0]['result_id'] == 'lsr_default_scope_regression'


### PR DESCRIPTION
WO-KMASS-01.02 and WO-KMASS-01.03 (delivery-excellence#31 baseline) turned out to be one root cause, not two: `SearchRequest.scope` defaulted to `None`, and `main.py` read `scope is not None and scope.cloud_workspace` — so a request that omits `scope` entirely returns nothing from **every** source, silently, with no error. Every one of the baseline's 30 probe queries omitted `scope`, which is exactly what a naive client would send — nothing in the API surface signals it's required.

## Why the policy gate read zero too

The evaluator (`app/policy.py`) is correct and was already unit-tested in isolation. `academy_record_visible()` **does** call `academy_policy_evaluator.decide()` — but `query_academy_records()` returns `[]` before ever reaching that call, at the `if not enabled: return []` guard, because `enabled` was never `True`. The gate wasn't short-circuited by empty results; it was never reached at all.

## Fix

`SearchRequest.scope` now defaults to `SearchScope()` via `Field(default_factory=...)` instead of `None`, matching `SearchScope`'s own `cloud_workspace=True` default. A request with no scope object now behaves identically to one with an explicit empty scope object, not to one that explicitly disabled everything. Simplified `main.py`'s now-dead `scope is not None` check accordingly.

## Why nothing caught this

Every existing test happens to send `scope` explicitly (see `test_academy_visibility.py`) — nobody tested the no-scope case. One existing test had in fact **codified the bug as expected behavior**: `test_query_endpoint_returns_normalized_empty_results` sent no `scope` and asserted `results == []`. Renamed and fixed it to assert the platform-workspace placeholder stub's real, intentional response (`query_platform_workspace` deliberately echoes the query back as a fake match — it's an honest stub, not something I fixed).

Added two regression tests:
- A real ingested academy record is retrievable with no `scope` field sent at all.
- The policy gate fires on the request path **both ways** (allow and deny) — the exact "prove teeth both ways" gap the baseline flagged, now closed with a real test.

**32/32 tests pass** (30 existing + 2 new; 1 renamed and corrected).