### PR TITLE
feat(resilience): Phase 1 — ephemeral real-apply preflight (L1) + derived manifest completeness (L2, INV-DEP-11)

### DIFF
--- a/.github/app-ci/ephemeral-apply-assert.sh
+++ b/.github/app-ci/ephemeral-apply-assert.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# ephemeral-apply-assert.sh — the effect-canary body for the L1 ephemeral real-apply preflight
+# (.github/workflows/ephemeral-apply-preflight.yml). It renders ONE overlay, applies it to a
+# throwaway namespace on a hermetic kind cluster, and asserts the CREATE / SPEC-time failure class
+# from the 2026-08-02 wave-deploy incident does NOT occur. It lives here, not trapped in YAML, so it
+# is invocable and testable on its own (`bash -n` clean; `bash … <overlay> <ns>` locally against a
+# kind cluster).
+#
+# VERDICT:
+#   FAIL (exit 1) if a namespace Event has reason `FailedCreate`, or a Rollout/Deployment reports
+#     `InvalidSpec` — the SA-not-found / AnalysisTemplate-not-found failure class.
+#   PASS (exit 0) as soon as a pod object is CREATED and SCHEDULED (reaches Pending/ContainerCreating
+#     with a node assigned). That proves the SA / ConfigMap / PVC / AnalysisTemplate references all
+#     resolved. We deliberately do NOT wait for Ready: the real GAR image cannot pull inside kind, so
+#     ImagePullBackOff is EXPECTED and is NOT a gate failure — we gate on create/spec signals only.
+#   TIMEOUT with neither signal -> exit 1 (fail-closed: an apply that never schedules a pod and never
+#     names a failure is not a pass).
+#
+# The overlay's baked namespace is rewritten onto every rendered object so each wave lands in its own
+# throwaway namespace, isolated on the ephemeral cluster.
+#
+# Env seams (defaults are the CI values):
+#   APPLY_ASSERT_TIMEOUT   overall poll budget in seconds   (default 150)
+#   APPLY_ASSERT_POLL      seconds between polls             (default 5)
+set -euo pipefail
+
+OVERLAY="${1:?usage: ephemeral-apply-assert.sh <overlay-dir> <namespace>}"
+NS="${2:?usage: ephemeral-apply-assert.sh <overlay-dir> <namespace>}"
+TIMEOUT="${APPLY_ASSERT_TIMEOUT:-150}"
+POLL="${APPLY_ASSERT_POLL:-5}"
+
+log() { printf '[apply-assert %s] %s\n' "$NS" "$*" >&2; }
+
+kubectl create namespace "$NS" >/dev/null 2>&1 || true
+
+log "rendering $OVERLAY into namespace $NS and applying"
+# Rewrite metadata.namespace onto every object so the whole set lands in the throwaway namespace.
+# A kustomize render OR apply error is itself a failure (fail-closed).
+if ! kubectl kustomize "$OVERLAY" \
+      | python3 -c '
+import sys, yaml
+ns = sys.argv[1]
+docs = [d for d in yaml.safe_load_all(sys.stdin) if isinstance(d, dict)]
+for d in docs:
+    d.setdefault("metadata", {})["namespace"] = ns
+sys.stdout.write(yaml.safe_dump_all(docs))
+' "$NS" \
+      | kubectl apply -n "$NS" -f - ; then
+  log "kustomize render or apply FAILED — fail-closed"
+  exit 1
+fi
+
+# Return 0 and print a reason when a create/spec-time failure is observed in the namespace.
+failure_reason() {
+  kubectl get events -n "$NS" -o json 2>/dev/null | python3 -c '
+import sys, json
+data = json.load(sys.stdin)
+for it in data.get("items", []):
+    if it.get("reason") == "FailedCreate":
+        obj = it.get("involvedObject", {})
+        print("FailedCreate on %s/%s: %s" % (obj.get("kind"), obj.get("name"), (it.get("message") or "").strip()))
+        sys.exit(0)
+sys.exit(1)
+' && return 0
+
+  kubectl get rollouts.argoproj.io -n "$NS" -o json 2>/dev/null | python3 -c '
+import sys, json
+data = json.load(sys.stdin)
+for it in data.get("items", []):
+    st = it.get("status", {})
+    name = it.get("metadata", {}).get("name")
+    for c in st.get("conditions", []):
+        if (c.get("type") == "InvalidSpec" or c.get("reason") == "InvalidSpec") and c.get("status") == "True":
+            print("InvalidSpec Rollout/%s: %s" % (name, (c.get("message") or "").strip()))
+            sys.exit(0)
+    if st.get("phase") == "Degraded" and "InvalidSpec" in (st.get("message") or ""):
+        print("InvalidSpec Rollout/%s: %s" % (name, st.get("message")))
+        sys.exit(0)
+sys.exit(1)
+' && return 0
+
+  kubectl get deployments -n "$NS" -o json 2>/dev/null | python3 -c '
+import sys, json
+data = json.load(sys.stdin)
+for it in data.get("items", []):
+    name = it.get("metadata", {}).get("name")
+    for c in it.get("status", {}).get("conditions", []):
+        if c.get("reason") == "InvalidSpec":
+            print("InvalidSpec Deployment/%s: %s" % (name, (c.get("message") or "").strip()))
+            sys.exit(0)
+sys.exit(1)
+' && return 0
+
+  return 1
+}
+
+# Return 0 and print a reason once a pod object exists AND has been scheduled (reaches
+# Pending/ContainerCreating with a node) — proving the workload's references resolved.
+scheduled_pod() {
+  kubectl get pods -n "$NS" -o json 2>/dev/null | python3 -c '
+import sys, json
+data = json.load(sys.stdin)
+for it in data.get("items", []):
+    spec = it.get("spec", {})
+    status = it.get("status", {})
+    name = it.get("metadata", {}).get("name")
+    phase = status.get("phase")
+    scheduled = bool(spec.get("nodeName"))
+    if not scheduled:
+        for c in status.get("conditions", []):
+            if c.get("type") == "PodScheduled" and c.get("status") == "True":
+                scheduled = True
+    # container statuses present (ContainerCreating/ImagePullBackOff/etc.) also imply the pod was
+    # created and admitted — the create/spec class is cleared regardless of pull outcome.
+    cs_present = bool(status.get("containerStatuses") or status.get("initContainerStatuses"))
+    if scheduled or cs_present or phase in ("Running", "Succeeded"):
+        print("pod %s created+scheduled (phase=%s node=%s)" % (name, phase, spec.get("nodeName") or "-"))
+        sys.exit(0)
+sys.exit(1)
+'
+}
+
+log "polling up to ${TIMEOUT}s for a create/spec-time failure OR a scheduled pod"
+deadline=$(( SECONDS + TIMEOUT ))
+while (( SECONDS < deadline )); do
+  if reason="$(failure_reason)"; then
+    log "DETECTED create/spec-time failure -> FAIL: $reason"
+    exit 1
+  fi
+  if ok="$(scheduled_pod)"; then
+    log "PASS: $ok (SA/ConfigMap/PVC/AnalysisTemplate resolved; not waiting for Ready)"
+    exit 0
+  fi
+  sleep "$POLL"
+done
+
+log "TIMEOUT after ${TIMEOUT}s: no pod scheduled and no explicit failure — fail-closed. Diagnostics:"
+kubectl get events -n "$NS" --sort-by=.lastTimestamp >&2 2>/dev/null || true
+kubectl get pods,rollouts.argoproj.io,replicasets,deployments -n "$NS" >&2 2>/dev/null || true
+exit 1

