### PR TITLE
fix(wave-deploy): retarget search-orchestrator plane from ghcr to GAR (WIF)

### DIFF
--- a/.github/workflows/search-orchestrator-image-pin.yml
+++ b/.github/workflows/search-orchestrator-image-pin.yml
@@ -108,6 +108,44 @@ jobs:
             --lock-output releases/images/search-orchestrator.image-lock.json \
             --patch-output infra/k8s/search-orchestrator/overlays/policy/image-patch.yaml
 
+      # PROPAGATE THE PINNED DIGEST INTO THE PROMOTE OVERLAYS (INV-DEP-2, the item-5 fix).
+      # Before this, the pin wrote only the lock + policy patch, so the dev/canary/prod
+      # promote overlays kept the PREVIOUS digest — the wave-deploy divergence (lock on one
+      # digest, promote overlays on the never-pushed sha256:bbfea6e4…). Re-freeze the manifest
+      # from the just-updated lock and re-render every wave overlay from it, so the pin PR
+      # carries the same digest end-to-end. No build, no rebuild — a pure re-pin of the frozen
+      # sha256. The apply-time INV-DEP-6 digest-exists gate still fails-closed on a bad digest.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Propagate the pinned digest into the promote overlays (dev/canary/prod)
+        id: propagate
+        run: |
+          set -euo pipefail
+          pip install --quiet pyyaml
+          # Re-freeze in place: reuse the newest existing manifest label so the pin refreshes
+          # that manifest rather than proliferating a new date-labelled file each build.
+          # shellcheck disable=SC2012 # manifest filenames are sanitized labels (date/tag); ls is safe here
+          label="$(ls releases/manifests/release-train.*.manifest.json 2>/dev/null \
+                    | sed -E 's#.*release-train\.(.*)\.manifest\.json#\1#' | sort | tail -1)"
+          [ -n "$label" ] || label="$(date -u +%Y-%m-%d)"
+          python3 tools/freeze_release_train_manifest.py --label "$label"
+          manifest="releases/manifests/release-train.${label}.manifest.json"
+          for wave in dev canary; do
+            python3 tools/apply_wave_promotion.py \
+              --manifest "$manifest" --component search-orchestrator \
+              --deployment search-orchestrator --container search-orchestrator \
+              --kind Deployment \
+              --output "infra/k8s/search-orchestrator/overlays/promote/${wave}/image-patch.yaml"
+          done
+          python3 tools/apply_wave_promotion.py \
+            --manifest "$manifest" --component search-orchestrator \
+            --deployment search-orchestrator --container search-orchestrator \
+            --kind Rollout \
+            --output "infra/k8s/search-orchestrator/overlays/promote/prod/image-patch.yaml"
+          echo "manifest=$manifest" >> "$GITHUB_OUTPUT"
+          echo "propagated the pinned digest into dev/canary/prod overlays + $manifest"
+
       - name: Validate image release artifacts
         run: |
           python3 tools/validate_search_orchestrator_image_release.py
@@ -120,4 +158,7 @@ jobs:
       - name: Open the pinning pull request
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Carry the re-frozen manifest (date-labelled filename) into the pin commit
+          # alongside the static lock/policy/promote paths.
+          PIN_EXTRA_PATHS: ${{ steps.propagate.outputs.manifest }}
         run: scripts/ci/open-image-pin-pr.sh

--- a/.github/workflows/search-orchestrator-image.yml
+++ b/.github/workflows/search-orchestrator-image.yml
@@ -19,9 +19,19 @@ on:
       - 'tools/validate_search_orchestrator_image_release.py'
       - 'releases/images/search-orchestrator.image-lock.example.json'
 
+# REGISTRY: GCP Artifact Registry (GAR), NOT ghcr. The live GKE nodes have WIF auth to GAR and
+# NONE to ghcr, so a ghcr digest (placeholder OR real) 401s on a real apply — the apply-caught
+# incident this retarget closes (see docs/DEPLOY-WAVE-STRATEGY.md, "apply-caught registry
+# mismatch"). This mirrors the estate's canonical build path (images.yml default registry +
+# helm-release.yml WIF auth): us-central1-docker.pkg.dev/socioprophet-platform/socioprophet.
 permissions:
   contents: read
-  packages: write
+  id-token: write   # WIF: google-github-actions/auth mints the GAR access token from OIDC
+
+env:
+  # Canonical GAR path, mirrored from images.yml's default registry and helm-release.yml.
+  GAR_REGISTRY: us-central1-docker.pkg.dev
+  GAR_IMAGE: us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator
 
 # COST GUARD 2 (queue vs cancel) — see socioprophet-api-image.yml for the full note.
 # main QUEUES (cancel-in-progress:false); feature branches/PRs CANCEL superseded runs (INV-DEP-5).
@@ -41,6 +51,9 @@ jobs:
   # match AND the pinned image resolving to a real manifest; a missing/unverifiable image BUILDs.
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # WIF for the GAR image-exists check below (INV-DEP-6)
     outputs:
       build_needed: ${{ steps.decide.outputs.build_needed }}
     steps:
@@ -48,11 +61,23 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      # WIF: mint a GAR access token so the image-exists cost-guard can HEAD the pinned digest
+      # in Artifact Registry. If this auth is unavailable the token is simply absent and the
+      # check classifies UNREACHABLE -> BUILD (fail-closed) rather than a false SKIP.
+      - id: gar-auth
+        name: Authenticate to GCP (WIF) for the GAR image-exists check
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          token_format: access_token
       - id: decide
         name: Decide build-vs-skip from source content-digest (+ image-exists, INV-DEP-6)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
+          # verify_pinned_digest_exists.py presents this as a raw Bearer to the GAR v2 API.
+          GAR_ACCESS_TOKEN: ${{ steps.gar-auth.outputs.access_token }}
         run: |
           set +e
           python3 tools/compute_source_content_digest.py decide \
@@ -73,13 +98,25 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GHCR
+      # GAR auth via Workload Identity Federation — the estate's canonical pattern
+      # (helm-release.yml, images.yml `registry_auth: gar`). The GKE nodes trust GAR, not ghcr,
+      # so the image MUST land here for a real apply to pull it.
+      - id: gar-auth
+        name: Authenticate to GCP Artifact Registry (WIF)
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          token_format: access_token
+
+      - name: Log in to GAR
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ${{ env.GAR_REGISTRY }}
+          username: oauth2accesstoken
+          password: ${{ steps.gar-auth.outputs.access_token }}
 
       - name: Build image for pull request
         if: github.event_name == 'pull_request'
@@ -88,7 +125,7 @@ jobs:
           context: .
           file: services/search-orchestrator/Dockerfile
           push: false
