### PR TITLE
feat(catalog-gateway): deploy as first-party reference-tier platform app (supersedes #1214)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -56,6 +56,7 @@ jobs:
           - { image: reporting-watcher,     context: apps/reporting-watcher,    dockerfile: Dockerfile }
           - { image: osm-map-api,           context: .,                         dockerfile: apps/osm-map-api/Dockerfile }
           - { image: dashboard-bff,         context: .,                         dockerfile: apps/dashboard-bff/Dockerfile }
+          - { image: catalog-gateway,       context: apps/catalog-gateway,      dockerfile: Dockerfile }
           - { image: workspace-mail,        context: services/workspace-mail,   dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
           - { image: workspace-caldav,      context: services/workspace-caldav, dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }
           - { image: workspace-smtp,        context: services/workspace-smtp,   dockerfile: Dockerfile, registry: registry.socioprophet.ai, registry_auth: basic }

--- a/apps/catalog-gateway/Dockerfile
+++ b/apps/catalog-gateway/Dockerfile
@@ -1,0 +1,14 @@
+# catalog-gateway — the unified read/resolve/lineage + DCAT interop seam over the
+# Crystal Atlas catalog families (the GMS-equivalent). Read/display + interop surface
+# that also captures its own operational events. Control-plane only (no user code) →
+# platform namespace.
+FROM python:3.12-slim
+RUN useradd -m -u 10001 gateway
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+ENV PORT=8080 PYTHONUNBUFFERED=1 CATALOG_OPS_CAPTURE=true
+EXPOSE 8080
+USER gateway
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/apps/catalog-gateway/requirements.txt
+++ b/apps/catalog-gateway/requirements.txt
@@ -1,0 +1,2 @@
+fastapi>=0.110,<1
+uvicorn[standard]>=0.29,<1

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -34,6 +34,7 @@ spec:
           - { name: hellgraph-service, tier: foundation }        # graph kernel — the spine every graph consumer speaks to
           - { name: osm-map-api, tier: reference }               # geo tiles/lookup — swappable impl
           - { name: dashboard-bff, tier: reference }             # dashboard backend-for-frontend
+          - { name: catalog-gateway, tier: reference }           # Catalog Gateway — resolve/lineage/DCAT interop seam over crystal-atlas + ops-event capture
           - { name: reasoning-failure-runner, tier: reference }  # chaos/resilience orchestrator
           - { name: search-orchestrator, tier: reference }       # search orchestration impl
           - { name: search-gateway, tier: reference }            # public search edge for the search product

--- a/deploy/values/catalog-gateway.yaml
+++ b/deploy/values/catalog-gateway.yaml
@@ -19,3 +19,8 @@ config:
 autoscaling: { enabled: false }
 replicaCount: 1
 persistence: { enabled: true, storageClass: dynamic-rwo, size: 1Gi, mountPath: /data }
+# Single-writer on a ReadWriteOnce PVC: the default RollingUpdate (maxSurge 25%)
+# can deadlock — the new pod is created before the old pod releases the RWO volume.
+# Recreate tears the old pod down first, per the chart's guidance for persistent
+# single-writer services.
+strategy: { type: Recreate }

--- a/deploy/values/catalog-gateway.yaml
+++ b/deploy/values/catalog-gateway.yaml
@@ -1,0 +1,21 @@
+# catalog-gateway — the unified read/resolve/lineage + DCAT interop seam over the
+# Crystal Atlas catalog families (docs/strategy/PROPHET_DATA_CATALOG_DESIGN.md). The
+# GMS-equivalent: resolve source|asset|model|workflow entries, walk lineage, emit the
+# first real DCAT/schema.org projection (the CKAN/DataHub/CK.org harvest seam), and
+# capture its own operational events (catalog.*.v0) into the shared file-state.
+#
+# Reference tier: a replaceable catalog surface over the crystal-atlas contracts
+# (the foundation). First-party ⇒ built by images.yml, so no image.registry override
+# (inherits the platform default; the preflight contract asserts that claim).
+#
+# tag:latest is the bootstrap for a brand-new service; gitops-promote sha-pins it
+# after the first images.yml build.
+image: { repository: catalog-gateway, tag: latest }
+service: { port: 8080, portName: http }
+# app serves @app.get('/healthz') — the chart default — so no probes override needed.
+config:
+  SOCIOPROFIT_STATE_HOME: "/data"
+  CATALOG_OPS_CAPTURE: "true"
+autoscaling: { enabled: false }
+replicaCount: 1
+persistence: { enabled: true, storageClass: dynamic-rwo, size: 1Gi, mountPath: /data }

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -168,6 +168,11 @@ KNOWN_BROKEN = {
         "New service — first-party embeddings image (apps/embeddings, FastAPI + nomic-embed-text) added to CI "
         "this PR. Pin tag:latest -> the sha- tag after the first CI build; no sha exists until merge."
     ),
+    "catalog-gateway:moving-tag": (
+        "New service — first-party catalog-gateway image (apps/catalog-gateway: the read/resolve/lineage + DCAT "
+        "interop seam over the Crystal Atlas catalog families) gets its Dockerfile + images.yml build entry in "
+        "this PR. Pin tag:latest -> the sha- tag after the first CI build; no sha exists until merge."
+    ),
     "nugget-extractor:moving-tag": (
         "New service — Seal-the-Walls W6.2 extraction spine (apps/nugget-extractor: documents -> warrant-typed "
         "KnowledgeNuggets) added to CI this PR. Pin tag:latest -> the sha- tag after the first CI build; no sha "


### PR DESCRIPTION
## What

Deploys **`apps/catalog-gateway`** — the read/resolve/lineage + DCAT interop seam over the Crystal Atlas catalog families (the GMS-equivalent; `docs/strategy/PROPHET_DATA_CATALOG_DESIGN.md`) — as a first-party **reference-tier** platform app. The app code itself already merged (#1158); this is the container + GitOps wiring only:

- `apps/catalog-gateway/Dockerfile` + `requirements.txt` (python:3.12-slim, non-root uid 10001, `uvicorn app.main:app`)
- `.github/workflows/images.yml` build entry
- `deploy/argocd/platform-services.yaml` appset entry `{ name: catalog-gateway, tier: reference }`
- `deploy/values/catalog-gateway.yaml` (port 8080, `/healthz`, PVC at `/data`, `CATALOG_OPS_CAPTURE=true`)
- `tools/preflight_deploy_contract.py`: ratcheted `catalog-gateway:moving-tag` deferral

## Why the moving-tag deferral is correct, not a regression

`tag: latest` is the sanctioned **bootstrap** for a brand-new first-party service with no CI build yet — identical to the existing `embeddings`, `memoryd`, `entity-resolution` entries. The preflight ratchet **forces this line's deletion** once the first CI build lets `gitops-promote` sha-pin the tag, so it can never silently regress to `:latest`. `python3 tools/preflight_deploy_contract.py` → exit 0.

## Supersedes / relationship

- **Supersedes #1214** (`feat/catalog-gateway-deploy`), which was stacked on the pre-merge `feat/catalog-gateway-ops` base and ~70 commits behind. This branch is a single clean commit **fresh on current `main`**. Recommend closing #1214.
- **Independent of #1213** (ops-capture layer) — that lands the `catalog.*.v0` event capture separately; this PR only packages/deploys the app.

## Provenance

Consolidates deploy work that was in-flight across multiple local sessions onto one governed branch. Not auto-merging — leaving for Copilot review first.