--- a/.github/workflows/ephemeral-apply-preflight.yml
+++ b/.github/workflows/ephemeral-apply-preflight.yml
@@ -1,0 +1,105 @@
+# ephemeral-apply-preflight — L1 of the resilience-engineering program (docs/RESILIENCE_ENGINEERING.md).
+#
+# THE FAILURE CLASS. On 2026-08-02 a prod blue-green deploy repeatedly reached the cluster with
+# manifests that `kubectl kustomize` rendered green but the LIVE cluster rejected at create/spec
+# time: an overlay referenced a ServiceAccount/ConfigMap/PVC it never rendered (FailedCreate,
+# 0 pods); a Rollout referenced a namespaced AnalysisTemplate not in its namespace (InvalidSpec,
+# Degraded). Dry-run kustomize could not see any of it — only the REAL apply did.
+#
+# WHAT THIS DOES. It stands up a hermetic `kind` cluster, installs the argo-rollouts CRDs +
+# controller, and ACTUALLY applies each promote overlay to a throwaway namespace, asserting the
+# create/spec failure class does NOT occur. The real GAR image cannot pull inside kind, so the gate
+# keys ONLY on create/spec-time signals (FailedCreate / InvalidSpec), never on image pull:
+# reaching Pending/ContainerCreating is a PASS (it proves SA/ConfigMap/PVC/AnalysisTemplate all
+# resolved); we do not wait for Ready. The apply+assert body lives in
+# .github/app-ci/ephemeral-apply-assert.sh so it is testable and not trapped in YAML.
+#
+# NEVER-FIRED == SUSPECT. Before trusting a green on the real overlays, the job first applies a
+# DELIBERATELY broken negative fixture (overlays/_selftest-broken — a Rollout naming a
+# ServiceAccount the overlay does not render) and asserts the detector REPORTS FailedCreate
+# (returns non-zero). If the detector PASSES the broken fixture, the effect-canary is toothless and
+# THIS JOB FAILS. That is the can-fail proof this whole gate rests on.
+#
+# This EXTENDS, does not replace, the static point-gates INV-DEP-9/10/11 (analysis / SA-ConfigMap-PVC
+# / Secret+digest). Those render and inspect YAML; this one proves the live cluster accepts it.
+name: ephemeral-apply-preflight
+
+on:
+  pull_request:
+    paths:
+      - 'infra/k8s/search-orchestrator/**'
+      - 'infra/k8s/rollouts/**'
+      - '.github/app-ci/ephemeral-apply-assert.sh'
+      - '.github/workflows/ephemeral-apply-preflight.yml'
+  workflow_dispatch:
+
+# Pinned so the ephemeral controller version is deterministic (a moving `latest` would let an
+# upstream change silently alter what "the cluster accepts" means).
+env:
+  ARGO_ROLLOUTS_VERSION: v1.7.2
+  KIND_CLUSTER: ephemeral-apply-preflight
+
+jobs:
+  ephemeral-apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup Python (used by the apply-assert namespace rewrite + JSON verdicts)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install pyyaml
+        run: python -m pip install --upgrade pip pyyaml
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v4
+      - name: Create hermetic kind cluster
+        uses: helm/kind-action@v1.10.0
+        with:
+          cluster_name: ${{ env.KIND_CLUSTER }}
+      - name: Install argo-rollouts CRDs + controller
+        run: |
+          set -euo pipefail
+          kubectl create namespace argo-rollouts
+          kubectl apply -n argo-rollouts \
+            -f "https://github.com/argoproj/argo-rollouts/releases/download/${ARGO_ROLLOUTS_VERSION}/install.yaml"
+          # CRDs must be established before any Rollout / (Cluster)AnalysisTemplate applies.
+          kubectl wait --for condition=established --timeout=120s \
+            crd/rollouts.argoproj.io \
+            crd/analysistemplates.argoproj.io \
+            crd/clusteranalysistemplates.argoproj.io
+          # Controller must be running so it reconciles Rollouts (creates ReplicaSets/pods, and
+          # emits InvalidSpec) — otherwise the assert would time out with no signal.
+          kubectl rollout status deployment/argo-rollouts -n argo-rollouts --timeout=180s
+      - name: Install the shared slo-gate ClusterAnalysisTemplate
+        # The prod overlay's Rollout references slo-gate with clusterScope: true (INV-DEP-9). Install
+        # the repo's ClusterAnalysisTemplate so that ref resolves — otherwise the Rollout would be
+        # InvalidSpec here for a reason unrelated to the overlay under test.
+        run: kubectl apply -f infra/k8s/rollouts/base/analysistemplate-slo.yaml
+
+      # ---- CAN-FAIL PROOF FIRST: the detector must catch the broken fixture, or the gate is a lie.
+      - name: Prove the detector can FAIL (negative fixture — never-fired == suspect)
+        run: |
+          set -euo pipefail
+          # The fixture's Rollout names a ServiceAccount the overlay does not render. The detector
+          # MUST report the create-time failure (non-zero). A PASS here means the gate is toothless.
+          if bash .github/app-ci/ephemeral-apply-assert.sh \
+               infra/k8s/search-orchestrator/overlays/_selftest-broken selftest-broken ; then
+            echo "::error::negative fixture PASSED the detector — the ephemeral-apply gate is toothless"
+            exit 1
+          fi
+          echo "OK: detector correctly reported the create-time failure on the broken fixture"
+
+      # ---- REAL OVERLAYS: each must apply and schedule a pod with no create/spec-time failure.
+      - name: Apply each promote overlay and assert no create/spec-time failure
+        run: |
+          set -euo pipefail
+          for wave in dev canary prod; do
+            echo "::group::preflight overlays/promote/$wave"
+            bash .github/app-ci/ephemeral-apply-assert.sh \
+              "infra/k8s/search-orchestrator/overlays/promote/$wave" "preflight-$wave"
+            echo "::endgroup::"
+          done
+
+      - name: Tear down kind cluster
+        if: always()
+        run: kind delete cluster --name "${KIND_CLUSTER}" || true

--- a/.github/workflows/ephemeral-apply-preflight.yml
+++ b/.github/workflows/ephemeral-apply-preflight.yml
@@ -38,6 +38,12 @@ on:
 env:
   ARGO_ROLLOUTS_VERSION: v1.7.2
   KIND_CLUSTER: ephemeral-apply-preflight
