### PR TITLE
feat(deploy): fail-closed digest-exists gate (INV-DEP-6) + lock-provenance (INV-DEP-7)

### DIFF
--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -42,6 +42,7 @@ on:
 
 permissions:
   contents: read
+  packages: read   # INV-DEP-6: HEAD ghcr/zot manifests to prove each frozen digest exists
 
 concurrency:
   # Only one train at a time; QUEUE trains, never cancel one mid-promotion (INV-DEP-5).
@@ -101,6 +102,18 @@ jobs:
 
       - name: Validate frozen manifest (fail-closed — INV-DEP-1/2)
         run: python3 tools/validate_release_train_manifest.py "${{ steps.freeze.outputs.manifest }}"
+
+      # INV-DEP-6 — a frozen digest that names bytes the registry does not have is worse than a
+      # moving tag: it looks immutable, passes every shape check, then ImagePullBackOffs on the
+      # cluster (the wave-deploy incident: search-orchestrator@sha256:bbfea6e4… was frozen +
+      # promoted but never pushed). REFUSE to freeze a digest with no manifest. Fail-closed: an
+      # unreachable registry (auth/DNS/5xx) is treated as "not proven to exist" and also fails —
+      # distinctly from ABSENT — never a silent pass.
+      - name: Assert every frozen digest EXISTS in the registry (fail-closed — INV-DEP-6)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        run: python3 tools/verify_pinned_digest_exists.py manifest "${{ steps.freeze.outputs.manifest }}"
 
       # In production the freeze commits the manifest via a values-only PR the way
       # gitops-promote.yml does (so the wave jobs, which check out the repo, can read it).

--- a/.github/workflows/search-orchestrator-image.yml
+++ b/.github/workflows/search-orchestrator-image.yml
@@ -33,6 +33,12 @@ jobs:
   # COST GUARD 1 (change-detection skip) — this component has a committed image-lock carrying a
   # source_content_digest, so an unchanged services/search-orchestrator tree SKIPS the build and
   # reuses the already-pinned digest (releases/images/search-orchestrator.image-lock.json).
+  #
+  # BUT a SKIP is only safe if the recorded digest STILL EXISTS in the registry. The wave-deploy
+  # incident proved the failure: the lock recorded a source_content_digest next to a digest that
+  # was never pushed, so an unchanged tree would SKIP forever and "reuse" a phantom digest. So the
+  # decide step runs with --verify-image-exists (INV-DEP-6): SKIP requires BOTH the source-content
+  # match AND the pinned image resolving to a real manifest; a missing/unverifiable image BUILDs.
   changes:
     runs-on: ubuntu-latest
     outputs:
@@ -43,13 +49,17 @@ jobs:
         with:
           python-version: '3.11'
       - id: decide
-        name: Decide build-vs-skip from source content-digest
+        name: Decide build-vs-skip from source content-digest (+ image-exists, INV-DEP-6)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           set +e
           python3 tools/compute_source_content_digest.py decide \
             --path services/search-orchestrator \
             --path .github/workflows/search-orchestrator-image.yml \
             --lock releases/images/search-orchestrator.image-lock.json \
+            --verify-image-exists \
             --allow-missing
           rc=$?
           if [ "$rc" != "0" ] && [ "$rc" != "10" ]; then exit "$rc"; fi

--- a/.github/workflows/socioprophet-api-image.yml
+++ b/.github/workflows/socioprophet-api-image.yml
@@ -44,7 +44,10 @@ jobs:
         with:
           python-version: '3.11'
       - id: decide
-        name: Decide build-vs-skip from source content-digest
+        name: Decide build-vs-skip from source content-digest (+ image-exists, INV-DEP-6)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           set +e
           python3 tools/compute_source_content_digest.py decide \
@@ -52,6 +55,7 @@ jobs:
             --path libs/go/tritrpcbridge \
             --path .github/workflows/socioprophet-api-image.yml \
             --lock releases/images/socioprophet-api.image-lock.json \
+            --verify-image-exists \
             --allow-missing
           rc=$?
           # exit 0 = SKIP, 10 = BUILD; anything else is a real (fail-closed) error.

--- a/.github/workflows/tritrpc-gateway-image.yml
+++ b/.github/workflows/tritrpc-gateway-image.yml
@@ -39,7 +39,10 @@ jobs:
         with:
           python-version: '3.11'
       - id: decide
-        name: Decide build-vs-skip from source content-digest
+        name: Decide build-vs-skip from source content-digest (+ image-exists, INV-DEP-6)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
           set +e
           python3 tools/compute_source_content_digest.py decide \
@@ -47,6 +50,7 @@ jobs:
             --path libs/go/tritrpcbridge \
             --path .github/workflows/tritrpc-gateway-image.yml \
             --lock releases/images/tritrpc-gateway.image-lock.json \
+            --verify-image-exists \
             --allow-missing
           rc=$?
           if [ "$rc" != "0" ] && [ "$rc" != "10" ]; then exit "$rc"; fi

--- a/.github/workflows/wave-promote.yml
+++ b/.github/workflows/wave-promote.yml
@@ -45,6 +45,7 @@ on:
 
 permissions:
   contents: read
+  packages: read   # INV-DEP-6: HEAD ghcr/zot manifests to prove the promoted digest exists
 
 concurrency:
   # Serialize promotions of the same component+wave; never cancel an in-flight promotion —
@@ -69,6 +70,17 @@ jobs:
       # GATE 0 — the frozen set must be legal to promote (digest-pinned, one digest/image).
       - name: Validate frozen release-train manifest (fail-closed)
         run: python3 tools/validate_release_train_manifest.py "${{ inputs.manifest }}"
+
+      # GATE 0b (INV-DEP-6) — the digest about to be promoted must actually EXIST in the
+      # registry. Shape-valid is not enough: search-orchestrator@sha256:bbfea6e4… promoted
+      # cleanly through every wave and ImagePullBackOff'd because Wave 0 never pushed it. A
+      # promotion of a non-existent digest is refused here, before any overlay is re-pinned.
+      # Fail-closed: an unreachable registry counts as "not proven to exist", never a pass.
+      - name: Assert the promoted digest EXISTS in the registry (fail-closed — INV-DEP-6)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        run: python3 tools/verify_pinned_digest_exists.py manifest "${{ inputs.manifest }}"
 
       # PROMOTE-MANY — re-pin the SAME frozen digest into this wave's overlay. No build.
       - name: Promote frozen digest into the wave overlay (no rebuild)

--- a/docs/DEPLOY-WAVE-STRATEGY.md
+++ b/docs/DEPLOY-WAVE-STRATEGY.md
@@ -9,7 +9,7 @@ appset sync-waves, `releases/images/*.image-lock.json`); it does not replace it.
 
 The normative invariants are in
 [`docs/standards/deploy-wave-invariants-v0.md`](standards/deploy-wave-invariants-v0.md)
-(INV-DEP-1…5). This doc is the operator/design narrative.
+(INV-DEP-1…7). This doc is the operator/design narrative.
 
 ---
 
@@ -22,9 +22,17 @@ Two estate rules converge here:
    pulls the fix. **Only an immutable digest rolls deterministically.**
 2. **Deploys drifted from builds** (the incident `gitops-promote.yml` was written for):
    `images.yml` built `sha-<commit>` on every merge but nothing advanced the deployed pins.
+3. **A frozen digest that was never pushed** (the wave-deploy incident, INV-DEP-6/7): a lock
+   recorded `search-orchestrator@sha256:bbfea6e4…` with a matching `source_content_digest`, both
+   entered by hand — Wave 0 never built or pushed it. Every shape/ordering gate passed; the
+   apply `ImagePullBackOff`'d on the live cluster, and the cost guard would have *skipped* the
+   real build forever because the recorded content-digest matched the source. **A digest-pinned
+   reference is only trustworthy if the bytes it names exist and came from a real push.**
 
