### PR TITLE
feat(embeddings-client): the one sovereign-embeddings client, fail-closed on space drift (PR-2/3)

### DIFF
--- a/libs/ts/embeddings-client/README.md
+++ b/libs/ts/embeddings-client/README.md
@@ -1,0 +1,59 @@
+# @socioprophet/embeddings-client
+
+The **one** client for the estate's sovereign embedding service
+(`prophet-platform/apps/embeddings`, serving `nomic-ai/nomic-embed-text-v1.5`
+over an OpenAI-compatible `POST /v1/embeddings`).
+
+It is the **runtime** half of the ingestion-pipeline seam. The
+[`sourceos-spec` `EmbeddingRequest` contract](../../../../sourceos-spec/specs/ingestion-pipeline-contract.md)
+pins the model and dimension *statically* (by `const`); this client enforces the
+**same pin at call time and fails closed** on any drift.
+
+## Why it exists
+
+`health-twin`, `hellgraph-service`, and Noetica's `doc-store` each grew their own
+`/v1/embeddings` fetch — with different default model strings
+(`nomic-embed-text` vs `nomic-ai/nomic-embed-text-v1.5`), different URLs, and
+**no verification of the response**. That is the `platform-services`-not-`Noetica`-only
+duplication, and a live vector-space-drift risk: two producers writing vectors
+that silently are not comparable. This lib is the single reuse point.
+
+## Use
+
+```ts
+import { embed, embedOne } from '@socioprophet/embeddings-client';
+
+const vectors = await embed(['first chunk', 'second chunk']); // number[][], each length 768
+const one = await embedOne('a query');                         // number[]
+```
+
+Point it at the service with `EMBEDDINGS_URL` (default
+`http://embeddings:8080/v1/embeddings`) or the `url` option.
+
+## The guarantee (fail closed)
+
+`embed()` returns **only** vectors provably in the pinned space. It throws
+`EmbeddingSpaceError` — a refusal, never a fallback — when:
+
+- the response `model` is not `nomic-ai/nomic-embed-text-v1.5` (a different space);
+- any vector length is not `768` (a truncated/foreign vector);
+- the vector count does not match the input count, or the service errors.
+
+A caller gets correct vectors or an error — never a silently-incomparable one.
+
+## Test
+
+```
+node --import tsx --test src/*.test.ts
+```
+
+Includes teeth tests: wrong dimension, wrong model, count mismatch and HTTP
+error each raise `EmbeddingSpaceError`.
+
+## Adoption (rollout)
+
+Replace the hand-rolled `/v1/embeddings` fetches in `apps/hellgraph-service`
+(`graphrag.ts` — currently defaults to the unpinned `nomic-embed-text` and does
+no dimension check), `apps/health-twin` (`reconcile/clients.ts`), and — via the
+Noetica `doc-store` rewire (PR-3) — the Noetica producer, so all embedding lands
+in one verified space.