+  # kind is installed via a pinned, checksum-verified download rather than a third-party
+  # action: the SocioProphet org enforces allowed_actions=selected, and helm/kind-action is
+  # not on the allowlist (a workflow using it fails at startup). Shell-install keeps L1 on
+  # the estate's allowed publishers only and pins exactly what runs (no moving `latest`).
+  KIND_VERSION: v0.23.0
+  KIND_SHA256: 1d86e3069ffbe3da9f1a918618aecbc778e00c75f838882d0dfa2d363bc4a68c
 
 jobs:
   ephemeral-apply:
@@ -52,10 +58,16 @@ jobs:
         run: python -m pip install --upgrade pip pyyaml
       - name: Setup kubectl
         uses: azure/setup-kubectl@v4
+      - name: Install kind (pinned + checksum-verified; no third-party action per org allowlist)
+        run: |
+          set -euo pipefail
+          curl -fsSLo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          echo "${KIND_SHA256}  ./kind" | sha256sum -c -
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          kind version
       - name: Create hermetic kind cluster
-        uses: helm/kind-action@v1.10.0
-        with:
-          cluster_name: ${{ env.KIND_CLUSTER }}
+        run: kind create cluster --name "${KIND_CLUSTER}" --wait 120s
       - name: Install argo-rollouts CRDs + controller
         run: |
           set -euo pipefail

--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -105,6 +105,7 @@ jobs:
           - canary-slo-gate-check
           - rollout-analysis-refs-check
           - overlay-self-contained-check
+          - manifest-completeness-check
           - fips-conformance-check
           - imageschemanet-grounding-check
     steps:
@@ -114,8 +115,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.25'
-      - name: Setup kubectl (renders overlays for the self-containment gates, INV-DEP-9/10)
-        if: matrix.target == 'rollout-analysis-refs-check' || matrix.target == 'overlay-self-contained-check'
+      - name: Setup kubectl (renders overlays for the completeness gates, INV-DEP-9/10/11)
+        if: matrix.target == 'rollout-analysis-refs-check' || matrix.target == 'overlay-self-contained-check' || matrix.target == 'manifest-completeness-check'
         uses: azure/setup-kubectl@v4
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/Makefile
+++ b/Makefile
@@ -606,6 +606,19 @@ rollout-analysis-refs-check:
 overlay-self-contained-check:
 	python3 tools/verify_overlay_self_contained.py
 
+.PHONY: manifest-completeness-check
+# DERIVED reference completeness (INV-DEP-11): the reference classes INV-DEP-9 (analysis templates)
+# and INV-DEP-10 (SA/ConfigMap/PVC) do NOT cover — Secret refs and image digest-pinning — so a
+# novel ref type can't render clean under `kubectl kustomize` and then FailedMount / ImagePullBackOff
+# on the live apply before someone hand-writes the next point gate. For every workload in each
+# promote overlay: every referenced Secret (secret volumes, envFrom.secretRef, env.secretKeyRef,
+# projected secret sources, imagePullSecrets) must be rendered in-set or listed in
+# infra/k8s/search-orchestrator/external-secrets.allowlist.yaml, and every image (initContainers +
+# containers) must be pinned to a real @sha256 digest (no floating tag, no placeholder digest).
+# tools/verify_manifest_completeness.py — sibling of 9/10, in the validate-target-diagnostics matrix.
+manifest-completeness-check:
+	python3 tools/verify_manifest_completeness.py
+
 .PHONY: fips-conformance-check
 # FIPS algorithm conformance in the declared crypto boundary (security/fips-boundary.yaml):
 # no non-FIPS algorithm (BLAKE2/3, MD5, SHA-1) may be called inside the boundary, and a

--- a/docs/RESILIENCE_ENGINEERING.md
+++ b/docs/RESILIENCE_ENGINEERING.md
@@ -1,0 +1,66 @@
+# Resilience Engineering — deploy-time failure classes and the layered gates that close them
+
+Status: Phase 1 (L1 + L2) shipped. L3–L6 are declared, not yet built.
+
+## The failure class we are automating away
+
+On 2026-08-02 a prod blue-green deploy repeatedly reached the cluster with manifests that
+`kubectl kustomize` rendered **green** but the LIVE cluster rejected at **create / spec-admission
+time** — a class of defect that dry-run rendering structurally cannot see, because it is about
+whether *references resolve against the running cluster*, not about whether YAML is well-formed:
+
+- An overlay referenced a `ServiceAccount` / `ConfigMap` / `PVC` it never rendered
+  → `FailedCreate: serviceaccount not found`, **0 pods**.
+- A Rollout referenced a **namespaced** `AnalysisTemplate` not in its namespace
+  → `InvalidSpec: AnalysisTemplate not found`, **Degraded**.
+- A placeholder / floating image reference
+  → `ImagePullBackOff`.
+
+Every one was caught **only by the real apply**. "Dry-run green, apply red" is the signature.
+
+## The layered plan
+
+The strategy is two-pronged and defence-in-depth: **derive** the references statically so a whole
+*class* is caught without hand-writing a gate per type (cheap, fast, every PR), and **apply for
+real** on an ephemeral cluster so the ground truth — "does the live API accept this?" — is a
+continuous gate, not a thing we learn in prod.
+
+| Layer | What | Status |
+|---|---|---|
+| **L1** | **Ephemeral real-apply preflight.** Stand up a hermetic `kind` cluster, install argo-rollouts CRDs + controller, ACTUALLY apply each promote overlay to a throwaway namespace, and assert the create/spec failure class does not occur. The effect-canary as a continuous gate. | **shipped** |
+| **L2** | **Derived reference completeness (INV-DEP-11).** One checker that derives and resolves the reference types the point-gates do NOT cover (Secrets, image digest-pinning), so a novel ref type can't reach prod before someone hand-writes a gate for it. | **shipped** |
+| L3 | **Blast-radius-on-refactor.** When a shared resource (a base, a ClusterAnalysisTemplate, a support kustomization) changes, compute which overlays/waves it affects and re-render/apply exactly those — refuse a refactor whose blast radius is unproven. | future |
+| L4 | **Evidence-ref verification.** Every claim a gate makes (a digest exists, a series is present, a receipt is sealed) must resolve to real evidence, not a string that looks right — extend the "reference resolves" discipline from cluster objects to evidence artifacts. | future |
+| L5 | **Local == CI parity.** The commands a developer runs locally must be byte-for-byte the commands CI runs (`pytest` == `python -m pytest`, same make target, same interpreter), so "green on my machine" and "green in CI" cannot diverge. | future |
+| L6 | **Auto-remediation.** When a derived gate knows the fix (render the missing SA, pin the floating tag), offer/produce the patch, not just the refusal. | future |
+| — | **Last-fired gate registry (cross-cutting).** A control that has never fired is suspect. Every gate here records when it last actually FAILED on something (the negative fixtures included), so a gate that has only ever passed is flagged for an adversarial review rather than trusted. L1's negative fixture is the first entry. | future |
+
+## How the invariants + ephemeral-apply map onto it
+
+The `INV-DEP-*` family (canonical: `docs/standards/deploy-wave-invariants-v0.md`) is the static half;
+ephemeral-apply is the live half. They are complementary, not redundant — each INV-DEP-N is a
+*derivation* that says "here is a reference class; prove every instance resolves in the rendered
+set", and L1 is the *proof by construction* that the live API agrees.
+
+| Gate | Reference class it resolves | Signal it prevents | Where |
+|---|---|---|---|
+| **INV-DEP-6** | Every promoted digest exists in the registry the nodes pull from | `ErrImagePull: manifest unknown` | `tools/verify_pinned_digest_exists.py` |
+| **INV-DEP-9** | Rollout → AnalysisTemplate (namespaced) / ClusterAnalysisTemplate (clusterScope) | `InvalidSpec: AnalysisTemplate not found` (Degraded) | `tools/verify_rollout_analysis_refs.py` |
+| **INV-DEP-10** | Workload → ServiceAccount / ConfigMap / PVC rendered in-overlay | `FailedCreate: serviceaccount not found` (0 pods) | `tools/verify_overlay_self_contained.py` |
+| **INV-DEP-11** | Workload → Secret (rendered or allowlisted) **+** every image digest-pinned | `secret not found` (FailedMount) / `ImagePullBackOff` (placeholder/floating) | `tools/verify_manifest_completeness.py` |
+| **ephemeral-apply (L1)** | ALL of the above, proven against a live API server, not derived | any create/spec-time rejection | `.github/workflows/ephemeral-apply-preflight.yml` + `.github/app-ci/ephemeral-apply-assert.sh` |
+
+INV-DEP-9/10 are **point gates**: each was written after an incident named its one reference type.
+INV-DEP-11 is **derived** — it closes the reference classes 9/10 do not cover (Secrets, image
+pinning) in one checker, so the *next* novel ref type is caught by the derivation rather than by the
+next incident. L1 is the backstop under all of them: it renders and applies for real, so a reference
+class nobody has thought to derive yet still fails the moment the live cluster rejects it.
+
+### Never-fired == suspect
+
+Every gate here is proven **both ways**. INV-DEP-9/10/11 each ship teeth in `tools/tests/` that feed
+a resolvable overlay (must pass) and a dangling ref (must fail). L1 carries a negative fixture,
+`infra/k8s/search-orchestrator/overlays/_selftest-broken/` — a Rollout naming a ServiceAccount the
+overlay does not render — and the workflow applies ONLY that fixture and fails the job unless the
+detector reports the `FailedCreate` (returns non-zero). A gate that has only ever passed proves
+nothing; the fixture is the standing proof that this one can still fail.

