### PR TITLE
feat(catalog-gateway): operational plane — capture layer (crystallized catalog events)

### DIFF
--- a/apps/catalog-gateway/app/main.py
+++ b/apps/catalog-gateway/app/main.py
@@ -44,7 +44,10 @@ def _resolve_or_404(kind: str, entry_id: str) -> dict:
 def asset_dcat(entry_id: str) -> JSONResponse:
     entry = _resolve_or_404("asset", entry_id)
     doc = asset_to_dcat(entry)
-    ops.record_dcat_emitted(entry_id, doc.get("dct:accessRights", ""),
+    # Log the entry's OWN asset_id (what the DCAT doc is identified by), falling
+    # back to the request path — so the ops event can never disagree with the
+    # emitted document when the stored asset_id differs from the path.
+    ops.record_dcat_emitted(entry.get("asset_id") or entry_id, doc.get("dct:accessRights", ""),
                             distribution_class=entry.get("distribution_class"))
     return JSONResponse(content=doc, media_type="application/ld+json")
 

--- a/apps/catalog-gateway/app/main.py
+++ b/apps/catalog-gateway/app/main.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 
+from . import ops
 from .dcat import asset_to_dcat
 from .store import KINDS, SERVICE, get_entry, is_valid_id
 
@@ -42,7 +43,10 @@ def _resolve_or_404(kind: str, entry_id: str) -> dict:
 @app.get("/v1/catalog/asset/{entry_id}.dcat.json")
 def asset_dcat(entry_id: str) -> JSONResponse:
     entry = _resolve_or_404("asset", entry_id)
-    return JSONResponse(content=asset_to_dcat(entry), media_type="application/ld+json")
+    doc = asset_to_dcat(entry)
+    ops.record_dcat_emitted(entry_id, doc.get("dct:accessRights", ""),
+                            distribution_class=entry.get("distribution_class"))
+    return JSONResponse(content=doc, media_type="application/ld+json")
 
 
 @app.get("/v1/catalog/{kind}/{entry_id}/lineage")
@@ -60,4 +64,11 @@ def lineage(kind: str, entry_id: str) -> dict:
 
 @app.get("/v1/catalog/{kind}/{entry_id}")
 def resolve(kind: str, entry_id: str) -> dict:
-    return {"kind": kind, "entry": _resolve_or_404(kind, entry_id)}
+    try:
+        entry = _resolve_or_404(kind, entry_id)
+    except HTTPException as exc:
+        if exc.status_code == 404 and kind in KINDS:
+            ops.record_resolved(kind, entry_id, hit=False)  # capture misses too
+        raise
+    ops.record_resolved(kind, entry_id, hit=True)
+    return {"kind": kind, "entry": entry}

--- a/apps/catalog-gateway/app/ops.py
+++ b/apps/catalog-gateway/app/ops.py
@@ -51,7 +51,10 @@ def emit(event_type: str, record: dict[str, Any]) -> str | None:
             json.dumps({"event_type": event_type, "event": record}, indent=2), encoding="utf-8"
         )
         return event_id
-    except OSError:
+    except (OSError, TypeError, ValueError):
+        # Best-effort: a filesystem error (OSError) OR a non-serializable record
+        # (json.dumps -> TypeError/ValueError, e.g. circular refs) must never
+        # break the read path this capture is observing.
         return None
 
 

