### PR TITLE
feat(deploy): cluster-scope slo-gate + INV-DEP-9 self-contained-overlay guard

### DIFF
--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -103,6 +103,7 @@ jobs:
           - validate-storage-suite
           - trustops-art-runner-smoke
           - canary-slo-gate-check
+          - rollout-analysis-refs-check
           - fips-conformance-check
           - imageschemanet-grounding-check
     steps:
@@ -112,6 +113,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.25'
+      - name: Setup kubectl (renders overlays for the analysis-ref gate, INV-DEP-9)
+        if: matrix.target == 'rollout-analysis-refs-check'
+        uses: azure/setup-kubectl@v4
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/wave-promote.yml
+++ b/.github/workflows/wave-promote.yml
@@ -125,6 +125,15 @@ jobs:
       - name: Canary SLO gate is fail-closed (INV-DEP-3)
         run: python3 tools/check_canary_slo_gate.py
 
+      # GATE 3b — every Rollout analysis ref in THIS overlay must resolve where it deploys
+      # (INV-DEP-9). A namespaced AnalysisTemplate only resolves in its own namespace, so a
+      # Rollout in a fresh wave namespace that names one the overlay does not render renders
+      # clean here yet InvalidSpec's on the live controller (Degraded, no pods — the wave-deploy
+      # prod incident). Renders the overlay (kubectl kustomize) and proves each ref points at a
+      # rendered namespaced template or a declared ClusterAnalysisTemplate.
+      - name: Overlay analysis refs are self-contained (INV-DEP-9)
+        run: python3 tools/verify_rollout_analysis_refs.py "${{ inputs.overlay_dir }}/${{ inputs.wave }}"
+
       # GATE 4 — the prod wave (blue-green cutover) must carry the SLO prePromotionAnalysis.
       # A prod cutover with no analysis gate is a time-based promotion; refuse it.
       - name: Prod cutover must be SLO-gated (blue-green)

--- a/Makefile
+++ b/Makefile
@@ -585,6 +585,16 @@ validate-isota-tournament:
 canary-slo-gate-check:
 	python3 tools/check_canary_slo_gate.py
 
+.PHONY: rollout-analysis-refs-check
+# Self-contained overlays (INV-DEP-9): a Rollout may only reference an AnalysisTemplate the
+# overlay renders (namespaced, same ns) or a declared ClusterAnalysisTemplate (clusterScope).
+# A dangling ref renders clean under `kubectl kustomize` but the LIVE Rollout controller rejects
+# it (InvalidSpec: AnalysisTemplate not found, Degraded/no pods) — the wave-deploy prod incident.
+# tools/verify_rollout_analysis_refs.py renders each promote overlay and proves every analysis
+# ref resolves. Wired into the validate-target-diagnostics matrix so it rides the required gate.
+rollout-analysis-refs-check:
+	python3 tools/verify_rollout_analysis_refs.py
+
 .PHONY: fips-conformance-check
 # FIPS algorithm conformance in the declared crypto boundary (security/fips-boundary.yaml):
 # no non-FIPS algorithm (BLAKE2/3, MD5, SHA-1) may be called inside the boundary, and a

--- a/charts/socioprophet-service/templates/rollout.yaml
+++ b/charts/socioprophet-service/templates/rollout.yaml
@@ -43,6 +43,12 @@ spec:
       analysis:
         templates:
           - templateName: {{ .templateName }}
+            {{- /* clusterScope: true resolves a ClusterAnalysisTemplate (the estate's shared
+                   slo-gate is cluster-scoped, INV-DEP-9) so a Rollout in ANY service namespace
+                   resolves it — a namespaced AnalysisTemplate only resolves in its own ns. */}}
+            {{- if .clusterScope }}
+            clusterScope: true
+            {{- end }}
         {{- with .args }}
         args:
           {{- toYaml . | nindent 10 }}

--- a/charts/socioprophet-service/values.yaml
+++ b/charts/socioprophet-service/values.yaml
@@ -127,6 +127,11 @@ rollout:
   steps: []
   analysis:
     templateName: ""   # e.g. "slo-gate" (infra/k8s/rollouts/base/analysistemplate-slo.yaml)
+    # slo-gate is a ClusterAnalysisTemplate (cluster-scoped) so it resolves from THIS service's
+    # namespace — a namespaced AnalysisTemplate only resolves in its own ns (INV-DEP-9). Leave
+    # true when pointing at the shared cluster gate; set false only for a same-namespace
+    # AnalysisTemplate this chart also renders.
+    clusterScope: true
     args: []            # [{ name: service, value: <job label the AnalysisTemplate queries> }]
     startingStep: 1
   trafficRouting:

--- a/docs/DEPLOY-WAVE-STRATEGY.md
+++ b/docs/DEPLOY-WAVE-STRATEGY.md
@@ -161,7 +161,7 @@ dependency waves (0…13).
 
 `infra/k8s/search-orchestrator/overlays/promote/prod` renders an Argo Rollouts `Rollout`
 (`strategy.blueGreen`), reusing the estate's existing fail-closed