--- a/infra/k8s/search-orchestrator/external-secrets.allowlist.yaml
+++ b/infra/k8s/search-orchestrator/external-secrets.allowlist.yaml
@@ -1,0 +1,25 @@
+# External-secret allowlist (INV-DEP-11, tools/verify_manifest_completeness.py).
+#
+# A workload's pod template may reference a Secret by name (a secret volume, envFrom.secretRef,
+# env.valueFrom.secretKeyRef, a projected secret source, or imagePullSecrets). At pod-create time the
+# live cluster resolves that name against the workload's OWN namespace — if nothing rendered it and
+# nothing provisioned it, the pod FailedMount's / FailedCreate's ("secret not found").
+#
+# INV-DEP-11 therefore requires every referenced Secret to be EITHER rendered by the same overlay OR
+# listed HERE as externally provisioned. This file is the audited exception list: a Secret is only
+# safe to reference-without-rendering because something else guarantees it exists in the namespace
+# before the pod schedules (the External Secrets operator syncing from Secret Manager, a bootstrap
+# Job, a sealed-secret controller, …). Each entry must say WHO provisions it and WHY it is not
+# rendered inline — an unlisted, unrendered ref fails the gate.
+#
+# Deny-closed: an EMPTY list means "no workload may reference an unrendered Secret". Today the
+# search-orchestrator promote overlays reference no Secrets at all (config is a ConfigMap; the image
+# is public GAR pulled via Workload Identity, no imagePullSecret), so the list is intentionally
+# empty. Add an entry only when a real external Secret is introduced.
+#
+# Schema:
+#   externalSecrets:
+#     - name: <secret-name>          # the metadata.name the workload references
+#       provisionedBy: <mechanism>   # e.g. "external-secrets operator (ClusterSecretStore gsm)"
+#       why: <reason not rendered>   # why it is not a rendered manifest in the overlay
+externalSecrets: []

--- a/infra/k8s/search-orchestrator/overlays/_selftest-broken/kustomization.yaml
+++ b/infra/k8s/search-orchestrator/overlays/_selftest-broken/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# NEGATIVE FIXTURE for the L1 ephemeral real-apply gate — NOT a deploy target.
+#
+# This overlay renders perfectly under `kubectl kustomize` (dry-run green) but is DELIBERATELY
+# broken the way the 2026-08-02 prod wave-deploy was: its Rollout references a ServiceAccount
+# (`search-orchestrator-selftest-missing`) that the overlay does NOT render. On a real apply the
+# ReplicaSet controller cannot create the pod and the namespace gets a `FailedCreate` Event
+# ("serviceaccount not found", 0 pods).
+#
+# .github/workflows/ephemeral-apply-preflight.yml applies ONLY this fixture and asserts the detector
+# REPORTS that failure (returns non-zero). A gate that has never fired is suspect: if the detector
+# PASSES this fixture, the job fails — proving the effect-canary has teeth.
+#
+# It is intentionally kept OUT of the INV-DEP-9/10/11 DEFAULT_OVERLAYS (those target promote/dev|
+# canary|prod only), and its parent dir starts with `_` so it is never mistaken for a promote wave.
+namespace: selftest-broken
+resources:
+  - rollout.yaml

--- a/infra/k8s/search-orchestrator/overlays/_selftest-broken/rollout.yaml
+++ b/infra/k8s/search-orchestrator/overlays/_selftest-broken/rollout.yaml
@@ -1,0 +1,32 @@
+# NEGATIVE FIXTURE (see kustomization.yaml). A blue-green-style Rollout that names a ServiceAccount
+# this overlay never renders — the exact 2026-08-02 shape. Renders clean; FailedCreate's on a real
+# apply. The image IS a real digest so the ONLY defect is the dangling ServiceAccount (the failure
+# the L1 gate must catch); do not "fix" the SA — that would disarm the self-test.
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: search-orchestrator-selftest
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: search-orchestrator-selftest
+  strategy:
+    canary:
+      steps:
+        - setWeight: 100
+  template:
+    metadata:
+      labels:
+        app: search-orchestrator-selftest
+    spec:
+      # DELIBERATELY dangling: no ServiceAccount 'search-orchestrator-selftest-missing' is rendered
+      # by this overlay, so pod-create is forbidden -> FailedCreate (0 pods).
+      serviceAccountName: search-orchestrator-selftest-missing
+      containers:
+        - name: search-orchestrator
+          image: us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator@sha256:f5b051131d2bc451c4bdd710daaa5261aee45182cc68a840c8ea7539d9d97201
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080