--- a/libs/ts/embeddings-client/package.json
+++ b/libs/ts/embeddings-client/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@socioprophet/embeddings-client",
+  "version": "0.1.0",
+  "private": true,
+  "description": "The one client for the estate's sovereign embedding service (prophet-platform apps/embeddings). Speaks the sourceos-spec EmbeddingRequest shape and fails closed on model/dimension drift — the runtime guard against silently-incomparable vector spaces.",
+  "type": "commonjs",
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "node --import tsx --test src/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/libs/ts/embeddings-client/src/index.test.ts
+++ b/libs/ts/embeddings-client/src/index.test.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  embed,
+  embedOne,
+  embeddingRequest,
+  EmbeddingSpaceError,
+  EMBEDDINGS_MODEL,
+  EMBEDDINGS_DIMENSION,
+} from './index.ts';
+
+// A fake sovereign service. `over` lets each test bend one thing.
+function fakeFetch(over: { model?: string; dim?: number; status?: number; count?: number } = {}): typeof fetch {
+  const model = over.model ?? EMBEDDINGS_MODEL;
+  const dim = over.dim ?? EMBEDDINGS_DIMENSION;
+  return (async (_url: string, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body ?? '{}'));
+    const inputs: string[] = Array.isArray(body.input) ? body.input : [body.input];
+    const n = over.count ?? inputs.length;
+    const data = Array.from({ length: n }, (_v, index) => ({
+      object: 'embedding',
+      index,
+      embedding: Array.from({ length: dim }, (_x, i) => Math.sin(index + i)),
+    }));
+    return {
+      ok: (over.status ?? 200) < 400,
+      status: over.status ?? 200,
+      json: async () => ({ object: 'list', model, data }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+test('happy path: returns one pinned-dimension vector per input, in order', async () => {
+  const vecs = await embed(['alpha', 'beta'], { fetchImpl: fakeFetch() });
+  assert.equal(vecs.length, 2);
+  assert.equal(vecs[0].length, EMBEDDINGS_DIMENSION);
+  assert.equal(vecs[1].length, EMBEDDINGS_DIMENSION);
+});
+
+test('request is contract-shaped: sends the pinned model id', async () => {
+  let sent: any;
+  const capturing = (async (_u: string, init?: RequestInit) => {
+    sent = JSON.parse(String(init?.body));
+    return { ok: true, status: 200, json: async () => ({ model: EMBEDDINGS_MODEL, data: [{ index: 0, embedding: Array(EMBEDDINGS_DIMENSION).fill(0) }] }) } as unknown as Response;
+  }) as unknown as typeof fetch;
+  await embedOne('x', { fetchImpl: capturing });
+  assert.equal(sent.model, EMBEDDINGS_MODEL);
+  assert.deepEqual(sent.input, ['x']);
+});
+
+// ── TEETH: drift must be a refusal, not a silent wrong ──────────────────────
+test('fail-closed: wrong dimension throws EmbeddingSpaceError', async () => {
+  await assert.rejects(
+    () => embed('x', { fetchImpl: fakeFetch({ dim: 512 }) }),
+    (e: unknown) => e instanceof EmbeddingSpaceError && /length 512/.test((e as Error).message),
+  );
+});
+
+test('fail-closed: wrong model throws EmbeddingSpaceError', async () => {
+  await assert.rejects(
+    () => embed('x', { fetchImpl: fakeFetch({ model: 'ollama/nomic-embed-text' }) }),
+    (e: unknown) => e instanceof EmbeddingSpaceError && /incomparable space/.test((e as Error).message),
+  );
+});
+
+test('fail-closed: vector-count mismatch throws', async () => {
+  await assert.rejects(
+    () => embed(['a', 'b', 'c'], { fetchImpl: fakeFetch({ count: 2 }) }),
+    (e: unknown) => e instanceof EmbeddingSpaceError,
+  );
+});
+
+test('fail-closed: HTTP error throws', async () => {
+  await assert.rejects(
+    () => embed('x', { fetchImpl: fakeFetch({ status: 503 }) }),
+    (e: unknown) => e instanceof EmbeddingSpaceError && /HTTP 503/.test((e as Error).message),
+  );
+});
+
+test('empty input short-circuits to no vectors (no network call)', async () => {
+  const boom = (() => { throw new Error('must not fetch'); }) as unknown as typeof fetch;
+  assert.deepEqual(await embed([], { fetchImpl: boom }), []);
+});
+
+test('embeddingRequest builds the pinned contract record', () => {
+  assert.deepEqual(embeddingRequest('x'), {
+    model: EMBEDDINGS_MODEL,
+    dimension: EMBEDDINGS_DIMENSION,
+    input: 'x',
+  });
+});

--- a/libs/ts/embeddings-client/src/index.test.ts
+++ b/libs/ts/embeddings-client/src/index.test.ts
@@ -59,7 +59,7 @@ test('fail-closed: wrong dimension throws EmbeddingSpaceError', async () => {
 test('fail-closed: wrong model throws EmbeddingSpaceError', async () => {
   await assert.rejects(
     () => embed('x', { fetchImpl: fakeFetch({ model: 'ollama/nomic-embed-text' }) }),
-    (e: unknown) => e instanceof EmbeddingSpaceError && /incomparable space/.test((e as Error).message),
+    (e: unknown) => e instanceof EmbeddingSpaceError && /different space/.test((e as Error).message),
   );
 });
 
@@ -74,6 +74,53 @@ test('fail-closed: HTTP error throws', async () => {
   await assert.rejects(
     () => embed('x', { fetchImpl: fakeFetch({ status: 503 }) }),
     (e: unknown) => e instanceof EmbeddingSpaceError && /HTTP 503/.test((e as Error).message),
+  );
+});
+
+test('fail-closed: missing model in response is unverifiable and throws', async () => {
+  const noModel = (async () => ({
+    ok: true, status: 200,
+    json: async () => ({ object: 'list', data: [{ index: 0, embedding: Array(EMBEDDINGS_DIMENSION).fill(0) }] }),
+  } as unknown as Response)) as unknown as typeof fetch;
+  await assert.rejects(
+    () => embed('x', { fetchImpl: noModel }),
+    (e: unknown) => e instanceof EmbeddingSpaceError && /unverifiable or different space/.test((e as Error).message),
+  );
+});
+
+test('fail-closed: unparseable JSON throws EmbeddingSpaceError', async () => {
+  const badJson = (async () => ({
+    ok: true, status: 200,
+    json: async () => { throw new SyntaxError('Unexpected token < in JSON'); },
+  } as unknown as Response)) as unknown as typeof fetch;
+  await assert.rejects(
+    () => embed('x', { fetchImpl: badJson }),
+    (e: unknown) => e instanceof EmbeddingSpaceError && /unparseable JSON/.test((e as Error).message),
+  );
+});
+
+test('fail-closed: a network/fetch failure surfaces as EmbeddingSpaceError', async () => {
+  const boom = (async () => { throw new TypeError('network down'); }) as unknown as typeof fetch;
+  await assert.rejects(
+    () => embed('x', { fetchImpl: boom }),
+    (e: unknown) => e instanceof EmbeddingSpaceError && /failed: network down/.test((e as Error).message),
+  );
+});
+
+test('fail-closed: duplicate/missing indices (correct count) throw rather than mis-map', async () => {
+  const dupIdx = (async () => ({
+    ok: true, status: 200,
+    json: async () => ({
+      object: 'list', model: EMBEDDINGS_MODEL,
+      data: [
+        { index: 0, embedding: Array(EMBEDDINGS_DIMENSION).fill(1) },
+        { index: 0, embedding: Array(EMBEDDINGS_DIMENSION).fill(2) }, // duplicate index
+      ],
+    }),
+  } as unknown as Response)) as unknown as typeof fetch;
+  await assert.rejects(
+    () => embed(['a', 'b'], { fetchImpl: dupIdx }),
+    (e: unknown) => e instanceof EmbeddingSpaceError && /permutation of 0\.\.1/.test((e as Error).message),
   );
 });
 

--- a/libs/ts/embeddings-client/src/index.ts
+++ b/libs/ts/embeddings-client/src/index.ts
@@ -75,27 +75,41 @@ export async function embed(
   if (opts.apiKey) headers['authorization'] = `Bearer ${opts.apiKey}`;
 
   // Wire body is OpenAI/Ollama compatible; we always send the pinned model id so
-  // the request itself is contract-shaped (EmbeddingRequest).
+  // Wire body is OpenAI/Ollama compatible ({model, input}); the full contract
+  // record (incl. dimension) is available via embeddingRequest().
   const body = JSON.stringify({ model: EMBEDDINGS_MODEL, input: texts });
 
-  const res = await fetchImpl(url, {
-    method: 'POST',
-    headers,
-    body,
-    signal: AbortSignal.timeout(opts.timeoutMs ?? 15_000),
-  });
+  // Fail closed on transport too: fetch/JSON failures must surface as
+  // EmbeddingSpaceError so a caller gets correct vectors or that error — never
+  // some other exception type that slips past the contract.
+  let res: Response;
+  try {
+    res = await fetchImpl(url, {
+      method: 'POST',
+      headers,
+      body,
+      signal: AbortSignal.timeout(opts.timeoutMs ?? 15_000),
+    });
+  } catch (err) {
+    throw new EmbeddingSpaceError(`embeddings request to ${url} failed: ${(err as Error).message}`);
+  }
   if (!res.ok) {
     throw new EmbeddingSpaceError(`embeddings service returned HTTP ${res.status} from ${url}`);
   }
 
-  const payload = (await res.json()) as OpenAIEmbeddingsResponse;
+  let payload: OpenAIEmbeddingsResponse;
+  try {
+    payload = (await res.json()) as OpenAIEmbeddingsResponse;
+  } catch (err) {
+    throw new EmbeddingSpaceError(`embeddings service returned unparseable JSON from ${url}: ${(err as Error).message}`);
+  }
 
-  // Fail closed on model drift. A service that answers as a different model is,
-  // by construction, a different vector space — refuse rather than compare.
-  if (payload.model && payload.model !== EMBEDDINGS_MODEL) {
+  // Fail closed on model drift — INCLUDING a missing model. The guarantee is
+  // "provably in the pinned space"; an unnamed model is unverifiable, so refuse.
+  if (payload.model !== EMBEDDINGS_MODEL) {
     throw new EmbeddingSpaceError(
-      `embeddings service reported model ${JSON.stringify(payload.model)}, not the pinned ` +
-        `${JSON.stringify(EMBEDDINGS_MODEL)} — a different, incomparable space`,
+      `embeddings service reported model ${JSON.stringify(payload.model ?? null)}, not the pinned ` +
+        `${JSON.stringify(EMBEDDINGS_MODEL)} — an unverifiable or different space`,
     );
   }
 
@@ -106,8 +120,23 @@ export async function embed(
     );
   }
 
-  // Preserve input order (OpenAI guarantees index, but do not trust it — sort).
-  const ordered = [...rows].sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+  // Trust `index` only after proving it is a permutation of 0..n-1. Duplicate or
+  // missing indices with a correct count would otherwise silently associate a
+  // vector with the wrong input — the exact silent-wrong the guarantee forbids.
+  const n = rows.length;
+  const seen = new Array<boolean>(n).fill(false);
+  for (const row of rows) {
+    const idx = row.index;
+    if (typeof idx !== 'number' || !Number.isInteger(idx) || idx < 0 || idx >= n || seen[idx]) {
+      throw new EmbeddingSpaceError(
+        `embeddings response indices are not a permutation of 0..${n - 1} ` +
+          `(bad or duplicate index ${JSON.stringify(idx)})`,
+      );
+    }
+    seen[idx] = true;
+  }
+
+  const ordered = [...rows].sort((a, b) => (a.index as number) - (b.index as number));
   return ordered.map((row, i) => {
     const vec = row.embedding;
     if (!Array.isArray(vec) || vec.length !== EMBEDDINGS_DIMENSION) {

--- a/libs/ts/embeddings-client/src/index.ts
+++ b/libs/ts/embeddings-client/src/index.ts
@@ -1,0 +1,132 @@
+// @socioprophet/embeddings-client — the one client for the estate's sovereign
+// embedding service (prophet-platform apps/embeddings). It is the runtime
+// complement to the sourceos-spec Ingestion-Pipeline contract's EmbeddingRequest:
+// the contract pins the model and dimension by `const` statically; this client
+// enforces the SAME pin at call time and FAILS CLOSED on any drift, so a caller
+// can never silently land vectors from a different, incomparable space.
+//
+// Why this exists: health-twin, hellgraph-service and Noetica's doc-store each
+// grew their own /v1/embeddings fetch, with different default model strings
+// (e.g. 'nomic-embed-text' vs 'nomic-ai/nomic-embed-text-v1.5') and NO response
+// verification — the platform-services-not-Noetica-only duplication, and a live
+// vector-space-drift risk. This lib is the single reuse point for all of them.
+
+/** The sovereign embedding model. Pinned — matches sourceos-spec EmbeddingRequest.model. */
+export const EMBEDDINGS_MODEL = 'nomic-ai/nomic-embed-text-v1.5';
+/** The pinned embedding dimension. Matches sourceos-spec EmbeddingRequest.dimension. */
+export const EMBEDDINGS_DIMENSION = 768;
+
+/** The contract-shaped request record (mirror of sourceos-spec EmbeddingRequest). */
+export interface EmbeddingRequest {
+  readonly model: typeof EMBEDDINGS_MODEL;
+  readonly dimension: typeof EMBEDDINGS_DIMENSION;
+  readonly input: string | readonly string[];
+}
+
+export interface EmbedOptions {
+  /** Full URL of the sovereign service's embeddings endpoint (…/v1/embeddings). */
+  url?: string;
+  /** Optional bearer token. */
+  apiKey?: string;
+  /** Injected for tests; defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Per-call timeout (ms). */
+  timeoutMs?: number;
+}
+
+/** Thrown when the service returns vectors that are not in the pinned space.
+ *  This is a REFUSAL, not a fallback — the whole point is that drift is loud. */
+export class EmbeddingSpaceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EmbeddingSpaceError';
+  }
+}
+
+const DEFAULT_URL =
+  (typeof process !== 'undefined' && process.env && process.env['EMBEDDINGS_URL']?.trim()) ||
+  'http://embeddings:8080/v1/embeddings';
+
+interface OpenAIEmbeddingsResponse {
+  object?: string;
+  model?: string;
+  data?: Array<{ object?: string; index?: number; embedding?: number[] }>;
+}
+
+/**
+ * Embed one or more texts against the sovereign service and RETURN ONLY vectors
+ * that are provably in the pinned space. Any response whose model differs from
+ * {@link EMBEDDINGS_MODEL}, or any vector whose length differs from
+ * {@link EMBEDDINGS_DIMENSION}, throws {@link EmbeddingSpaceError} — the caller
+ * gets correct vectors or an error, never a silently-incomparable vector.
+ *
+ * Returns one vector per input string, in input order.
+ */
+export async function embed(
+  input: string | readonly string[],
+  opts: EmbedOptions = {},
+): Promise<number[][]> {
+  const texts = typeof input === 'string' ? [input] : [...input];
+  if (texts.length === 0) return [];
+
+  const url = opts.url ?? DEFAULT_URL;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (opts.apiKey) headers['authorization'] = `Bearer ${opts.apiKey}`;
+
+  // Wire body is OpenAI/Ollama compatible; we always send the pinned model id so
+  // the request itself is contract-shaped (EmbeddingRequest).
+  const body = JSON.stringify({ model: EMBEDDINGS_MODEL, input: texts });
+
+  const res = await fetchImpl(url, {
+    method: 'POST',
+    headers,
+    body,
+    signal: AbortSignal.timeout(opts.timeoutMs ?? 15_000),
+  });
+  if (!res.ok) {
+    throw new EmbeddingSpaceError(`embeddings service returned HTTP ${res.status} from ${url}`);
+  }
+
+  const payload = (await res.json()) as OpenAIEmbeddingsResponse;
+
+  // Fail closed on model drift. A service that answers as a different model is,
+  // by construction, a different vector space — refuse rather than compare.
+  if (payload.model && payload.model !== EMBEDDINGS_MODEL) {
+    throw new EmbeddingSpaceError(
+      `embeddings service reported model ${JSON.stringify(payload.model)}, not the pinned ` +
+        `${JSON.stringify(EMBEDDINGS_MODEL)} — a different, incomparable space`,
+    );
+  }
+
+  const rows = payload.data;
+  if (!Array.isArray(rows) || rows.length !== texts.length) {
+    throw new EmbeddingSpaceError(
+      `embeddings service returned ${rows?.length ?? 0} vectors for ${texts.length} inputs`,
+    );
+  }
+
+  // Preserve input order (OpenAI guarantees index, but do not trust it — sort).
+  const ordered = [...rows].sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+  return ordered.map((row, i) => {
+    const vec = row.embedding;
+    if (!Array.isArray(vec) || vec.length !== EMBEDDINGS_DIMENSION) {
+      throw new EmbeddingSpaceError(
+        `vector ${i} has length ${vec?.length ?? 0}, not the pinned ${EMBEDDINGS_DIMENSION} — ` +
+          `a truncated or foreign vector is not in the shared space`,
+      );
+    }
+    return vec;
+  });
+}
+
+/** Convenience for the common single-text case. */
+export async function embedOne(text: string, opts: EmbedOptions = {}): Promise<number[]> {
+  const [vec] = await embed(text, opts);
+  return vec;
+}
+
+/** Build the contract-shaped request record (for provenance / typing at call sites). */
+export function embeddingRequest(input: string | readonly string[]): EmbeddingRequest {
+  return { model: EMBEDDINGS_MODEL, dimension: EMBEDDINGS_DIMENSION, input };
+}

--- a/libs/ts/embeddings-client/tsconfig.json
+++ b/libs/ts/embeddings-client/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What & why

**PR-2 of 3** in the ingestion-pipeline lift (follows the contract in [sourceos-spec#239](https://github.com/SourceOS-Linux/sourceos-spec/pull/239)). Adds `libs/ts/embeddings-client` — the **one** client for the sovereign embedding service (`apps/embeddings`, `nomic-ai/nomic-embed-text-v1.5`).

It's the **runtime** half of the seam: the contract pins model + dimension *statically* (`const`); this lib enforces the **same pin at call time and fails closed**.

## The problem it closes
`health-twin` (`reconcile/clients.ts`), `hellgraph-service` (`graphrag.ts`), and Noetica's `doc-store` each grew their own `/v1/embeddings` fetch — with **different default model strings** (`hellgraph-service` defaults to the *unpinned* `nomic-embed-text`), different URLs, and **no verification of the response vector**. That is the `platform-services`-not-`Noetica`-only duplication and a live vector-space-drift risk.

## Guarantee (fail closed)
`embed()`/`embedOne()` return only vectors provably in the pinned space, else throw `EmbeddingSpaceError` — a refusal, not a fallback — when: response model ≠ `nomic-ai/nomic-embed-text-v1.5`, any vector length ≠ `768`, count mismatch, or HTTP error.

## Tests — 8/8, teeth included
`node --import tsx --test` → wrong-dimension, wrong-model, count-mismatch and HTTP-error each raise `EmbeddingSpaceError`; happy path + contract-shaped request + empty-input short-circuit pass.

## Rollout (follow-ups, not this PR)
Adopt in `hellgraph-service` / `health-twin`, and via **PR-3** the Noetica `doc-store` rewire, so all embedding lands in one verified space. Kept separate to avoid bundling behavioural changes to live services with the lib introduction.

Not auto-merging — for review first.