--- a/apps/catalog-gateway/app/ops.py
+++ b/apps/catalog-gateway/app/ops.py
@@ -1,0 +1,71 @@
+"""Catalog operational plane — capture layer.
+
+The Catalog Gateway keeps a record of what it does. Every resolve / DCAT emission is
+crystallized as a `catalog.*.v0` event (contracts/crystal-atlas/events/) and written
+into the SAME shared file-state that evidence-receipts / crystal-atlas-contract-intel
+already read — so catalog operations are observable and queryable with zero new store.
+
+Capture is best-effort: an emit failure must never break a read. Toggle with
+CATALOG_OPS_CAPTURE (default on). Downstream: a scheduled readout folds these into
+catalog KPIs (hit/miss, hot assets, stale sources, DCAT coverage), and SLOs gate them.
+"""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .store import SERVICE, state_home
+
+PRODUCER = "catalog-gateway"
+
+
+def _enabled() -> bool:
+    return os.getenv("CATALOG_OPS_CAPTURE", "true").lower() != "false"
+
+
+def _events_dir() -> Path:
+    return state_home() / "prophet-platform" / "events" / SERVICE
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def emit(event_type: str, record: dict[str, Any]) -> str | None:
+    """Write one crystallized operational event. Best-effort: returns the event_id, or
+    None if capture is off or the write fails (never raises into the caller)."""
+    if not _enabled():
+        return None
+    try:
+        event_id = record.get("event_id") or f"ce_{uuid.uuid4().hex[:16]}"
+        record.setdefault("event_id", event_id)
+        record.setdefault("emitted_at", _now())
+        record.setdefault("producer", PRODUCER)
+        d = _events_dir()
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{event_id}.event.json").write_text(
+            json.dumps({"event_type": event_type, "event": record}, indent=2), encoding="utf-8"
+        )
+        return event_id
+    except OSError:
+        return None
+
+
+def record_resolved(kind: str, entry_id: str, hit: bool, *, requester: str | None = None,
+                    latency_ms: float | None = None) -> str | None:
+    return emit("catalog.resolved.v0", {
+        "kind": kind, "entry_id": entry_id, "hit": hit,
+        "requester": requester, "latency_ms": latency_ms,
+    })
+
+
+def record_dcat_emitted(asset_id: str, access_rights: str, *, distribution_class: str | None = None,
+                        requester: str | None = None) -> str | None:
+    return emit("catalog.dcat.emitted.v0", {
+        "asset_id": asset_id, "access_rights": access_rights,
+        "distribution_class": distribution_class, "requester": requester,
+    })