-`slo-gate` AnalysisTemplate (`infra/k8s/rollouts/base/analysistemplate-slo.yaml`) as
+`slo-gate` gate (`infra/k8s/rollouts/base/analysistemplate-slo.yaml`) as
 `prePromotionAnalysis`:
 
 - the frozen digest deploys to **GREEN** (`previewService: search-orchestrator-preview`);
@@ -171,6 +171,19 @@ dependency waves (0…13).
   (`autoPromotionEnabled: false`);
 - the old ReplicaSet is retained `scaleDownDelaySeconds: 600` for **instant rollback** — flip
   the Service selector back, no rebuild, no re-pull.
+
+> **Self-contained overlays — the apply-caught lesson (INV-DEP-9).** `slo-gate` is a
+> **`ClusterAnalysisTemplate` (cluster-scoped)**, referenced `clusterScope: true`. It used to be a
+> namespaced `AnalysisTemplate` in `socioprophet` — and `AnalysisTemplate`s are namespaced, so a
+> Rollout only resolves one in its OWN namespace. The prod overlay deploys into a fresh
+> `prophet-platform-prod` namespace that held no such template, so the LIVE Rollout controller
+> rejected it: `InvalidSpec: AnalysisTemplate 'slo-gate' not found` (Degraded, **no pods**) — even
+> though `kubectl kustomize` rendered clean and every shape/existence gate was green. Same
+> "dry-run green, apply red" class as INV-DEP-6/8, now for a *namespaced-resource* reference. The
+> rule an overlay must satisfy: **every cluster resource it references is either rendered by the
+> overlay itself (namespaced, same namespace) or is cluster-scoped.** Enforced before any apply by
+> `tools/verify_rollout_analysis_refs.py` (`make rollout-analysis-refs-check`; `wave-promote.yml`
+> GATE 3b renders the promoting overlay and refuses a dangling analysis ref).
 
 ## Scheduled release train
 
@@ -208,7 +221,9 @@ overlays with the identical digest and ascending sync-waves; the frozen manifest
 the skip/build decision (including "source matches but image missing ⇒ BUILD"), the digest-exists
 gate (both ways), the lock-provenance guard and the queue-vs-cancel contract are unit-tested;
 all workflows pass `actionlint` + `yaml.safe_load`; `preflight_deploy_contract.py` and
-`check_canary_slo_gate.py` pass. The INV-DEP-6 gate is also proven live against a public registry:
+`check_canary_slo_gate.py` pass; `verify_rollout_analysis_refs.py` renders the promote overlays
+and proves every Rollout analysis ref resolves (INV-DEP-9) — proven both ways, a planted dangling
+ref fails the gate. The INV-DEP-6 gate is also proven live against a public registry:
 a real `ghcr.io/oras-project/oras@sha256:0087224…` HEADs 200 ⇒ EXISTS (exit 0); a fabricated
 digest on the same repo HEADs 404 ⇒ ABSENT (exit 4).
 

--- a/docs/standards/deploy-wave-invariants-v0.md
+++ b/docs/standards/deploy-wave-invariants-v0.md
@@ -138,6 +138,39 @@ image ref pointing at ghcr is flagged `wrong-registry` in CI, not just at apply)
 `verify_pinned_digest_exists.py` authenticates GAR HEADs with the WIF access token
 (`GAR_ACCESS_TOKEN`) so INV-DEP-6 verifies against the registry the nodes actually use.
 
+## INV-DEP-9 — An overlay MUST be self-contained: every referenced cluster resource is rendered by the overlay or is cluster-scoped
+
+A workload in an overlay MUST NOT reference a **namespaced** cluster resource that the overlay
+does not itself render. Specifically for Argo Rollouts: an `AnalysisTemplate` is namespaced, so a
+Rollout may reference it ONLY if the overlay renders an `AnalysisTemplate` of that name into the
+SAME namespace; otherwise the reference MUST be to a cluster-scoped `ClusterAnalysisTemplate`
+(with `clusterScope: true`), which resolves from any namespace. The estate's shared SLO gate is
+therefore a **`ClusterAnalysisTemplate` `slo-gate`** (`infra/k8s/rollouts/base/analysistemplate-slo.yaml`),
+applied once cluster-wide and referenced `clusterScope: true` by every wave Rollout — one
+definition, no per-namespace copy to drift.
+
+*Rationale.* The wave-deploy prod blue-green Rollout referenced `slo-gate`, but that
+`AnalysisTemplate` existed ONLY in the `socioprophet` namespace. `kubectl kustomize` rendered the
+prod overlay perfectly and every shape/existence gate (INV-DEP-1/2/6/8) passed — yet deploying it
+to a fresh `prophet-platform-prod` namespace failed on the LIVE Rollout controller with
+`InvalidSpec: AnalysisTemplate 'slo-gate' not found` (Degraded, **no pods**). A namespaced
+cross-namespace reference is invisible to a dry-run render; only a real apply surfaces it — the
+same "dry-run green, apply red" class as INV-DEP-6/8, now for a *namespaced-resource* reference
+rather than an image.
+
+*Fail-closed distinction.* The check renders each overlay and classifies every Rollout analysis
+ref: RESOLVED (a namespaced ref whose template the overlay renders, OR a clusterScope ref whose
+`ClusterAnalysisTemplate` the repo declares) vs DANGLING (neither). A DANGLING ref FAILS. A render
+that will not `kubectl kustomize`, or output that will not parse, also FAILS — an overlay that
+cannot be certified self-contained is treated as not self-contained.
+
+*Enforced by.* `tools/verify_rollout_analysis_refs.py` (renders the promote overlays; proven both
+ways by `tools/tests/test_verify_rollout_analysis_refs.py` — a resolvable overlay passes, a
+dangling namespaced ref and an undeclared-clusterScope ref both fail); `make
+rollout-analysis-refs-check` in the required `validate-target-diagnostics` matrix;
+`wave-promote.yml` GATE 3b renders the promoting wave's overlay and refuses a dangling ref before
+any apply.
+
 ---
 
 ## Conformance checklist
