### PR TITLE
fix(inventory): quote notes value with embedded colon (unbreaks yaml.safe_load)

### DIFF
--- a/releases/images/component-inventory.v1.yaml
+++ b/releases/images/component-inventory.v1.yaml
@@ -116,7 +116,7 @@ components:
     vulnerability_scan_required: false
     evaluation_record_required: true
     angel_required: conditional
-    notes: Safety boundary is explicit: no artifact fetching, host mutation, disk writes, kexec, or execution plans with execute=true.
+    notes: "Safety boundary is explicit: no artifact fetching, host mutation, disk writes, kexec, or execution plans with execute=true."
 
   - id: search_orchestrator
     name: Search Orchestrator


### PR DESCRIPTION
`releases/images/component-inventory.v1.yaml:119` — the `notes:` value contained an unquoted embedded colon, so `yaml.safe_load` raised ScannerError and every inventory-loading tool silently got nothing. Quoted the value; the file now parses (8 components). One-line change; scanned the rest of the file (colon-space aware) — no other offenders. Separate from the wave-deploy work that surfaced it.

Verify: `python3 -c "import yaml; yaml.safe_load(open('releases/images/component-inventory.v1.yaml'))"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)