--- a/apps/catalog-gateway/tests/test_ops.py
+++ b/apps/catalog-gateway/tests/test_ops.py
@@ -1,0 +1,67 @@
+"""Catalog operational-plane capture tests."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from app.main import app  # noqa: E402
+
+client = TestClient(app)
+
+ASSET = {
+    "asset_id": "asset-ops-001", "asset_kind": "dataset", "tenant_id": "t",
+    "distribution_class": "public_derived", "source_refs": ["src-1"],
+    "created_at": "2026-08-01T00:00:00Z", "updated_at": "2026-08-01T00:00:00Z",
+}
+
+
+def _seed(monkeypatch, tmp_path):
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path))
+    monkeypatch.setenv("CATALOG_OPS_CAPTURE", "true")
+    d = tmp_path / "prophet-platform" / "catalog" / "asset"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "asset-ops-001.json").write_text(json.dumps(ASSET), encoding="utf-8")
+
+
+def _events(tmp_path) -> list[dict]:
+    ev = tmp_path / "prophet-platform" / "events" / "catalog-gateway"
+    return [json.loads(p.read_text()) for p in sorted(ev.glob("*.event.json"))] if ev.exists() else []
+
+
+def test_resolve_hit_is_captured(monkeypatch, tmp_path):
+    _seed(monkeypatch, tmp_path)
+    assert client.get("/v1/catalog/asset/asset-ops-001").status_code == 200
+    evs = _events(tmp_path)
+    resolved = [e for e in evs if e["event_type"] == "catalog.resolved.v0"]
+    assert resolved and resolved[0]["event"]["hit"] is True
+    assert resolved[0]["event"]["entry_id"] == "asset-ops-001"
+    assert resolved[0]["event"]["producer"] == "catalog-gateway"
+
+
+def test_resolve_miss_is_captured(monkeypatch, tmp_path):
+    _seed(monkeypatch, tmp_path)
+    assert client.get("/v1/catalog/asset/nope").status_code == 404
+    misses = [e for e in _events(tmp_path) if e["event_type"] == "catalog.resolved.v0" and e["event"]["hit"] is False]
+    assert misses and misses[0]["event"]["entry_id"] == "nope"
+
+
+def test_dcat_emission_is_captured(monkeypatch, tmp_path):
+    _seed(monkeypatch, tmp_path)
+    assert client.get("/v1/catalog/asset/asset-ops-001.dcat.json").status_code == 200
+    dcat = [e for e in _events(tmp_path) if e["event_type"] == "catalog.dcat.emitted.v0"]
+    assert dcat and dcat[0]["event"]["asset_id"] == "asset-ops-001"
+    assert dcat[0]["event"]["access_rights"] == "public"  # public_derived -> public
+    assert dcat[0]["event"]["distribution_class"] == "public_derived"
+
+
+def test_capture_can_be_disabled(monkeypatch, tmp_path):
+    _seed(monkeypatch, tmp_path)
+    monkeypatch.setenv("CATALOG_OPS_CAPTURE", "false")
+    assert client.get("/v1/catalog/asset/asset-ops-001").status_code == 200
+    assert _events(tmp_path) == []  # nothing captured when off

--- a/apps/catalog-gateway/tests/test_ops.py
+++ b/apps/catalog-gateway/tests/test_ops.py
@@ -34,6 +34,16 @@ def _events(tmp_path) -> list[dict]:
     return [json.loads(p.read_text()) for p in sorted(ev.glob("*.event.json"))] if ev.exists() else []
 
 
+def test_emit_is_best_effort_on_nonserializable_record(monkeypatch, tmp_path):
+    # A non-JSON-serializable value (e.g. a set) must not raise into the caller —
+    # emit() returns None rather than breaking the read path it observes.
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path))
+    monkeypatch.setenv("CATALOG_OPS_CAPTURE", "true")
+    from app import ops
+    assert ops.emit("catalog.resolved.v0", {"kind": "asset", "bad": {1, 2, 3}}) is None
+    assert _events(tmp_path) == []
+
+
 def test_resolve_hit_is_captured(monkeypatch, tmp_path):
     _seed(monkeypatch, tmp_path)
     assert client.get("/v1/catalog/asset/asset-ops-001").status_code == 200

--- a/contracts/crystal-atlas/events/catalog.dcat.emitted.v0.schema.json
+++ b/contracts/crystal-atlas/events/catalog.dcat.emitted.v0.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/crystal-atlas/catalog_dcat_emitted.schema.json",
+  "title": "catalog.dcat.emitted.v0",
+  "description": "Operational record: the Catalog Gateway emitted a DCAT/schema.org projection of an asset (the external-interop seam CKAN/DataHub/CK.org harvest). Captured for coverage analysis and operational excellence.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["event_id", "emitted_at", "producer", "asset_id", "access_rights"],
+  "properties": {
+    "event_id": { "type": "string", "minLength": 8 },
+    "emitted_at": { "type": "string" },
+    "producer": { "type": "string" },
+    "asset_id": { "type": "string" },
+    "access_rights": { "type": "string" },
+    "distribution_class": { "type": ["string", "null"] },
+    "requester": { "type": ["string", "null"] },
+    "notes": { "type": "object", "additionalProperties": true }
+  }
+}

--- a/contracts/crystal-atlas/events/catalog.resolved.v0.schema.json
+++ b/contracts/crystal-atlas/events/catalog.resolved.v0.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/crystal-atlas/catalog_resolved.schema.json",
+  "title": "catalog.resolved.v0",
+  "description": "Operational record: the Catalog Gateway resolved (or failed to resolve) a catalog entry. Captured into the shared file-state so catalog operations are observable, analyzable, and SLO-gated.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["event_id", "emitted_at", "producer", "kind", "entry_id", "hit"],
+  "properties": {
+    "event_id": { "type": "string", "minLength": 8 },
+    "emitted_at": { "type": "string" },
+    "producer": { "type": "string" },
+    "kind": { "type": "string", "enum": ["source", "asset", "model", "workflow"] },
+    "entry_id": { "type": "string" },
+    "hit": { "type": "boolean" },
+    "requester": { "type": ["string", "null"] },
+    "latency_ms": { "type": ["number", "null"] },
+    "notes": { "type": "object", "additionalProperties": true }
+  }
+}


### PR DESCRIPTION
**Stacked on #1158.** Gives the data catalog its own operational log — the capture layer of a catalog operational plane (your "crystallize + register + lifecycle automation" directive).

The gateway now records what it does: every resolve / DCAT emission is **crystallized** as a `catalog.*.v0` event and **registered** into the shared file-state (`events/catalog-gateway/`) that `evidence-receipts` / `crystal-atlas-contract-intel` already read — observable and queryable with zero new storage.

- `contracts/crystal-atlas/events/catalog.resolved.v0` + `catalog.dcat.emitted.v0`
- `app/ops.py` — best-effort emitter (never breaks a read; `CATALOG_OPS_CAPTURE` toggle)
- emit on resolve (hit **and** miss) and on DCAT emission
- tests (4): hit/miss/dcat captured + capture-disable honoured. Suite: **11 pass**.

**Next in the loop:** a scheduled readout folding these into catalog KPIs (hit/miss, hot assets, stale sources, DCAT coverage) → `catalog.ops.readout.v0`, then SLOs — and the cockpit UX that surfaces them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)