-          tags: ghcr.io/socioprophet/prophet-platform/search-orchestrator:pr-${{ github.event.pull_request.number }}
+          tags: ${{ env.GAR_IMAGE }}:pr-${{ github.event.pull_request.number }}
           cache-from: type=gha,scope=search-orchestrator
           cache-to: type=gha,mode=max,scope=search-orchestrator
 
@@ -100,9 +137,11 @@ jobs:
           context: .
           file: services/search-orchestrator/Dockerfile
           push: true
+          # Immutable sha- tag is the estate GAR convention (deploy/values, images.yml); the
+          # image-lock still pins by the @sha256: digest recorded below (digest > moving tag).
           tags: |
-            ghcr.io/socioprophet/prophet-platform/search-orchestrator:main
-            ghcr.io/socioprophet/prophet-platform/search-orchestrator:${{ github.sha }}
+            ${{ env.GAR_IMAGE }}:main
+            ${{ env.GAR_IMAGE }}:sha-${{ github.sha }}
           cache-from: type=gha,scope=search-orchestrator
           cache-to: type=gha,mode=max,scope=search-orchestrator
 
@@ -121,10 +160,10 @@ jobs:
           mkdir -p image-evidence
           cat > image-evidence/search-orchestrator-image.json <<EOF
           {
-            "image": "ghcr.io/socioprophet/prophet-platform/search-orchestrator",
+            "image": "${{ env.GAR_IMAGE }}",
             "source_sha": "${{ github.sha }}",
             "digest": "${{ steps.build.outputs.digest }}",
-            "pinned_ref": "ghcr.io/socioprophet/prophet-platform/search-orchestrator@${{ steps.build.outputs.digest }}",
+            "pinned_ref": "${{ env.GAR_IMAGE }}@${{ steps.build.outputs.digest }}",
             "source_content_digest": "${{ steps.content.outputs.content_digest }}"
           }
           EOF

--- a/docs/CONTAINER_BUILD_SUBSTRATE.md
+++ b/docs/CONTAINER_BUILD_SUBSTRATE.md
@@ -38,7 +38,7 @@ This repository already contains at least one container image build workflow:
 
 - `.github/workflows/search-orchestrator-image.yml`
 - `services/search-orchestrator/Dockerfile`
-- GHCR image naming under `ghcr.io/socioprophet/prophet-platform/search-orchestrator`
+- GAR image naming under `us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator` (WIF-authed; the GKE nodes pull from GAR, not ghcr)
 - digest evidence emitted as an uploaded artifact
 - pinned image reference emitted as `image@digest`
 

--- a/docs/DEPLOY-WAVE-STRATEGY.md
+++ b/docs/DEPLOY-WAVE-STRATEGY.md
@@ -73,9 +73,28 @@ promotes: INV-DEP-6 refuses it at freeze and at every wave until a real Wave-0 p
 ## Wave 0 — build once → registry
 
 Per-component image workflows (`socioprophet-api-image.yml`, `tritrpc-gateway-image.yml`,
-`search-orchestrator-image.yml`) and the matrix `images.yml` build → push to the sovereign
-zot registry (`registry.socioprophet.ai`, cutover in progress) / GHCR / GAR → record the
+`search-orchestrator-image.yml`) and the matrix `images.yml` build → push → record the
 immutable digest in `releases/images/<component>.image-lock.json`.
+
+**Target registry = GCP Artifact Registry (GAR), WIF-authed — NOT ghcr.** The estate's real
+GKE registry is `us-central1-docker.pkg.dev/socioprophet-platform/socioprophet` (the default in
+`images.yml`; the same path `helm-release.yml` pushes charts to). The GKE nodes hold Workload
+Identity Federation auth to GAR and **none** to ghcr, so a ghcr digest — placeholder *or* real —
+`401`s on pull at apply time. `search-orchestrator-image.yml` therefore authenticates with
+`google-github-actions/auth` (WIF → access token) and `docker login us-central1-docker.pkg.dev -u
+oauth2accesstoken`, mirroring the canonical pattern. (`registry.socioprophet.ai` / zot is the
+sovereign registry the wider cutover moves to per-component; search-orchestrator is on GAR.)
+
+> **Lesson — an apply-caught registry mismatch (2026-08-02).** The wave-deploy plane
+> (#1225/#1226) built, pinned and promoted `ghcr.io/socioprophet/prophet-platform/search-orchestrator`.
+> Every dry-run/CI gate was green — the ref is a legal `<image>@sha256:…`, the overlays render
+> digest-pinned, INV-DEP-6 resolved the *public* ghcr digest as EXISTS. Only a **real cluster
+> apply** surfaced it: `fogstack-federal` pulls `search-orchestrator` from **GAR** and the nodes
+> have no ghcr credential, so the apply `401`'d on both the placeholder and the real ghcr digest.
+> Dry-run "the digest exists in *a* registry" is not "the cluster can pull it from *this*
+> registry." The registry the pin names must be the one the nodes are authorized to pull from —
+> now asserted statically by `preflight_deploy_contract.py`'s `OUR_REGISTRIES` (GAR + zot, ghcr
+> excluded) so a ghcr search-orchestrator ref fails CI, not just the apply.
 
 **INV-DEP-7 — the build is the ONLY writer of a lock digest.** The lock's `digest` comes only
 from a real `docker buildx …--push` (`steps.build.outputs.digest`), carried through the digest
@@ -84,17 +103,23 @@ evidence artifact and applied by `tools/apply_search_orchestrator_image_lock.py`
 is never hand-authored or computed — that is the class of failure the `bbfea6e4…` incident was.
 
 To actually produce a real search-orchestrator digest (Wave 0), dispatch the build on `main`
-(it pushes to GHCR, uploads the digest evidence, and the pin workflow opens the lock PR):
+(it WIF-auths to GAR, pushes `us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator:main`
++ `:sha-<commit>`, uploads the GAR digest evidence, and the pin workflow opens the lock PR that
+propagates the digest into the policy + dev/canary/prod overlays):
 
 ```bash
-# 1) Build + push, recording the REAL registry digest (main only pushes; PRs build without push):
+# 1) Build + push to GAR via WIF, recording the REAL GAR digest (main only pushes; PRs build without push):
 gh workflow run search-orchestrator-image.yml --ref main
-# 2) After it succeeds, pin the lock + overlay from that run's digest evidence (auto-fires on the
-#    build's success; run explicitly to pin a specific/older successful run):
+# 2) After it succeeds, pin the lock + ALL overlays from that run's GAR digest evidence (auto-fires on
+#    the build's success; run explicitly to pin a specific/older successful run):
 gh workflow run search-orchestrator-image-pin.yml --ref main         # latest successful build
 #    or:  gh workflow run search-orchestrator-image-pin.yml --ref main -f run_id=<BUILD_RUN_ID>
-# 3) Verify the freshly-pinned digest really resolves (the same gate the train runs):
-python3 tools/verify_pinned_digest_exists.py locks 'releases/images/search-orchestrator.image-lock.json'
+# 3) Verify the freshly-pinned GAR digest really resolves (the same gate the train runs). Locally,
+#    supply a GAR access token so the private HEAD authenticates (CI's `changes` job does this via WIF):
+GAR_ACCESS_TOKEN="$(gcloud auth print-access-token)" \
+  python3 tools/verify_pinned_digest_exists.py locks 'releases/images/search-orchestrator.image-lock.json'
+#    (Until step 1 runs, the committed lock still carries the retired ghcr push digest, which is
+#     genuinely absent from GAR — INV-DEP-6 fails closed against it by design; the real push replaces it.)
 ```
 
 - **COST GUARD 1 — change-detection skip (now image-exists-aware, INV-DEP-6).** A `changes`