-Build-once-promote-many answers both: the thing that moves between environments is an
-**immutable digest**, and it moves on a **train**, gated, not on every merge.
+Build-once-promote-many answers all three: the thing that moves between environments is an
+**immutable digest**, it moves on a **train**, gated, not on every merge — and every freeze,
+promote and skip is now fail-closed on the digest *actually existing* in the registry
+(INV-DEP-6), with the build workflow the only writer of a lock digest (INV-DEP-7).
 
 ---
 
@@ -53,9 +61,12 @@ Build-once-promote-many answers both: the thing that moves between environments 
                                               ArgoCD sync (Michael's gated apply)
 ```
 
-Every wave carries the **identical** `sha256:` (proven in the dry-run: the dev, canary and
-prod overlays all render
-`…/search-orchestrator@sha256:bbfea6e4a7ea432…`). A wave re-pins, it never rebuilds.
+Every wave carries the **identical** `sha256:`: the dev, canary and prod overlays all render the
+same `…/search-orchestrator@sha256:…` digest — a wave re-pins, it never rebuilds. (Note: the
+digest currently committed across the lock, frozen manifest and overlays,
+`…@sha256:bbfea6e4a7ea432…`, is the never-pushed placeholder from the incident. It no longer
+promotes: INV-DEP-6 refuses it at freeze and at every wave until a real Wave-0 push (see the
+`gh workflow run` sequence below) replaces it with a digest that actually exists.)
 
 ---
 
@@ -66,11 +77,35 @@ Per-component image workflows (`socioprophet-api-image.yml`, `tritrpc-gateway-im
 zot registry (`registry.socioprophet.ai`, cutover in progress) / GHCR / GAR → record the
 immutable digest in `releases/images/<component>.image-lock.json`.
 
-- **COST GUARD 1 — change-detection skip.** A `changes` preflight job runs
-  `tools/compute_source_content_digest.py decide`, which hashes the component's source paths
-  into a `source_content_digest` and compares it to the value recorded in the image-lock.
-  Byte-identical source ⇒ `build_needed=false` ⇒ the build job is skipped and the already-
-  pinned digest is reused. (Proven both ways in `tools/tests/test_compute_source_content_digest.py`.)
+**INV-DEP-7 — the build is the ONLY writer of a lock digest.** The lock's `digest` comes only
+from a real `docker buildx …--push` (`steps.build.outputs.digest`), carried through the digest
+evidence artifact and applied by `tools/apply_search_orchestrator_image_lock.py`, which stamps
+`digest_provenance: buildx-push` and refuses a blank/placeholder evidence digest. A lock digest
+is never hand-authored or computed — that is the class of failure the `bbfea6e4…` incident was.
+
+To actually produce a real search-orchestrator digest (Wave 0), dispatch the build on `main`
+(it pushes to GHCR, uploads the digest evidence, and the pin workflow opens the lock PR):
+
+```bash
+# 1) Build + push, recording the REAL registry digest (main only pushes; PRs build without push):
+gh workflow run search-orchestrator-image.yml --ref main
+# 2) After it succeeds, pin the lock + overlay from that run's digest evidence (auto-fires on the
+#    build's success; run explicitly to pin a specific/older successful run):
+gh workflow run search-orchestrator-image-pin.yml --ref main         # latest successful build
+#    or:  gh workflow run search-orchestrator-image-pin.yml --ref main -f run_id=<BUILD_RUN_ID>
+# 3) Verify the freshly-pinned digest really resolves (the same gate the train runs):
+python3 tools/verify_pinned_digest_exists.py locks 'releases/images/search-orchestrator.image-lock.json'
+```
+
+- **COST GUARD 1 — change-detection skip (now image-exists-aware, INV-DEP-6).** A `changes`
+  preflight job runs `tools/compute_source_content_digest.py decide --verify-image-exists`, which
+  hashes the component's source paths into a `source_content_digest` and compares it to the value
+  recorded in the image-lock **AND** confirms the recorded digest still resolves to a registry
+  manifest. Byte-identical source **and** a real, present image ⇒ `build_needed=false` ⇒ the build
+  is skipped and the already-pinned digest reused; a missing/unverifiable image forces BUILD even
+  when the source matches (so a phantom digest can never win an eternal skip). Proven both ways —
+  including "source matches but image missing ⇒ BUILD" — in
+  `tools/tests/test_compute_source_content_digest.py`.
 - **COST GUARD 2 — queue vs cancel.** `concurrency.cancel-in-progress:
   ${{ github.ref != 'refs/heads/main' }}` — main builds **queue** (never cancelled, so every
   built image reaches the registry and no pin dangles); feature/PR builds **cancel** superseded
@@ -81,12 +116,17 @@ immutable digest in `releases/images/<component>.image-lock.json`.
 
 `wave-promote.yml` (reusable) advances the SAME frozen digest through env overlays. It:
 1. validates the frozen manifest (`validate_release_train_manifest.py`, fail-closed);
-2. re-pins the digest into the wave's kustomize `image-patch.yaml`
+2. **asserts the promoted digest EXISTS in the registry** (`verify_pinned_digest_exists.py`,
+   GATE 0b, INV-DEP-6) — a promotion of a non-existent digest is refused before any re-pin;
+3. re-pins the digest into the wave's kustomize `image-patch.yaml`
    (`apply_wave_promotion.py`) — **no build**;
-3. renders the overlay and asserts every image is `@sha256:…` (INV-DEP-1);
-4. runs `preflight_deploy_contract.py` + `check_canary_slo_gate.py` (fail-closed);
-5. for prod, asserts the blue-green `slo-gate` prePromotionAnalysis is present and the cutover
+4. renders the overlay and asserts every image is `@sha256:…` (INV-DEP-1);
+5. runs `preflight_deploy_contract.py` + `check_canary_slo_gate.py` (fail-closed);
+6. for prod, asserts the blue-green `slo-gate` prePromotionAnalysis is present and the cutover
    is gated (`autoPromotionEnabled:false`).
+
+The freeze step in `release-train.yml` runs the SAME INV-DEP-6 check on the whole frozen set
+before any wave starts, so a phantom digest is refused at freeze, not just at promote.
 
 Ordering is enforced twice: as GitHub `needs:` chaining in the train (dev → canary → prod),
 and as ArgoCD `sync-wave` annotations (20/21/22) layered above the appset's existing
@@ -140,12 +180,18 @@ environment. Build-once-promote-many makes it **one** build and `N` cheap re-pin
 
 **Validated offline in this PR** (no cluster): `kubectl kustomize` renders all three promote
 overlays with the identical digest and ascending sync-waves; the frozen manifest validates;
-the skip/build decision and the queue-vs-cancel contract are unit-tested; all workflows pass
-`actionlint` + `yaml.safe_load`; `preflight_deploy_contract.py` and `check_canary_slo_gate.py`
-pass.
+the skip/build decision (including "source matches but image missing ⇒ BUILD"), the digest-exists
+gate (both ways), the lock-provenance guard and the queue-vs-cancel contract are unit-tested;
+all workflows pass `actionlint` + `yaml.safe_load`; `preflight_deploy_contract.py` and
+`check_canary_slo_gate.py` pass. The INV-DEP-6 gate is also proven live against a public registry:
+a real `ghcr.io/oras-project/oras@sha256:0087224…` HEADs 200 ⇒ EXISTS (exit 0); a fabricated
+digest on the same repo HEADs 404 ⇒ ABSENT (exit 4).
 
-**Needs Michael's gated apply** (a live cluster): ArgoCD actually syncing the promote overlays;
-the argo-rollouts controller + Gateway API plugin installed
+**Needs Michael's gated apply / CI credentials** (not done here): ArgoCD actually syncing the
+promote overlays; the argo-rollouts controller + Gateway API plugin installed
 (`deploy/argocd/progressive-delivery-services.yaml`); the blue-green cutover and `slo-gate`
-querying real Prometheus series; the per-component registry push + digest recording running in
-CI. Nothing here has been applied to any cluster.
+querying real Prometheus series; and — the root cause — the per-component **registry push +
+digest recording** actually running in CI (the `gh workflow run` sequence above) to replace the
+`bbfea6e4…` placeholder with a real digest. Against the private repo without the CI token, the
+INV-DEP-6 gate here reports UNREACHABLE (401) and still fails closed — it never passes on an
+unverified image. Nothing here has been applied to any cluster.

--- a/docs/standards/deploy-wave-invariants-v0.md
+++ b/docs/standards/deploy-wave-invariants-v0.md
@@ -71,6 +71,52 @@ the `concurrency.cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` blo
 per-component image workflow; `type=gha` scoped layer cache;
 `test_image_workflows_queue_on_main_cancel_on_feature` / `test_release_and_wave_workflows_never_cancel`.
 
+## INV-DEP-6 — A promoted digest MUST exist in the registry
+
+A digest MUST NOT be frozen or promoted unless it resolves to a real manifest in its registry
+(Registry HTTP API v2 `HEAD`/`GET …/manifests/<digest>` returns the manifest). "Digest-shaped"
+(INV-DEP-1) and "one digest per image" (INV-DEP-2) are necessary but NOT sufficient: a
+never-pushed placeholder is a perfectly-shaped `sha256:<64hex>` that `ImagePullBackOff`s on the
+cluster. A **skip** is likewise only safe if the recorded digest still exists — an unchanged
+source that "reuses" a phantom digest is the same failure via the cost guard.
+
+*Rationale.* A wave-deploy froze + promoted `search-orchestrator@sha256:bbfea6e4…` through every
+overlay — every shape/ordering gate green — and it `ImagePullBackOff`'d on the live cluster
+because Wave 0 (the real build+push) never ran. Every prior gate checked the *shape* of the
+reference; none checked that the bytes it names EXIST.
+
+*Fail-closed distinction.* The check returns three DISTINCT outcomes — EXISTS (pass), ABSENT
+(registry answered 404/`MANIFEST_UNKNOWN` — the fabricated/never-pushed case), and UNREACHABLE
+(DNS/TLS/timeout/5xx/auth-challenge-unsatisfiable). Both ABSENT and UNREACHABLE FAIL the gate
+(existence was not proven), but they are reported distinctly so an operator is never told
+"fabricated digest" when the real problem is reachability.
+
+*Enforced by.* `tools/verify_pinned_digest_exists.py` (unit-tested both ways, `check_manifest`);
+`release-train.yml`'s freeze step and `wave-promote.yml`'s GATE 0b both call it and REFUSE to
+freeze/promote a digest with no manifest; `compute_source_content_digest.py decide
+--verify-image-exists` forces BUILD when a source-matched lock's pinned digest is missing
+(`test_decide_build_when_source_matches_but_image_missing`).
+
+## INV-DEP-7 — A lock digest is only ever a real push output
+
+The `digest` recorded in a `releases/images/<component>.image-lock.json` MUST come from an actual
+`docker buildx …--push` (the registry's own content digest, `steps.build.outputs.digest`). It is
+NEVER hand-authored and NEVER *computed*. The image build workflow — via its digest-evidence
+artifact — is the SOLE writer of the lock's `digest`; the applier stamps `digest_provenance:
+buildx-push` and refuses evidence whose digest is empty or a placeholder sentinel. A lock without
+that provenance, or carrying a `source_content_digest` divorced from a real push, is illegitimate.
+
+*Rationale.* The `bbfea6e4…` incident began as a lock whose `digest` (and its neighbouring
+`source_content_digest`) were entered by hand, with no push behind either. Making the build the
+only writer removes the class of failure at the source: there is no code path that puts a
+non-push digest into a lock.
+
+*Enforced by.* `tools/apply_search_orchestrator_image_lock.py` (sole lock writer; refuses a
+non-`sha256:<64hex>` / placeholder evidence digest, carries the build's `source_content_digest`,
+stamps `digest_provenance`) — `test_build_lock_refuses_placeholder_digest`,
+`test_build_lock_carries_source_content_digest_from_the_same_build`; INV-DEP-6 catches any lock
+digest that slips through and does not actually exist.
+
 ---
 
 ## Conformance checklist
@@ -83,3 +129,5 @@ per-component image workflow; `type=gha` scoped layer cache;
 | 4 | Overlays render, all `@sha256:` | `kubectl kustomize infra/k8s/search-orchestrator/overlays/promote/{dev,canary,prod}` |
 | 5 | Skip + queue/cancel contract | `python3 -m pytest -q tools/tests/test_compute_source_content_digest.py tools/tests/test_release_train_manifest.py` |
 | 6 | Workflows lint | `actionlint .github/workflows/{release-train,wave-promote,*-image}.yml` |
+| 7 | Every frozen digest exists in the registry (INV-DEP-6) | `python3 tools/verify_pinned_digest_exists.py manifest releases/manifests/release-train.<label>.manifest.json` |
+| 8 | Digest-exists + lock-provenance gates, both ways (INV-DEP-6/7) | `python3 -m pytest -q tools/tests/test_verify_pinned_digest_exists.py tools/tests/test_apply_search_orchestrator_image_lock.py` |

--- a/tools/apply_search_orchestrator_image_lock.py
+++ b/tools/apply_search_orchestrator_image_lock.py
@@ -1,13 +1,28 @@
+"""Apply a Wave-0 image build's DIGEST EVIDENCE to the search-orchestrator image-lock + patch.
+
+INV-DEP-7 — a lock digest is ONLY EVER a real push output. This tool is the SOLE writer of
+``releases/images/search-orchestrator.image-lock.json``, and it writes only from the evidence
+artifact that ``search-orchestrator-image.yml`` uploads AFTER a successful
+``docker buildx …--push`` (``steps.build.outputs.digest`` — the registry's own content digest).
+A lock digest is never hand-authored and never *computed*; the wave-deploy incident
+(``sha256:bbfea6e4…`` frozen + promoted but never pushed) is exactly a lock digest that did not
+come from a push. So this refuses evidence whose digest is empty or a placeholder sentinel, and
+it carries the build's ``source_content_digest`` through so the cost-guard's next skip decision
+compares against the SAME real build (never a hand-entered content-digest divorced from a push).
+"""
 from __future__ import annotations
 
 import argparse
 import json
+import re
 from pathlib import Path
 
 from render_search_orchestrator_image_patch import IMAGE, validate_lock, render_patch
 
 LOCK_PATH = Path("releases/images/search-orchestrator.image-lock.json")
 PATCH_PATH = Path("infra/k8s/search-orchestrator/overlays/policy/image-patch.yaml")
+
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
 def load_json(path: Path) -> dict:
@@ -21,6 +36,20 @@ def build_lock(evidence: dict) -> dict:
     digest = str(evidence.get("digest", ""))
     source_sha = str(evidence.get("source_sha", ""))
     pinned_ref = str(evidence.get("pinned_ref", ""))
+    source_content_digest = str(evidence.get("source_content_digest", "") or "")
+
+    # INV-DEP-7 writer discipline: the evidence MUST carry a real registry digest produced by
+    # the push. A blank or placeholder digest (REPLACE_…, a bare tag, anything not sha256:<64hex>)
+    # means this evidence did not come from a real buildx --push — refuse to mint a lock from it.
+    if not _DIGEST_RE.match(digest):
+        raise SystemExit(
+            f"::error::INV-DEP-7: image-build evidence digest {digest!r} is not a real push output "
+            f"(want sha256:<64hex> from steps.build.outputs.digest). Refusing to write a lock — a "
+            f"lock digest is only ever a real docker buildx --push output, never computed/placeholder."
+        )
+    if source_sha in ("", "REPLACE_WITH_GIT_SHA"):
+        raise SystemExit("::error::INV-DEP-7: evidence has no source_sha — not a real build")
+
     lock = {
         "image_lock_id": "search-orchestrator-image-lock",
         "component": "services/search-orchestrator",
@@ -28,9 +57,19 @@ def build_lock(evidence: dict) -> dict:
         "source_sha": source_sha,
         "digest": digest,
         "pinned_ref": pinned_ref,
+        # Carried from the SAME build that pushed the digest, so the cost-guard's next skip
+        # decision compares against the content that produced this exact pushed image.
+        "source_content_digest": source_content_digest or None,
         "workflow": ".github/workflows/search-orchestrator-image.yml",
+        # Provenance marker: this digest came from a real push, applied by this tool. Nothing
+        # else writes the lock; a lock without this marker is a hand-authored placeholder.
+        "digest_provenance": "buildx-push",
         "status": "pinned",
     }
+    if lock["source_content_digest"] is None:
+        # A real push always emits it; if absent, drop the key rather than record a null so the
+        # cost-guard treats it as "no recorded content-digest" => BUILD (fail-closed), not a match.
+        del lock["source_content_digest"]
     validate_lock(lock)
     return lock
 

--- a/tools/compute_source_content_digest.py
+++ b/tools/compute_source_content_digest.py
@@ -10,9 +10,18 @@ touch a component, even when the *content* is byte-identical to what was already
 (a whitespace-only merge, a revert-to-same, a re-run). A rebuild that produces the same
 layers is wasted runner minutes. This tool gives the workflows a cheap preflight:
 
-    content-digest(source paths)  ==  content-digest recorded in the image-lock ?
+    content-digest(source paths)  ==  content-digest recorded in the image-lock
+        AND  the recorded pinned digest STILL EXISTS in the registry (INV-DEP-6) ?
         yes -> SKIP the build, REUSE the already-pinned immutable sha256 digest
         no  -> build, push, and record the new content-digest alongside the new digest
+
+The second half of that AND is not optional cosmetics — it closes the exact hole the
+wave-deploy incident surfaced. A lock can record a ``source_content_digest`` next to a
+``digest`` that was NEVER pushed (a pre-computed placeholder, or a lock committed before its
+Wave-0 build ran / after a registry GC). A content match against such a lock would SKIP the
+build and "reuse" a digest that ImagePullBackOffs. So with ``--verify-image-exists`` a SKIP
+requires BOTH the source-content match AND the recorded image resolving to a real manifest;
+a missing image forces BUILD regardless of source match.
 
 The content-digest is a sha256 over the SORTED list of ``<posix-path>\\0<sha256(bytes)>``
 for every file under the declared source paths. It is:
@@ -102,7 +111,7 @@ def compute_digest(paths: Iterable[Path], root: Path | None = None) -> str:
     return f"sha256:{agg}"
 
 
-def _load_lock_content_digest(lock_path: Path, allow_missing: bool) -> str | None:
+def _load_lock(lock_path: Path, allow_missing: bool) -> dict | None:
     if not lock_path.exists():
         if allow_missing:
             return None
@@ -110,7 +119,67 @@ def _load_lock_content_digest(lock_path: Path, allow_missing: bool) -> str | Non
     data = json.loads(lock_path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise SystemExit(f"::error::image-lock is not a JSON object: {lock_path}")
-    return data.get(CONTENT_DIGEST_FIELD)
+    return data
+
+
+def _load_lock_content_digest(lock_path: Path, allow_missing: bool) -> str | None:
+    lock = _load_lock(lock_path, allow_missing)
+    return None if lock is None else lock.get(CONTENT_DIGEST_FIELD)
+
+
+def _default_image_checker(image: str, digest: str) -> str:
+    """Return the registry existence status ('exists' | 'absent' | 'unreachable') of a pinned
+    digest, delegating to tools/verify_pinned_digest_exists.py (INV-DEP-6). Imported lazily so
+    the pure content-digest path never needs the network layer."""
+    import importlib.util
+
+    mod_path = Path(__file__).with_name("verify_pinned_digest_exists.py")
+    spec = importlib.util.spec_from_file_location("verify_pinned_digest_exists", mod_path)
+    assert spec is not None and spec.loader is not None
+    verify = importlib.util.module_from_spec(spec)
+    # Register before exec so the module's @dataclass resolves its own __module__ under
+    # `from __future__ import annotations`.
+    sys.modules.setdefault(spec.name, verify)
+    spec.loader.exec_module(verify)
+    return verify.check_manifest(image, digest).status
+
+
+def decide_build(current: str, lock: dict | None, *, verify_image: bool,
+                 image_checker=_default_image_checker) -> "tuple[int, str]":
+    """Pure skip-vs-build decision. Returns (exit_code, message).
+
+    exit 0  => SKIP (source content matches AND, when verify_image, the pinned image EXISTS).
+    exit 10 => BUILD (content changed / no lock / recorded image missing or unverifiable).
+
+    A SKIP is granted ONLY when both conditions hold. If the recorded source matches but the
+    pinned digest has no registry manifest (or cannot be proven to), we force BUILD — a skip
+    that reuses a non-existent digest is exactly the deploy-time ImagePullBackOff (INV-DEP-6).
+    """
+    recorded = None if lock is None else lock.get(CONTENT_DIGEST_FIELD)
+    if recorded is None or recorded != current:
+        reason = "no recorded content-digest" if recorded is None else "content-digest changed"
+        return 10, f"BUILD: {reason} (current={current}, recorded={recorded})"
+
+    # Source content matches. Without the image-exists check that alone would SKIP.
+    if not verify_image:
+        return 0, f"SKIP: source content-digest unchanged ({current}) — reuse pinned digest"
+
+    image = str((lock or {}).get("image", ""))
+    digest = str((lock or {}).get("digest", ""))
+    if not image or not digest:
+        return 10, ("BUILD: source matched but the lock records no image/digest to verify "
+                    f"(image={image!r}, digest={digest!r}) — refusing to reuse an unverifiable pin")
+    status = image_checker(image, digest)
+    if status == "exists":
+        return 0, (f"SKIP: source content-digest unchanged ({current}) AND pinned image exists "
+                   f"in the registry — reuse {image}@{digest}")
+    if status == "absent":
+        return 10, ("BUILD: source content matches but the recorded pinned digest does NOT exist "
+                    f"in the registry ({image}@{digest}) — a placeholder/never-pushed digest; "
+                    "forcing a real build (INV-DEP-6)")
+    # unreachable / anything non-definitive: we could not PROVE the image exists -> BUILD.
+    return 10, ("BUILD: source content matches but the registry could not confirm the pinned "
+                f"digest exists ({image}@{digest}; status={status}) — fail-closed, forcing build")
 
 
 def _emit_github_output(**kv: str) -> None:
@@ -139,6 +208,10 @@ def main(argv: list[str] | None = None) -> int:
     c.add_argument("--root", type=Path, default=None)
     c.add_argument("--allow-missing", action="store_true",
                    help="a missing lock means BUILD (first build of a new component), not error")
+    c.add_argument("--verify-image-exists", action="store_true",
+                   help="on a source-content match, ALSO require the recorded pinned digest to "
+                        "resolve to a registry manifest (INV-DEP-6); a missing/unverifiable image "
+                        "forces BUILD, never SKIP")
 
     args = parser.parse_args(argv)
 
@@ -148,15 +221,11 @@ def main(argv: list[str] | None = None) -> int:
 
     # decide
     current = compute_digest(args.paths, args.root)
-    recorded = _load_lock_content_digest(args.lock, args.allow_missing)
-    if recorded is not None and recorded == current:
-        print(f"SKIP: source content-digest unchanged ({current}) — reuse pinned digest")
-        _emit_github_output(build_needed="false", content_digest=current)
-        return 0
-    reason = "no recorded content-digest" if recorded is None else "content-digest changed"
-    print(f"BUILD: {reason} (current={current}, recorded={recorded})")
-    _emit_github_output(build_needed="true", content_digest=current)
-    return 10
+    lock = _load_lock(args.lock, args.allow_missing)
+    rc, message = decide_build(current, lock, verify_image=args.verify_image_exists)
+    print(message)
+    _emit_github_output(build_needed="true" if rc == 10 else "false", content_digest=current)
+    return rc
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_apply_search_orchestrator_image_lock.py
+++ b/tools/tests/test_apply_search_orchestrator_image_lock.py
@@ -41,3 +41,38 @@ def test_image_lock_applier_writes_lock_and_patch(tmp_path, monkeypatch) -> None
     rendered = patch_path.read_text(encoding="utf-8")
     assert "image: " + IMAGE + "@" + digest in rendered
     assert "name: search-orchestrator" in rendered
+    # INV-DEP-7: a lock minted from a real push output is stamped with its provenance.
+    assert lock["digest_provenance"] == "buildx-push"
+
+
+# ── INV-DEP-7: the lock digest is ONLY EVER a real push output ─────────────────────────────
+
+def test_build_lock_refuses_placeholder_digest() -> None:
+    for bad in ("", "sha256:REPLACE_WITH_IMAGE_DIGEST", "ghcr.io/x:latest", "sha256:" + ("z" * 64)):
+        try:
+            MODULE.build_lock({"digest": bad, "source_sha": "abc", "pinned_ref": "x"})
+        except SystemExit as exc:
+            assert "INV-DEP-7" in str(exc)
+        else:
+            raise AssertionError(f"a non-push digest {bad!r} must be refused (INV-DEP-7)")
+
+
+def test_build_lock_refuses_placeholder_source_sha() -> None:
+    digest = "sha256:" + ("b" * 64)
+    try:
+        MODULE.build_lock({"digest": digest, "source_sha": "REPLACE_WITH_GIT_SHA",
+                           "pinned_ref": IMAGE + "@" + digest})
+    except SystemExit as exc:
+        assert "INV-DEP-7" in str(exc)
+    else:
+        raise AssertionError("a placeholder source_sha must be refused (INV-DEP-7)")
+
+
+def test_build_lock_carries_source_content_digest_from_the_same_build() -> None:
+    digest = "sha256:" + ("b" * 64)
+    scd = "sha256:" + ("c" * 64)
+    lock = MODULE.build_lock({"digest": digest, "source_sha": "abc",
+                              "pinned_ref": IMAGE + "@" + digest,
+                              "source_content_digest": scd})
+    assert lock["source_content_digest"] == scd, "the content-digest must ride the real build"
+    assert lock["digest_provenance"] == "buildx-push"

--- a/tools/tests/test_compute_source_content_digest.py
+++ b/tools/tests/test_compute_source_content_digest.py
@@ -78,3 +78,51 @@ def test_missing_source_path_is_fail_closed(tmp_path) -> None:
         assert "does not exist" in str(exc)
     else:
         raise AssertionError("a missing source path must ERROR, not hash a partial tree")
+
+
+# ── INV-DEP-6: a SKIP requires BOTH source-match AND the pinned image existing ─────────────
+# The wave-deploy incident: the lock recorded a source_content_digest next to a `digest` that
+# was never pushed. Source matched, so the old logic SKIPPED and "reused" a phantom digest.
+
+def _lock(image="ghcr.io/x/svc", digest="sha256:" + ("a" * 64), content_digest=""):
+    return {"image": image, "digest": digest, "source_content_digest": content_digest}
+
+
+def test_decide_build_when_source_matches_but_image_missing() -> None:
+    """recorded-source-matches-but-image-missing => BUILD, not SKIP (INV-DEP-6)."""
+    current = "sha256:" + ("c" * 64)
+    lock = _lock(content_digest=current)  # source content DOES match
+    rc, msg = MOD.decide_build(current, lock, verify_image=True,
+                               image_checker=lambda img, dig: "absent")
+    assert rc == 10, "a matching source but a non-existent pinned digest must BUILD, never SKIP"
+    assert "does NOT exist" in msg
+
+
+def test_decide_skip_when_source_matches_and_image_exists() -> None:
+    current = "sha256:" + ("c" * 64)
+    lock = _lock(content_digest=current)
+    rc, msg = MOD.decide_build(current, lock, verify_image=True,
+                               image_checker=lambda img, dig: "exists")
+    assert rc == 0, "source match + real image => SKIP"
+    assert "SKIP" in msg
+
+
+def test_decide_build_when_source_matches_but_registry_unreachable() -> None:
+    current = "sha256:" + ("c" * 64)
+    lock = _lock(content_digest=current)
+    rc, msg = MOD.decide_build(current, lock, verify_image=True,
+                               image_checker=lambda img, dig: "unreachable")
+    assert rc == 10, "cannot PROVE the image exists => fail-closed, BUILD"
+    assert "could not confirm" in msg
+
+
+def test_verify_image_disabled_keeps_pure_content_skip() -> None:
+    # Without --verify-image-exists the checker is never consulted (would raise if it were).
+    current = "sha256:" + ("c" * 64)
+    lock = _lock(content_digest=current)
+
+    def _boom(image, digest):
+        raise AssertionError("image checker must not run when verify_image=False")
+
+    rc, _ = MOD.decide_build(current, lock, verify_image=False, image_checker=_boom)
+    assert rc == 0

--- a/tools/tests/test_verify_pinned_digest_exists.py
+++ b/tools/tests/test_verify_pinned_digest_exists.py
@@ -1,0 +1,151 @@
+"""Prove INV-DEP-6 (the digest-exists gate) both ways, offline.
+
+A gate that has only ever passed proves nothing. So this drives the classifier against a
+FAKE registry (an injected HTTP seam — no socket) through every outcome:
+
+  * a real digest (registry 200)            => EXISTS   (exit 0)   — a build must be reusable;
+  * a fabricated digest (registry 404)      => ABSENT   (exit 4)   — the incident's placeholder;
+  * a registry that raises (DNS/TLS/timeout)=> UNREACHABLE (exit 3) — DISTINCT from ABSENT, so an
+                                                                      operator is never told a
+                                                                      fabricated digest when the
+                                                                      real problem is reachability;
+  * a 401 challenge + working token exchange resolves to EXISTS/ABSENT (private-repo path);
+  * a 401 we cannot satisfy                 => UNREACHABLE, never a silent pass (fail-closed).
+
+The live ghcr proof (real oras digest passes, a fabricated one fails) is recorded in the PR;
+this keeps the teeth provable with no network in CI.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "verify_pinned_digest_exists.py"
+sys.path.insert(0, str(MODULE_PATH.parent))
+SPEC = importlib.util.spec_from_file_location("verify_pinned_digest_exists", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MOD = importlib.util.module_from_spec(SPEC)
+# Register before exec so the module's @dataclass can resolve its own __module__ under
+# `from __future__ import annotations` (importlib does not auto-register the module name).
+sys.modules[SPEC.name] = MOD
+SPEC.loader.exec_module(MOD)
+
+IMAGE = "ghcr.io/socioprophet/prophet-platform/search-orchestrator"
+DIGEST = "sha256:" + ("b" * 64)
+
+
+def _http(responses):
+    """Build a fake HTTP seam. `responses` is a list of (status, headers, body) or an
+    Exception to raise, consumed in order per call."""
+    calls = iter(responses)
+
+    def fn(method, url, headers):
+        item = next(calls)
+        if isinstance(item, Exception):
+            raise item
+        status, hdrs, body = item
+        return status, hdrs, body
+
+    return fn
+
+
+# ── the two headline outcomes ──────────────────────────────────────────────────────────────
+
+def test_real_digest_exists() -> None:
+    r = MOD.check_manifest(IMAGE, DIGEST, http=_http([(200, {}, b"{}")]))
+    assert r.status == MOD.EXISTS
+
+
+def test_fabricated_digest_absent() -> None:
+    body = b'{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}'
+    r = MOD.check_manifest(IMAGE, DIGEST, http=_http([(404, {}, body)]))
+    assert r.status == MOD.ABSENT
+
+
+# ── unreachable is DISTINCT from absent ─────────────────────────────────────────────────────
+
+def test_transport_failure_is_unreachable_not_absent() -> None:
+    r = MOD.check_manifest(IMAGE, DIGEST, http=_http([TimeoutError("timed out")]))
+    assert r.status == MOD.UNREACHABLE, "a timeout must never be reported as a fabricated digest"
+
+
+def test_5xx_is_unreachable() -> None:
+    r = MOD.check_manifest(IMAGE, DIGEST, http=_http([(503, {}, b"bad gateway")]))
+    assert r.status == MOD.UNREACHABLE
+
+
+# ── the private-repo Bearer token exchange ─────────────────────────────────────────────────
+
+def test_auth_challenge_then_token_then_exists() -> None:
+    challenge = {"www-authenticate":
+                 'Bearer realm="https://ghcr.io/token",service="ghcr.io",'
+                 'scope="repository:socioprophet/prophet-platform/search-orchestrator:pull"'}
+    seq = [
+        (401, challenge, b""),                       # first HEAD -> challenge
+        (200, {}, json.dumps({"token": "T"}).encode()),  # token endpoint GET
+        (200, {}, b"{}"),                            # retried HEAD with the token -> exists
+    ]
+    r = MOD.check_manifest(IMAGE, DIGEST, username="x-access-token", password="p",
+                           http=_http(seq))
+    assert r.status == MOD.EXISTS
+
+
+def test_auth_challenge_then_token_then_absent() -> None:
+    challenge = {"www-authenticate": 'Bearer realm="https://ghcr.io/token",service="ghcr.io"'}
+    body = b'{"errors":[{"code":"MANIFEST_UNKNOWN"}]}'
+    seq = [
+        (401, challenge, b""),
+        (200, {}, json.dumps({"token": "T"}).encode()),
+        (404, {}, body),                             # authenticated, and the digest is unknown
+    ]
+    r = MOD.check_manifest(IMAGE, DIGEST, username="x-access-token", password="p",
+                           http=_http(seq))
+    assert r.status == MOD.ABSENT, "authenticated 404 is the real fabricated-digest verdict"
+
+
+def test_unsatisfiable_auth_is_unreachable_never_pass() -> None:
+    # 401, and the token endpoint refuses our creds -> we cannot prove existence -> UNREACHABLE.
+    challenge = {"www-authenticate": 'Bearer realm="https://ghcr.io/token",service="ghcr.io"'}
+    seq = [
+        (401, challenge, b""),
+        (401, {}, b"denied"),   # token endpoint denies -> no bearer minted
+    ]
+    r = MOD.check_manifest(IMAGE, DIGEST, http=_http(seq))
+    assert r.status == MOD.UNREACHABLE
+
+
+# ── the manifest/lock roll-ups return the fail-closed exit codes ────────────────────────────
+
+def test_verify_all_absent_returns_exit_absent() -> None:
+    body = b'{"errors":[{"code":"MANIFEST_UNKNOWN"}]}'
+    rc = MOD._verify_all([(IMAGE, DIGEST)], http=_http([(404, {}, body)]))
+    assert rc == MOD.EXIT_ABSENT
+
+
+def test_verify_all_unreachable_returns_exit_unreachable() -> None:
+    rc = MOD._verify_all([(IMAGE, DIGEST)], http=_http([ConnectionError("no route")]))
+    assert rc == MOD.EXIT_UNREACHABLE
+
+
+def test_verify_all_exists_returns_ok() -> None:
+    rc = MOD._verify_all([(IMAGE, DIGEST)], http=_http([(200, {}, b"{}")]))
+    assert rc == MOD.EXIT_OK
+
+
+def test_parse_ref_rejects_non_digest() -> None:
+    for bad in ("ghcr.io/x/y:latest", "ghcr.io/x/y", "ghcr.io/x/y@sha256:short"):
+        try:
+            MOD.parse_ref(bad)
+        except SystemExit:
+            pass
+        else:
+            raise AssertionError(f"parse_ref must reject {bad!r}")
+
+
+def test_manifest_rollup_reads_components(tmp_path) -> None:
+    m = tmp_path / "rt.manifest.json"
+    m.write_text(json.dumps({"components": [{"image": IMAGE, "digest": DIGEST}]}), encoding="utf-8")
+    rc = MOD._verify_all(MOD._components_from_manifest(m), http=_http([(200, {}, b"{}")]))
+    assert rc == MOD.EXIT_OK

--- a/tools/verify_pinned_digest_exists.py
+++ b/tools/verify_pinned_digest_exists.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Verify that every pinned ``@sha256:`` digest actually RESOLVES to a manifest in its
+registry — INV-DEP-6, the gate that stops a freeze/promote from shipping a digest that was
+never pushed.
+
+Why this exists (the incident this closes)
+------------------------------------------
+A wave-deploy froze + promoted ``search-orchestrator@sha256:bbfea6e4…`` all the way through
+its overlays. Every existing gate was green: the string is a legal ``<image>@sha256:<64hex>``
+(INV-DEP-1 passes), it is one digest per image (INV-DEP-2 passes), the overlays render
+digest-pinned (the render gate passes). But that digest is NOT a real registry manifest —
+Wave 0 (the real build+push) never ran, so deploying it ``ImagePullBackOff``'d on the live
+cluster. Every prior invariant checked the *shape* of the reference; none checked that the
+bytes it names EXIST. This does.
+
+  INV-DEP-6 — a digest MUST NOT be frozen or promoted unless it resolves to a manifest in the
+  registry (Registry HTTP API v2 ``HEAD``/``GET .../manifests/<digest>`` returns the manifest).
+  Fail-closed: ``freeze`` and ``wave-promote`` REFUSE a digest with no manifest.
+
+Three outcomes, kept DISTINCT (so callers can tell "you shipped a fabricated digest" from
+"I couldn't reach the registry to check"):
+
+  * EXISTS      — the registry returned the manifest for that digest.               exit 0
+  * ABSENT      — the registry answered and the manifest is unknown (404 /          exit 4
+                  MANIFEST_UNKNOWN). This is the fabricated / never-pushed case.
+  * UNREACHABLE — DNS/TLS/timeout/5xx/auth-challenge-failed: the registry could     exit 3
+                  not give a definitive answer. We did not PROVE existence, so a
+                  gate MUST still fail-closed — but the operator sees it is a
+                  reachability problem, not a fabricated digest.
+
+Registries supported
+---------------------
+  * ghcr.io                         (GitHub Container Registry)
+  * registry.socioprophet.ai / zot  (the sovereign zot registry)
+  * any Registry-HTTP-API-v2 host    (generic Bearer / Basic token flow)
+
+Auth
+----
+Anonymous by default (public repos resolve without a token). For private repos, supply a
+credential and the tool performs the standard ``WWW-Authenticate: Bearer`` token exchange:
+
+  * ``--username`` / ``--password``    — e.g. ``x-access-token`` + ``$GITHUB_TOKEN`` in CI;
+  * env ``REGISTRY_USERNAME`` / ``REGISTRY_PASSWORD`` (or ``GITHUB_ACTOR`` / ``GITHUB_TOKEN``
+    for ghcr.io) are picked up automatically when the flags are absent.
+  * ``--token`` supplies a ready Bearer token directly (skips the exchange).
+
+Usage
+-----
+  # One reference:
+  verify_pinned_digest_exists.py ref \\
+      ghcr.io/socioprophet/prophet-platform/search-orchestrator@sha256:<64hex>
+
+  # Every component in a frozen release-train manifest (the freeze/promote gate):
+  verify_pinned_digest_exists.py manifest releases/manifests/release-train.<label>.manifest.json
+
+  # Every non-example image-lock:
+  verify_pinned_digest_exists.py locks 'releases/images/*.image-lock.json'
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import glob
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+REF_RE = re.compile(r"^(?P<registry>[^/]+)/(?P<repo>.+?)@(?P<digest>sha256:[0-9a-f]{64})$")
+
+# The manifest media types a registry may answer with. We must Accept all of them or a
+# multi-arch image (an OCI index / manifest list) HEAD can 404 under a too-narrow Accept.
+_MANIFEST_ACCEPT = ", ".join([
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+    "application/vnd.docker.distribution.manifest.v1+json",
+])
+
+# Outcome names (kept as strings so evidence records read plainly).
+EXISTS = "exists"
+ABSENT = "absent"
+UNREACHABLE = "unreachable"
+
+# Exit codes — DISTINCT per the incident requirement (fabricated != unreachable).
+EXIT_OK = 0
+EXIT_UNREACHABLE = 3
+EXIT_ABSENT = 4
+EXIT_USAGE = 2
+
+
+@dataclass
+class Result:
+    status: str          # EXISTS | ABSENT | UNREACHABLE
+    image: str
+    digest: str
+    detail: str = ""
+
+    @property
+    def ref(self) -> str:
+        return f"{self.image}@{self.digest}"
+
+
+# A single seam for the HTTP layer so tests can inject a fake registry without a socket.
+# Returns (status_code, headers, body_bytes); raises on transport failure (DNS/TLS/timeout).
+HttpFn = Callable[[str, str, dict], "tuple[int, dict, bytes]"]
+
+
+def _default_http(method: str, url: str, headers: dict) -> "tuple[int, dict, bytes]":
+    req = urllib.request.Request(url, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=_default_http.timeout) as r:  # type: ignore[attr-defined]
+            return r.status, {k.lower(): v for k, v in r.headers.items()}, r.read()
+    except urllib.error.HTTPError as e:
+        # An HTTP status IS a definitive answer from the registry (401/404/…): return it,
+        # do not treat it as a transport failure.
+        return e.code, {k.lower(): v for k, v in e.headers.items()}, e.read()
+
+
+_default_http.timeout = 15  # type: ignore[attr-defined]
+
+
+def parse_ref(ref: str) -> "tuple[str, str, str]":
+    """``registry/repo@sha256:hex`` -> (registry, repo, digest). Fail-closed on a bad ref."""
+    m = REF_RE.match(ref.strip())
+    if not m:
+        raise SystemExit(f"::error::not a digest-pinned reference: {ref!r} "
+                         f"(want <registry>/<repo>@sha256:<64hex>)")
+    return m.group("registry"), m.group("repo"), m.group("digest")
+
+
+def _auth_header_from_challenge(challenge: str, registry: str, repo: str,
+                                username: str | None, password: str | None,
+                                http: HttpFn) -> str | None:
+    """Perform the Registry v2 token exchange from a ``WWW-Authenticate`` challenge.
+
+    Returns an ``Authorization: Bearer <token>`` value, or None if we could not obtain one.
+    """
+    # WWW-Authenticate: Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:owner/name:pull"
+    if not challenge.lower().startswith("bearer"):
+        return None
+    params: dict[str, str] = {}
+    for part in re.finditer(r'(\w+)="([^"]*)"', challenge):
+        params[part.group(1)] = part.group(2)
+    realm = params.get("realm")
+    if not realm:
+        return None
+    scope = params.get("scope") or f"repository:{repo}:pull"
+    service = params.get("service", registry)
+    url = f"{realm}?service={urllib.request.quote(service)}&scope={urllib.request.quote(scope)}"
+    headers = {"Accept": "application/json"}
+    # If we have creds, present them via Basic to the token endpoint (this is how a private
+    # repo mints a pull-scoped Bearer token). Anonymous otherwise (public repos still work).
+    if username and password:
+        basic = base64.b64encode(f"{username}:{password}".encode()).decode()
+        headers["Authorization"] = f"Basic {basic}"
+    status, _, body = http("GET", url, headers)
+    if status != 200:
+        return None
+    try:
+        data = json.loads(body.decode("utf-8"))
+    except Exception:  # noqa: BLE001
+        return None
+    token = data.get("token") or data.get("access_token")
+    return f"Bearer {token}" if token else None
+
+
+def _resolve_credentials(registry: str, username: str | None,
+                         password: str | None) -> "tuple[str | None, str | None]":
+    """Fill credentials from the environment when the flags are absent (CI convenience)."""
+    if username or password:
+        return username, password
+    user = os.environ.get("REGISTRY_USERNAME")
+    pw = os.environ.get("REGISTRY_PASSWORD")
+    if user or pw:
+        return user, pw
+    # ghcr.io reads the standard Actions identity by default.
+    if registry == "ghcr.io" and os.environ.get("GITHUB_TOKEN"):
+        return os.environ.get("GITHUB_ACTOR", "x-access-token"), os.environ.get("GITHUB_TOKEN")
+    return None, None
+
+
+def check_manifest(image: str, digest: str, *,
+                   username: str | None = None, password: str | None = None,
+                   bearer: str | None = None, http: HttpFn | None = None) -> Result:
+    """Resolve ``image@digest`` against its registry. Never raises for a definitive registry
+    answer — only classifies EXISTS / ABSENT / UNREACHABLE."""
+    http = http or _default_http
+    if not DIGEST_RE.match(digest):
+        raise SystemExit(f"::error::{digest!r} is not sha256:<64hex>")
+    registry, _, repo = image.partition("/")
+    if not repo:
+        raise SystemExit(f"::error::image {image!r} has no repository path")
+
+    scheme = "http" if (registry.startswith("localhost") or registry.startswith("127.")) else "https"
+    url = f"{scheme}://{registry}/v2/{repo}/manifests/{digest}"
+    headers = {"Accept": _MANIFEST_ACCEPT}
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}" if not bearer.lower().startswith("bearer") else bearer
+
+    def _classify(status: int, hdrs: dict, body: bytes) -> Result | None:
+        if 200 <= status < 300:
+            return Result(EXISTS, image, digest, f"registry returned manifest ({status})")
+        if status == 404:
+            return Result(ABSENT, image, digest,
+                          "registry answered MANIFEST_UNKNOWN (404) — digest not pushed")
+        return None
+
+    try:
+        status, hdrs, body = http("HEAD", url, headers)
+    except Exception as exc:  # noqa: BLE001 - transport failure, not an HTTP answer
+        return Result(UNREACHABLE, image, digest, f"registry unreachable: {exc!r}")
+
+    verdict = _classify(status, hdrs, body)
+    if verdict is not None:
+        return verdict
+
+    # 401/403 -> attempt the token exchange, then retry once.
+    if status in (401, 403) and "www-authenticate" in hdrs:
+        user, pw = _resolve_credentials(registry, username, password)
+        auth = _auth_header_from_challenge(hdrs["www-authenticate"], registry, repo, user, pw, http)
+        if auth:
+            headers["Authorization"] = auth
+            try:
+                status, hdrs, body = http("HEAD", url, headers)
+            except Exception as exc:  # noqa: BLE001
+                return Result(UNREACHABLE, image, digest, f"registry unreachable after auth: {exc!r}")
+            verdict = _classify(status, hdrs, body)
+            if verdict is not None:
+                return verdict
+        # Could not authenticate / still ambiguous — UNREACHABLE, never a silent pass.
+        return Result(UNREACHABLE, image, digest,
+                      f"registry needs auth we could not satisfy (status {status})")
+
+    # Some registries answer HEAD with 405; fall back to GET before giving up.
+    if status == 405:
+        try:
+            status, hdrs, body = http("GET", url, headers)
+        except Exception as exc:  # noqa: BLE001
+            return Result(UNREACHABLE, image, digest, f"registry unreachable on GET: {exc!r}")
+        verdict = _classify(status, hdrs, body)
+        if verdict is not None:
+            return verdict
+
+    return Result(UNREACHABLE, image, digest, f"registry gave a non-definitive status {status}")
+
+
+def check_ref(ref: str, **kw) -> Result:
+    registry, repo, digest = parse_ref(ref)
+    return check_manifest(f"{registry}/{repo}", digest, **kw)
+
+
+def _components_from_manifest(path: Path) -> list["tuple[str, str]"]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    out: list[tuple[str, str]] = []
+    for c in data.get("components", []):
+        image = str(c.get("image", ""))
+        digest = str(c.get("digest", ""))
+        if image and digest:
+            out.append((image, digest))
+    if not out:
+        raise SystemExit(f"::error::{path}: no (image, digest) components to verify")
+    return out
+
+
+def _components_from_locks(lock_glob: str) -> list["tuple[str, str]"]:
+    out: list[tuple[str, str]] = []
+    for lf in sorted(glob.glob(lock_glob)):
+        if lf.endswith(".example.json"):
+            continue
+        lock = json.loads(Path(lf).read_text(encoding="utf-8"))
+        if lock.get("status") == "example":
+            continue
+        image = str(lock.get("image", ""))
+        digest = str(lock.get("digest", ""))
+        if image and digest:
+            out.append((image, digest))
+    if not out:
+        raise SystemExit(f"::error::no non-example locks matched {lock_glob!r} to verify")
+    return out
+
+
+def _verify_all(pairs: list["tuple[str, str]"], **kw) -> int:
+    results = [check_manifest(img, dig, **kw) for img, dig in pairs]
+    absent = [r for r in results if r.status == ABSENT]
+    unreachable = [r for r in results if r.status == UNREACHABLE]
+    for r in results:
+        mark = {EXISTS: "OK   ", ABSENT: "ABSENT", UNREACHABLE: "UNREACH"}[r.status]
+        print(f"  [{mark}] {r.ref}  — {r.detail}")
+    if absent:
+        print(f"::error::INV-DEP-6: {len(absent)} pinned digest(s) do NOT exist in the registry "
+              f"(fabricated / never pushed). REFUSING to freeze/promote.")
+        return EXIT_ABSENT
+    if unreachable:
+        print(f"::error::INV-DEP-6: could not PROVE existence of {len(unreachable)} digest(s) "
+              f"(registry unreachable). Fail-closed: refusing to freeze/promote on unverified images.")
+        return EXIT_UNREACHABLE
+    print(f"OK: all {len(results)} pinned digest(s) resolve to a registry manifest (INV-DEP-6)")
+    return EXIT_OK
+
+
+def _common_auth_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--username", default=None, help="registry username (CI: x-access-token)")
+    p.add_argument("--password", default=None, help="registry password/token (CI: $GITHUB_TOKEN)")
+    p.add_argument("--token", default=None, help="ready Bearer token (skips the token exchange)")
+    p.add_argument("--timeout", type=int, default=15, help="per-request timeout seconds")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pr = sub.add_parser("ref", help="verify a single <registry>/<repo>@sha256:<hex> reference")
+    pr.add_argument("reference")
+    _common_auth_args(pr)
+
+    pm = sub.add_parser("manifest", help="verify every component in a frozen release-train manifest")
+    pm.add_argument("manifest", type=Path)
+    _common_auth_args(pm)
+
+    pl = sub.add_parser("locks", help="verify every non-example image-lock in a glob")
+    pl.add_argument("glob", default="releases/images/*.image-lock.json", nargs="?")
+    _common_auth_args(pl)
+
+    args = p.parse_args(argv)
+    _default_http.timeout = args.timeout  # type: ignore[attr-defined]
+    kw = dict(username=args.username, password=args.password, bearer=args.token)
+
+    if args.cmd == "ref":
+        r = check_ref(args.reference, **kw)
+        print(f"  [{r.status.upper()}] {r.ref} — {r.detail}")
+        return {EXISTS: EXIT_OK, ABSENT: EXIT_ABSENT, UNREACHABLE: EXIT_UNREACHABLE}[r.status]
+    if args.cmd == "manifest":
+        return _verify_all(_components_from_manifest(args.manifest), **kw)
+    if args.cmd == "locks":
+        return _verify_all(_components_from_locks(args.glob), **kw)
+    return EXIT_USAGE
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## apply surfaced a placeholder digest; make freeze/promote fail-closed on missing images

An **actual apply** (isolated dev namespace, live GKE) proved the wave-deploy (`#1225`)
froze/promoted `search-orchestrator@sha256:bbfea6e4…`, which is **not a real registry
manifest** — it `ImagePullBackOff`'d. Wave 0 (real build+push) never ran, and the cost-guard
change-detection would even **SKIP** the real build because it trusts a recorded
`source_content_digest` that never corresponded to a push. Every prior gate checked the
*shape* of the digest reference; none checked that the bytes it names **exist**. This closes
that, fail-closed, at freeze, at promote, and at the skip decision.

### What changed

1. **INV-DEP-6 — digest-exists gate.** New `tools/verify_pinned_digest_exists.py` resolves
   every pinned `@sha256:` against its registry (Registry HTTP API v2 `HEAD`/`GET
   …/manifests/<digest>`; ghcr + the sovereign zot; anonymous or `WWW-Authenticate: Bearer`
   token exchange with the CI token). Three **distinct** outcomes — `EXISTS` (0) / `ABSENT`
   (4, 404/`MANIFEST_UNKNOWN`) / `UNREACHABLE` (3, auth/DNS/TLS/5xx). Both `ABSENT` and
   `UNREACHABLE` fail closed (existence not proven), reported distinctly. `release-train.yml`
   freeze **and** `wave-promote.yml` GATE 0b call it and **refuse** to freeze/promote a digest
   with no manifest.

2. **Change-detection skip fixed.** `compute_source_content_digest.py decide
   --verify-image-exists`: a SKIP now requires **both** source-content match **and** the
   recorded pinned image resolving to a real manifest. A missing/unverifiable image forces
   **BUILD** regardless of source match. Wired into all three per-component image workflows.
   Unit test `test_decide_build_when_source_matches_but_image_missing` covers exactly
   "recorded-source-matches-but-image-missing ⇒ BUILD, not SKIP".

3. **INV-DEP-7 — a lock digest is only ever a real push output.**
   `apply_search_orchestrator_image_lock.py` is the **sole** writer of the lock `digest`:
   it refuses a blank/placeholder evidence digest, carries the build's
   `source_content_digest` through, and stamps `digest_provenance: buildx-push`. The build
   workflow already sources the digest from `docker buildx …--push`
   (`steps.build.outputs.digest`) — never computed.

4. **Docs.** INV-DEP-6 + INV-DEP-7 added to `docs/standards/deploy-wave-invariants-v0.md`
   (+ conformance checklist) and the `docs/DEPLOY-WAVE-STRATEGY.md` narrative, including the
   exact `gh workflow run` sequence to produce a real search-orchestrator digest.

### The gate proven both ways (live, public registry)

```
$ verify_pinned_digest_exists.py ref ghcr.io/oras-project/oras@sha256:0087224dd0decc354b5b0689068fbbc40cd5dc3dbf65fcb3868dfbd363dc790b
  [EXISTS] …@sha256:0087224… — registry returned manifest (200)      exit 0
$ verify_pinned_digest_exists.py ref ghcr.io/oras-project/oras@sha256:bbbb…bbbb   (fabricated)
  [ABSENT] …@sha256:bbbb…bbbb — registry answered MANIFEST_UNKNOWN (404)   exit 4
```

Against the incident's own manifest (private repo, no CI token in this task) the gate reports
`UNREACHABLE` (401) and **still fails closed** (exit 3) — it never passes on an unverified
image. In CI, with `GITHUB_TOKEN`, the token exchange resolves it to `ABSENT` until a real push
exists. The integrated skip path is proven live too: source matches the lock but the pinned
digest 404s ⇒ `BUILD … does NOT exist in the registry … (INV-DEP-6)` (exit 10).

### Produce a REAL search-orchestrator digest (Wave 0)

```bash
gh workflow run search-orchestrator-image.yml --ref main        # build + push, records the REAL digest
gh workflow run search-orchestrator-image-pin.yml --ref main    # pin lock+overlay from that run's digest evidence
python3 tools/verify_pinned_digest_exists.py locks 'releases/images/search-orchestrator.image-lock.json'
```

### Validation
- `python3 -m pytest -q` over the 5 affected test files — **33 passed** (digest-exists both
  ways incl. private-repo token flow; skip source-match-but-image-missing ⇒ BUILD;
  lock-provenance refuses placeholder evidence).
- `actionlint` clean on all 5 touched workflows; `yaml.safe_load` parses all.

Scope note: the `bbfea6e4…` placeholder remains committed across the lock, frozen manifest and
overlays as the failing fixture these gates now reject; it is replaced only by the real Wave-0
push above (not fabricated here). Do **not** merge until reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
