### PR TITLE
feat(iac): mint search-orchestrator WIF identity (zero-role, least-privilege)

### DIFF
--- a/infra/tofu/envs/shared/main.tf
+++ b/infra/tofu/envs/shared/main.tf
@@ -51,6 +51,22 @@ module "wi_cicd" {
         "roles/container.developer",
       ]
     }
+    # Runtime identity for the prod search-orchestrator workload (blue-green Rollout).
+    # Minted by tofu so the prod overlay's KSA annotation
+    # (iam.gke.io/gcp-service-account: search-orchestrator@…) resolves to a real GSA —
+    # one-click deploy, no engineer wires this by hand.
+    #
+    # roles = [] BY DESIGN (least privilege): the workload calls NO GCP APIs — config is
+    # in a ConfigMap, image-pull is the node SA, the PVC is storageclass-provisioned. The
+    # identity exists (audit/VPC-SC/future use) but grants nothing. When the app first needs
+    # a GCP API, add the SINGLE matching role here (e.g. roles/secretmanager.secretAccessor)
+    # — that is the only change, and it stays one-click.
+    search-orchestrator = {
+      sa_name       = "search-orchestrator"
+      k8s_namespace = "prophet-platform-prod"
+      k8s_sa_name   = "search-orchestrator"
+      roles         = []
+    }
   }
 }
 


### PR DESCRIPTION
Completes the one-click prod deploy from #1230: that PR annotated the prod KSA with a WIF GSA (`iam.gke.io/gcp-service-account: search-orchestrator@socioprophet-platform…`). This makes that GSA **real in IaC** so the annotation resolves — no engineer wires it by hand.

## `roles = []` by design (least-privilege)

Adversarial review before granting any role: **search-orchestrator calls no GCP APIs** — no `google-cloud`/`secretmanager`/`storage` imports, config is in a ConfigMap, image-pull is the node SA's job, the PVC is storageclass-provisioned. Granting `artifactregistry.reader` / `secretmanager.secretAccessor` (my first draft) would **over-provision against a workload that uses neither**.

So the binding mints the **identity** (the module still creates the GSA + `workloadIdentityUser` binding, so the annotation resolves and WIF token-exchange works) but grants **zero project roles**. When the app first needs a GCP API, the only change is adding the single matching role to `roles = [...]` here — still one-click.

## Scope
- `infra/tofu/envs/shared/main.tf` — one `search-orchestrator` binding added to `module.wi_cicd.bindings`.
- Module is empty-roles-safe (`google_project_iam_member.wi_roles` iterates `cfg.roles`, producing zero grants).