### PR TITLE
board-parity: reconciler + fail-closed drill + workflow (from main, minted App token)

### DIFF
--- a/.github/workflows/board-parity.yml
+++ b/.github/workflows/board-parity.yml
@@ -1,0 +1,93 @@
+name: board-parity
+
+# Fail-closed parity between the program boards' source of truth
+# (sociosphere registry/board-spec.yaml) and GitHub Projects.
+#
+#   schedule        -> DRILL: assert GitHub matches the spec; red on drift.
+#   workflow_dispatch -> DRILL (default) or RECONCILE (converge GitHub to spec).
+#
+# Governed by git-ops-standards controls this estate just adopted:
+#   * ops-workflows-run-from-default-branch — this operational workflow runs
+#     from the default branch (GitHub only fires `schedule` from the default
+#     branch), never a feature ref.
+#   * ci-secrets-minted-never-static-pat — auth is a MINTED GitHub App
+#     installation token (actions/create-github-app-token), never a static
+#     PAT. A minted App token is single-org, so the MVP scopes to the App's
+#     org (SocioProphet, where all but one board item live); extending to
+#     SourceOS-Linux / SociOS-Linux = install the App there and drop --owner.
+#
+# No-op (green) until the org App is configured, exactly like estate-ci-health.
+
+on:
+  schedule:
+    - cron: "17 7 * * *"   # daily drill
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "drill (assert only) or reconcile (converge GitHub to spec)"
+        type: choice
+        options: [drill, reconcile]
+        default: drill
+
+permissions:
+  contents: read
+
+concurrency:
+  group: board-parity
+  cancel-in-progress: false
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint org App token (never a static PAT)
+        id: app-token
+        if: ${{ vars.GH_OPS_APP_CONFIGURED == 'true' }}
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.GH_OPS_APP_ID }}
+          private-key: ${{ secrets.GH_OPS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Skip until the App is configured
+        if: ${{ vars.GH_OPS_APP_CONFIGURED != 'true' }}
+        run: |
+          echo "GH_OPS_APP_CONFIGURED != true — board-parity needs a minted App token"
+          echo "(App must have org Projects write). Skipping (green, not a failure)."
+
+      - uses: actions/checkout@v4
+        if: ${{ vars.GH_OPS_APP_CONFIGURED == 'true' }}
+
+      - name: Fetch board-spec.yaml (source of truth) from sociosphere
+        if: ${{ vars.GH_OPS_APP_CONFIGURED == 'true' }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository_owner }}/sociosphere
+          path: _sociosphere
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: actions/setup-python@v5
+        if: ${{ vars.GH_OPS_APP_CONFIGURED == 'true' }}
+        with:
+          python-version: "3.12"
+      - if: ${{ vars.GH_OPS_APP_CONFIGURED == 'true' }}
+        run: pip install pyyaml
+
+      - name: Prove the drill fires both ways
+        if: ${{ vars.GH_OPS_APP_CONFIGURED == 'true' }}
+        run: python3 tools/tests/test_board_parity_drill.py
+
+      - name: Run parity (drill by default; reconcile on dispatch)
+        if: ${{ vars.GH_OPS_APP_CONFIGURED == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SPEC: _sociosphere/registry/board-spec.yaml
+          OWNER: ${{ github.repository_owner }}
+          MODE: ${{ github.event.inputs.mode || 'drill' }}
+        run: |
+          set -euo pipefail
+          if [ "$MODE" = "reconcile" ]; then
+            python3 tools/reconcile_program_boards.py --spec "$SPEC" --owner "$OWNER"
+          fi
+          # Always finish with the fail-closed drill (also the post-reconcile assertion).
+          python3 tools/board_parity_drill.py --spec "$SPEC" --owner "$OWNER"

--- a/tools/board_parity_drill.py
+++ b/tools/board_parity_drill.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Fail-closed parity drill: does GitHub match board-spec.yaml?
+
+For every board in the spec that declares issue items, assert each declared
+issue is actually present on the corresponding GitHub Project. Any missing
+item is DRIFT and the drill exits non-zero (fail-closed) — a scheduled run of
+this on the default branch turns drift into a red CI signal that
+github-ci-health-current watches. This is a control-that-cannot-fail: it is
+proven to fire on seeded drift by tools/tests/test_board_parity_drill.py, so a
+silent green is meaningful rather than merely "nothing checked".
+
+Usage:
+    python3 tools/board_parity_drill.py --spec <path-to-board-spec.yaml> [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import board_spec_lib as lib
+
+
+def compute_drift(boards: list[dict], fetch) -> list[dict]:
+    """Pure diff: boards = spec boards with items; fetch(owner, number) -> set of
+    issue numbers present on that board. Returns a drift record per missing item.
+    No network here so it is unit-testable both ways."""
+    drift: list[dict] = []
+    for b in boards:
+        present = fetch(b["owner_org"], b["github_number"])
+        for item in b.get("items", []):
+            n = item["issue"]
+            if n not in present:
+                drift.append({
+                    "board": b["title"],
+                    "owner": b["owner_org"],
+                    "project": b["github_number"],
+                    "issue": n,
+                    "kind": "missing_from_board",
+                })
+    return drift
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--spec", required=True)
+    ap.add_argument("--owner", help="restrict to boards owned by this org "
+                    "(a minted App token is single-org; MVP covers the App's org)")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    spec = lib.load_spec(args.spec)
+    boards = lib.boards_with_items(spec)
+    if args.owner:
+        boards = [b for b in boards if b["owner_org"] == args.owner]
+    drift = compute_drift(boards, lib.project_issue_numbers)
+
+    if args.json:
+        print(json.dumps(drift, indent=2))
+    else:
+        checked = sum(len(b["items"]) for b in boards)
+        print(f"Board parity drill: {len(boards)} boards, {checked} declared items checked.")
+        if not drift:
+            print("OK: every spec'd item is present on its GitHub Project.")
+        else:
+            print(f"DRIFT: {len(drift)} declared item(s) missing from their board:")
+            for d in drift:
+                print(f"  - {d['board']} (proj {d['owner']}#{d['project']}): issue #{d['issue']} missing")
+            print("\nRun the reconciler (tools/reconcile_program_boards.py) to converge, "
+                  "then investigate why the drift occurred.")
+
+    return 1 if drift else 0  # fail-closed
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/board_parity_drill.py
+++ b/tools/board_parity_drill.py
@@ -50,9 +50,11 @@ def main() -> int:
     args = ap.parse_args()
 
     spec = lib.load_spec(args.spec)
-    boards = lib.boards_with_items(spec)
-    if args.owner:
-        boards = [b for b in boards if b["owner_org"] == args.owner]
+    try:
+        boards = lib.select_boards(spec, args.owner)
+    except ValueError as e:
+        print(f"ERROR: {e}")
+        return 2  # not "green with nothing checked"
     drift = compute_drift(boards, lib.project_issue_numbers)
 
     if args.json:

--- a/tools/board_spec_lib.py
+++ b/tools/board_spec_lib.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Shared helpers for the program-board reconciler + parity drill.
+
+The source of truth is sociosphere's registry/board-spec.yaml. GitHub Projects
+(and any sovereign board surface) are RENDER TARGETS converged from it. These
+helpers load the spec and read actual GitHub Project state via `gh`; the pure
+diff logic lives in board_parity_drill.compute_drift so it is unit-testable
+offline (no network) — see tools/tests/test_board_parity_drill.py.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+try:
+    import yaml  # type: ignore
+except Exception as exc:  # pragma: no cover
+    raise SystemExit("PyYAML is required (pip install pyyaml)") from exc
+
+
+def load_spec(path: str | Path) -> dict:
+    data = yaml.safe_load(Path(path).read_text())
+    if not isinstance(data, dict) or data.get("boards") is None:
+        raise SystemExit(f"{path}: not a board-spec (no 'boards')")
+    return data
+
+
+def boards_with_items(spec: dict) -> list[dict]:
+    """Spec boards that declare at least one issue item (the ones a drill checks)."""
+    return [b for b in spec["boards"] if b.get("items")]
+
+
+def sh(args: list[str], timeout: int = 60) -> tuple[int, str, str]:
+    r = subprocess.run(args, capture_output=True, text=True, timeout=timeout)
+    return r.returncode, r.stdout.strip(), r.stderr.strip()
+
+
+def project_issue_numbers(owner: str, number: int) -> set[int]:
+    """Issue numbers currently present as items on a GitHub Project (via gh)."""
+    rc, out, err = sh(
+        ["gh", "project", "item-list", str(number), "--owner", owner,
+         "--format", "json", "--limit", "300"]
+    )
+    if rc != 0:
+        raise SystemExit(f"gh project item-list {owner}#{number} failed: {err}")
+    items = json.loads(out).get("items", []) if out else []
+    return {
+        (it.get("content") or {}).get("number")
+        for it in items
+        if (it.get("content") or {}).get("number") is not None
+    }

--- a/tools/board_spec_lib.py
+++ b/tools/board_spec_lib.py
@@ -31,6 +31,25 @@ def boards_with_items(spec: dict) -> list[dict]:
     return [b for b in spec["boards"] if b.get("items")]
 
 
+def select_boards(spec: dict, owner: str | None = None) -> list[dict]:
+    """Boards a run should act on: those with items, optionally restricted to one
+    org. Refuses to return an EMPTY set — a drill that checks nothing must not be
+    able to report green (control-that-cannot-fail). Raises ValueError so callers
+    exit loudly instead of silently passing."""
+    boards = boards_with_items(spec)
+    if owner:
+        boards = [b for b in boards if b.get("owner_org") == owner]
+    if not boards:
+        raise ValueError(
+            f"no boards with items match owner={owner!r} — refusing to report "
+            "green on an empty check (is the owner/spec correct?)"
+        )
+    return boards
+
+
+ITEM_LIST_LIMIT = 300
+
+
 def sh(args: list[str], timeout: int = 60) -> tuple[int, str, str]:
     r = subprocess.run(args, capture_output=True, text=True, timeout=timeout)
     return r.returncode, r.stdout.strip(), r.stderr.strip()
@@ -40,11 +59,17 @@ def project_issue_numbers(owner: str, number: int) -> set[int]:
     """Issue numbers currently present as items on a GitHub Project (via gh)."""
     rc, out, err = sh(
         ["gh", "project", "item-list", str(number), "--owner", owner,
-         "--format", "json", "--limit", "300"]
+         "--format", "json", "--limit", str(ITEM_LIST_LIMIT)]
     )
     if rc != 0:
         raise SystemExit(f"gh project item-list {owner}#{number} failed: {err}")
     items = json.loads(out).get("items", []) if out else []
+    if len(items) >= ITEM_LIST_LIMIT:
+        # Truncation would silently hide members and mis-report drift. Fail loud.
+        raise SystemExit(
+            f"{owner} project #{number}: hit item-list limit ({ITEM_LIST_LIMIT}); "
+            "cannot guarantee full membership — raise the limit or paginate"
+        )
     return {
         (it.get("content") or {}).get("number")
         for it in items

--- a/tools/reconcile_program_boards.py
+++ b/tools/reconcile_program_boards.py
@@ -34,9 +34,11 @@ def main() -> int:
     args = ap.parse_args()
 
     spec = lib.load_spec(args.spec)
-    boards = lib.boards_with_items(spec)
-    if args.owner:
-        boards = [b for b in boards if b["owner_org"] == args.owner]
+    try:
+        boards = lib.select_boards(spec, args.owner)
+    except ValueError as e:
+        print(f"ERROR: {e}")
+        return 2
 
     added = present = failed = 0
     for b in boards:

--- a/tools/reconcile_program_boards.py
+++ b/tools/reconcile_program_boards.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Idempotent reconciler: converge GitHub Projects to board-spec.yaml.
+
+For each board in the spec, ensure every declared issue is an item on the
+GitHub Project (add if missing). Converge-not-recreate: adding an item that
+already exists is a no-op, so re-running is safe. Setting per-item field
+values (Status/Plane/...) is a follow-on pass; this MVP guarantees membership
+parity, which is exactly what the fail-closed drill asserts.
+
+Cutover portability: this is one adapter (GitHub). A Gitea adapter converging
+the same spec is the sibling; the spec never changes.
+
+Usage:
+    python3 tools/reconcile_program_boards.py --spec <path> [--dry-run]
+Auth: expects GH_TOKEN in the environment to be a MINTED token (GitHub App
+installation token or WIF-derived) with Projects write — never a static PAT.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+import board_spec_lib as lib
+
+ISSUE_URL = "https://github.com/{repo}/issues/{n}"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--spec", required=True)
+    ap.add_argument("--owner", help="restrict to boards owned by this org "
+                    "(a minted App token is single-org)")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    spec = lib.load_spec(args.spec)
+    boards = lib.boards_with_items(spec)
+    if args.owner:
+        boards = [b for b in boards if b["owner_org"] == args.owner]
+
+    added = present = failed = 0
+    for b in boards:
+        owner, number = b["owner_org"], b["github_number"]
+        have = lib.project_issue_numbers(owner, number)
+        for item in b["items"]:
+            n = item["issue"]
+            if n in have:
+                present += 1
+                continue
+            url = ISSUE_URL.format(repo=item["repo"], n=n)
+            if args.dry_run:
+                print(f"  would add #{n} -> {b['title']} ({owner}#{number})")
+                added += 1
+                continue
+            rc, _, err = lib.sh(
+                ["gh", "project", "item-add", str(number), "--owner", owner, "--url", url]
+            )
+            if rc == 0:
+                added += 1
+                print(f"  added #{n} -> {b['title']}")
+            else:
+                failed += 1
+                print(f"  FAILED #{n} -> {b['title']}: {err[:100]}")
+
+    print(f"\nReconcile: present={present} added={added} failed={failed}"
+          f"{' (dry-run)' if args.dry_run else ''}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_board_parity_drill.py
+++ b/tools/tests/test_board_parity_drill.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import board_parity_drill as drill  # noqa: E402
+import board_spec_lib as lib  # noqa: E402
 
 BOARDS = [
     {"title": "Product Surfaces", "owner_org": "SocioProphet", "github_number": 9,
@@ -45,7 +46,28 @@ def test_silent_when_in_parity() -> None:
     print("PASS: drill stays silent when GitHub matches the spec")
 
 
+def test_empty_selection_refuses_green() -> None:
+    # An owner that matches no board must raise, not yield an empty (green) check.
+    spec = {"boards": BOARDS}
+    try:
+        lib.select_boards(spec, owner="NoSuchOrg")
+    except ValueError:
+        print("PASS: select_boards refuses to check nothing (no false green)")
+        return
+    raise AssertionError("select_boards returned for an owner with no boards")
+
+
+def test_selection_returns_matching() -> None:
+    spec = {"boards": BOARDS}
+    got = lib.select_boards(spec, owner="SocioProphet")
+    assert len(got) == 2, got
+    print("PASS: select_boards returns the matching boards")
+
+
 if __name__ == "__main__":
     test_fires_on_drift()
     test_silent_when_in_parity()
-    print("\nBoth directions proven: the drill detects drift and stays quiet on parity.")
+    test_empty_selection_refuses_green()
+    test_selection_returns_matching()
+    print("\nBoth directions proven: the drill detects drift, stays quiet on parity, "
+          "and refuses to report green when it would check nothing.")

--- a/tools/tests/test_board_parity_drill.py
+++ b/tools/tests/test_board_parity_drill.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Adversarial proof the board-parity drill fires both ways.
+
+A drill that has never been shown to detect drift, and never been shown to
+stay quiet on a matching estate, is as suspect as an unenforced rule
+(control-that-cannot-fail). compute_drift is pure, so we drive it with a fake
+`fetch` and assert: DRIFT on a board missing a declared item; SILENT when the
+board contains every declared item.
+
+Run: python3 tools/tests/test_board_parity_drill.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import board_parity_drill as drill  # noqa: E402
+
+BOARDS = [
+    {"title": "Product Surfaces", "owner_org": "SocioProphet", "github_number": 9,
+     "items": [{"repo": "SocioProphet/socioprophet", "issue": 187},
+               {"repo": "SocioProphet/socioprophet", "issue": 188}]},
+    {"title": "Governance & Control Plane", "owner_org": "SocioProphet", "github_number": 7,
+     "items": [{"repo": "SocioProphet/socioprophet", "issue": 490}]},
+]
+
+
+def test_fires_on_drift() -> None:
+    # #188 is missing from Product Surfaces -> must be reported.
+    def fetch(owner, number):
+        return {187} if number == 9 else {490}
+    drift = drill.compute_drift(BOARDS, fetch)
+    assert len(drift) == 1, drift
+    assert drift[0]["issue"] == 188 and drift[0]["board"] == "Product Surfaces"
+    print("PASS: drill fires when a declared item is missing from its board")
+
+
+def test_silent_when_in_parity() -> None:
+    # every declared item present -> no drift.
+    def fetch(owner, number):
+        return {187, 188} if number == 9 else {490}
+    drift = drill.compute_drift(BOARDS, fetch)
+    assert drift == [], drift
+    print("PASS: drill stays silent when GitHub matches the spec")
+
+
+if __name__ == "__main__":
+    test_fires_on_drift()
+    test_silent_when_in_parity()
+    print("\nBoth directions proven: the drill detects drift and stays quiet on parity.")


### PR DESCRIPTION
## What
The MVP of the GitHub⇄sovereign **board parity** engine, driven by sociosphere `registry/board-spec.yaml` (source of truth; GitHub Projects are a render target).

- **`tools/board_parity_drill.py`** — fail-closed drill: asserts every spec'd issue is present on its GitHub Project, exits nonzero on drift. The pure `compute_drift` is **unit-tested both ways** (`tools/tests/test_board_parity_drill.py`), so a green run means parity, not "nothing checked".
- **`tools/reconcile_program_boards.py`** — idempotent converge (adds missing items; re-run safe).
- **`tools/board_spec_lib.py`** — shared spec loader + `gh` reader.
- **`.github/workflows/board-parity.yml`** — scheduled drill + dispatch reconcile; runs from the default branch; mints a **GitHub App token** (never a static PAT); no-ops green until the org App (`GH_OPS_APP_CONFIGURED`) is set.

## Compliant by construction
With the just-merged git-ops-standards controls: `ops-workflows-run-from-default-branch` (operational workflow on the default branch) and `ci-secrets-minted-never-static-pat` (App token, not a PAT).

## Verified
Compile ✓ · both-ways drill test ✓ · YAML ✓ · **live drill against the real boards: 6 SocioProphet boards, 33 items, OK — parity holds** (the 34th item is SourceOS-Linux/BearBrowser, outside the App's single-org scope — see below).

## Scope / follow-ups
A minted App token is single-org, so this covers the App's org (SocioProphet — all but one board item). Extending to SourceOS-Linux / SociOS-Linux = install the App there + drop `--owner`. Siblings: **Gitea adapter** (same spec → Gitea status axis) and **Zot digest-parity drill** (GHCR→Zot). Per-item field-tagging (Plane/Risk/…) is a later pass; MVP guarantees membership parity, which is what the drill asserts.

Foundation: sociosphere#529 (board-spec.yaml).