@@ -153,3 +186,4 @@ image ref pointing at ghcr is flagged `wrong-registry` in CI, not just at apply)
 | 7 | Every frozen digest exists in the registry (INV-DEP-6) — GAR needs a WIF token | `GAR_ACCESS_TOKEN="$(gcloud auth print-access-token)" python3 tools/verify_pinned_digest_exists.py manifest releases/manifests/release-train.<label>.manifest.json` |
 | 8 | Digest-exists (incl. GAR) + lock-provenance gates, both ways (INV-DEP-6/7) | `python3 -m pytest -q tools/tests/test_verify_pinned_digest_exists.py tools/tests/test_apply_search_orchestrator_image_lock.py` |
 | 9 | First-party refs point at a pullable registry — GAR/zot, not ghcr (INV-DEP-8) | `python3 tools/preflight_deploy_contract.py` |
+| 10 | Overlays self-contained — every Rollout analysis ref resolves (INV-DEP-9) | `python3 tools/verify_rollout_analysis_refs.py` (+ `python3 -m pytest -q tools/tests/test_verify_rollout_analysis_refs.py`) |

--- a/infra/k8s/rollouts/README.md
+++ b/infra/k8s/rollouts/README.md
@@ -6,11 +6,16 @@ Metric-gated **canary** deploys via Argo Rollouts, and Gateway API traffic-shape
 
 ## Progressive delivery (`infra/k8s/rollouts`)
 
-- **`analysistemplate-slo.yaml`** (`slo-gate`) — the canary gate. At each step
-  Rollouts queries Prometheus for the Wave-1 recording rules
+- **`analysistemplate-slo.yaml`** (`slo-gate`) — the canary gate, a **`ClusterAnalysisTemplate`
+  (cluster-scoped)**. At each step Rollouts queries Prometheus for the Wave-1 recording rules
   (`job:request_error_ratio:rate5m`, `job:request_latency_p99:5m`) and **aborts**
   the rollout if 5xx ratio ≥ 5% or p99 ≥ 1.5s. Promotion is metric-gated, not
-  time-based. **Not wired to any service yet** — see hellgraph-service below.
+  time-based. It is cluster-scoped **on purpose (INV-DEP-9)**: a namespaced `AnalysisTemplate`
+  only resolves for a Rollout in its OWN namespace, so the old `socioprophet/slo-gate` resolved
+  for nothing but `socioprophet` and a prod-overlay apply to `prophet-platform-prod` failed
+  `InvalidSpec: AnalysisTemplate 'slo-gate' not found`. Reference it with `clusterScope: true`
+  and one definition is shared by every wave/service namespace. **Not wired to any service yet**
+  — see hellgraph-service below.
 - **Adoption pattern** (2026-07-31: no longer a standalone example manifest here —
   see `charts/socioprophet-service/templates/rollout.yaml`): set
   `rollout.enabled: true` in a service's `deploy/values/<name>.yaml` and the shared

--- a/infra/k8s/rollouts/base/analysistemplate-slo.yaml
+++ b/infra/k8s/rollouts/base/analysistemplate-slo.yaml
@@ -3,6 +3,18 @@
 # Wave 1 (infra/k8s/observability). This is what makes promotion metric-gated
 # rather than time-based.
 #
+# CLUSTER-SCOPED (ClusterAnalysisTemplate), not namespaced (INV-DEP-9). AnalysisTemplates are
+# namespaced: a Rollout can only reference one that lives in ITS OWN namespace. The wave deploy
+# runs the blue-green Rollout in a FRESH per-wave namespace (prophet-platform-prod / -canary),
+# and services adopting charts/socioprophet-service run Rollouts in their own namespaces — none
+# of which is `socioprophet`. A namespaced `socioprophet/slo-gate` therefore resolved for
+# NOTHING but socioprophet: deploying the prod overlay to prophet-platform-prod failed
+# `InvalidSpec: AnalysisTemplate 'slo-gate' not found` (Degraded, no pods) — kustomize dry-run
+# rendered fine; the Rollout controller rejected it live. Promoting the gate to a
+# ClusterAnalysisTemplate makes ONE definition resolvable from EVERY namespace (referenced with
+# `clusterScope: true`), so every wave shares the identical fail-closed SLO gate with no
+# per-namespace copy to drift. Enforced by tools/verify_rollout_analysis_refs.py.
+#
 # FAIL-CLOSED ON NO DATA — do not "simplify" this back to a failureCondition-only
 # metric. Each metric declares BOTH a successCondition that requires the series to
 # EXIST and be healthy (len(result) > 0 && ...) and a failureCondition that fires
