### PR TITLE
fix(ci): mirror workflow_dispatch diagnostics runs onto gate / check

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -15,13 +15,28 @@
 # only mirrors a gate that actually ran and passed. So it is a real check with teeth,
 # not a green rubber stamp.
 #
-# VERIFY LIVE AFTER MERGE (workflow_run check-runs attaching to a PR head as a
-# required context is the one behaviour that cannot be tested off-GitHub): open a
-# throwaway PR, confirm `gate / check` posts and that a passing gate clears BLOCKED
-# without --admin. If it does not surface as the required context, the fallback is to
-# retire the legacy `gate / check` from branch protection (the ruleset's
-# `diagnostics-gate` already enforces the same thing) — but that is a branch-
-# protection change held for explicit sign-off.
+# VERIFIED LIVE 2026-08-02: the throwaway-PR check above passed (a human-pushed
+# branch's pull_request-triggered diagnostics run mirrors correctly), but that is not
+# the only path that produces a validate-target-diagnostics run. gitops-promote.yml's
+# own PRs (bot-authored, opened with GITHUB_TOKEN) hit a SEPARATE, already-documented
+# problem: their pull_request-triggered diagnostics run is parked at
+# conclusion=action_required by the fork-pr-contributor-approval gate and never
+# executes, so gitops-promote dispatches validate-target-diagnostics itself via
+# workflow_dispatch and publishes `diagnostics-gate` manually (see that workflow's
+# comments). This job's filter originally excluded 'workflow_dispatch', so those
+# dispatched runs — real, green, and the ONLY diagnostics run that ever completes for
+# a promote branch — were silently never mirrored onto `gate / check`. Measured on
+# #1209 and #1210: both promote PRs sat MERGEABLE-but-BLOCKED with `diagnostics-gate`
+# satisfied and `gate / check` stuck at "Expected", because no gate.yml run ever fired
+# for their workflow_dispatch completions (confirmed via the Actions API: zero gate.yml
+# runs exist for either promote branch's head SHA). Including 'workflow_dispatch' below
+# closes that gap the same way gitops-promote already closes it for `diagnostics-gate` —
+# by trusting the same real, green run regardless of which trigger produced it.
+#
+# The fallback if this ever needs reverting is to retire the legacy `gate / check` from
+# branch protection (the ruleset's `diagnostics-gate` already enforces the same thing)
+# — but that is a branch-protection change held for explicit sign-off, so mirroring
+# workflow_dispatch is the smaller, in-scope fix.
 name: gate
 
 on:
@@ -39,10 +54,13 @@ permissions:
 
 jobs:
   check:
-    # Only mirror runs that actually gate a change (PRs and pushes to main).
+    # Only mirror runs that actually gate a change: PRs, pushes to main, and the
+    # workflow_dispatch runs gitops-promote uses to work around its own PRs' parked
+    # pull_request diagnostics (see comment above).
     if: >-
       github.event.workflow_run.event == 'pull_request' ||
-      github.event.workflow_run.event == 'push'
+      github.event.workflow_run.event == 'push' ||
+      github.event.workflow_run.event == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Mirror the diagnostics gate verdict onto 'gate / check'


### PR DESCRIPTION
## The defect

`gate.yml` mirrors `validate-target-diagnostics` verdicts onto the legacy required
status context `gate / check`, but only for `pull_request` and `push` triggers.

`gitops-promote.yml`'s own PRs are bot-authored (opened with `GITHUB_TOKEN`). Their
`pull_request`-triggered diagnostics run parks at `conclusion=action_required` (the
fork-pr-contributor-approval gate) and never executes — this was already
known and is why `gitops-promote` dispatches diagnostics itself via
`workflow_dispatch` and publishes `diagnostics-gate` manually via the commit-statuses
API.

`gate.yml`'s filter excluded `workflow_dispatch`, so that dispatched run — the ONLY
diagnostics run that ever completes for a promote branch — was never mirrored onto
`gate / check`. Result: every promote PR opened since `gate / check` became required
sits `MERGEABLE`-but-`BLOCKED` forever, with `diagnostics-gate` green and `gate / check`
stuck at "Expected — waiting for status to be reported".

**Measured live**, not assumed: [#1209](https://github.com/SocioProphet/prophet-platform/pull/1209)
and [#1210](https://github.com/SocioProphet/prophet-platform/pull/1210) are both stuck
exactly this way right now. Queried the Actions API directly: zero `gate.yml` runs
exist for either promote branch's head SHA, despite both branches' `workflow_dispatch`
diagnostics runs completing successfully.

## The fix

Add `workflow_dispatch` to `gate.yml`'s trigger-event allowlist. Same trust boundary as
before (still fail-closed on anything but a literal `success` conclusion) — this just
stops discriminating against the one trigger `gitops-promote` is forced to use.

## Not taken

Retiring `gate / check` from branch protection instead (the ruleset's `diagnostics-gate`
already enforces the same thing) — smaller, in-scope fix preferred; a branch-protection
change is held for explicit sign-off.