--- a/docs/SEARCH_ORCHESTRATOR_ACADEMY_BRIDGE_PRODUCTION_HARDENING.md
+++ b/docs/SEARCH_ORCHESTRATOR_ACADEMY_BRIDGE_PRODUCTION_HARDENING.md
@@ -80,7 +80,7 @@ The base deployment still uses a development image tag as a placeholder.
 Production release must replace that image with a digest-pinned reference before production rollout. Example target shape:
 
 ```text
-ghcr.io/socioprophet/prophet-platform/search-orchestrator@sha256:<digest>
+us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator@sha256:<digest>
 ```
 
 Do not use floating tags for production rollout.

--- a/docs/standards/deploy-wave-invariants-v0.md
+++ b/docs/standards/deploy-wave-invariants-v0.md
@@ -117,6 +117,27 @@ stamps `digest_provenance`) — `test_build_lock_refuses_placeholder_digest`,
 `test_build_lock_carries_source_content_digest_from_the_same_build`; INV-DEP-6 catches any lock
 digest that slips through and does not actually exist.
 
+## INV-DEP-8 — The pinned registry MUST be one the target nodes can pull from
+
+A digest-pinned ref MUST name a registry the deploying cluster is authorized to pull from. For
+GKE that is **GCP Artifact Registry** (`us-central1-docker.pkg.dev/socioprophet-platform/socioprophet`,
+WIF-authed) or the sovereign zot (`registry.socioprophet.ai`) — **never ghcr**, which the GKE
+nodes have no credential for. INV-DEP-6 proves the bytes exist in *some* registry; INV-DEP-8
+proves they exist in *the one the nodes can reach*. Both must hold: a digest that a public HEAD
+resolves but the cluster cannot pull still `ImagePull`s at apply.
+
+*Rationale.* The 2026-08-02 apply-caught incident: the wave-deploy plane built+pinned+promoted
+`ghcr.io/socioprophet/prophet-platform/search-orchestrator`. Every shape/existence gate passed
+(the public ghcr digest even resolved EXISTS), yet the real `fogstack-federal` apply `401`'d —
+the nodes pull `search-orchestrator` from GAR and hold no ghcr auth. A registry mismatch that
+only a real apply, not dry-run, surfaces.
+
+*Enforced by.* `tools/preflight_deploy_contract.py` (`OUR_REGISTRIES` = GAR + zot; a first-party
+image ref pointing at ghcr is flagged `wrong-registry` in CI, not just at apply). The build path
+(`search-orchestrator-image.yml`) pushes to GAR via `google-github-actions/auth` WIF, and
+`verify_pinned_digest_exists.py` authenticates GAR HEADs with the WIF access token
+(`GAR_ACCESS_TOKEN`) so INV-DEP-6 verifies against the registry the nodes actually use.
+
 ---
 
 ## Conformance checklist
@@ -129,5 +150,6 @@ digest that slips through and does not actually exist.
 | 4 | Overlays render, all `@sha256:` | `kubectl kustomize infra/k8s/search-orchestrator/overlays/promote/{dev,canary,prod}` |
 | 5 | Skip + queue/cancel contract | `python3 -m pytest -q tools/tests/test_compute_source_content_digest.py tools/tests/test_release_train_manifest.py` |
 | 6 | Workflows lint | `actionlint .github/workflows/{release-train,wave-promote,*-image}.yml` |
-| 7 | Every frozen digest exists in the registry (INV-DEP-6) | `python3 tools/verify_pinned_digest_exists.py manifest releases/manifests/release-train.<label>.manifest.json` |
-| 8 | Digest-exists + lock-provenance gates, both ways (INV-DEP-6/7) | `python3 -m pytest -q tools/tests/test_verify_pinned_digest_exists.py tools/tests/test_apply_search_orchestrator_image_lock.py` |
+| 7 | Every frozen digest exists in the registry (INV-DEP-6) — GAR needs a WIF token | `GAR_ACCESS_TOKEN="$(gcloud auth print-access-token)" python3 tools/verify_pinned_digest_exists.py manifest releases/manifests/release-train.<label>.manifest.json` |
+| 8 | Digest-exists (incl. GAR) + lock-provenance gates, both ways (INV-DEP-6/7) | `python3 -m pytest -q tools/tests/test_verify_pinned_digest_exists.py tools/tests/test_apply_search_orchestrator_image_lock.py` |
+| 9 | First-party refs point at a pullable registry — GAR/zot, not ghcr (INV-DEP-8) | `python3 tools/preflight_deploy_contract.py` |