@@ -15,10 +27,12 @@
 # failure, makes a metrics gap ABORT the rollout instead of silently promoting it.
 # Enforced by tools/check_canary_slo_gate.py in the validate-target-diagnostics gate.
 apiVersion: argoproj.io/v1alpha1
-kind: AnalysisTemplate
+kind: ClusterAnalysisTemplate   # cluster-scoped: resolvable from every wave/service namespace
 metadata:
   name: slo-gate
-  namespace: socioprophet
+  # No namespace — ClusterAnalysisTemplate is cluster-scoped. Applied once cluster-wide by the
+  # rollouts base app (deploy/argocd/progressive-delivery-services.yaml), it is shared by every
+  # Rollout that references it with `clusterScope: true`, in any namespace.
 spec:
   args:
     - name: service        # the Rollout passes its job/service label in

--- a/infra/k8s/rollouts/base/kustomization.yaml
+++ b/infra/k8s/rollouts/base/kustomization.yaml
@@ -1,6 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-# The AnalysisTemplate deploys (shared canary gate). The Rollout itself is no longer a
+# The ClusterAnalysisTemplate deploys (shared, cluster-scoped canary gate — INV-DEP-9: one
+# definition resolvable from every wave/service namespace, referenced with clusterScope: true).
+# This base carries NO `namespace:` transformer — a ClusterAnalysisTemplate is cluster-scoped
+# and must not be namespaced. The Rollout itself is no longer a
 # standalone manifest here — as of explore/rollouts-hellgraph-pilot (2026-07-31) it's rendered
 # by charts/socioprophet-service (templates/rollout.yaml + rollout-services.yaml) when a
 # service's deploy/values/<name>.yaml sets rollout.enabled: true, e.g. deploy/values/

--- a/infra/k8s/search-orchestrator/overlays/promote/prod/rollout.yaml
+++ b/infra/k8s/search-orchestrator/overlays/promote/prod/rollout.yaml
@@ -1,8 +1,16 @@
 # WAVE 3 (prod) — BLUE-GREEN cutover via Argo Rollouts, reusing the estate's existing
 # canary/SLO machinery (infra/k8s/rollouts/base/analysistemplate-slo.yaml, the shared
-# `slo-gate` AnalysisTemplate). This is NOT a second deploy path: it is the same digest the
+# `slo-gate` gate). This is NOT a second deploy path: it is the same digest the
 # dev/canary Deployments carry (INV-DEP-2, build-once-promote-many), advanced into a
 # blueGreen Rollout for the production cutover.
+#
+# The gate is referenced as a CLUSTER-scoped template (`clusterScope: true`), INV-DEP-9. This
+# overlay renders into the fresh `prophet-platform-prod` namespace, which holds NO namespaced
+# `slo-gate`; a bare `templateName: slo-gate` resolved only in `socioprophet` and made a live
+# apply fail `InvalidSpec: AnalysisTemplate 'slo-gate' not found` (Degraded, no pods) even
+# though kustomize dry-run rendered clean. slo-gate is now a ClusterAnalysisTemplate (applied
+# once cluster-wide), resolvable from this namespace without the overlay having to bundle a
+# per-namespace copy. Guarded by tools/verify_rollout_analysis_refs.py.
 #
 # Cutover rule (INV-DEP-3): the frozen digest deploys to GREEN (preview). prePromotionAnalysis
 # runs the fail-closed slo-gate against the preview; promotion to active (the cutover) happens
@@ -34,6 +42,7 @@ spec:
       prePromotionAnalysis:
         templates:
           - templateName: slo-gate                  # reuse the in-repo fail-closed SLO gate
+            clusterScope: true                      # ClusterAnalysisTemplate — resolvable in any ns (INV-DEP-9)
         args:
           - name: service
             value: search-orchestrator

