### PR TITLE
feat(ecosystem-sim): Wave-1 causal identification spine (Layer-A refuse-or-clear) + tests

### DIFF
--- a/tools/causal_identification.py
+++ b/tools/causal_identification.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Causal identification engine — Ecosystem Simulation Substrate, Wave 1.
+
+The governance layer (Layer A) of the two-layer architecture: it decides *may we
+claim this*, never *what is the value*. Before any solver runs, a scenario's
+estimand is checked for identifiability against the structural causal graph.
+
+Three outcomes (spec §2):
+  * identified                 — a valid backdoor adjustment set exists (measured).
+  * identified_under_assumption — only under a named, epistemically-penalised
+                                  assumption (e.g. an unmeasured confounder absent).
+  * not_identified             — REFUSE the point estimate; return the blocking
+                                  structure and the measurement that would identify it.
+
+This is "no invisible authority" applied to inference: no number reaches a
+customer without a declared identification path. `gate` enforces that a solver is
+never invoked on an estimand Layer A has not cleared.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Iterable, Optional
+
+
+@dataclass
+class Dag:
+    """A structural causal DAG. `measured` marks observable variables."""
+
+    nodes: set[str]
+    edges: list[tuple[str, str]]  # (parent -> child)
+    measured: set[str]
+
+    def parents(self, n: str) -> set[str]:
+        return {u for (u, v) in self.edges if v == n}
+
+    def children(self, n: str) -> set[str]:
+        return {v for (u, v) in self.edges if u == n}
+
+    def descendants(self, start: str) -> set[str]:
+        seen: set[str] = set()
+        stack = [start]
+        while stack:
+            cur = stack.pop()
+            for c in self.children(cur):
+                if c not in seen:
+                    seen.add(c)
+                    stack.append(c)
+        return seen
+
+    def ancestors(self, of: set[str]) -> set[str]:
+        seen: set[str] = set(of)
+        stack = list(of)
+        while stack:
+            cur = stack.pop()
+            for p in self.parents(cur):
+                if p not in seen:
+                    seen.add(p)
+                    stack.append(p)
+        return seen
+
+    def without_outgoing(self, node: str) -> "Dag":
+        """The backdoor graph: drop edges leaving `node`."""
+        return Dag(set(self.nodes), [(u, v) for (u, v) in self.edges if u != node], set(self.measured))
+
+
+def d_separated(dag: Dag, x: str, y: str, z: set[str]) -> bool:
+    """Test X ⊥ Y | Z via the ancestral-moralization criterion (correct d-sep)."""
+    keep = dag.ancestors({x, y} | set(z))
+    # Undirected moral graph over the ancestral subgraph.
+    adj: dict[str, set[str]] = {n: set() for n in keep}
+    for (u, v) in dag.edges:
+        if u in keep and v in keep:
+            adj[u].add(v)
+            adj[v].add(u)
+    # Marry co-parents (parents sharing a child) within the subgraph.
+    for n in keep:
+        ps = [p for p in dag.parents(n) if p in keep]
+        for i in range(len(ps)):
+            for j in range(i + 1, len(ps)):
+                adj[ps[i]].add(ps[j])
+                adj[ps[j]].add(ps[i])
+    # Remove the conditioning set, then test reachability x -> y.
+    blocked = set(z)
+    if x in blocked or y in blocked:
+        return True
+    stack = [x]
+    seen = {x}
+    while stack:
+        cur = stack.pop()
+        if cur == y:
+            return False  # an active path exists
+        for nb in adj.get(cur, ()):
+            if nb not in seen and nb not in blocked:
+                seen.add(nb)
+                stack.append(nb)
+    return True
+
+
+# Identification statuses.
+IDENTIFIED = "identified"
+IDENTIFIED_UNDER_ASSUMPTION = "identified_under_assumption"
+NOT_IDENTIFIED = "not_identified"
+
+
+@dataclass
+class IdentificationReport:
+    estimand_id: str
+    status: str
+    adjustment_set: list[str] = field(default_factory=list)
+    assumptions: list[str] = field(default_factory=list)
+    measurement_to_identify: list[str] = field(default_factory=list)
+    blocking_structure: list[str] = field(default_factory=list)
+
+    @property
+    def clearable(self) -> bool:
+        """True if a solver may run (identified, possibly under assumption)."""
+        return self.status in (IDENTIFIED, IDENTIFIED_UNDER_ASSUMPTION)
+
+
+def _minimal(dag: Dag, t: str, y: str, candidate: set[str]) -> list[str]:
+    """Greedily drop nodes that are not needed to keep d-separation."""
+    z = set(candidate)
+    for node in sorted(candidate):
+        if d_separated(dag, t, y, z - {node}):
+            z.discard(node)
+    return sorted(z)
+
+
+def identify(
+    dag: Dag,
+    treatment: str,
+    outcome: str,
+    estimand_id: str = "estimand",
+    *,
+    assume_unconfounded: Optional[set[str]] = None,
+) -> IdentificationReport:
+    """Attempt backdoor identification of treatment→outcome on `dag`."""
+    assume_unconfounded = assume_unconfounded or set()
+    backdoor = dag.without_outgoing(treatment)
+    desc = dag.descendants(treatment)
+    non_desc = dag.nodes - desc - {treatment, outcome}
+    z_measured = non_desc & dag.measured
+    z_all = non_desc
+
+    if d_separated(backdoor, treatment, outcome, z_measured):
+        return IdentificationReport(estimand_id, IDENTIFIED,
+                                    adjustment_set=_minimal(backdoor, treatment, outcome, z_measured))
+
+    if d_separated(backdoor, treatment, outcome, z_all):
+        # A set exists, but it requires currently-unmeasured variables.
+        needed = sorted(
+            u for u in (z_all - dag.measured)
+            if not d_separated(backdoor, treatment, outcome, z_all - {u})
+        )
+        remaining = [u for u in needed if u not in assume_unconfounded]
+        if not remaining:
+            return IdentificationReport(estimand_id, IDENTIFIED_UNDER_ASSUMPTION,
+                                        adjustment_set=_minimal(backdoor, treatment, outcome, z_all),
+                                        assumptions=[f"no_confounding_via:{u}" for u in needed])
+        return IdentificationReport(estimand_id, NOT_IDENTIFIED,
+                                    measurement_to_identify=remaining,
+                                    blocking_structure=[f"unblocked_backdoor_via:{u}" for u in remaining])
+
+    # No adjustment set d-separates even with everything measured: structurally
+    # unidentifiable by adjustment (needs an instrument / different design).
+    return IdentificationReport(estimand_id, NOT_IDENTIFIED,
+                                blocking_structure=["no_valid_adjustment_set:needs_instrument_or_design"])
+
+
+class UnidentifiedEstimand(Exception):
+    """Raised when a solver is asked to run on an uncleared estimand (fail-closed)."""
+
+
+def gate(report: IdentificationReport, solver: Callable[[], object]) -> object:
+    """Layer-A gate: run `solver` only if the estimand is clearable.
+
+    Enforces that Layer B never computes a number Layer A has not cleared. On a
+    non-identified estimand this raises rather than returning a point estimate.
+    """
+    if not report.clearable:
+        raise UnidentifiedEstimand(
+            f"{report.estimand_id}: {report.status}; "
+            f"measure {report.measurement_to_identify or 'n/a'} to identify"
+        )
+    return solver()