--- a/tools/tests/test_verify_manifest_completeness.py
+++ b/tools/tests/test_verify_manifest_completeness.py
@@ -1,0 +1,233 @@
+"""Teeth for the manifest completeness gate (INV-DEP-11).
+
+INV-DEP-9 resolves analysis-template refs; INV-DEP-10 resolves SA/ConfigMap/PVC refs. This gate
+covers the reference classes those two do NOT: Secret refs (must be rendered in-set or allowlisted)
+and image digest-pinning (every image must carry a real @sha256 digest). It must PASS the shipped
+promote overlays and FAIL a dangling secretRef, a floating-tag image, a placeholder digest, and
+malformed YAML (fail-closed). A gate that has only ever passed proves nothing.
+"""
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import verify_manifest_completeness as chk  # noqa: E402
+
+_GOOD_IMAGE = (
+    "us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator"
+    "@sha256:f5b051131d2bc451c4bdd710daaa5261aee45182cc68a840c8ea7539d9d97201"
+)
+
+# A Rollout that references a Secret NONE of the rendered docs provide — the class INV-DEP-10 does
+# not cover. Image is a real digest so ONLY the secret ref should fail.
+ROLLOUT_DANGLING_SECRET = textwrap.dedent(
+    f"""
+    apiVersion: argoproj.io/v1alpha1
+    kind: Rollout
+    metadata: {{ name: search-orchestrator, namespace: prophet-platform-prod }}
+    spec:
+      template:
+        spec:
+          containers:
+            - name: app
+              image: {_GOOD_IMAGE}
+              envFrom:
+                - secretRef: {{ name: search-orchestrator-tls }}
+    """
+)
+
+# The fixed shape: same Rollout WITH its Secret rendered alongside.
+ROLLOUT_SECRET_RENDERED = ROLLOUT_DANGLING_SECRET + textwrap.dedent(
+    """
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata: { name: search-orchestrator-tls, namespace: prophet-platform-prod }
+    """
+)
+
+ROLLOUT_FLOATING_TAG = textwrap.dedent(
+    """
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata: { name: search-orchestrator, namespace: prophet-platform-dev }
+    spec:
+      template:
+        spec:
+          containers:
+            - name: app
+              image: us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator:latest
+    """
+)
+
+ROLLOUT_PLACEHOLDER_DIGEST = textwrap.dedent(
+    """
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata: { name: search-orchestrator, namespace: prophet-platform-dev }
+    spec:
+      template:
+        spec:
+          containers:
+            - name: app
+              image: us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/search-orchestrator@sha256:REPLACE_WITH_FROZEN_DIGEST
+    """
+)
+
+ROLLOUT_ALLZEROS_DIGEST = textwrap.dedent(
+    """
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata: { name: search-orchestrator, namespace: prophet-platform-dev }
+    spec:
+      template:
+        spec:
+          containers:
+            - name: app
+              image: search-orchestrator@sha256:0000000000000000000000000000000000000000000000000000000000000000
+    """
+)
+
+
+def test_dangling_secret_ref_fails():
+    violations = chk.scan_rendered(ROLLOUT_DANGLING_SECRET, set(), "prod")
+    assert any("Secret 'search-orchestrator-tls'" in v and "not found" in v for v in violations), violations
+
+
+def test_secret_ref_passes_when_rendered():
+    assert chk.scan_rendered(ROLLOUT_SECRET_RENDERED, set(), "prod") == []
+
+
+def test_secret_ref_passes_when_allowlisted():
+    assert chk.scan_rendered(ROLLOUT_DANGLING_SECRET, {"search-orchestrator-tls"}, "prod") == []
+
+
+def test_projected_secret_source_is_checked():
+    doc = textwrap.dedent(
+        f"""
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata: {{ name: svc, namespace: ns-a }}
+        spec:
+          template:
+            spec:
+              containers: [{{ name: app, image: {_GOOD_IMAGE} }}]
+              volumes:
+                - name: proj
+                  projected:
+                    sources:
+                      - secret: {{ name: missing-secret }}
+        """
+    )
+    violations = chk.scan_rendered(doc, set(), "ns-a")
+    assert any("Secret 'missing-secret'" in v for v in violations), violations
+
+
+def test_image_pull_secret_is_checked():
+    doc = textwrap.dedent(
+        f"""
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata: {{ name: svc, namespace: ns-a }}
+        spec:
+          template:
+            spec:
+              imagePullSecrets:
+                - name: gar-pull
+              containers: [{{ name: app, image: {_GOOD_IMAGE} }}]
+        """
+    )
+    violations = chk.scan_rendered(doc, set(), "ns-a")
+    assert any("Secret 'gar-pull'" in v for v in violations), violations
+
+
+def test_floating_tag_image_fails():
+    violations = chk.scan_rendered(ROLLOUT_FLOATING_TAG, set(), "dev")
+    assert any("not digest-pinned" in v for v in violations), violations
+
+
+def test_placeholder_digest_fails():
+    violations = chk.scan_rendered(ROLLOUT_PLACEHOLDER_DIGEST, set(), "dev")
+    assert any("PLACEHOLDER digest" in v for v in violations), violations
+
+
+def test_all_zeros_digest_fails():
+    violations = chk.scan_rendered(ROLLOUT_ALLZEROS_DIGEST, set(), "dev")
+    assert any("all-zeros" in v for v in violations), violations
+
+
+def test_real_digest_passes():
+    doc = textwrap.dedent(
+        f"""
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata: {{ name: svc, namespace: ns-a }}
+        spec:
+          template:
+            spec:
+              containers: [{{ name: app, image: {_GOOD_IMAGE} }}]
+        """
+    )
+    assert chk.scan_rendered(doc, set(), "ns-a") == []
+
+
+def test_init_container_image_is_checked():
+    doc = textwrap.dedent(
+        f"""
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata: {{ name: svc, namespace: ns-a }}
+        spec:
+          template:
+            spec:
+              initContainers:
+                - name: migrate
+                  image: busybox:1.36
+              containers: [{{ name: app, image: {_GOOD_IMAGE} }}]
+        """
+    )
+    violations = chk.scan_rendered(doc, set(), "ns-a")
+    assert any("'migrate'" in v and "not digest-pinned" in v for v in violations), violations
+
+
+def test_no_workload_passes():
+    svc_only = "apiVersion: v1\nkind: Service\nmetadata: { name: svc }\n"
+    assert chk.scan_rendered(svc_only, set(), "ns-a") == []
+
+
+def test_malformed_rendered_yaml_fails_closed():
+    bad = "kind: Rollout\nspec: template: spec: [ this: not: valid : :\n"
+    violations = chk.scan_rendered(bad, set(), "prod")
+    assert violations and "not valid YAML" in violations[0]
+
+
+def test_image_digest_problem_helper():
+    assert chk.image_digest_problem(_GOOD_IMAGE) is None
+    assert chk.image_digest_problem("repo/app:latest") is not None
+    assert chk.image_digest_problem("repo/app@sha256:REPLACE_ME") is not None
+    assert chk.image_digest_problem("repo/app@sha256:" + "0" * 64) is not None
+    assert chk.image_digest_problem("repo/app@sha256:deadbeef") is not None  # too short
+    assert chk.image_digest_problem("repo/app@sha256:" + "z" * 64) is not None  # non-hex
+
+
+def test_allowlist_loads_from_repo():
+    # The shipped allowlist parses and is deny-closed (empty today) — a malformed allowlist would
+    # surface an error, never silently allow everything.
+    allowed, err = chk.load_external_secret_allowlist(Path(chk.ROOT))
+    assert err is None, err
+    assert allowed == set()
+
+
+def test_shipped_promote_overlays_render_complete():
+    import shutil
+
+    if shutil.which("kubectl") is None:
+        import pytest
+
+        pytest.skip("kubectl not available to render overlays")
+    root = Path(chk.ROOT)
+    violations = chk.check_overlays(root, chk.DEFAULT_OVERLAYS)
+    assert violations == [], f"shipped promote overlays must be reference-complete: {violations}"