--- a/tools/tests/test_verify_rollout_analysis_refs.py
+++ b/tools/tests/test_verify_rollout_analysis_refs.py
@@ -1,0 +1,153 @@
+"""Teeth for the Rollout analysis-ref gate (INV-DEP-9).
+
+A namespaced AnalysisTemplate only resolves for a Rollout in its OWN namespace; a
+ClusterAnalysisTemplate resolves everywhere (referenced with clusterScope: true). This gate
+must PASS an overlay whose Rollout analysis refs all resolve, and FAIL a dangling ref — a
+namespaced template the overlay doesn't render, or a clusterScope ref to an undeclared
+ClusterAnalysisTemplate. It also proves the real search-orchestrator promote overlays render
+self-contained (against the shipped cluster-scoped slo-gate).
+"""
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import verify_rollout_analysis_refs as chk  # noqa: E402
+
+# A blue-green Rollout referencing slo-gate as a CLUSTER-scoped template — the fixed shape.
+ROLLOUT_CLUSTER_REF = textwrap.dedent(
+    """
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
+    metadata:
+      name: search-orchestrator
+      namespace: prophet-platform-prod
+    spec:
+      strategy:
+        blueGreen:
+          prePromotionAnalysis:
+            templates:
+              - templateName: slo-gate
+                clusterScope: true
+            args:
+              - { name: service, value: search-orchestrator }
+    """
+)
+
+# Same Rollout but the ref is NAMESPACED (no clusterScope) and the overlay renders no
+# AnalysisTemplate — the exact dangling shape that InvalidSpec'd on a live apply.
+ROLLOUT_DANGLING_NS_REF = textwrap.dedent(
+    """
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
+    metadata:
+      name: search-orchestrator
+      namespace: prophet-platform-prod
+    spec:
+      strategy:
+        blueGreen:
+          prePromotionAnalysis:
+            templates:
+              - templateName: slo-gate
+    """
+)
+
+# A namespaced ref WITH the AnalysisTemplate bundled into the same overlay (Option B shape).
+ROLLOUT_NS_REF_WITH_BUNDLED_TEMPLATE = ROLLOUT_DANGLING_NS_REF + textwrap.dedent(
+    """
+    ---
+    apiVersion: argoproj.io/v1alpha1
+    kind: AnalysisTemplate
+    metadata:
+      name: slo-gate
+      namespace: prophet-platform-prod
+    spec:
+      metrics:
+        - name: error-ratio
+          successCondition: len(result) > 0 && result[0] < 0.05
+          failureCondition: len(result) == 0 || result[0] >= 0.05
+    """
+)
+
+
+def test_cluster_ref_resolves_when_template_declared():
+    # slo-gate declared cluster-wide -> the clusterScope ref resolves from any namespace.
+    assert chk.scan_rendered(ROLLOUT_CLUSTER_REF, {"slo-gate"}, "prod") == []
+
+
+def test_cluster_ref_fails_when_template_not_declared():
+    violations = chk.scan_rendered(ROLLOUT_CLUSTER_REF, set(), "prod")
+    assert violations, "a clusterScope ref to an undeclared ClusterAnalysisTemplate must fail"
+    assert "no ClusterAnalysisTemplate 'slo-gate' is declared" in violations[0]
+
+
+def test_dangling_namespaced_ref_fails():
+    # This is the bug: namespaced ref, overlay renders no AnalysisTemplate. Even with slo-gate
+    # declared cluster-wide, a NON-clusterScope ref does not resolve against it.
+    violations = chk.scan_rendered(ROLLOUT_DANGLING_NS_REF, {"slo-gate"}, "prod")
+    assert violations, "a namespaced ref with no rendered AnalysisTemplate must fail"
+    assert "does not render it" in violations[0]
+    assert "not found" in violations[0]
+
+
+def test_namespaced_ref_passes_when_template_bundled():
+    # Option B: overlay bundles the namespaced AnalysisTemplate alongside the Rollout.
+    assert chk.scan_rendered(ROLLOUT_NS_REF_WITH_BUNDLED_TEMPLATE, set(), "prod") == []
+
+
+def test_overlay_without_rollout_passes():
+    deployment_only = textwrap.dedent(
+        """
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata: { name: search-orchestrator, namespace: prophet-platform-canary }
+        spec: { replicas: 1 }
+        """
+    )
+    assert chk.scan_rendered(deployment_only, set(), "canary") == []
+
+
+def test_canary_step_analysis_ref_is_checked():
+    canary = textwrap.dedent(
+        """
+        apiVersion: argoproj.io/v1alpha1
+        kind: Rollout
+        metadata: { name: svc, namespace: ns-a }
+        spec:
+          strategy:
+            canary:
+              steps:
+                - setWeight: 20
+                - analysis:
+                    templates:
+                      - templateName: slo-gate
+        """
+    )
+    # namespaced ref, nothing rendered -> fail
+    assert chk.scan_rendered(canary, {"slo-gate"}, "canary")
+
+
+def test_malformed_rendered_yaml_fails_closed():
+    bad = "kind: Rollout\nspec: strategy: blueGreen: [ this: is not: valid : :\n"
+    violations = chk.scan_rendered(bad, {"slo-gate"}, "prod")
+    assert violations, "malformed rendered YAML must not pass silently"
+    assert "not valid YAML" in violations[0]
+
+
+def test_shipped_promote_overlays_render_self_contained():
+    # The real overlays, rendered by kubectl kustomize, must pass against the shipped
+    # cluster-scoped slo-gate. Skips gracefully if kubectl/kustomize is unavailable.
+    root = Path(chk.ROOT)
+    declared = chk.discover_cluster_templates(root)
+    assert "slo-gate" in declared, "slo-gate must be a declared ClusterAnalysisTemplate"
+    import shutil
+
+    if shutil.which("kubectl") is None:
+        import pytest
+
+        pytest.skip("kubectl not available to render overlays")
+    violations = chk.check_overlays(root, chk.DEFAULT_OVERLAYS)
+    assert violations == [], f"shipped promote overlays must be self-contained: {violations}"