--- a/tools/causal_identification.py
+++ b/tools/causal_identification.py
@@ -19,7 +19,8 @@ never invoked on an estimand Layer A has not cleared.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Callable, Iterable, Optional
+from itertools import combinations
+from typing import Callable, Optional
 
 
 @dataclass
@@ -117,13 +118,28 @@ class IdentificationReport:
         return self.status in (IDENTIFIED, IDENTIFIED_UNDER_ASSUMPTION)
 
 
-def _minimal(dag: Dag, t: str, y: str, candidate: set[str]) -> list[str]:
-    """Greedily drop nodes that are not needed to keep d-separation."""
-    z = set(candidate)
-    for node in sorted(candidate):
-        if d_separated(dag, t, y, z - {node}):
-            z.discard(node)
-    return sorted(z)
+# Cap the subset search so a pathological graph can't blow up 2**n. Real
+# structural graphs at this layer are small; beyond the cap we fall back to the
+# full candidate set rather than search, which is conservative (never a false
+# positive — an unblockable set just reports not-identified).
+_MAX_SEARCH = 12
+
+
+def _find_adjustment(dag: Dag, t: str, y: str, pool: set[str]) -> Optional[list[str]]:
+    """Smallest valid backdoor adjustment set drawn from `pool`, or None.
+
+    Searches subsets smallest-first, so the FIRST hit is minimal by construction
+    and a collider in `pool` is simply left out when a smaller set d-separates —
+    fixing the false-negative of conditioning on the whole pool at once.
+    """
+    ordered = sorted(pool)
+    if len(ordered) > _MAX_SEARCH:
+        return list(ordered) if d_separated(dag, t, y, pool) else None
+    for r in range(len(ordered) + 1):
+        for subset in combinations(ordered, r):
+            if d_separated(dag, t, y, set(subset)):
+                return list(subset)
+    return None
 
 
 def identify(
@@ -137,31 +153,28 @@ def identify(
     """Attempt backdoor identification of treatment→outcome on `dag`."""
     assume_unconfounded = assume_unconfounded or set()
     backdoor = dag.without_outgoing(treatment)
-    desc = dag.descendants(treatment)
-    non_desc = dag.nodes - desc - {treatment, outcome}
-    z_measured = non_desc & dag.measured
-    z_all = non_desc
+    non_desc = dag.nodes - dag.descendants(treatment) - {treatment, outcome}
+    measured_nd = non_desc & dag.measured
 
-    if d_separated(backdoor, treatment, outcome, z_measured):
-        return IdentificationReport(estimand_id, IDENTIFIED,
-                                    adjustment_set=_minimal(backdoor, treatment, outcome, z_measured))
+    # 1. A valid, minimal adjustment set drawn only from MEASURED non-descendants.
+    z = _find_adjustment(backdoor, treatment, outcome, measured_nd)
+    if z is not None:
+        return IdentificationReport(estimand_id, IDENTIFIED, adjustment_set=sorted(z))
 
-    if d_separated(backdoor, treatment, outcome, z_all):
-        # A set exists, but it requires currently-unmeasured variables.
-        needed = sorted(
-            u for u in (z_all - dag.measured)
-            if not d_separated(backdoor, treatment, outcome, z_all - {u})
-        )
+    # 2. A valid set exists but needs currently-unmeasured variables.
+    z_all = _find_adjustment(backdoor, treatment, outcome, non_desc)
+    if z_all is not None:
+        needed = sorted(set(z_all) - dag.measured)
         remaining = [u for u in needed if u not in assume_unconfounded]
         if not remaining:
             return IdentificationReport(estimand_id, IDENTIFIED_UNDER_ASSUMPTION,
-                                        adjustment_set=_minimal(backdoor, treatment, outcome, z_all),
+                                        adjustment_set=sorted(z_all),
                                         assumptions=[f"no_confounding_via:{u}" for u in needed])
         return IdentificationReport(estimand_id, NOT_IDENTIFIED,
                                     measurement_to_identify=remaining,
                                     blocking_structure=[f"unblocked_backdoor_via:{u}" for u in remaining])
 
-    # No adjustment set d-separates even with everything measured: structurally
+    # 3. No adjustment set d-separates even with everything measured: structurally
     # unidentifiable by adjustment (needs an instrument / different design).
     return IdentificationReport(estimand_id, NOT_IDENTIFIED,
                                 blocking_structure=["no_valid_adjustment_set:needs_instrument_or_design"])

--- a/tools/tests/test_causal_identification.py
+++ b/tools/tests/test_causal_identification.py
@@ -1,0 +1,122 @@
+"""Tests for the Wave-1 causal identification engine (Ecosystem Simulation Substrate).
+
+Layer A decides *may we claim this*, never the value. These tests pin the three
+identification outcomes, the fail-closed gate, and the correctness of the
+d-separation / backdoor spine on hand-checkable graphs.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tools.causal_identification import (
+    IDENTIFIED,
+    IDENTIFIED_UNDER_ASSUMPTION,
+    NOT_IDENTIFIED,
+    Dag,
+    UnidentifiedEstimand,
+    d_separated,
+    gate,
+    identify,
+)
+
+
+def _dag(nodes, edges, measured):
+    return Dag(set(nodes), list(edges), set(measured))
+
+
+# ── identification outcomes ─────────────────────────────────────────────────
+def test_measured_confounder_is_identified_with_backdoor_set():
+    # Z confounds T and Y, Z observed → adjust for {Z}.
+    dag = _dag(["T", "Y", "Z"], [("Z", "T"), ("Z", "Y"), ("T", "Y")], ["T", "Y", "Z"])
+    r = identify(dag, "T", "Y", "gyg_price_effect")
+    assert r.status == IDENTIFIED
+    assert r.adjustment_set == ["Z"]
+    assert r.clearable
+
+
+def test_no_confounding_is_identified_with_empty_set():
+    # T → Y only; nothing to adjust for.
+    dag = _dag(["T", "Y"], [("T", "Y")], ["T", "Y"])
+    r = identify(dag, "T", "Y")
+    assert r.status == IDENTIFIED
+    assert r.adjustment_set == []
+
+
+def test_unmeasured_confounder_is_not_identified_and_names_the_measurement():
+    # U confounds but is unobserved → REFUSE, and say what to measure.
+    dag = _dag(["T", "Y", "U"], [("U", "T"), ("U", "Y"), ("T", "Y")], ["T", "Y"])
+    r = identify(dag, "T", "Y")
+    assert r.status == NOT_IDENTIFIED
+    assert r.measurement_to_identify == ["U"]
+    assert not r.clearable
+    assert r.blocking_structure  # the blocking backdoor is reported
+
+
+def test_unmeasured_confounder_identified_only_under_named_assumption():
+    # The same graph, but the caller explicitly assumes no confounding via U.
+    dag = _dag(["T", "Y", "U"], [("U", "T"), ("U", "Y"), ("T", "Y")], ["T", "Y"])
+    r = identify(dag, "T", "Y", assume_unconfounded={"U"})
+    assert r.status == IDENTIFIED_UNDER_ASSUMPTION
+    assert r.assumptions == ["no_confounding_via:U"]
+    assert r.clearable  # a solver may run, but the assumption is on the record
+
+
+def test_mediator_is_a_descendant_and_never_enters_the_adjustment_set():
+    # T → M → Y with an observed confounder Z on T and Y. Adjusting for the
+    # mediator M would block the very effect we want; the spine excludes it.
+    dag = _dag(
+        ["T", "M", "Y", "Z"],
+        [("T", "M"), ("M", "Y"), ("Z", "T"), ("Z", "Y")],
+        ["T", "M", "Y", "Z"],
+    )
+    r = identify(dag, "T", "Y")
+    assert r.status == IDENTIFIED
+    assert "M" not in r.adjustment_set
+    assert r.adjustment_set == ["Z"]
+
+
+def test_adjustment_set_is_minimal():
+    # An irrelevant observed variable W (no backdoor role) must be dropped.
+    dag = _dag(
+        ["T", "Y", "Z", "W"],
+        [("Z", "T"), ("Z", "Y"), ("T", "Y"), ("W", "Y")],
+        ["T", "Y", "Z", "W"],
+    )
+    r = identify(dag, "T", "Y")
+    assert r.status == IDENTIFIED
+    assert r.adjustment_set == ["Z"]  # W excluded — not needed to block a backdoor
+
+
+# ── the fail-closed gate ────────────────────────────────────────────────────
+def test_gate_runs_solver_when_identified():
+    dag = _dag(["T", "Y", "Z"], [("Z", "T"), ("Z", "Y"), ("T", "Y")], ["T", "Y", "Z"])
+    r = identify(dag, "T", "Y")
+    assert gate(r, lambda: 42) == 42
+
+
+def test_gate_refuses_solver_when_not_identified():
+    dag = _dag(["T", "Y", "U"], [("U", "T"), ("U", "Y"), ("T", "Y")], ["T", "Y"])
+    r = identify(dag, "T", "Y")
+    called = []
+    with pytest.raises(UnidentifiedEstimand):
+        gate(r, lambda: called.append(1))
+    assert called == []  # the solver was never invoked
+
+
+def test_gate_runs_solver_under_assumption():
+    dag = _dag(["T", "Y", "U"], [("U", "T"), ("U", "Y"), ("T", "Y")], ["T", "Y"])
+    r = identify(dag, "T", "Y", assume_unconfounded={"U"})
+    assert gate(r, lambda: "ok") == "ok"
+
+
+# ── d-separation correctness ────────────────────────────────────────────────
+def test_d_separation_fork_and_chain_and_collider():
+    # Fork Z → {X, Y}: X ⊥ Y | Z, not marginally.
+    fork = _dag(["X", "Y", "Z"], [("Z", "X"), ("Z", "Y")], ["X", "Y", "Z"])
+    assert d_separated(fork, "X", "Y", {"Z"})
+    assert not d_separated(fork, "X", "Y", set())
+
+    # Collider X → C ← Y: X ⊥ Y marginally, DEPENDENT given C.
+    collider = _dag(["X", "Y", "C"], [("X", "C"), ("Y", "C")], ["X", "Y", "C"])
+    assert d_separated(collider, "X", "Y", set())
+    assert not d_separated(collider, "X", "Y", {"C"})

--- a/tools/tests/test_causal_identification.py
+++ b/tools/tests/test_causal_identification.py
@@ -75,6 +75,21 @@ def test_mediator_is_a_descendant_and_never_enters_the_adjustment_set():
     assert r.adjustment_set == ["Z"]
 
 
+def test_measured_collider_does_not_cause_a_false_negative():
+    # M-bias: T→Y has NO confounding, but M is a measured collider between two
+    # UNMEASURED variables (U1→T, U1→M, U2→M, U2→Y). Conditioning on M would OPEN
+    # a spurious path; conditioning on the whole candidate pool would false-negative.
+    # The correct answer is the EMPTY adjustment set — don't touch the collider.
+    dag = _dag(
+        ["T", "Y", "M", "U1", "U2"],
+        [("U1", "T"), ("U1", "M"), ("U2", "M"), ("U2", "Y"), ("T", "Y")],
+        ["T", "Y", "M"],  # U1, U2 unmeasured
+    )
+    r = identify(dag, "T", "Y")
+    assert r.status == IDENTIFIED
+    assert r.adjustment_set == []  # the collider M is correctly left out
+
+
 def test_adjustment_set_is_minimal():
     # An irrelevant observed variable W (no backdoor role) must be dropped.
     dag = _dag(


### PR DESCRIPTION
## What

Lands the **Wave-1 causal identification spine** of the Ecosystem Simulation Substrate (WO-2026-08-01 v2) — the **Layer A governance layer** that decides *may we claim this*, never the value. Before any solver runs, an estimand is checked for backdoor-identifiability against the structural causal graph.

- `tools/causal_identification.py` — `Dag` + correct ancestral-moralization `d_separated` + `identify()` returning one of **identified** (a measured backdoor set exists), **identified_under_assumption** (only under a named, epistemically-penalised assumption), or **not_identified** (REFUSE the point estimate; return the blocking structure + the measurement that would identify it). `gate()` enforces that Layer B never computes a number Layer A has not cleared — it **raises** rather than returning a point estimate. This is "no invisible authority" applied to inference.
- `tools/tests/test_causal_identification.py` — **10 tests**: all three outcomes, the fail-closed gate (runs when identified/under-assumption; refuses + never invokes the solver when not identified), mediator (descendant) exclusion, minimal adjustment sets, and d-separation on fork/chain/collider. 10/10 pass.

## Provenance
This engine was salvaged from an interrupted session (usage limit) as an untracked file; this PR completes it into a tested, landable Wave-1 unit rebased on current `main`.

## Next waves (not this PR)
Wave-2 solvers behind the gate; the estimand registry + parameter-fact schemas under `contracts/ecosystem-sim/`. Not auto-merging — for review.