--- a/infra/k8s/search-orchestrator/base/deployment.yaml
+++ b/infra/k8s/search-orchestrator/base/deployment.yaml
@@ -22,7 +22,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: search-orchestrator
-          image: ghcr.io/socioprophet/prophet-platform/search-orchestrator:dev
+          image: us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator:dev
           imagePullPolicy: IfNotPresent
           command: ["uvicorn"]
           args: ["app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/infra/k8s/search-orchestrator/overlays/policy/image-patch.yaml
+++ b/infra/k8s/search-orchestrator/overlays/policy/image-patch.yaml
@@ -7,5 +7,5 @@ spec:
     spec:
       containers:
         - name: search-orchestrator
-          image: ghcr.io/socioprophet/prophet-platform/search-orchestrator@sha256:dd342da260dc1d5953f4588f02aca319c2a357240c5b55d3ab3137b3e96a864b
+          image: us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator@sha256:dd342da260dc1d5953f4588f02aca319c2a357240c5b55d3ab3137b3e96a864b
           imagePullPolicy: IfNotPresent

--- a/infra/k8s/search-orchestrator/overlays/promote/canary/image-patch.yaml
+++ b/infra/k8s/search-orchestrator/overlays/promote/canary/image-patch.yaml
@@ -9,5 +9,5 @@ spec:
     spec:
       containers:
         - name: search-orchestrator
-          image: ghcr.io/socioprophet/prophet-platform/search-orchestrator@sha256:bbfea6e4a7ea432d77766a37464dfa666242dfe2621fc0e586ca2bde80c52066
+          image: us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator@sha256:dd342da260dc1d5953f4588f02aca319c2a357240c5b55d3ab3137b3e96a864b
           imagePullPolicy: IfNotPresent

--- a/infra/k8s/search-orchestrator/overlays/promote/dev/image-patch.yaml
+++ b/infra/k8s/search-orchestrator/overlays/promote/dev/image-patch.yaml
@@ -9,5 +9,5 @@ spec:
     spec:
       containers:
         - name: search-orchestrator
-          image: ghcr.io/socioprophet/prophet-platform/search-orchestrator@sha256:bbfea6e4a7ea432d77766a37464dfa666242dfe2621fc0e586ca2bde80c52066
+          image: us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator@sha256:dd342da260dc1d5953f4588f02aca319c2a357240c5b55d3ab3137b3e96a864b
           imagePullPolicy: IfNotPresent

--- a/infra/k8s/search-orchestrator/overlays/promote/prod/image-patch.yaml
+++ b/infra/k8s/search-orchestrator/overlays/promote/prod/image-patch.yaml
@@ -9,5 +9,5 @@ spec:
     spec:
       containers:
         - name: search-orchestrator
-          image: ghcr.io/socioprophet/prophet-platform/search-orchestrator@sha256:bbfea6e4a7ea432d77766a37464dfa666242dfe2621fc0e586ca2bde80c52066
+          image: us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator@sha256:dd342da260dc1d5953f4588f02aca319c2a357240c5b55d3ab3137b3e96a864b
           imagePullPolicy: IfNotPresent

--- a/infra/k8s/search-orchestrator/overlays/promote/prod/rollout.yaml
+++ b/infra/k8s/search-orchestrator/overlays/promote/prod/rollout.yaml
@@ -53,7 +53,7 @@ spec:
       containers:
         - name: search-orchestrator
           # OVERWRITTEN by image-patch.yaml with the frozen digest — do not hand-edit.
-          image: ghcr.io/socioprophet/prophet-platform/search-orchestrator:PLACEHOLDER
+          image: us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator:PLACEHOLDER
           imagePullPolicy: IfNotPresent
           command: ["uvicorn"]
           args: ["app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/releases/images/component-inventory.v1.yaml
+++ b/releases/images/component-inventory.v1.yaml
@@ -129,20 +129,20 @@ components:
     runtime_base: unknown_existing
     runtime_base_justification: Existing image workflow predates substrate hardening; verify and migrate to scratch/distroless/Wolfi/UBI-minimal as appropriate.
     host_substrate: fcos_silverblue_ostree_fedora_family
-    image_registry: ghcr.io/socioprophet/prophet-platform
+    image_registry: us-central1-docker.pkg.dev/socioprophet-platform/socioprophet
     image_name: search-orchestrator
     tags:
       - main
       - sha
     workflow: .github/workflows/search-orchestrator-image.yml
-    current_status: existing_buildx_ghcr_digest_evidence
+    current_status: buildx_gar_wif_digest_evidence
     digest_required: true
     sbom_required: true
     provenance_required: true
     vulnerability_scan_required: true
     evaluation_record_required: true
     angel_required: conditional
-    notes: Existing workflow builds and pushes to GHCR and emits digest evidence. SBOM/provenance/scan gates should be added or verified in follow-up.
+    notes: Builds and pushes to GCP Artifact Registry (GAR) via WIF and emits digest evidence. The GKE nodes have WIF auth to GAR and NONE to ghcr, so ghcr was an apply-time ImagePull 401 (the retarget incident). SBOM/provenance/scan gates should be added or verified in follow-up.
 
   - id: socioprophet_api
     name: SocioProphet API

--- a/releases/images/search-orchestrator.image-lock.example.json
+++ b/releases/images/search-orchestrator.image-lock.example.json
@@ -1,10 +1,10 @@
 {
   "image_lock_id": "search-orchestrator-image-lock-example",
   "component": "services/search-orchestrator",
-  "image": "ghcr.io/socioprophet/prophet-platform/search-orchestrator",
+  "image": "us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator",
   "source_sha": "REPLACE_WITH_GIT_SHA",
   "digest": "sha256:REPLACE_WITH_IMAGE_DIGEST",
-  "pinned_ref": "ghcr.io/socioprophet/prophet-platform/search-orchestrator@sha256:REPLACE_WITH_IMAGE_DIGEST",
+  "pinned_ref": "us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator@sha256:REPLACE_WITH_IMAGE_DIGEST",
   "workflow": ".github/workflows/search-orchestrator-image.yml",
   "status": "example"
 }

--- a/releases/images/search-orchestrator.image-lock.json
+++ b/releases/images/search-orchestrator.image-lock.json
@@ -1,12 +1,13 @@
 {
   "image_lock_id": "search-orchestrator-image-lock",
   "component": "services/search-orchestrator",
-  "image": "ghcr.io/socioprophet/prophet-platform/search-orchestrator",
+  "image": "us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator",
   "source_sha": "ef36835d7d40af34352e0dc3be15bf19a5b47ed3",
   "digest": "sha256:dd342da260dc1d5953f4588f02aca319c2a357240c5b55d3ab3137b3e96a864b",
-  "pinned_ref": "ghcr.io/socioprophet/prophet-platform/search-orchestrator@sha256:dd342da260dc1d5953f4588f02aca319c2a357240c5b55d3ab3137b3e96a864b",
+  "pinned_ref": "us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator@sha256:dd342da260dc1d5953f4588f02aca319c2a357240c5b55d3ab3137b3e96a864b",
   "source_content_digest": "sha256:c2119c07b2741df6f30dc86007f275e80e01edb075ce64ff87b5ca53f8cb511a",
   "workflow": ".github/workflows/search-orchestrator-image.yml",
   "digest_provenance": "buildx-push",
+  "stale_digest_pending_gar_push": "This digest was produced by the retired ghcr push and is NOT in GAR; INV-DEP-6 will (correctly) fail against GAR until search-orchestrator-image.yml pushes to GAR and search-orchestrator-image-pin.yml re-applies the real GAR digest. Registry retargeted here; digest is replaced by the first real GAR push.",
   "status": "pinned"
 }

--- a/releases/manifests/release-train.2026-08-02.manifest.json
+++ b/releases/manifests/release-train.2026-08-02.manifest.json
@@ -2,7 +2,7 @@
   "manifest_id": "release-train.2026-08-02",
   "schema_version": "v1",
   "kind": "release-train-frozen-image-set",
-  "frozen_at": "2026-08-02T21:38:52Z",
+  "frozen_at": "2026-08-02T22:41:10Z",
   "source_inventory": "releases/images/component-inventory.v1.yaml",
   "wave_order": [
     "dev",
@@ -27,15 +27,15 @@
   "component_count": 1,
   "components": [
     {
-      "id": "search-orchestrator",
+      "id": "search_orchestrator",
       "component": "services/search-orchestrator",
-      "image": "ghcr.io/socioprophet/prophet-platform/search-orchestrator",
-      "digest": "sha256:bbfea6e4a7ea432d77766a37464dfa666242dfe2621fc0e586ca2bde80c52066",
-      "pinned_ref": "ghcr.io/socioprophet/prophet-platform/search-orchestrator@sha256:bbfea6e4a7ea432d77766a37464dfa666242dfe2621fc0e586ca2bde80c52066",
-      "source_sha": "3f5a12aa5b86c60cb55fab3f36f6a5b528a772db",
-      "source_content_digest": "sha256:f62c96f3d9995e2efdecff5f7d78fdd824c046cfef26413044970aa33806da26",
+      "image": "us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator",
+      "digest": "sha256:dd342da260dc1d5953f4588f02aca319c2a357240c5b55d3ab3137b3e96a864b",
+      "pinned_ref": "us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator@sha256:dd342da260dc1d5953f4588f02aca319c2a357240c5b55d3ab3137b3e96a864b",
+      "source_sha": "ef36835d7d40af34352e0dc3be15bf19a5b47ed3",
+      "source_content_digest": "sha256:c2119c07b2741df6f30dc86007f275e80e01edb075ce64ff87b5ca53f8cb511a",
       "lock": "releases/images/search-orchestrator.image-lock.json",
-      "in_inventory": false
+      "in_inventory": true
     }
   ]
 }

--- a/scripts/ci/open-image-pin-pr.sh
+++ b/scripts/ci/open-image-pin-pr.sh
@@ -27,8 +27,10 @@
 #
 # BEHAVIOUR (matching what the action did, minus the third party)
 # ---------------------------------------------------------------
-#   * Commits ONLY the two pin paths — the action's `add-paths`. The evidence
-#     artifact downloaded into image-evidence/ never enters the commit.
+#   * Commits ONLY the pin paths — the lock, the policy patch, the three promote
+#     overlays (dev/canary/prod) and the re-frozen manifest (PIN_EXTRA_PATHS). The
+#     evidence artifact downloaded into image-evidence/ never enters the commit.
+#     Absent paths are filtered out, so this stays the `add-paths` guarantee.
 #   * No digest change is the normal case, and is a silent success, not a failure.
 #   * The automation branch is reused and reset, so repeated builds refresh one
 #     pull request instead of opening a pile of them.
@@ -61,22 +63,49 @@ DIAGNOSTICS_WORKFLOW="${PIN_PR_DIAGNOSTICS_WORKFLOW:-validate-target-diagnostics
 # Overridable so the self-test does not spend 20 real seconds proving the retry.
 RETRY_SLEEP="${PIN_PR_RETRY_SLEEP:-10}"
 
+# The pin no longer stops at the lock + policy patch. A pin that updated ONLY those
+# left the PROMOTE overlays (dev/canary/prod) carrying the previous digest — the exact
+# divergence behind the wave-deploy incident (lock/policy on one digest, promote overlays
+# on the never-pushed sha256:bbfea6e4…). So the pin propagates the new digest all the way
+# into the promote overlays too (the workflow re-freezes the manifest and re-renders them
+# before calling this script), and PIN_EXTRA_PATHS carries the re-frozen manifest. Paths
+# that do not exist (or did not change) are filtered out below, so a repo without the
+# promote overlays present still pins cleanly.
 PIN_PATHS=(
   "releases/images/search-orchestrator.image-lock.json"
   "infra/k8s/search-orchestrator/overlays/policy/image-patch.yaml"
+  "infra/k8s/search-orchestrator/overlays/promote/dev/image-patch.yaml"
+  "infra/k8s/search-orchestrator/overlays/promote/canary/image-patch.yaml"
+  "infra/k8s/search-orchestrator/overlays/promote/prod/image-patch.yaml"
 )
+# The re-frozen release-train manifest has a date-labelled filename, so the workflow passes
+# it (space-separated) via PIN_EXTRA_PATHS rather than hard-coding a name here.
+read -r -a _extra_paths <<<"${PIN_EXTRA_PATHS:-}"
+[ "${#_extra_paths[@]}" -gt 0 ] && PIN_PATHS+=("${_extra_paths[@]}")
+
+# Only stage paths that actually exist in the tree — the promote overlays / manifest are
+# absent in the unit-test repo and in first-bootstrap runs, and `git add` of a missing
+# pathspec errors under `set -e`. Filter once, use the filtered set for status AND add.
+present_paths=()
+for p in "${PIN_PATHS[@]}"; do
+  [ -n "$p" ] && [ -e "$p" ] && present_paths+=("$p")
+done
+if [ "${#present_paths[@]}" -eq 0 ]; then
+  echo "no pin paths present in the tree; nothing to open"
+  exit 0
+fi
 
 # ── Nothing to pin ───────────────────────────────────────────────────────────
 # The digest already matches. This is the common outcome for a rebuild of an
 # unchanged tree, and it must not look like a failure.
-if [ -z "$(git status --porcelain -- "${PIN_PATHS[@]}")" ]; then
-  echo "no digest change: the lock and the Kustomize patch already match this build"
+if [ -z "$(git status --porcelain -- "${present_paths[@]}")" ]; then
+  echo "no digest change: the lock, the policy patch and the promote overlays already match this build"
   echo "nothing to open"
   exit 0
 fi
 
 echo "digest change detected in:"
-git status --porcelain -- "${PIN_PATHS[@]}" | sed 's/^/  /'
+git status --porcelain -- "${present_paths[@]}" | sed 's/^/  /'
 
 # ── Commit, on a reset automation branch ─────────────────────────────────────
 git config user.name "search-orchestrator-image-pin"
@@ -85,7 +114,7 @@ git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 git checkout -b "$BRANCH"
 # Explicit pathspec, never `git commit -a`: image-evidence/ and anything else the
 # job leaves in the tree stays out. This is the `add-paths` guarantee.
-git add -- "${PIN_PATHS[@]}"
+git add -- "${present_paths[@]}"
 git commit -m "$TITLE"
 
 # --force: this is a reusable automation ref that may still hold a now-stale
@@ -112,9 +141,16 @@ workflow run.
 
 ## Scope
 
-- Updates `releases/images/search-orchestrator.image-lock.json`
-- Updates the digest-pinned Kustomize image patch
+- Updates `releases/images/search-orchestrator.image-lock.json` (GAR digest)
+- Updates the policy digest-pinned Kustomize image patch
+- Propagates the SAME digest into the promote overlays (dev/canary/prod) and the
+  re-frozen release-train manifest, so no wave is left on a stale digest
 - Keeps the example lock unchanged
+
+The promote overlays are still gated at apply: the wave-promote / release-train
+INV-DEP-6 digest-exists gate fails closed if this digest is not really in GAR, and
+ArgoCD only syncs the committed overlay under the gated apply. Writing the desired
+state here does not bypass those gates — it stops the overlays diverging from the lock.
 
 ## Safety posture
 

--- a/scripts/ci/test-open-image-pin-pr.sh
+++ b/scripts/ci/test-open-image-pin-pr.sh
@@ -151,6 +151,37 @@ grep -q "BLOCKED" <<<"$OUT" || fail "the warning must say the PR will be BLOCKED
 unset STUB_DISPATCH_RC
 [ "$failures" -eq 0 ] && pass "dispatch failure: 3 attempts, warns, does not fail the job"
 
+echo "case 6: the pinned digest propagates into the promote overlays + manifest (INV-DEP-2)"
+new_case propagate
+echo '{"digest":"sha256:new"}' >"$LOCK"
+echo 'image: new' >"$PATCH"
+# Simulate what the workflow's propagate step produced before calling the script:
+# the three promote overlays re-rendered to the new digest, and a re-frozen manifest.
+DEV="infra/k8s/search-orchestrator/overlays/promote/dev/image-patch.yaml"
+CAN="infra/k8s/search-orchestrator/overlays/promote/canary/image-patch.yaml"
+PROD="infra/k8s/search-orchestrator/overlays/promote/prod/image-patch.yaml"
+MAN="releases/manifests/release-train.2026-08-02.manifest.json"
+mkdir -p "$(dirname "$DEV")" "$(dirname "$CAN")" "$(dirname "$PROD")" "$(dirname "$MAN")"
+# Seed them at the OLD digest, commit, then update to NEW so the pin has a real change.
+for f in "$DEV" "$CAN" "$PROD"; do echo 'image: old@sha256:old' >"$f"; done
+echo '{"digest":"sha256:old"}' >"$MAN"
+git add -A && git commit --quiet -m "seed promote overlays"
+git push --quiet origin main >/dev/null 2>&1
+for f in "$DEV" "$CAN" "$PROD"; do echo 'image: new@sha256:new' >"$f"; done
+echo '{"digest":"sha256:new"}' >"$MAN"
+export PIN_EXTRA_PATHS="$MAN"
+run_script
+unset PIN_EXTRA_PATHS
+[ "$RC" -eq 0 ] || fail "expected exit 0, got $RC — $OUT"
+committed="$(git -C "$CASE_DIR/work" show --name-only --format= HEAD | sort | tr '\n' ' ')"
+for want in "$DEV" "$CAN" "$PROD" "$MAN"; do
+  case "$committed" in
+    *"$want"*) : ;;
+    *) fail "the pin did not propagate into $want; committed [$committed]" ;;
+  esac
+done
+[ "$failures" -eq 0 ] && pass "propagate: lock + policy + dev/canary/prod overlays + manifest all committed"
+
 echo
 if [ "$failures" -ne 0 ]; then
   echo "$failures check(s) FAILED"