--- a/tools/verify_rollout_analysis_refs.py
+++ b/tools/verify_rollout_analysis_refs.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Preflight (INV-DEP-9): every Rollout analysis ref must resolve in the overlay it deploys to.
+
+Argo Rollouts `AnalysisTemplate`s are **namespaced** — a Rollout may only reference an
+AnalysisTemplate that lives in ITS OWN namespace. `ClusterAnalysisTemplate`s are cluster-scoped
+and resolve from any namespace (referenced with `clusterScope: true`). A Rollout that references
+a namespaced template which its overlay does NOT render — or a cluster-scoped template that no
+`ClusterAnalysisTemplate` in the repo declares — is a manifest that `kubectl kustomize` renders
+perfectly and the LIVE Rollout controller rejects:
+
+    InvalidSpec: AnalysisTemplate 'slo-gate' not found      (Degraded, no pods)
+
+That is exactly what a wave-deploy hit: the prod blue-green Rollout referenced `slo-gate`, but
+that AnalysisTemplate existed ONLY in the `socioprophet` namespace; deploying the prod overlay
+to a fresh `prophet-platform-prod` namespace failed with no pods. Dry-run kustomize was green.
+This gate makes an overlay prove it is **self-contained**: every AnalysisTemplate a Rollout
+names is either rendered by the overlay itself (namespaced, same namespace) or is a declared
+cluster-scoped `ClusterAnalysisTemplate` (resolvable everywhere).
+
+Teeth both ways: tools/tests/test_verify_rollout_analysis_refs.py feeds a resolvable overlay
+(passes) and a dangling ref — namespaced template not rendered, and a clusterScope ref to an
+undeclared template — (fails). A gate that has only ever passed proves nothing.
+
+Runs static (no cluster): it shells out to `kubectl kustomize` to render each overlay, then
+inspects the rendered YAML. Wired into `make rollout-analysis-refs-check` (the
+validate-target-diagnostics matrix) and `wave-promote.yml`.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+ROLLOUT_KIND = "Rollout"
+NS_TEMPLATE_KIND = "AnalysisTemplate"
+CLUSTER_TEMPLATE_KIND = "ClusterAnalysisTemplate"
+
+# The wave overlays this gate renders by default. Each must be self-contained: a Rollout it
+# renders may only reference an AnalysisTemplate the overlay also renders, or a cluster-scoped
+# ClusterAnalysisTemplate declared in the repo.
+DEFAULT_OVERLAYS = [
+    "infra/k8s/search-orchestrator/overlays/promote/dev",
+    "infra/k8s/search-orchestrator/overlays/promote/canary",
+    "infra/k8s/search-orchestrator/overlays/promote/prod",
+]
+
+
+def _load_docs(text: str) -> tuple[list[dict[str, Any]], str | None]:
+    """Parse every YAML doc. Fail-closed: a parse error is surfaced, never swallowed — a
+    manifest that will not parse cannot be certified self-contained."""
+    try:
+        return [d for d in yaml.safe_load_all(text) if isinstance(d, dict)], None
+    except yaml.YAMLError as e:
+        return [], type(e).__name__
+
+
+def _analysis_blocks(spec: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    """Yield every analysis block reachable from a Rollout spec — blueGreen pre/post-promotion
+    and canary top-level + per-step analyses. Each block carries a `templates:` list."""
+    strategy = spec.get("strategy") or {}
+    bg = strategy.get("blueGreen") or {}
+    for key in ("prePromotionAnalysis", "postPromotionAnalysis"):
+        blk = bg.get(key)
+        if isinstance(blk, dict):
+            yield blk
+    canary = strategy.get("canary") or {}
+    top = canary.get("analysis")
+    if isinstance(top, dict):
+        yield top
+    for step in canary.get("steps") or []:
+        if isinstance(step, dict) and isinstance(step.get("analysis"), dict):
+            yield step["analysis"]
+
+
+def rollout_analysis_refs(doc: dict[str, Any]) -> list[tuple[str, bool]]:
+    """(templateName, cluster_scoped) for every analysis-template ref in a Rollout doc."""
+    refs: list[tuple[str, bool]] = []
+    spec = doc.get("spec") or {}
+    for block in _analysis_blocks(spec):
+        for tmpl in block.get("templates") or []:
+            if not isinstance(tmpl, dict):
+                continue
+            name = tmpl.get("templateName")
+            if name:
+                refs.append((str(name), bool(tmpl.get("clusterScope", False))))
+    return refs
+
+
+def rendered_templates(docs: list[dict[str, Any]]) -> tuple[set[str], set[str]]:
+    """Names of (namespaced AnalysisTemplates, ClusterAnalysisTemplates) present in a doc set."""
+    ns: set[str] = set()
+    cluster: set[str] = set()
+    for d in docs:
+        name = (d.get("metadata") or {}).get("name")
+        if not name:
+            continue
+        if d.get("kind") == NS_TEMPLATE_KIND:
+            ns.add(str(name))
+        elif d.get("kind") == CLUSTER_TEMPLATE_KIND:
+            cluster.add(str(name))
+    return ns, cluster
+
+
+def ref_violations(
+    docs: list[dict[str, Any]],
+    declared_cluster_templates: set[str],
+    where: str,
+) -> list[str]:
+    """Every Rollout analysis ref in `docs` must resolve: a namespaced ref against templates
+    rendered in this SAME overlay; a clusterScope ref against a declared ClusterAnalysisTemplate
+    (or one rendered in the set)."""
+    rendered_ns, rendered_cluster = rendered_templates(docs)
+    resolvable_cluster = declared_cluster_templates | rendered_cluster
+    out: list[str] = []
+    for d in docs:
+        if d.get("kind") != ROLLOUT_KIND:
+            continue
+        rname = (d.get("metadata") or {}).get("name", "<unnamed>")
+        for tmpl_name, cluster_scoped in rollout_analysis_refs(d):
+            if cluster_scoped:
+                if tmpl_name not in resolvable_cluster:
+                    out.append(
+                        f"{where}: Rollout '{rname}' references clusterScope template "
+                        f"'{tmpl_name}', but no ClusterAnalysisTemplate '{tmpl_name}' is declared "
+                        f"in the repo — the live Rollout would be InvalidSpec "
+                        f"(declare it in infra/k8s/rollouts/base or drop clusterScope)."
+                    )
+            else:
+                if tmpl_name not in rendered_ns:
+                    out.append(
+                        f"{where}: Rollout '{rname}' references namespaced AnalysisTemplate "
+                        f"'{tmpl_name}', but this overlay does not render it — an apply to a fresh "
+                        f"namespace fails 'InvalidSpec: AnalysisTemplate {tmpl_name!r} not found' "
+                        f"(bundle a namespaced AnalysisTemplate '{tmpl_name}' into this overlay, "
+                        f"or make it a ClusterAnalysisTemplate and set clusterScope: true)."
+                    )
+    return out
+
+
+def scan_rendered(
+    text: str,
+    declared_cluster_templates: set[str] | None = None,
+    where: str = "<rendered>",
+) -> list[str]:
+    """Parse rendered multi-doc YAML and return analysis-ref violations. The test seam."""
+    docs, err = _load_docs(text)
+    if err is not None:
+        return [f"{where}: rendered output is not valid YAML ({err}); cannot certify self-contained"]
+    return ref_violations(docs, declared_cluster_templates or set(), where)
+
+
+def discover_cluster_templates(root: Path) -> set[str]:
+    """Every ClusterAnalysisTemplate name declared anywhere in the repo. These are cluster-scoped
+    (applied once cluster-wide) so a clusterScope ref resolves against them from any namespace.
+    Helm template dirs are skipped (they are not concrete manifests); unparseable files are
+    ignored here — the fail-closed parse guard applies to the RENDERED overlay, not to sources
+    scanned for declarations."""
+    names: set[str] = set()
+    for path in root.rglob("*.y*ml"):
+        parts = path.parts
+        if "templates" in parts and "charts" in parts:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if CLUSTER_TEMPLATE_KIND not in text:
+            continue
+        try:
+            docs = [d for d in yaml.safe_load_all(text) if isinstance(d, dict)]
+        except yaml.YAMLError:
+            continue
+        for d in docs:
+            if d.get("kind") == CLUSTER_TEMPLATE_KIND:
+                name = (d.get("metadata") or {}).get("name")
+                if name:
+                    names.add(str(name))
+    return names
+
+
+def render_overlay(overlay: Path) -> tuple[str, str | None]:
+    """Render an overlay via `kubectl kustomize`. Returns (stdout, error) — a non-zero exit is a
+    fail-closed error, not swallowed."""
+    try:
+        proc = subprocess.run(
+            ["kubectl", "kustomize", str(overlay)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return "", "kubectl not found (needed to render the overlay)"
+    if proc.returncode != 0:
+        return "", f"kubectl kustomize failed (exit {proc.returncode}): {proc.stderr.strip()}"
+    return proc.stdout, None
+
+
+def check_overlays(root: Path, overlays: list[str]) -> list[str]:
+    declared = discover_cluster_templates(root)
+    violations: list[str] = []
+    for rel in overlays:
+        overlay = root / rel
+        if not overlay.exists():
+            violations.append(f"{rel}: overlay path does not exist")
+            continue
+        text, err = render_overlay(overlay)
+        if err is not None:
+            violations.append(f"{rel}: {err}")
+            continue
+        violations.extend(scan_rendered(text, declared, where=rel))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "overlays",
+        nargs="*",
+        default=DEFAULT_OVERLAYS,
+        help="overlay dirs to render + check (default: the search-orchestrator promote waves)",
+    )
+    args = ap.parse_args(argv)
+    overlays = args.overlays or DEFAULT_OVERLAYS
+    violations = check_overlays(ROOT, overlays)
+    if violations:
+        print("Rollout analysis-ref check FAILED (INV-DEP-9):", file=sys.stderr)
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        return 1
+    declared = discover_cluster_templates(ROOT)
+    print(
+        f"OK: {len(overlays)} overlay(s) render self-contained analysis refs "
+        f"(declared ClusterAnalysisTemplates: {sorted(declared) or 'none'})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What an apply caught

Deploying `infra/k8s/search-orchestrator/overlays/promote/prod` to a **fresh `prophet-platform-prod` namespace** failed on the live Argo Rollouts controller:

```
InvalidSpec: AnalysisTemplate 'slo-gate' not found   (Degraded, no pods)
```

The prod blue-green Rollout's `prePromotionAnalysis` referenced `slo-gate`, but that `AnalysisTemplate` existed **only in the `socioprophet` namespace**. `AnalysisTemplate`s are namespaced — a Rollout resolves one only in its own namespace. `kubectl kustomize` rendered the overlay perfectly and every shape/existence gate (INV-DEP-1/2/6/8) was green; only a real apply surfaced it. Same "dry-run green, apply red" class as INV-DEP-6/8, now for a **namespaced-resource reference** instead of an image.

## Fix — Option A (ClusterAnalysisTemplate), and why

The SLO gate is **estate-wide**: it is shared across the dev/canary/prod wave namespaces and by any service that adopts `charts/socioprophet-service` with `rollout.enabled: true` (each in its own namespace). Bundling a namespaced copy into every overlay (Option B) would mean N copies to drift. So per the task's "preferred if the SLO gate is estate-wide":

- **`infra/k8s/rollouts/base/analysistemplate-slo.yaml`** — `kind: AnalysisTemplate` (ns `socioprophet`) → **`kind: ClusterAnalysisTemplate`** (cluster-scoped, no namespace). One definition, applied once cluster-wide, resolvable from every namespace. The fail-closed no-data metric shape is unchanged (`check_canary_slo_gate.py` still green — it already accepts `ClusterAnalysisTemplate`).
- **prod `rollout.yaml`** — `prePromotionAnalysis.templates[0]` now carries `clusterScope: true`. Grep-gate `templateName: slo-gate` in `wave-promote.yml` still matches.
- **`charts/socioprophet-service`** — template gains an optional `clusterScope: true` under the analysis ref; `values.yaml` defaults `rollout.analysis.clusterScope: true`, so chart-deployed Rollouts in any namespace resolve the same shared gate. Migration is in lockstep — nothing actively references the old namespaced template (`rollout.enabled` is off everywhere).

canary/dev overlays render a `Deployment` (no Rollout, no analysis ref), so they need no template.

## Guard — INV-DEP-9 (effect > artifact)

`tools/verify_rollout_analysis_refs.py` renders each promote overlay with `kubectl kustomize` and **fails** if a Rollout references:
- a **namespaced** `AnalysisTemplate` the overlay does not itself render, or
- a **clusterScope** template with no `ClusterAnalysisTemplate` of that name declared in the repo.

Fail-closed: a render that won't `kubectl kustomize` or output that won't parse also fails. Wired into `make rollout-analysis-refs-check` (the required `validate-target-diagnostics` matrix, with a conditional `azure/setup-kubectl` step) and **`wave-promote.yml` GATE 3b** (renders the promoting wave's overlay before any apply). This is the control that would have caught the incident before the apply.

### Teeth, both ways

| Case | Result |
|---|---|
| Fixed prod/canary/dev overlays (real `kubectl kustomize` render) | **PASS** (exit 0) |
| Planted dangling ref — dropped `clusterScope`, real render | **FAIL** (exit 1): `references namespaced AnalysisTemplate 'slo-gate', but this overlay does not render it … InvalidSpec … not found` |
| `test_verify_rollout_analysis_refs.py` (8 tests) | resolvable/bundled pass; dangling-ns + undeclared-clusterScope + malformed-YAML fail |

## Validation (dry-run, no cluster apply)

- `kubectl kustomize` renders base → cluster-scoped `slo-gate`; prod → Rollout with `clusterScope: true`.
- `make canary-slo-gate-check` ✅ · new guard on real overlays ✅ · `preflight_deploy_contract.py` exit 0.
- `pytest tools/tests/test_verify_rollout_analysis_refs.py tools/tests/test_check_canary_slo_gate.py` → **17 passed**.
- `helm template` of the chart emits `clusterScope: true` when set, omits it when false.
- `actionlint` clean on the two edited workflows (one pre-existing info-level SC2086 in an untouched script block, unrelated); all edited YAML `yaml.safe_load`s.
- Nothing applied to any cluster.

## Docs

- **INV-DEP-9** added to `docs/standards/deploy-wave-invariants-v0.md` (+ conformance checklist row 10).
- Apply-caught lesson recorded in `docs/DEPLOY-WAVE-STRATEGY.md`: overlays must be self-contained — every referenced cluster resource is either rendered by the overlay or cluster-scoped.

Do **not** merge — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)