--- a/tools/verify_manifest_completeness.py
+++ b/tools/verify_manifest_completeness.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Preflight (INV-DEP-11): DERIVED reference completeness for every promote overlay.
+
+INV-DEP-9 (verify_rollout_analysis_refs.py) resolves Rollout analysis-template refs and INV-DEP-10
+(verify_overlay_self_contained.py) resolves ServiceAccount / ConfigMap / PVC refs. Each of those is
+a POINT gate: someone read a live incident, named the one reference type that bit us, and hand-wrote
+a checker for it. That leaves a standing hole — the NEXT reference type a workload can name (a
+Secret, a floating image tag) reaches prod uncaught until a fresh incident teaches us to write the
+next point gate. This gate closes that hole for the reference classes 9/10 do not cover, so a novel
+ref type cannot ride to a fresh namespace and fail at create/spec time before anyone notices:
+
+    Warning  FailedMount  pod/search-orchestrator-...  secret "search-orchestrator-tls" not found
+    Warning  Failed       pod/search-orchestrator-...  Error: ErrImagePull (manifest unknown)
+
+Like 9/10 it renders each promote overlay with `kubectl kustomize` (dry-run green) and then proves
+the rendered set is COMPLETE, deny-closed, one specific reason per miss:
+
+  * SECRET refs — for every workload (Deployment/Rollout/StatefulSet/DaemonSet) it derives every
+    Secret the pod template names (volumes[].secret.secretName; envFrom[].secretRef.name;
+    env[].valueFrom.secretKeyRef.name; volumes[].projected.sources[].secret.name;
+    imagePullSecrets[].name) and requires each to be rendered in the SAME set OR listed in
+    infra/k8s/search-orchestrator/external-secrets.allowlist.yaml (externally provisioned — e.g. by
+    the External Secrets operator — with a documented reason). A ref that is neither rendered nor
+    allowlisted FailedMount's / FailedCreate's on a real apply, so it fails here.
+
+  * IMAGE digest-pinning — every container image (initContainers + containers) MUST be pinned to a
+    real `@sha256:<64 hex>` digest (INV-DEP-1/2, build-once-promote-many). A floating tag is
+    repointed under you between render and pull; a placeholder digest (contains REPLACE/PLACEHOLDER,
+    is all-zeros, or is not 64 lowercase hex) never resolves to an image (ImagePullBackOff). Either
+    fails here.
+
+It deliberately does NOT re-implement SA/ConfigMap/PVC (INV-DEP-10) or analysis-template
+(INV-DEP-9) resolution — those two are its siblings; run all three. Together they make the promote
+overlays prove, statically, that a single `kustomize build | kubectl apply` resolves every reference
+the live cluster checks at pod-create / spec-admission time.
+
+Teeth both ways: tools/tests/test_verify_manifest_completeness.py feeds shipped overlays (pass), a
+dangling secretRef, a floating-tag image, a placeholder digest (each fails), and malformed YAML
+(fail-closed). A gate that has only ever passed proves nothing.
+
+Runs static (no cluster): shells out to `kubectl kustomize`, then inspects the rendered YAML. Wired
+into `make manifest-completeness-check` (the validate-target-diagnostics matrix), alongside
+INV-DEP-9/10. The complementary L1 gate (.github/workflows/ephemeral-apply-preflight.yml) then
+actually applies each overlay to a throwaway kind namespace and asserts the same failure class does
+not occur live — static derivation here, real apply there.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+WORKLOAD_KINDS = {"Deployment", "Rollout", "StatefulSet", "DaemonSet"}
+
+# The wave overlays this gate renders by default — the SAME set INV-DEP-9/10 render. Each must
+# render (or allowlist) every Secret its workloads name and pin every image to a real digest.
+# NOTE: the negative fixture overlays/_selftest-broken is deliberately NOT in this list — it exists
+# to prove the L1 real-apply detector can fail, and must never be certified by 9/10/11.
+DEFAULT_OVERLAYS = [
+    "infra/k8s/search-orchestrator/overlays/promote/dev",
+    "infra/k8s/search-orchestrator/overlays/promote/canary",
+    "infra/k8s/search-orchestrator/overlays/promote/prod",
+]
+
+# Externally-provisioned Secrets a workload may reference without the overlay rendering them (the
+# External Secrets operator / a bootstrap job materialises them). Each entry is documented + reasoned
+# in the file; an unlisted, unrendered Secret ref fails.
+EXTERNAL_SECRETS_ALLOWLIST = "infra/k8s/search-orchestrator/external-secrets.allowlist.yaml"
+
+_HEX = set("0123456789abcdef")
+
+
+def _load_docs(text: str) -> tuple[list[dict[str, Any]], str | None]:
+    """Parse every YAML doc. Fail-closed: a parse error is surfaced, never swallowed — a
+    manifest that will not parse cannot be certified complete."""
+    try:
+        return [d for d in yaml.safe_load_all(text) if isinstance(d, dict)], None
+    except yaml.YAMLError as e:
+        return [], type(e).__name__
+
+
+def _pod_spec(doc: dict[str, Any]) -> dict[str, Any]:
+    """The pod spec inside a workload (Deployment/Rollout/StatefulSet/DaemonSet share the shape:
+    spec.template.spec)."""
+    tmpl = ((doc.get("spec") or {}).get("template") or {})
+    return tmpl.get("spec") or {}
+
+
+def _containers(pod: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    """Every image-bearing / secret-referencing container: initContainers + containers (and
+    ephemeralContainers, a strict superset — being broader is deny-closed)."""
+    for key in ("initContainers", "containers", "ephemeralContainers"):
+        for c in pod.get(key) or []:
+            if isinstance(c, dict):
+                yield c
+
+
+def workload_secret_refs(doc: dict[str, Any]) -> set[str]:
+    """Every Secret name a workload's pod template references — the classes INV-DEP-10 does NOT
+    cover: secret volumes, envFrom.secretRef, env.valueFrom.secretKeyRef, projected secret sources,
+    and imagePullSecrets."""
+    pod = _pod_spec(doc)
+    secrets: set[str] = set()
+
+    for vol in pod.get("volumes") or []:
+        if not isinstance(vol, dict):
+            continue
+        sec = vol.get("secret")
+        if isinstance(sec, dict) and sec.get("secretName"):
+            secrets.add(str(sec["secretName"]))
+        proj = vol.get("projected")
+        if isinstance(proj, dict):
+            for src in proj.get("sources") or []:
+                if isinstance(src, dict) and isinstance(src.get("secret"), dict) and src["secret"].get("name"):
+                    secrets.add(str(src["secret"]["name"]))
+
+    for c in _containers(pod):
+        for ef in c.get("envFrom") or []:
+            if isinstance(ef, dict) and isinstance(ef.get("secretRef"), dict) and ef["secretRef"].get("name"):
+                secrets.add(str(ef["secretRef"]["name"]))
+        for e in c.get("env") or []:
+            if not isinstance(e, dict):
+                continue
+            vf = e.get("valueFrom")
+            if isinstance(vf, dict) and isinstance(vf.get("secretKeyRef"), dict) and vf["secretKeyRef"].get("name"):
+                secrets.add(str(vf["secretKeyRef"]["name"]))
+
+    for ips in pod.get("imagePullSecrets") or []:
+        if isinstance(ips, dict) and ips.get("name"):
+            secrets.add(str(ips["name"]))
+
+    return secrets
+
+
+def workload_images(doc: dict[str, Any]) -> list[tuple[str, str]]:
+    """(containerName, image) for every image-bearing container in a workload."""
+    out: list[tuple[str, str]] = []
+    for c in _containers(_pod_spec(doc)):
+        image = c.get("image")
+        if image is not None:
+            out.append((str(c.get("name", "<unnamed>")), str(image)))
+    return out
+
+
+def image_digest_problem(image: str) -> str | None:
+    """Return a human reason `image` is not pinned to a REAL sha256 digest, or None if it is.
+
+    Deny-closed: a floating tag, a placeholder digest (REPLACE/PLACEHOLDER text, all-zeros, or a
+    digest that is not exactly 64 lowercase hex chars) all fail — only a genuine 64-hex digest
+    resolves to an immutable image."""
+    if "@sha256:" not in image:
+        return (
+            "is not digest-pinned (no '@sha256:' digest) — a floating tag is repointed under you "
+            "between render and pull; pin it to a sha256 digest (INV-DEP-1/2, build-once-promote-"
+            "many)"
+        )
+    if "REPLACE" in image.upper() or "PLACEHOLDER" in image.upper():
+        return (
+            "carries a PLACEHOLDER digest (contains REPLACE/PLACEHOLDER) — the promotion never "
+            "stamped the frozen digest; this pulls nothing (ImagePullBackOff)"
+        )
+    digest = image.partition("@sha256:")[2]
+    if len(digest) != 64 or any(c not in _HEX for c in digest):
+        return (
+            f"has a malformed sha256 digest {digest!r} — a real digest is exactly 64 lowercase hex "
+            f"chars; a truncated/hand-typed digest never resolves to an image"
+        )
+    if digest == "0" * 64:
+        return (
+            "has an all-zeros sha256 digest (a placeholder), never a real image "
+            "(ImagePullBackOff)"
+        )
+    return None
+
+
+def rendered_names(docs: list[dict[str, Any]], kind: str) -> set[str]:
+    out: set[str] = set()
+    for d in docs:
+        if d.get("kind") == kind:
+            name = (d.get("metadata") or {}).get("name")
+            if name:
+                out.add(str(name))
+    return out
+
+
+def ref_violations(
+    docs: list[dict[str, Any]],
+    allowed_external_secrets: set[str],
+    where: str,
+) -> list[str]:
+    """Every Secret a workload names must be rendered in the SAME set or allowlisted; every image
+    must be pinned to a real digest."""
+    rendered_secrets = rendered_names(docs, "Secret")
+    resolvable_secrets = rendered_secrets | allowed_external_secrets
+    out: list[str] = []
+    for d in docs:
+        if d.get("kind") not in WORKLOAD_KINDS:
+            continue
+        wname = (d.get("metadata") or {}).get("name", "<unnamed>")
+        kind = d.get("kind")
+        for sec in sorted(workload_secret_refs(d)):
+            if sec not in resolvable_secrets:
+                out.append(
+                    f"{where}: {kind} '{wname}' references Secret '{sec}', but this overlay does "
+                    f"not render it and it is not in {EXTERNAL_SECRETS_ALLOWLIST} — a real apply "
+                    f"FailedMount's / FailedCreate's ('secret {sec!r} not found'). Render the "
+                    f"Secret in this overlay, or add '{sec}' to the external-secrets allowlist with "
+                    f"a documented provisioner."
+                )
+        for cname, image in workload_images(d):
+            problem = image_digest_problem(image)
+            if problem is not None:
+                out.append(
+                    f"{where}: {kind} '{wname}' container '{cname}' image {image!r} {problem}."
+                )
+    return out
+
+
+def scan_rendered(
+    text: str,
+    allowed_external_secrets: set[str] | None = None,
+    where: str = "<rendered>",
+) -> list[str]:
+    """Parse rendered multi-doc YAML and return completeness violations. The test seam."""
+    docs, err = _load_docs(text)
+    if err is not None:
+        return [f"{where}: rendered output is not valid YAML ({err}); cannot certify complete"]
+    return ref_violations(docs, allowed_external_secrets or set(), where)
+
+
+def load_external_secret_allowlist(root: Path) -> tuple[set[str], str | None]:
+    """Names of externally-provisioned Secrets a workload may reference without the overlay
+    rendering them. Absent file == nothing allowlisted (deny-closed). A malformed allowlist is a
+    fail-closed error, never silently treated as empty (that would launder every dangling ref)."""
+    path = root / EXTERNAL_SECRETS_ALLOWLIST
+    if not path.exists():
+        return set(), None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        return set(), f"{EXTERNAL_SECRETS_ALLOWLIST}: cannot read ({type(e).__name__})"
+    try:
+        doc = yaml.safe_load(text)
+    except yaml.YAMLError as e:
+        return set(), f"{EXTERNAL_SECRETS_ALLOWLIST}: not valid YAML ({type(e).__name__})"
+    if doc is None:
+        return set(), None
+    if not isinstance(doc, dict):
+        return set(), f"{EXTERNAL_SECRETS_ALLOWLIST}: expected a mapping with 'externalSecrets:'"
+    names: set[str] = set()
+    for entry in doc.get("externalSecrets") or []:
+        if isinstance(entry, dict) and entry.get("name"):
+            names.add(str(entry["name"]))
+    return names, None
+
+
+def render_overlay(overlay: Path) -> tuple[str, str | None]:
+    """Render an overlay via `kubectl kustomize`. A non-zero exit is a fail-closed error."""
+    try:
+        proc = subprocess.run(
+            ["kubectl", "kustomize", str(overlay)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return "", "kubectl not found (needed to render the overlay)"
+    if proc.returncode != 0:
+        return "", f"kubectl kustomize failed (exit {proc.returncode}): {proc.stderr.strip()}"
+    return proc.stdout, None
+
+
+def check_overlays(root: Path, overlays: list[str]) -> list[str]:
+    allowed, alerr = load_external_secret_allowlist(root)
+    if alerr is not None:
+        return [alerr]
+    violations: list[str] = []
+    for rel in overlays:
+        overlay = root / rel
+        if not overlay.exists():
+            violations.append(f"{rel}: overlay path does not exist")
+            continue
+        text, err = render_overlay(overlay)
+        if err is not None:
+            violations.append(f"{rel}: {err}")
+            continue
+        violations.extend(scan_rendered(text, allowed, where=rel))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "overlays",
+        nargs="*",
+        default=DEFAULT_OVERLAYS,
+        help="overlay dirs to render + check (default: the search-orchestrator promote waves)",
+    )
+    args = ap.parse_args(argv)
+    overlays = args.overlays or DEFAULT_OVERLAYS
+    violations = check_overlays(ROOT, overlays)
+    if violations:
+        print("Manifest completeness check FAILED (INV-DEP-11):", file=sys.stderr)
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        return 1
+    allowed, _ = load_external_secret_allowlist(ROOT)
+    print(
+        f"OK: {len(overlays)} overlay(s) render every Secret their workloads reference "
+        f"(allowlisted external: {sorted(allowed) or 'none'}) and pin every image to a digest."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## The failure class this automates away

On 2026-08-02 a prod blue-green deploy repeatedly reached the cluster with manifests that `kubectl kustomize` rendered **green** but the LIVE cluster rejected at **create/spec time** — a defect class dry-run rendering structurally cannot see:

- overlay referenced a `ServiceAccount`/`ConfigMap`/`PVC` it never rendered → `FailedCreate: serviceaccount not found`, 0 pods
- Rollout referenced a namespaced `AnalysisTemplate` not in its namespace → `InvalidSpec: AnalysisTemplate not found`, Degraded
- placeholder/floating image → `ImagePullBackOff`

Each was caught **only by the real apply**. Two point-gates already exist for this ("dry-run green, apply red"): INV-DEP-9 (analysis refs) and INV-DEP-10 (SA/ConfigMap/PVC). This PR **extends that family, it does not replace it.**

## L2 — `tools/verify_manifest_completeness.py` (INV-DEP-11), derived completeness

One derived checker for the reference classes 9/10 do **not** cover, so a novel ref type can't reach prod before someone hand-writes a gate:

- **Secret refs** (`volumes[].secret.secretName`, `envFrom[].secretRef.name`, `env[].valueFrom.secretKeyRef.name`, `volumes[].projected.sources[].secret.name`, `imagePullSecrets[].name`) — each must be rendered in-set **or** listed in the new `infra/k8s/search-orchestrator/external-secrets.allowlist.yaml` (documented + reasoned). Unresolved + not allowlisted = fail.
- **Image digest-pinning** — every container image (initContainers + containers) must be `@sha256:`+64 hex; floating tag or placeholder digest (REPLACE/PLACEHOLDER, all-zeros, non-hex) = fail.

Same structure as its siblings: fail-closed YAML parse, `scan_rendered(text, where)` seam, `render_overlay` via `kubectl kustomize`, same `DEFAULT_OVERLAYS`. Does **not** re-implement SA/ConfigMap/PVC or analysis refs — references INV-DEP-9/10 as siblings. Teeth in `tools/tests/test_verify_manifest_completeness.py` (passes shipped overlays; fails on dangling secretRef, floating tag, placeholder digest, malformed YAML). Wired into `make manifest-completeness-check` and the `validate-target-diagnostics` matrix (`target:` list + the kubectl-setup `if:` condition).

## L1 — ephemeral real-apply preflight (the effect-canary as a continuous gate)

`.github/workflows/ephemeral-apply-preflight.yml` stands up a hermetic `kind` cluster, installs argo-rollouts CRDs + controller (+ the shared `slo-gate` ClusterAnalysisTemplate), and **actually applies** each promote overlay to a throwaway namespace. Apply+assert logic lives in `.github/app-ci/ephemeral-apply-assert.sh` (testable, not trapped in YAML):

- **FAIL** on any namespace Event reason `FailedCreate`, or a Rollout/Deployment `InvalidSpec`.
- **PASS** as soon as a pod is created + scheduled (Pending/ContainerCreating) — proving SA/ConfigMap/PVC/AnalysisTemplate resolved. The real GAR image can't pull in kind, so we gate **only on create/spec signals, never image pull**, and do not wait for Ready.
- Tears down always.

### Never-fired == suspect (the teeth)

Negative fixture `infra/k8s/search-orchestrator/overlays/_selftest-broken/` — a Rollout naming a ServiceAccount the overlay does not render. The workflow applies **only** the fixture first and **fails the job unless the detector reports `FailedCreate`** (returns non-zero). If the detector passes the broken fixture, the gate is toothless and the job goes red. The fixture is kept **out** of the INV-DEP-9/10/11 `DEFAULT_OVERLAYS` (promote/dev|canary|prod only) and its dir is `_`-prefixed.

## Docs

`docs/RESILIENCE_ENGINEERING.md`: the failure class, the layered plan (L1/L2 shipped; L3 blast-radius-on-refactor, L4 evidence-ref verification, L5 local=CI parity, L6 auto-remediation, + cross-cutting last-fired gate registry declared), and the INV-DEP-6/9/10/11 + ephemeral-apply mapping.

## Local proof (gates pass on real overlays, fail on broken fixtures)

```
$ make manifest-completeness-check
OK: 3 overlay(s) render every Secret their workloads reference (allowlisted external: none) and pin every image to a digest.   # exit 0

$ python3 -m pytest -q tools/tests/test_verify_manifest_completeness.py
15 passed          # incl. dangling secretRef, floating tag, placeholder digest, all-zeros, malformed-YAML fail-closed

$ python3 tools/verify_rollout_analysis_refs.py && python3 tools/verify_overlay_self_contained.py   # no regression, both exit 0
$ bash -n .github/app-ci/ephemeral-apply-assert.sh    # clean
$ actionlint .github/workflows/ephemeral-apply-preflight.yml   # OK

# negative fixture is genuinely broken (INV-DEP-10 flags its dangling SA):
$ kubectl kustomize .../_selftest-broken | python3 -c "...verify_overlay_self_contained.scan_rendered..."
_selftest-broken: Rollout 'search-orchestrator-selftest' sets serviceAccountName 'search-orchestrator-selftest-missing', but this overlay does not render a ServiceAccount ... FailedCreate's ... (0 pods).
```

Could not run `kind` locally, so L1's live behavior isn't exercised here — the negative fixture is the can-fail proof, and the workflow is actionlint-clean with the namespace-rewrite pipeline verified against real renders.

Do not merge — coordinator reviews and merges. cc @mdheller