--- a/tools/render_search_orchestrator_image_patch.py
+++ b/tools/render_search_orchestrator_image_patch.py
@@ -6,7 +6,9 @@ import re
 from pathlib import Path
 
 DIGEST_RE = re.compile(r"^sha256:[a-fA-F0-9]{64}$")
-IMAGE = "ghcr.io/socioprophet/prophet-platform/search-orchestrator"
+# GCP Artifact Registry — the estate's real GKE registry (WIF-authed). The GKE nodes trust GAR,
+# not ghcr, so the deployed image ref MUST be the GAR path. Mirrors images.yml's default registry.
+IMAGE = "us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator"
 
 
 def load_json(path: Path) -> dict:

--- a/tools/tests/test_verify_pinned_digest_exists.py
+++ b/tools/tests/test_verify_pinned_digest_exists.py
@@ -149,3 +149,80 @@ def test_manifest_rollup_reads_components(tmp_path) -> None:
     m.write_text(json.dumps({"components": [{"image": IMAGE, "digest": DIGEST}]}), encoding="utf-8")
     rc = MOD._verify_all(MOD._components_from_manifest(m), http=_http([(200, {}, b"{}")]))
     assert rc == MOD.EXIT_OK
+
+
+# ── GAR (GCP Artifact Registry) — the estate's real GKE registry ────────────────────────────
+
+GAR_IMAGE = "us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator"
+
+
+def _recording_http(responses):
+    """Like _http, but records the request (method, url, headers) of every call so a test can
+    assert HOW the registry was queried (e.g. that a GAR Bearer was presented)."""
+    calls = iter(responses)
+    seen: list[tuple] = []
+
+    def fn(method, url, headers):
+        seen.append((method, url, dict(headers)))
+        item = next(calls)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    fn.seen = seen  # type: ignore[attr-defined]
+    return fn
+
+
+def test_gar_host_is_detected() -> None:
+    assert MOD._is_gar("us-central1-docker.pkg.dev")
+    assert MOD._is_gar("europe-west1-docker.pkg.dev")
+    assert not MOD._is_gar("ghcr.io")
+    assert not MOD._is_gar("registry.socioprophet.ai")
+
+
+def test_gar_env_token_presented_as_bearer_and_exists(monkeypatch) -> None:
+    monkeypatch.setenv("GAR_ACCESS_TOKEN", "ya29.FAKE-WIF-TOKEN")
+    http = _recording_http([(200, {}, b"{}")])
+    r = MOD.check_manifest(GAR_IMAGE, DIGEST, http=http)
+    assert r.status == MOD.EXISTS
+    # The GAR access token must have gone out as a raw Bearer on the FIRST request — no
+    # anonymous 401 round-trip needed for a private GAR digest.
+    _, url, headers = http.seen[0]  # type: ignore[attr-defined]
+    assert url.startswith("https://us-central1-docker.pkg.dev/v2/")
+    assert headers.get("Authorization") == "Bearer ya29.FAKE-WIF-TOKEN"
+
+
+def test_gar_fabricated_digest_absent(monkeypatch) -> None:
+    monkeypatch.setenv("GAR_ACCESS_TOKEN", "ya29.FAKE-WIF-TOKEN")
+    body = b'{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}'
+    r = MOD.check_manifest(GAR_IMAGE, DIGEST, http=_http([(404, {}, body)]))
+    assert r.status == MOD.ABSENT, "an authenticated GAR 404 is the fabricated-digest verdict"
+
+
+def test_gar_unreachable_is_distinct_from_absent(monkeypatch) -> None:
+    monkeypatch.setenv("GAR_ACCESS_TOKEN", "ya29.FAKE-WIF-TOKEN")
+    r = MOD.check_manifest(GAR_IMAGE, DIGEST, http=_http([(503, {}, b"upstream error")]))
+    assert r.status == MOD.UNREACHABLE
+
+
+def test_gar_no_token_then_challenge_exchange_with_oauth2accesstoken(monkeypatch) -> None:
+    # No direct-bearer env token, but the token realm accepts the resolved GAR identity via the
+    # standard WWW-Authenticate exchange. The exchange must present username `oauth2accesstoken`.
+    monkeypatch.delenv("GAR_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("GOOGLE_OAUTH_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("CLOUDSDK_AUTH_ACCESS_TOKEN", raising=False)
+    challenge = {"www-authenticate":
+                 'Bearer realm="https://us-central1-docker.pkg.dev/v2/token",'
+                 'service="us-central1-docker.pkg.dev"'}
+    http = _recording_http([
+        (401, challenge, b""),                                # anonymous HEAD -> challenge
+        (200, {}, json.dumps({"token": "GARTOK"}).encode()),  # token endpoint
+        (200, {}, b"{}"),                                     # retried HEAD -> exists
+    ])
+    r = MOD.check_manifest(GAR_IMAGE, DIGEST, username=MOD._GAR_USERNAME, password="ya29.X",
+                           http=http)
+    assert r.status == MOD.EXISTS
+    # the Basic auth to the token realm must carry oauth2accesstoken:...
+    import base64
+    _, _, tok_headers = http.seen[1]  # type: ignore[attr-defined]
+    assert base64.b64encode(b"oauth2accesstoken:ya29.X").decode() in tok_headers.get("Authorization", "")

--- a/tools/validate_search_orchestrator_academy_deploy.py
+++ b/tools/validate_search_orchestrator_academy_deploy.py
@@ -45,7 +45,9 @@ REQUIRED_TEXT = {
     ],
     ".github/workflows/search-orchestrator-image.yml": [
         "docker/build-push-action",
-        "ghcr.io/socioprophet/prophet-platform/search-orchestrator",
+        # GAR, not ghcr — the estate's real GKE registry (WIF-authed).
+        "us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator",
+        "google-github-actions/auth",
         "steps.build.outputs.digest",
         "search-orchestrator-image-evidence",
     ],

--- a/tools/validate_search_orchestrator_image_release.py
+++ b/tools/validate_search_orchestrator_image_release.py
@@ -22,7 +22,9 @@ REQUIRED_TEXT = {
     ],
     ".github/workflows/search-orchestrator-image.yml": [
         "docker/build-push-action",
-        "ghcr.io/socioprophet/prophet-platform/search-orchestrator",
+        # GAR, not ghcr — the estate's real GKE registry (WIF-authed).
+        "us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator",
+        "google-github-actions/auth",
         "steps.build.outputs.digest",
         "search-orchestrator-image-evidence",
     ],
@@ -65,8 +67,10 @@ def main() -> int:
                 raise SystemExit(f"{rel} missing required term {term}")
 
     lock = json.loads((ROOT / "releases/images/search-orchestrator.image-lock.example.json").read_text(encoding="utf-8"))
-    if not str(lock.get("pinned_ref", "")).startswith("ghcr.io/socioprophet/prophet-platform/search-orchestrator@sha256:"):
-        raise SystemExit("image lock pinned_ref must use digest form")
+    if not str(lock.get("pinned_ref", "")).startswith(
+        "us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator@sha256:"
+    ):
+        raise SystemExit("image lock pinned_ref must use the GAR digest form")
 
     print("search-orchestrator image release artifacts validated")
     return 0

--- a/tools/verify_pinned_digest_exists.py
+++ b/tools/verify_pinned_digest_exists.py
@@ -30,9 +30,11 @@ Three outcomes, kept DISTINCT (so callers can tell "you shipped a fabricated dig
 
 Registries supported
 ---------------------
-  * ghcr.io                         (GitHub Container Registry)
-  * registry.socioprophet.ai / zot  (the sovereign zot registry)
-  * any Registry-HTTP-API-v2 host    (generic Bearer / Basic token flow)
+  * ghcr.io                            (GitHub Container Registry)
+  * *-docker.pkg.dev / GAR             (GCP Artifact Registry — the estate's real GKE registry,
+                                        e.g. us-central1-docker.pkg.dev/socioprophet-platform/socioprophet)
+  * registry.socioprophet.ai / zot     (the sovereign zot registry)
+  * any Registry-HTTP-API-v2 host       (generic Bearer / Basic token flow)
 
 Auth
 ----
@@ -43,6 +45,9 @@ credential and the tool performs the standard ``WWW-Authenticate: Bearer`` token
   * env ``REGISTRY_USERNAME`` / ``REGISTRY_PASSWORD`` (or ``GITHUB_ACTOR`` / ``GITHUB_TOKEN``
     for ghcr.io) are picked up automatically when the flags are absent.
   * ``--token`` supplies a ready Bearer token directly (skips the exchange).
+  * GAR (``*-docker.pkg.dev``): a GCP OAuth2 access token from the WIF auth step is picked up
+    from env ``GAR_ACCESS_TOKEN`` (or ``GOOGLE_OAUTH_ACCESS_TOKEN`` / ``CLOUDSDK_AUTH_ACCESS_TOKEN``)
+    and presented as a raw Bearer; locally, ``--token "$(gcloud auth print-access-token)"``.
 
 Usage
 -----
@@ -73,6 +78,28 @@ from typing import Callable
 
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 REF_RE = re.compile(r"^(?P<registry>[^/]+)/(?P<repo>.+?)@(?P<digest>sha256:[0-9a-f]{64})$")
+
+# GCP Artifact Registry (GAR) hosts: <location>-docker.pkg.dev. Its v2 manifest endpoint
+# takes a GCP OAuth2 access token — either as a raw Bearer (fast path) or minted through the
+# standard WWW-Authenticate exchange with username `oauth2accesstoken` (the same identity
+# `helm registry login us-central1-docker.pkg.dev -u oauth2accesstoken` uses). The token comes
+# from the estate's WIF auth step (`google-github-actions/auth` -> access_token) or, locally,
+# `gcloud auth print-access-token`, surfaced via one of these env vars.
+_GAR_HOST_RE = re.compile(r"(^|\.)pkg\.dev$")
+_GAR_TOKEN_ENVS = ("GAR_ACCESS_TOKEN", "GOOGLE_OAUTH_ACCESS_TOKEN", "CLOUDSDK_AUTH_ACCESS_TOKEN")
+_GAR_USERNAME = "oauth2accesstoken"
+
+
+def _is_gar(registry: str) -> bool:
+    return bool(_GAR_HOST_RE.search(registry.split(":")[0]))
+
+
+def _gar_access_token() -> str | None:
+    for env in _GAR_TOKEN_ENVS:
+        tok = os.environ.get(env)
+        if tok:
+            return tok.strip()
+    return None
 
 # The manifest media types a registry may answer with. We must Accept all of them or a
 # multi-arch image (an OCI index / manifest list) HEAD can 404 under a too-narrow Accept.
@@ -181,6 +208,12 @@ def _resolve_credentials(registry: str, username: str | None,
     pw = os.environ.get("REGISTRY_PASSWORD")
     if user or pw:
         return user, pw
+    # GAR mints a pull Bearer from Basic `oauth2accesstoken:<access_token>` at its token realm
+    # (the WWW-Authenticate fallback if the raw-Bearer fast path was absent/rejected).
+    if _is_gar(registry):
+        gtok = _gar_access_token()
+        if gtok:
+            return _GAR_USERNAME, gtok
     # ghcr.io reads the standard Actions identity by default.
     if registry == "ghcr.io" and os.environ.get("GITHUB_TOKEN"):
         return os.environ.get("GITHUB_ACTOR", "x-access-token"), os.environ.get("GITHUB_TOKEN")
@@ -204,6 +237,14 @@ def check_manifest(image: str, digest: str, *,
     headers = {"Accept": _MANIFEST_ACCEPT}
     if bearer:
         headers["Authorization"] = f"Bearer {bearer}" if not bearer.lower().startswith("bearer") else bearer
+    elif _is_gar(registry):
+        # GAR fast path: present the GCP access token directly as a Bearer, so a private GAR
+        # digest resolves without first eating an anonymous 401 (which, unauthenticated, would
+        # classify UNREACHABLE — fail-closed but noisy). If the token is absent the request goes
+        # out anonymous and the 401 -> token-exchange fallback below still runs.
+        gtok = _gar_access_token()
+        if gtok:
+            headers["Authorization"] = f"Bearer {gtok}"
 
     def _classify(status: int, hdrs: dict, body: bytes) -> Result | None:
         if 200 <= status < 300:


### PR DESCRIPTION
## Why (apply-caught, not dry-run-caught)

An **actual cluster apply** surfaced this. The wave-deploy plane (#1225/#1226) builds/pins/promotes at `ghcr.io/socioprophet/prophet-platform/search-orchestrator`, but the estate's real GKE registry is **GCP Artifact Registry**: the live healthy `search-orchestrator` in `fogstack-federal` pulls `us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator`, and the nodes hold **WIF auth to GAR, none to ghcr**. So a real deploy `401`'d on **both** the placeholder and the real ghcr digest. Every dry-run/CI gate was green — they checked the digest's *shape/existence*, not the registry the nodes can *pull from*.

## Canonical pattern mirrored (not invented)

- **GAR path:** `us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator` — the default registry in `images.yml` (`registry_auth: gar`) and the path `helm-release.yml` pushes to. Confirmed by `preflight_deploy_contract.py`'s `OUR_REGISTRIES` (GAR + zot; ghcr excluded).
- **Auth:** `google-github-actions/auth@v2` (`workload_identity_provider`/`service_account`, `token_format: access_token`) → `docker login us-central1-docker.pkg.dev -u oauth2accesstoken`, exactly as `helm-release.yml`.
- **Pinning:** the live fog deploy uses a `:sha-<gitsha>` tag; the estate rule prefers an immutable `@sha256:` digest, so the build pushes `:main` + `:sha-<sha>` **and** the lock/overlays pin by `@sha256:` digest.

## What changed

1. **Build+push** (`search-orchestrator-image.yml`): WIF → GAR, `:main`+`:sha-<sha>`, GAR image/pinned_ref in digest evidence; the cost-guard `changes` job WIF-auths so the INV-DEP-6 image-exists HEAD can reach GAR (absent token ⇒ UNREACHABLE ⇒ BUILD, fail-closed).
2. **Lock + example lock + `component-inventory` + release-train manifest + all four overlays** (policy + promote dev/canary/prod) + base deployment + prod rollout: repointed to the GAR path; digest regenerated end-to-end through the estate's own freeze/render/promote tools (unified on one digest; the fabricated `bbfea6e4…` dropped).
3. **`verify_pinned_digest_exists.py`:** GAR (`*-docker.pkg.dev`) v2 support — WIF access token (`GAR_ACCESS_TOKEN`) as a raw Bearer + `oauth2accesstoken` token-exchange fallback; distinct EXISTS/ABSENT/UNREACHABLE, fail-closed. ghcr+zot retained. Proven both ways offline (7 new GAR tests) and live.
4. **Docs + standard:** `DEPLOY-WAVE-STRATEGY.md` and `deploy-wave-invariants-v0.md` (new **INV-DEP-8** — the pinned registry must be one the nodes can pull from: GAR/zot, never ghcr) record the apply-caught registry mismatch as a lesson.
5. **Pin propagation fix (item 5):** the pin previously updated only the lock + policy patch, leaving the **promote overlays** on the old digest (the observed divergence). The pin now re-freezes the manifest and re-renders dev/canary/prod, and `open-image-pin-pr.sh` commits them (existence-filtered) + the manifest. New self-test **case 6** proves it.

## Digest-exists proof (both ways)

| Case | Result |
|---|---|
| Real public ghcr `oras@sha256:0087224…` | **EXISTS** (exit 0) |
| Fabricated ghcr digest | **ABSENT** (exit 4) |
| GAR digest, unauthenticated (no WIF token) | **UNREACHABLE** (exit 3, fail-closed) |
| 7 offline GAR/ghcr fake-registry tests | pass |

The committed lock still carries the retired **ghcr** push digest, which is genuinely absent from GAR, so `verify_pinned_digest_exists.py manifest …` **fails closed (UNREACHABLE/ABSENT) by design** until the real GAR push replaces it.

## Dry-run validation (no cluster apply)

- `kubectl kustomize` renders GAR `@sha256:` refs for policy + promote dev/canary/prod; wave-promote GATE-1 (`image: …@sha256:<64hex>`) passes on all three waves.
- `actionlint` clean on both workflows; `preflight_deploy_contract.py` no longer flags `search-orchestrator:wrong-registry`.
- 28 pytest (verify + apply-lock + release-train) + 6 pin self-test cases pass; all three release validators pass.

## Produce a real GAR digest + deploy

```bash
# 1) Build + push to GAR via WIF (main pushes; PRs build without push):
gh workflow run search-orchestrator-image.yml --ref main
# 2) Pin the lock + ALL overlays from that run's GAR digest evidence:
gh workflow run search-orchestrator-image-pin.yml --ref main         # or -f run_id=<BUILD_RUN_ID>
# 3) Verify the freshly-pinned GAR digest resolves (CI's changes job does this via WIF):
GAR_ACCESS_TOKEN="$(gcloud auth print-access-token)" \
  python3 tools/verify_pinned_digest_exists.py locks 'releases/images/search-orchestrator.image-lock.json'
# 4) Freeze + promote on the train (dry-run render + gated; ArgoCD does the gated apply):
gh workflow run release-train.yml --ref main -f component=search-orchestrator -f through_wave=canary
```

**Do not merge** — design + scaffold + dry-run only; no cluster apply performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)