### PR TITLE
fix(argo-rollouts): correct trafficRouterPlugins ConfigMap shape (live 14h outage)

### DIFF
--- a/deploy/argocd/progressive-delivery-services.yaml
+++ b/deploy/argocd/progressive-delivery-services.yaml
@@ -72,17 +72,34 @@ spec:
           # deploy/values/hellgraph-service.yaml's trafficRouting block) resolves on
           # the controller — without this the plugin name is a dangling reference and
           # the Rollout errors at reconcile, not at apply.
-          # UNVERIFIED offline (no live-cluster apply done from this branch): this
-          # key's shape against the pinned argo-rollouts chart 2.37.7 / controller
-          # v1.7.2 needs confirming once ArgoCD actually syncs it — the plugin
-          # release URL below is a placeholder pointer (upstream release asset), not
-          # a digest-pinned artifact per the estate's vendoring convention. hellgraph-
-          # service's own rollout doesn't reference this plugin yet either (its
-          # trafficRouting.enabled stays false — see deploy/values/hellgraph-service.yaml)
-          # until this is confirmed live.
+          #
+          # FIXED 2026-08-02 (live 14h outage): the "UNVERIFIED offline" note this
+          # comment used to carry was right to be worried — the original shape here
+          # was a bare YAML list, but argo-rollouts' own configmap.yaml template does
+          # `{{- with .Values.controller.trafficRouterPlugins }}{{ toYaml . | nindent 2 }}`
+          # DIRECTLY under `data:`, so the value must already be a MAP (whose key
+          # becomes the ConfigMap's data key, holding the plugin list as a nested YAML
+          # string) — not a bare list. A bare list rendered straight under `data:`,
+          # which Kubernetes rejects: "expected map, got &{[map[...]]}" (confirmed via
+          # `kubectl get application argo-rollouts -o json`'s operationState.message).
+          # ArgoCD retried the failing patch 5 times and gave up; argo-rollouts-config
+          # never existed; the controller queued "plugin ... not configured in
+          # configmap" for 5,212 retries; hellgraph-service ran zero pods for 14 hours.
+          # Verified via `helm template argo-rollouts <chart> -f <these values>
+          # --show-only templates/controller/configmap.yaml` before this landed —
+          # renders a real `data: {trafficRouterPlugins: "<yaml string>"}` map now.
+          #
+          # Also still true from the original note: the plugin release URL below is a
+          # placeholder pointer (upstream release asset), not a digest-pinned artifact
+          # per the estate's vendoring convention — tracked as a fast-follow, not
+          # blocking this outage fix. And the "hellgraph-service doesn't reference this
+          # plugin yet" claim was already stale before this fix — its rollout.enabled
+          # is true and its trafficRouting block is live; that's WHY the malformed
+          # ConfigMap caused a real outage instead of sitting unused.
           trafficRouterPlugins:
-            - name: argoproj-labs/gatewayAPI
-              location: https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/v0.4.0/gatewayapi-plugin-linux-amd64
+            trafficRouterPlugins: |-
+              - name: argoproj-labs/gatewayAPI
+                location: https://github.com/argoproj-labs/rollouts-plugin-trafficrouter-gatewayapi/releases/download/v0.4.0/gatewayapi-plugin-linux-amd64
         dashboard:
           enabled: true
   syncPolicy:


### PR DESCRIPTION
Root cause of hellgraph-service running zero pods since 2026-08-02T01:42Z: the argo-rollouts chart's `configmap.yaml` template renders `trafficRouterPlugins` directly under `data:` via `toYaml`. A bare YAML list there produces an invalid ConfigMap (`data` must be a map) — Kubernetes rejected the patch outright, ArgoCD retried 5 times and gave up, `argo-rollouts-config` never existed, and the controller queued 5,212 failed plugin-resolution retries.

Fixed by wrapping the plugin list as a map value (a nested YAML string) — the shape the chart's template actually expects. Verified by extracting the real values block from this file and rendering it through the pinned chart (argo-rollouts 2.37.7): produces a valid `data: {trafficRouterPlugins: "..."}` map now.

This was flagged as an explicit unverified risk in the original PR — it synced, and the risk was real. Also fixed two stale comments claiming hellgraph-service's trafficRouting wasn't live yet; it is, which is exactly why this broke instead of sitting unused.

Not blocking this fix: the plugin release URL is still a bare pointer, not digest-pinned per estate convention — tracked as a fast-follow.