### PR TITLE
feat(deploy): catalog-gateway as a deployed platform app (image + values + appset)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -55,6 +55,7 @@ jobs:
           - { image: reporting-watcher,     context: apps/reporting-watcher,    dockerfile: Dockerfile }
           - { image: osm-map-api,           context: .,                         dockerfile: apps/osm-map-api/Dockerfile }
           - { image: dashboard-bff,         context: .,                         dockerfile: apps/dashboard-bff/Dockerfile }
+          - { image: catalog-gateway,       context: apps/catalog-gateway,      dockerfile: Dockerfile }
           - { image: workspace-mail,        context: services/workspace-mail,   dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
           - { image: workspace-caldav,      context: services/workspace-caldav, dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
           - { image: workspace-smtp,        context: services/workspace-smtp,   dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }

--- a/apps/catalog-gateway/Dockerfile
+++ b/apps/catalog-gateway/Dockerfile
@@ -1,0 +1,14 @@
+# catalog-gateway — the unified read/resolve/lineage + DCAT interop seam over the
+# Crystal Atlas catalog families (the GMS-equivalent). Read/display + interop surface
+# that also captures its own operational events. Control-plane only (no user code) →
+# platform namespace.
+FROM python:3.12-slim
+RUN useradd -m -u 10001 gateway
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+ENV PORT=8080 PYTHONUNBUFFERED=1 CATALOG_OPS_CAPTURE=true
+EXPOSE 8080
+USER gateway
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/apps/catalog-gateway/requirements.txt
+++ b/apps/catalog-gateway/requirements.txt
@@ -1,0 +1,2 @@
+fastapi>=0.110,<1
+uvicorn[standard]>=0.29,<1

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -34,6 +34,7 @@ spec:
           - { name: hellgraph-service, tier: foundation }        # graph kernel — the spine every graph consumer speaks to
           - { name: osm-map-api, tier: reference }               # geo tiles/lookup — swappable impl
           - { name: dashboard-bff, tier: reference }             # dashboard backend-for-frontend
+          - { name: catalog-gateway, tier: reference }           # Catalog Gateway — resolve/lineage/DCAT interop seam over crystal-atlas + ops-event capture
           - { name: reasoning-failure-runner, tier: reference }  # chaos/resilience orchestrator
           - { name: search-orchestrator, tier: reference }       # search orchestration impl
           - { name: search-gateway, tier: reference }            # public search edge for the search product

--- a/deploy/values/catalog-gateway.yaml
+++ b/deploy/values/catalog-gateway.yaml
@@ -1,0 +1,25 @@
+# catalog-gateway — the unified read/resolve/lineage + DCAT interop seam over the
+# Crystal Atlas catalog families (docs/strategy/PROPHET_DATA_CATALOG_DESIGN.md). The
+# GMS-equivalent: resolve source|asset|model|workflow entries, walk lineage, emit the
+# first real DCAT/schema.org projection (the CKAN/DataHub/CK.org harvest seam), and
+# CAPTURE its own operational events (catalog.*.v0) into the shared file-state — the
+# capture layer of the catalog operational plane.
+#
+# Reference tier: a replaceable catalog surface layered over the crystal-atlas
+# contracts (the foundation). First-party ⇒ built by images.yml, so no image.registry
+# override (inherits the platform default; the preflight contract asserts that claim).
+#
+# tag:latest is the bootstrap for a brand-new service (no sha exists until the first
+# images.yml build); gitops-promote sha-pins it after that first build.
+image: { repository: catalog-gateway, tag: latest }
+service: { port: 8080, portName: http }
+# app serves @app.get('/healthz') — the chart default — so no probes override needed.
+config:
+  # Reads catalog entries from, and writes operational events to, the shared
+  # platform file-state layout. A single-service PVC for the first deploy; the
+  # cross-service shared-state (RWX) read is a deliberate follow-up.
+  SOCIOPROFIT_STATE_HOME: "/data"
+  CATALOG_OPS_CAPTURE: "true"
+autoscaling: { enabled: false }
+replicaCount: 1
+persistence: { enabled: true, storageClass: dynamic-rwo, size: 1Gi, mountPath: /data }

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -181,6 +181,11 @@ KNOWN_BROKEN = {
         "declarations -> fail-closed-validated DeviceReadings) added to CI this PR. Pin tag:latest -> the sha- "
         "tag after the first CI build; no sha exists until merge."
     ),
+    "catalog-gateway:moving-tag": (
+        "New service — Catalog Gateway (apps/catalog-gateway: resolve/lineage/DCAT interop seam over "
+        "crystal-atlas + operational-event capture) added to CI this PR. Pin tag:latest -> the sha- tag "
+        "after the first CI build; no sha exists until merge."
+    ),
     # health-twin pinned to a sha- tag by gitops-promote after its first CI build (#932) → removed
     # from the ratchet (it only shrinks).
     # portfolio-agent pinned to a sha- tag by gitops-promote after its first CI build (#925,


### PR DESCRIPTION
**Stacked on #1213.** Build + lifecycle + deployment automation so the Catalog Gateway is a live, gitops-promoted prophet-platform service — the "deployed app" half of the mission.

Wired per the estate convention (**`preflight_deploy_contract.py` passes**):
- `apps/catalog-gateway/Dockerfile` + `requirements.txt` — first-party image.
- `.github/workflows/images.yml` — builds `catalog-gateway`.
- `deploy/values/catalog-gateway.yaml` — chart values (port 8080, `/data` PVC, ops capture on); `tier: reference`; `tag:latest` bootstrap → gitops-promote sha-pins after first build.
- `deploy/argocd/platform-services.yaml` — appset entry.
- preflight deferral entry alongside peer new services.

**Next:** the cockpit UX (extend `StudioCatalog.vue`) + the ops readout job that folds the captured `catalog.*.v0` events into the dashboard KPIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)