### PR TITLE
feat(embeddings): route memoryd embeddings through a governed receipt-gateway

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -64,6 +64,7 @@ jobs:
           - { image: regis-acr-api,         context: apps/regis-acr-api,        dockerfile: Dockerfile }
           - { image: commons-search,        context: apps/commons-search,       dockerfile: Dockerfile }
           - { image: embeddings,           context: apps/embeddings,           dockerfile: Dockerfile }
+          - { image: receipt-gateway,      context: apps/receipt-gateway,      dockerfile: Dockerfile }
           - { image: reasoning-failure-runner, context: apps/reasoning-failure-runner, dockerfile: Dockerfile }
           - { image: search-gateway,        context: apps/search-gateway,        dockerfile: Dockerfile }
           - { image: sherlock-engine,       context: apps/sherlock-engine,       dockerfile: Dockerfile }

--- a/apps/receipt-gateway/Dockerfile
+++ b/apps/receipt-gateway/Dockerfile
@@ -1,0 +1,31 @@
+# Receipt-emitting inference gateway — a transparent proxy that fronts an OpenAI-compatible
+# embeddings/completions backend and emits a schema-conformant, hash-chained InferenceReceipt
+# for every call (SEAM-011: durable, non-local ledger). Self-contained build context
+# (apps/receipt-gateway) so it slots into the images.yml matrix like the other first-party apps.
+FROM python:3.12-slim
+
+WORKDIR /app
+RUN pip install --no-cache-dir "jsonschema>=4.0.0"
+
+COPY tools/inference_receipt_emitter.py tools/receipt_gateway.py /app/tools/
+COPY schemas/model-plane/InferenceReceipt.schema.json /app/schemas/model-plane/
+
+# Run unprivileged; own the ledger dir so a mounted volume inherits the right ownership.
+RUN useradd --system --uid 10001 --create-home gateway \
+    && mkdir -p /var/lib/receipt-gateway \
+    && chown -R gateway:gateway /var/lib/receipt-gateway /app
+
+# Ledger persists on a mounted volume (SEAM-011: durable, non-local ledger).
+ENV RECEIPT_GATEWAY_LEDGER=/var/lib/receipt-gateway/ledger.jsonl \
+    RECEIPT_GATEWAY_HOST=0.0.0.0 \
+    RECEIPT_GATEWAY_PORT=8898 \
+    RECEIPT_GATEWAY_BACKEND=http://embeddings:8080
+VOLUME ["/var/lib/receipt-gateway"]
+EXPOSE 8898
+USER gateway
+
+# RECEIPT_GATEWAY_MODEL_DIGEST(S) is provided at deploy time (the served model's real digest).
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD ["python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8898/health',timeout=2).status==200 else 1)"]
+
+ENTRYPOINT ["python", "tools/receipt_gateway.py", "--serve"]

--- a/apps/receipt-gateway/README.md
+++ b/apps/receipt-gateway/README.md
@@ -1,0 +1,44 @@
+# receipt-gateway
+
+The estate's **governed inference seam**: a transparent, OpenAI-compatible proxy that fronts an
+inference/embeddings backend and emits a schema-conformant, **hash-chained `InferenceReceipt`** for every
+call. Point a consumer's `OPENAI_BASE_URL` / `EMBEDDINGS_URL` at this gateway and every completion or
+embedding becomes receipted — **no per-service code change**.
+
+## What it does
+
+- Forwards `/v1/chat/completions` and `/v1/embeddings` (and the Ollama-native `/api/chat`,
+  `/api/generate`, `/api/embeddings`, `/api/embed`) to `RECEIPT_GATEWAY_BACKEND`, preserving client
+  headers (e.g. `Authorization`) and returning the backend's exact response.
+- On a successful non-streaming JSON response, emits an `InferenceReceipt` with the backend's **real**
+  usage token counts and real input/output hashes, appended to a durable ledger (`RECEIPT_GATEWAY_LEDGER`,
+  SEAM-011: durable non-local ledger). Each receipt chains to the previous via `ledgerPrevHash`.
+- Passes non-inference paths (`/health`, `/healthz`, and anything unrecognised) straight through.
+- Exit codes: `0` ok · `1` conformance failure · `2` usage/infra error.
+
+## How it's used in prophet-platform
+
+`memoryd` (`deploy/values/memoryd.yaml`) sets `EMBEDDINGS_URL` to this gateway instead of straight at the
+`embeddings` service, so its semantic vectors are receipted. `RECEIPT_GATEWAY_BACKEND` forwards to
+`http://embeddings:8080`. Deployed via the reusable `charts/socioprophet-service` chart with
+`deploy/values/receipt-gateway.yaml`; built by `.github/workflows/images.yml` like every other first-party
+app; listed in `deploy/argocd/platform-services.yaml`.
+
+## Configuration (env)
+
+| Var | Purpose |
+| --- | --- |
+| `RECEIPT_GATEWAY_BACKEND` | Upstream OpenAI-compatible server (default `http://embeddings:8080`). |
+| `RECEIPT_GATEWAY_HOST` / `RECEIPT_GATEWAY_PORT` | Listen address (default `0.0.0.0:8898`). |
+| `RECEIPT_GATEWAY_LEDGER` | Append-only receipt ledger path (on the mounted PVC). |
+| `RECEIPT_GATEWAY_MODEL_DIGESTS` | JSON `{model: digest}` map so each receipt records the served model's real digest. |
+| `RECEIPT_GATEWAY_MODEL_DIGEST` / `_MODEL_PATH` | Single-model digest, or a weights path to hash, when not using the map. |
+
+## Provenance
+
+Vendored from the estate's contract repo `SociOS-Linux/workstation-contracts`
+(`tools/receipt_gateway.py`, `tools/inference_receipt_emitter.py`,
+`schemas/model-plane/InferenceReceipt.schema.json`) at commit
+`c7c1071e4d4adfbf8ed73efe4609e48a7d9e5f68` — the same source and pin the Noetica compose overlay uses. This
+is a first-party estate component (dogfooding the model-plane spec), not a third-party dependency. Re-vendor
+from that repo when the gateway or the `InferenceReceipt` schema changes upstream.

--- a/apps/receipt-gateway/schemas/model-plane/InferenceReceipt.schema.json
+++ b/apps/receipt-gateway/schemas/model-plane/InferenceReceipt.schema.json
@@ -1,0 +1,360 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.srcos.ai/v2/InferenceReceipt.json",
+  "title": "InferenceReceipt",
+  "description": "VENDORED from SourceOS-Linux/sourceos-spec (Tranche 7, canonical owner). Provenance receipt emitted for every model-plane completion (Tranche 7 / Model Plane). Identifies the tier, the content-addressed base model / adapter / tokenizer digests, the serving daemon and provider, the data-residency class the request was served under, and the escalation chain if any. This is the provenance primitive that makes on-device inference auditable: it references the existing Model Carry family (InferenceProvider, ModelResidency, SourceOSModelCarryRef) rather than restating it. Receipts are ledger-bound; a local-only ledger is not permitted (SEAM-011).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "type",
+    "specVersion",
+    "issuedAt",
+    "providerDaemon",
+    "tier",
+    "baseModelDigest",
+    "task",
+    "inputHash",
+    "outputHash",
+    "dataResidencyClass",
+    "ledgerSeq"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^urn:srcos:inference-receipt:",
+      "description": "Stable URN identifier. Pattern: urn:srcos:inference-receipt:<local-id>"
+    },
+    "type": {
+      "const": "InferenceReceipt",
+      "description": "Discriminator constant \u2014 always \"InferenceReceipt\"."
+    },
+    "specVersion": {
+      "type": "string",
+      "description": "Spec version of this document, e.g. \"2.1.0\"."
+    },
+    "issuedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the completion finished and the receipt was issued."
+    },
+    "requestingAgentRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:agent-passport:",
+      "description": "AgentPassport URN of the agent that requested the inference. Null only for internal system-initiated inference."
+    },
+    "requestingAgentClass": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "system_core",
+        "intelligence_automation",
+        "app_helper",
+        "legacy_bridge",
+        "third_party",
+        null
+      ],
+      "description": "Mirror of the requesting agent's AgentPassport.agent_class, for at-a-glance audit. Authoritative source is the referenced passport."
+    },
+    "capabilityLeaseRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:lease:",
+      "description": "AgentCapabilityLease URN authorizing this provider connection. Null is only valid for on_device_only T0 system inference; any non-on_device_only receipt MUST carry a lease (enforced below)."
+    },
+    "providerDaemon": {
+      "type": "string",
+      "enum": [
+        "inferenced",
+        "embeddingd",
+        "visiond",
+        "distilld"
+      ],
+      "description": "The model-plane serving daemon that produced this completion. Note: modelplaned is a catalog authority and does not perform inference, so it never emits an InferenceReceipt."
+    },
+    "providerRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:inference-provider:",
+      "description": "InferenceProvider URN backing the serving daemon."
+    },
+    "tier": {
+      "type": "string",
+      "enum": [
+        "T0",
+        "T1",
+        "T2",
+        "T3",
+        "T4"
+      ],
+      "description": "Placement tier that served the request. Tier boundaries are data-residency boundaries (Model Plane \u00a7II)."
+    },
+    "baseModelDigest": {
+      "type": "string",
+      "pattern": "^sha256:[a-fA-F0-9]{64}$",
+      "description": "Content-addressed digest of the base model weights that served the request."
+    },
+    "adapterDigest": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^sha256:[a-fA-F0-9]{64}$",
+      "description": "Content-addressed digest of the active LoRA adapter, or null when the base model served the request with no adapter."
+    },
+    "tokenizerDigest": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^sha256:[a-fA-F0-9]{64}$",
+      "description": "Content-addressed digest of the tokenizer used."
+    },
+    "modelCarryRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:model-carry-ref:",
+      "description": "SourceOSModelCarryRef URN under which the model was carried/authorized."
+    },
+    "modelResidencyRef": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^urn:srcos:model-residency:",
+      "description": "ModelResidency URN observed at serving time."
+    },
+    "task": {
+      "type": "string",
+      "description": "Task label the request was routed as, e.g. summarization, embedding, agent_classification, ocr-recognize."
+    },
+    "inputHash": {
+      "type": "string",
+      "pattern": "^sha256:[a-fA-F0-9]{64}$",
+      "description": "Hash of the canonical input. The receipt records that an inference occurred and over what, not the content."
+    },
+    "inputTokenCount": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "description": "Input token count, or null for non-text modalities."
+    },
+    "outputHash": {
+      "type": "string",
+      "pattern": "^sha256:[a-fA-F0-9]{64}$",
+      "description": "Hash of the canonical output."
+    },
+    "outputTokenCount": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "description": "Output token count, or null for non-text modalities."
+    },
+    "confidence": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Model-reported confidence used for the escalation trigger, or null when not estimated."
+    },
+    "confidenceMethod": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "logit-entropy",
+        "verbalized",
+        "calibration-head",
+        "downstream-validation",
+        "none",
+        null
+      ],
+      "description": "How `confidence` was derived. REVIEW HARDENING (Model Plane OQ1 / finding: confidence is the load-bearing escalation gate and is self-reported): recording the method makes the number auditable and lets downstream calibration checks run. A null method with a non-null confidence should be treated as uncalibrated."
+    },
+    "latencyMs": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "description": "End-to-end serving latency in milliseconds."
+    },
+    "escalatedFrom": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "T0",
+        "T1",
+        "T2",
+        "T3",
+        null
+      ],
+      "description": "The tier this request was escalated FROM, or null if served at first placement. Must be null when dataResidencyClass is on_device_only (enforced below)."
+    },
+    "escalationChain": {
+      "type": "array",
+      "description": "Ordered EscalationDecision URNs recording each tier/residency boundary this request crossed. Empty when served at first placement.",
+      "items": {
+        "type": "string",
+        "pattern": "^urn:srcos:escalation-decision:"
+      }
+    },
+    "dataResidencyClass": {
+      "type": "string",
+      "enum": [
+        "on_device_only",
+        "sovereign_cluster",
+        "external_permitted"
+      ],
+      "description": "The residency class this completion was served under. Any class other than on_device_only means the input crossed a data boundary and MUST be accompanied by a lease and a non-empty escalation chain (enforced below; SEAM-015)."
+    },
+    "computeDevice": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "ane",
+        "gpu",
+        "cpu",
+        "npu",
+        "remote",
+        null
+      ],
+      "description": "Hardware path that executed the compute."
+    },
+    "ledgerSeq": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Monotonic sequence number of this receipt in the append-only ledger."
+    },
+    "ledgerPrevHash": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^sha256:[a-fA-F0-9]{64}$",
+      "description": "REVIEW HARDENING (finding: the ledger is the trust anchor for every Model Plane provenance claim but `ledgerSeq` alone does not bind entry N to N-1). Hash of the prior ledger entry, making the ledger tamper-evident/hash-chained so an enumerated contribution list cannot be retroactively rewritten."
+    },
+    "evidenceHash": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^sha256:[a-fA-F0-9]{64}$",
+      "description": "Hash of the canonical receipt evidence payload."
+    },
+    "evidenceRefs": {
+      "type": "array",
+      "description": "Additional evidence URNs or content hashes.",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "SEAM-015: a completion served off-device (not on_device_only) must carry both an authorizing capability lease and a non-empty escalation chain. Possession of the output is not authorization for the crossing.",
+      "if": {
+        "properties": {
+          "dataResidencyClass": {
+            "enum": [
+              "sovereign_cluster",
+              "external_permitted"
+            ]
+          }
+        },
+        "required": [
+          "dataResidencyClass"
+        ]
+      },
+      "then": {
+        "required": [
+          "capabilityLeaseRef",
+          "escalatedFrom",
+          "escalationChain"
+        ],
+        "properties": {
+          "capabilityLeaseRef": {
+            "type": "string"
+          },
+          "escalatedFrom": {
+            "type": "string",
+            "enum": [
+              "T0",
+              "T1",
+              "T2",
+              "T3"
+            ]
+          },
+          "escalationChain": {
+            "minItems": 1
+          }
+        }
+      }
+    },
+    {
+      "$comment": "An on_device_only completion cannot have been escalated from a lower tier.",
+      "if": {
+        "properties": {
+          "dataResidencyClass": {
+            "const": "on_device_only"
+          }
+        },
+        "required": [
+          "dataResidencyClass"
+        ]
+      },
+      "then": {
+        "properties": {
+          "escalatedFrom": {
+            "const": null
+          }
+        }
+      }
+    },
+    {
+      "$comment": "REVIEW HARDENING (ledger tamper-evidence): any non-genesis entry (ledgerSeq >= 1) must carry the prior entry's hash, so the append-only ledger is hash-chained and an enumerated contribution list cannot be retroactively rewritten.",
+      "if": {
+        "properties": {
+          "ledgerSeq": {
+            "minimum": 1
+          }
+        },
+        "required": [
+          "ledgerSeq"
+        ]
+      },
+      "then": {
+        "required": [
+          "ledgerPrevHash"
+        ],
+        "properties": {
+          "ledgerPrevHash": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/apps/receipt-gateway/tools/inference_receipt_emitter.py
+++ b/apps/receipt-gateway/tools/inference_receipt_emitter.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""InferenceReceipt emitter + hash-chained ledger (reference implementation).
+
+This is the emitter side of the Model Plane: when an inference completes, it writes a
+schema-conformant, hash-chained InferenceReceipt to an append-only ledger (SEAM-011:
+no local-only ledger; the chain makes it tamper-evident). The receipt/ledger machinery
+is REAL and self-proven here; wiring it to a live model is one call to `emit_receipt`.
+
+HONEST BOUNDARY: no local model runs (no weights present), so `--selftest` exercises the
+emitter with clearly-labelled synthetic completions (task "selftest"). It proves the
+emitter produces conformant receipts and an unbroken, tamper-evident chain — NOT that a
+real LLM completion occurred. Point `emit_receipt` at a real provider to emit real receipts.
+
+exit 0 ok; 1 = conformance/chain failure; 2 = usage error.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from collections import deque
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import fcntl  # POSIX advisory locking (Linux/macOS)
+except ImportError:  # pragma: no cover
+    fcntl = None
+
+try:
+    import jsonschema
+except ImportError:
+    print("ERR: jsonschema not installed", file=sys.stderr)
+    sys.exit(2)
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "schemas" / "model-plane" / "InferenceReceipt.schema.json"
+
+_UNSET = object()  # distinguishes "estimate it" from an explicit None (record null)
+
+
+def sha256(s: str) -> str:
+    return "sha256:" + hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+def canonical(obj: dict) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"))
+
+
+def _last_entry(f) -> dict | None:
+    """Last non-blank ledger entry, constant memory (deque(maxlen=1) over the file)."""
+    f.seek(0)
+    tail = deque((line for line in f if line.strip()), maxlen=1)
+    return json.loads(tail[0]) if tail else None
+
+
+def emit_receipt(ledger: Path, *, base_model_digest: str, task: str, input_text: str,
+                 output_text: str, provider_daemon: str = "inferenced", tier: str = "T1",
+                 tokenizer_digest: str | None = None, compute_device: str = "cpu",
+                 input_token_count=_UNSET, output_token_count=_UNSET) -> dict:
+    """Append one on-device InferenceReceipt to the hash-chained ledger, return it.
+
+    Read-tail + append happen under an exclusive advisory lock so concurrent emitters
+    cannot race into duplicate ledgerSeq or a broken chain (single-writer per entry).
+    """
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    with ledger.open("a+", encoding="utf-8") as f:
+        if fcntl is not None:
+            fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            prev = _last_entry(f)
+            seq = (prev["ledgerSeq"] + 1) if prev else 0
+            receipt = {
+                "id": f"urn:srcos:inference-receipt:{task}-{seq}",
+                "type": "InferenceReceipt",
+                "specVersion": "2.1.0",
+                "issuedAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "providerDaemon": provider_daemon,
+                "tier": tier,
+                "baseModelDigest": base_model_digest,
+                "tokenizerDigest": tokenizer_digest,
+                "task": task,
+                "inputHash": sha256(input_text),
+                # real provider token counts when supplied; explicit None -> null (e.g.
+                # embeddings have no output tokens); _UNSET -> a whitespace estimate.
+                "inputTokenCount": len(input_text.split()) if input_token_count is _UNSET else input_token_count,
+                "outputHash": sha256(output_text),
+                "outputTokenCount": len(output_text.split()) if output_token_count is _UNSET else output_token_count,
+                "dataResidencyClass": "on_device_only",
+                "escalatedFrom": None,
+                "escalationChain": [],
+                "computeDevice": compute_device,
+                "ledgerSeq": seq,
+            }
+            if seq >= 1:
+                # hash-chain: bind this entry to the canonical prior entry (SEAM-011)
+                receipt["ledgerPrevHash"] = sha256(canonical(prev))
+            f.write(canonical(receipt) + "\n")
+            f.flush()
+        finally:
+            if fcntl is not None:
+                fcntl.flock(f, fcntl.LOCK_UN)
+    return receipt
+
+
+def verify_ledger(ledger: Path, validator: "jsonschema.Draft202012Validator") -> tuple[bool, str]:
+    if not ledger.exists():
+        return False, f"ledger not found: {ledger}"
+    try:
+        lines = [l for l in ledger.read_text(encoding="utf-8").splitlines() if l.strip()]
+    except OSError as exc:
+        return False, f"cannot read ledger: {exc}"
+    prev = None
+    for i, line in enumerate(lines):
+        try:
+            r = json.loads(line)
+        except json.JSONDecodeError as exc:
+            return False, f"entry {i} is not valid JSON: {exc}"
+        errs = sorted(validator.iter_errors(r), key=lambda e: list(e.path))
+        if errs:
+            return False, f"entry {i} schema-invalid: {errs[0].message}"
+        if r["ledgerSeq"] != i:
+            return False, f"entry {i} has ledgerSeq {r['ledgerSeq']} (expected {i})"
+        if i >= 1:
+            expect = sha256(canonical(prev))
+            if r.get("ledgerPrevHash") != expect:
+                return False, f"entry {i} chain broken: ledgerPrevHash != hash(entry {i-1})"
+        prev = r
+    return True, f"{len(lines)} receipts: schema-conformant + unbroken hash-chain"
+
+
+def _selftest() -> int:
+    import tempfile
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    jsonschema.Draft202012Validator.check_schema(schema)
+    validator = jsonschema.Draft202012Validator(schema)
+    # A REAL model content-address (from the local ollama manifest); the completion is
+    # synthetic self-test data — no model is run here.
+    digest = "sha256:aabd4debf0c8f08881923f2c25fc0fdeed24435271c2b3e92c4af36704040dbc"
+    with tempfile.TemporaryDirectory() as d:
+        ledger = Path(d) / "ledger.jsonl"
+        for i in range(3):
+            emit_receipt(ledger, base_model_digest=digest, task="selftest",
+                         input_text=f"selftest prompt {i}", output_text=f"selftest completion {i}")
+        ok, msg = verify_ledger(ledger, validator)
+        if not ok:
+            print(f"FAIL selftest: {msg}", file=sys.stderr)
+            return 1
+        print(f"OK emitter: {msg}")
+        # Tamper-evidence (teeth both ways): mutate entry 1, chain must break.
+        lines = ledger.read_text(encoding="utf-8").splitlines()
+        e1 = json.loads(lines[1]); e1["outputHash"] = sha256("tampered")
+        lines[1] = canonical(e1); ledger.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        ok, msg = verify_ledger(ledger, validator)
+        if ok:
+            print("FAIL selftest: tamper NOT detected — chain has no teeth", file=sys.stderr)
+            return 1
+        print(f"OK tamper-evidence: mutation detected — {msg}")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) >= 2 and argv[1] == "--selftest":
+        return _selftest()
+    print("usage: inference_receipt_emitter.py --selftest", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/apps/receipt-gateway/tools/receipt_gateway.py
+++ b/apps/receipt-gateway/tools/receipt_gateway.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Receipt-emitting inference gateway — how the WHOLE estate gets receipts.
+
+A drop-in transparent proxy in front of any OpenAI-compatible provider (llama-server,
+vLLM, ollama, …): it forwards /v1/chat/completions to the backend (preserving client
+headers like Authorization) and, on a successful non-streaming JSON response, emits a
+schema-conformant, hash-chained InferenceReceipt with the backend's REAL usage token
+counts and real input/output hashes. Point an estate service's OPENAI_BASE_URL at this
+gateway and every completion gets a receipt — no per-service code change.
+
+Residency: the emitted receipt is on_device_only (the reference backend is local). An
+off-device/enterprise backend needs the escalation-grant path and is out of scope here.
+
+Modes:
+  --serve     run the proxy (threaded). Env: RECEIPT_GATEWAY_BACKEND, _MODEL_DIGEST or
+              _MODEL_PATH, _LEDGER, _HOST (default 127.0.0.1), _PORT (default 8898).
+  --selftest  forward ONE real request to the backend, emit + validate a receipt.
+exit 0 ok; 1 = conformance failure; 2 = usage/infra error.
+"""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlsplit
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from inference_receipt_emitter import canonical, emit_receipt  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND = os.environ.get("RECEIPT_GATEWAY_BACKEND", "http://127.0.0.1:8899").rstrip("/")
+LEDGER = Path(os.environ.get("RECEIPT_GATEWAY_LEDGER",
+                             ROOT / "evidence" / "model-plane" / "gateway-ledger.jsonl"))
+_FORWARD_HEADERS = ("authorization", "content-type", "openai-organization", "openai-project")
+
+
+@functools.lru_cache(maxsize=1)
+def _single_digest() -> str | None:
+    """The single-model digest (env or hashed weights path), or None. Cached: the weights
+    path is hashed at most once, not per request."""
+    d = os.environ.get("RECEIPT_GATEWAY_MODEL_DIGEST")
+    if d:
+        return d
+    p = os.environ.get("RECEIPT_GATEWAY_MODEL_PATH")
+    if p and Path(p).exists():
+        h = hashlib.sha256()
+        with open(p, "rb") as f:
+            for chunk in iter(lambda: f.read(1 << 20), b""):
+                h.update(chunk)
+        return "sha256:" + h.hexdigest()
+    return None
+
+
+def model_digest() -> str:
+    d = _single_digest()
+    if not d:
+        raise RuntimeError("set RECEIPT_GATEWAY_MODEL_DIGEST or RECEIPT_GATEWAY_MODEL_PATH")
+    return d
+
+
+# Per-request model -> digest map for multi-model backends (e.g. ollama serving several
+# models): {"qwen2.5:7b": "sha256:...", ...}. Kept only if it decodes to a str->str object.
+try:
+    _raw_map = json.loads(os.environ.get("RECEIPT_GATEWAY_MODEL_DIGESTS", "{}"))
+    _DIGEST_MAP: dict = ({k: v for k, v in _raw_map.items() if isinstance(v, str)}
+                         if isinstance(_raw_map, dict) else {})
+except (json.JSONDecodeError, ValueError):
+    _DIGEST_MAP = {}
+
+
+def _resolve_digest(model: str | None) -> str | None:
+    """Digest for the request's model; None means 'unknown' — forward but emit no receipt
+    (never fabricate a content digest, never stamp the wrong model). When a map is
+    configured it is AUTHORITATIVE (a named-but-unmapped model → None); with no map the
+    single-model digest applies to every request (single-model gateway)."""
+    if _DIGEST_MAP:
+        return _DIGEST_MAP.get(model)
+    return _single_digest()
+
+
+def _req_model(body: bytes) -> str | None:
+    try:
+        return json.loads(body).get("model")
+    except (json.JSONDecodeError, ValueError, AttributeError):
+        return None
+
+
+_CHAT = "/v1/chat/completions"
+_EMBED = "/v1/embeddings"
+_SUPPORTED = (_CHAT, _EMBED)
+
+
+def _messages_text(req: dict) -> str:
+    return "\n".join(f"{m.get('role')}: {m.get('content', '')}" for m in req.get("messages", []))
+
+
+def _embed_input_text(req: dict) -> str:
+    # /v1/embeddings input may be a string, list[str], or token-ID arrays (list[int] /
+    # list[list[int]]); stringify items so hashing never crashes on non-strings.
+    inp = req.get("input", "")
+    return "\n".join(str(x) for x in inp) if isinstance(inp, list) else str(inp)
+
+
+def _maybe_emit(path: str, req_body: bytes, resp_bytes: bytes, content_type: str,
+                digest: str | None) -> None:
+    """Emit the right receipt for a real, non-streaming JSON response."""
+    if digest is None:
+        return  # unknown model digest — forward the call, but don't fabricate a receipt
+    if "application/json" not in content_type.lower():
+        return  # streaming (SSE) or non-JSON error body — pass through, no receipt
+    try:
+        body = json.loads(resp_bytes)
+        req = json.loads(req_body)
+    except (json.JSONDecodeError, ValueError):
+        return
+    usage = body.get("usage") or {}
+    if path == _CHAT:
+        output = ((body.get("choices") or [{}])[0].get("message") or {}).get("content")
+        if not isinstance(output, str):
+            return  # tool-call / null content — nothing to hash as a completion
+        emit_receipt(LEDGER, base_model_digest=digest, task="chat.completion",
+                     input_text=_messages_text(req), output_text=output,
+                     provider_daemon="inferenced", tier="T1", compute_device="cpu",
+                     input_token_count=usage.get("prompt_tokens"),
+                     output_token_count=usage.get("completion_tokens"))
+    elif path == _EMBED:
+        vectors = [d.get("embedding") for d in (body.get("data") or [])]
+        if not vectors or not all(isinstance(v, list) for v in vectors):
+            return
+        # hash the real returned vectors; embeddings are a T0 workload with no output tokens
+        emit_receipt(LEDGER, base_model_digest=digest, task="embedding",
+                     input_text=_embed_input_text(req), output_text=canonical(vectors),
+                     provider_daemon="embeddingd", tier="T0", compute_device="cpu",
+                     input_token_count=usage.get("prompt_tokens"), output_token_count=None)
+
+
+def forward_and_receipt(path: str, req_body: bytes, digest: str, headers: dict | None = None
+                        ) -> tuple[int, str, bytes]:
+    """Forward to the backend path, return its (status, content-type, body); emit on success."""
+    fwd = {k: v for k, v in (headers or {}).items() if k.lower() in _FORWARD_HEADERS}
+    fwd.setdefault("Content-Type", "application/json")
+    r = urllib.request.Request(f"{BACKEND}{path}", data=req_body, headers=fwd, method="POST")
+    try:
+        with urllib.request.urlopen(r, timeout=300) as resp:
+            raw, status = resp.read(), resp.status
+            ctype = resp.headers.get("Content-Type", "application/json")
+    except urllib.error.HTTPError as e:  # non-2xx: return the backend's real error, no receipt
+        return e.code, e.headers.get("Content-Type", "application/json"), e.read()
+    _maybe_emit(path, req_body, raw, ctype, digest)
+    return status, ctype, raw
+
+
+# Ollama-native endpoints (e.g. noetica's OLLAMA_HOST) — translated to the OpenAI backend
+# so they get receipts too. Non-streaming (stream is forced false to the backend).
+_OLLAMA = ("/api/chat", "/api/generate", "/api/embeddings", "/api/embed")
+
+
+def _ollama_forward(path: str, req_body: bytes, digest: str, headers: dict | None
+                    ) -> tuple[int, str, bytes]:
+    try:
+        req = json.loads(req_body)
+    except (json.JSONDecodeError, ValueError):
+        return 400, "application/json", b'{"error":"invalid JSON"}'
+    model = req.get("model", "")
+    if path in ("/api/chat", "/api/generate"):
+        msgs = (req.get("messages") if path == "/api/chat"
+                else [{"role": "user", "content": req.get("prompt", "")}]) or []
+        oai = {"messages": msgs, "stream": False}
+        num = (req.get("options") or {}).get("num_predict")
+        if num:
+            oai["max_tokens"] = num
+        status, ctype, raw = forward_and_receipt(_CHAT, json.dumps(oai).encode(), digest, headers)
+        if not (200 <= status < 300) or "application/json" not in ctype.lower():
+            return status, ctype, raw  # pass backend error through
+        try:
+            body = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            return status, ctype, raw  # backend mislabeled/invalid JSON — pass through, don't crash
+        content = ((body.get("choices") or [{}])[0].get("message") or {}).get("content", "")
+        usage = body.get("usage") or {}
+        out = ({"model": model, "message": {"role": "assistant", "content": content}, "done": True}
+               if path == "/api/chat"
+               else {"model": model, "response": content, "done": True})
+        out["prompt_eval_count"], out["eval_count"] = usage.get("prompt_tokens"), usage.get("completion_tokens")
+        return 200, "application/json", json.dumps(out).encode()
+    # /api/embeddings (legacy single) or /api/embed (multi)
+    inp = req.get("input", req.get("prompt", ""))
+    status, ctype, raw = forward_and_receipt(_EMBED, json.dumps({"input": inp}).encode(),
+                                             digest, headers)
+    if not (200 <= status < 300) or "application/json" not in ctype.lower():
+        return status, ctype, raw
+    try:
+        data = json.loads(raw).get("data") or []
+    except (json.JSONDecodeError, ValueError):
+        return status, ctype, raw  # backend mislabeled/invalid JSON — pass through
+    vectors = [d.get("embedding") for d in data]
+    out = ({"embedding": vectors[0] if vectors else []} if path == "/api/embeddings"
+           else {"model": model, "embeddings": vectors})
+    return 200, "application/json", json.dumps(out).encode()
+
+
+# hop-by-hop / length headers we must not copy verbatim from the upstream response
+_HOP = {"connection", "keep-alive", "transfer-encoding", "content-length",
+        "content-encoding", "te", "trailers", "upgrade"}
+
+
+def _passthrough(method: str, full_path: str, body: bytes | None, headers: dict | None
+                 ) -> tuple[int, dict, bytes]:
+    """Transparently proxy an unhandled path to the backend (no receipt), preserving the
+    path+query and forwarding upstream response headers — so pointing OLLAMA_HOST/
+    OPENAI_BASE_URL at the gateway doesn't break or alter non-inference endpoints
+    (e.g. Ollama /api/tags, /api/show; OpenAI /v1/models)."""
+    sp = urlsplit(full_path)  # normalize (handles absolute-form request targets)
+    upstream = sp.path + (f"?{sp.query}" if sp.query else "")
+    fwd = {k: v for k, v in (headers or {}).items() if k.lower() in _FORWARD_HEADERS}
+    r = urllib.request.Request(f"{BACKEND}{upstream}", data=body, headers=fwd, method=method)
+    try:
+        with urllib.request.urlopen(r, timeout=300) as resp:
+            hdrs = {k: v for k, v in resp.headers.items() if k.lower() not in _HOP}
+            return resp.status, hdrs, resp.read()
+    except urllib.error.HTTPError as e:
+        hdrs = {k: v for k, v in e.headers.items() if k.lower() not in _HOP}
+        return e.code, hdrs, e.read()
+
+
+def _handler():
+    class H(BaseHTTPRequestHandler):
+        def _respond(self, status: int, ctype: str, raw: bytes) -> None:
+            self.send_response(status)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+        def _respond_full(self, status: int, hdrs: dict, raw: bytes) -> None:
+            self.send_response(status)
+            for k, v in hdrs.items():
+                self.send_header(k, v)
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+        def do_GET(self):
+            if urlsplit(self.path).path.rstrip("/") in ("/health", "/healthz"):
+                return self._respond(200, "application/json", b'{"status":"ok"}')
+            try:  # everything else: transparent passthrough (upstream headers preserved)
+                status, hdrs, raw = _passthrough("GET", self.path, None, dict(self.headers))
+            except urllib.error.URLError as exc:
+                self.send_error(502, f"backend unreachable: {exc}"); return
+            self._respond_full(status, hdrs, raw)
+
+        def do_POST(self):
+            path = urlsplit(self.path).path.rstrip("/")  # ignore any query string for routing
+            n = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(n)
+            digest = _resolve_digest(_req_model(body))  # per-request; None -> forward, no receipt
+            try:
+                if path in _SUPPORTED:
+                    status, ctype, raw = forward_and_receipt(path, body, digest, dict(self.headers))
+                    self._respond(status, ctype, raw)
+                elif path in _OLLAMA:
+                    status, ctype, raw = _ollama_forward(path, body, digest, dict(self.headers))
+                    self._respond(status, ctype, raw)
+                else:  # unhandled: transparent passthrough (no receipt, upstream headers preserved)
+                    status, hdrs, raw = _passthrough("POST", self.path, body, dict(self.headers))
+                    self._respond_full(status, hdrs, raw)
+            except urllib.error.URLError as exc:  # backend unreachable
+                self.send_error(502, f"backend unreachable: {exc}")
+
+        def log_message(self, *a):
+            pass
+    return H
+
+
+def _selftest() -> int:
+    try:
+        import jsonschema
+        from inference_receipt_emitter import verify_ledger
+    except ImportError as exc:
+        print(f"ERR: {exc}", file=sys.stderr); return 2
+    try:
+        digest = model_digest()
+    except RuntimeError as exc:
+        print(f"ERR: {exc}", file=sys.stderr); return 2
+    req = json.dumps({"messages": [{"role": "user", "content":
+                     "In one sentence, what is a knowledge graph?"}], "max_tokens": 40}).encode()
+    try:
+        status, _ctype, _raw = forward_and_receipt(_CHAT, req, digest)
+    except urllib.error.URLError as exc:
+        print(f"ERR: backend forward failed (is a provider at {BACKEND}?): {exc}", file=sys.stderr)
+        return 2
+    schema = json.loads((ROOT / "schemas" / "model-plane" / "InferenceReceipt.schema.json").read_text())
+    ok, msg = verify_ledger(LEDGER, jsonschema.Draft202012Validator(schema))
+    if not ok:
+        print(f"FAIL gateway: {msg}", file=sys.stderr); return 1
+    print(f"OK gateway: forwarded a real /v1/chat/completions (backend {status}) and emitted a receipt")
+    print(f"    ledger: {msg}")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--selftest" in argv:
+        return _selftest()
+    if "--serve" in argv:
+        if not _DIGEST_MAP and not _single_digest():
+            print("WARN: no RECEIPT_GATEWAY_MODEL_DIGEST(S) set — requests are forwarded but "
+                  "no receipts are emitted (a receipt needs the model's real digest)", file=sys.stderr)
+        host = os.environ.get("RECEIPT_GATEWAY_HOST", "127.0.0.1")
+        port = int(os.environ.get("RECEIPT_GATEWAY_PORT", "8898"))
+        print(f"receipt-gateway on {host}:{port} -> {BACKEND} (receipts -> {LEDGER}; "
+              f"{len(_DIGEST_MAP)} mapped model(s){', +single' if _single_digest() else ''})")
+        ThreadingHTTPServer((host, port), _handler()).serve_forever()
+        return 0
+    print("usage: receipt_gateway.py --serve | --selftest", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -59,6 +59,7 @@ spec:
           - { name: cloud-twin, tier: reference }                # Cloud-Twin as a Service — genesis/twin lifecycle (GenesisSeed → verified Twin → replayable events)
           - { name: memoryd, tier: foundation }                  # memory-plane daemon — contract other services call
           - { name: embeddings, tier: reference }                # swappable embedder (fogstack literally swaps it out)
+          - { name: receipt-gateway, tier: reference }           # governed inference seam — fronts embeddings, emits a hash-chained InferenceReceipt per call
           - { name: regis-acr-api, tier: reference }             # registry ACR product API
           - { name: node-commander, tier: foundation }           # node runtime command door — compute-doctrine control contract
           - { name: liberty-stack-readout, tier: reference }     # readout/reporting surface

--- a/deploy/values/memoryd.yaml
+++ b/deploy/values/memoryd.yaml
@@ -10,9 +10,12 @@ config:
   # resize to this), so the store MUST match the embedder or inserts mismatch. HashingEmbedder honours it
   # too, so this is safe whether the semantic endpoint is reachable at boot or not.
   MEMORYMESH_VECTOR_SIZE: "768"
-  # Sovereign semantic embeddings (Ollama /v1/embeddings). If unreachable at startup, memoryd logs and
-  # falls back to the hashing embedder — never mixes vector spaces. See infra/k8s/embeddings/base.
-  EMBEDDINGS_URL: "http://embeddings.socioprophet.svc.cluster.local:8080/v1/embeddings"
+  # Sovereign semantic embeddings, routed through the receipt-gateway (deploy/values/receipt-gateway.yaml)
+  # so every embedding call gets a governed, hash-chained InferenceReceipt — the gateway forwards
+  # transparently to the `embeddings` service and returns the same /v1/embeddings response, so memoryd is
+  # unchanged. If unreachable at startup, memoryd logs and falls back to the hashing embedder — never mixes
+  # vector spaces. See infra/k8s/embeddings/base and apps/receipt-gateway.
+  EMBEDDINGS_URL: "http://receipt-gateway.socioprophet.svc.cluster.local:8898/v1/embeddings"
   EMBEDDINGS_MODEL: "nomic-embed-text"
   # KMASS baseline (2026-08-01): mesh-qdrant (infra/k8s/mesh-qdrant) existed but was never
   # registered with ArgoCD, so this was always false against an unreachable URL. The code

--- a/deploy/values/receipt-gateway.yaml
+++ b/deploy/values/receipt-gateway.yaml
@@ -1,0 +1,40 @@
+# receipt-gateway — the estate's governed inference seam. A transparent OpenAI-compatible proxy that
+# fronts the sovereign `embeddings` service (apps/embeddings, /v1/embeddings) and emits a schema-conformant,
+# hash-chained InferenceReceipt for every embedding call (SEAM-011: durable, non-local ledger). memoryd's
+# EMBEDDINGS_URL points here instead of straight at `embeddings`, so semantic vectors become receipted with
+# NO app code change — the same "eat our own dogfood" governance the model-plane spec mandates.
+#
+# Reference tier: a replaceable governance surface in FRONT of the embedder. First-party ⇒ built by
+# images.yml, so no image.registry override (inherits the platform default; the preflight contract asserts it).
+# tag:latest is the bootstrap for a brand-new service; gitops-promote sha-pins it after the first build.
+image: { repository: receipt-gateway, tag: latest }
+
+# The gateway listens on 8898 (its Dockerfile default). memoryd + any other consumer reach it here.
+service: { port: 8898, portName: http }
+
+config:
+  # Forward to the sovereign embedder. Non-inference paths pass straight through. FQDN (matches memoryd's
+  # convention) so it resolves regardless of the gateway pod's namespace.
+  RECEIPT_GATEWAY_BACKEND: "http://embeddings.socioprophet.svc.cluster.local:8080"
+  RECEIPT_GATEWAY_HOST: "0.0.0.0"
+  RECEIPT_GATEWAY_PORT: "8898"
+  # Hash-chained ledger on the persistent volume (SEAM-011). readOnlyRootFilesystem ⇒ the ledger MUST live
+  # on the mounted PVC, not the image FS.
+  RECEIPT_GATEWAY_LEDGER: "/var/lib/receipt-gateway/ledger.jsonl"
+  # Model→digest map so each receipt records the REAL served model digest (not a guessed single value).
+  # NOTE: this is the upstream nomic-embed-text registry digest; gitops should pin it to the digest baked
+  # into the `embeddings` image's model manifest once that is surfaced (tracked as a follow-up). A receipt
+  # with a stale/foreign digest still proves "an embedding happened", but digest fidelity is the goal.
+  RECEIPT_GATEWAY_MODEL_DIGESTS: '{"nomic-embed-text":"sha256:970aa74c0a90ef7482477cf803618e776e173c007bf957f635f1015bfcfef0e6"}'
+
+# Durable ledger. Single-writer append-only file on a ReadWriteOnce PVC.
+persistence: { enabled: true, storageClass: dynamic-rwo, size: 1Gi, mountPath: /var/lib/receipt-gateway }
+# Single-writer on an RWO PVC: RollingUpdate can deadlock (new pod created before the old releases the
+# volume). Recreate tears the old pod down first — the chart's guidance for persistent single-writer services.
+strategy: { type: Recreate }
+autoscaling: { enabled: false }
+replicaCount: 1
+
+resources:
+  requests: { cpu: 50m, memory: 64Mi }
+  limits:   { cpu: 500m, memory: 256Mi }

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -168,6 +168,12 @@ KNOWN_BROKEN = {
         "New service — first-party embeddings image (apps/embeddings, FastAPI + nomic-embed-text) added to CI "
         "this PR. Pin tag:latest -> the sha- tag after the first CI build; no sha exists until merge."
     ),
+    "receipt-gateway:moving-tag": (
+        "New service — first-party receipt-gateway image (apps/receipt-gateway: transparent OpenAI-compatible "
+        "proxy that fronts embeddings and emits a hash-chained InferenceReceipt per call) gets its Dockerfile + "
+        "images.yml build entry in this PR. Pin tag:latest -> the sha- tag after the first CI build; none exists "
+        "until merge."
+    ),
     "catalog-gateway:moving-tag": (
         "New service — first-party catalog-gateway image (apps/catalog-gateway: the read/resolve/lineage + DCAT "
         "interop seam over the Crystal Atlas catalog families) gets its Dockerfile + images.yml build entry in "


### PR DESCRIPTION
## Why
Every inference/embedding call in the estate should carry a governed `InferenceReceipt`, not just Noetica's. This puts the model-plane **receipt gateway** in front of the sovereign `embeddings` service, so memoryd's semantic vectors become receipted with **no app code change** — the "eat our own dogfood" governance the model-plane spec mandates, mirroring the Noetica compose overlay (#601).

## What
- **`apps/receipt-gateway/`** — vendored from `SociOS-Linux/workstation-contracts@c7c1071e` (`receipt_gateway.py`, `inference_receipt_emitter.py`, `InferenceReceipt.schema.json`) + a self-contained `Dockerfile` (non-root uid 10001, RO-rootfs friendly, ledger on a mounted volume) + `README` (provenance + repo ontology). A transparent OpenAI-compatible proxy: forwards `/v1/embeddings` (and `/v1/chat/completions`, Ollama-native paths) to the backend and emits a schema-conformant, **hash-chained** `InferenceReceipt` per call.
- **`.github/workflows/images.yml`** — build `receipt-gateway` like every other first-party app.
- **`deploy/values/receipt-gateway.yaml`** — fronting service (`socioprophet-service` chart); `RECEIPT_GATEWAY_BACKEND → embeddings:8080`; durable ledger PVC (SEAM-011); `Recreate` strategy (single-writer RWO).
- **`deploy/argocd/platform-services.yaml`** — register `receipt-gateway` (reference tier).
- **`deploy/values/memoryd.yaml`** — `EMBEDDINGS_URL → receipt-gateway:8898/v1/embeddings`. memoryd is unchanged and already degrades to the hashing embedder if the URL is unreachable, so this adds governance, not fragility.
- **`tools/preflight_deploy_contract.py`** — register the new service's bootstrap `tag:latest` deferral (gitops sha-pins after the first build).

## Verification
- `helm template` renders correctly: probe `/healthz:8898`, ledger PVC at `/var/lib/receipt-gateway`, non-root, RO rootfs.
- `preflight_deploy_contract` + `verify_probe_contract` pass (exit 0).
- **Live run** of the vendored gateway: forwards a real `/v1/embeddings` (768-dim) **and** emits a schema-VALID hash-chained `InferenceReceipt`.

## Follow-up
`RECEIPT_GATEWAY_MODEL_DIGESTS` currently carries the upstream nomic-embed-text registry digest; gitops should pin it to the digest baked into the `embeddings` image's model manifest for full digest fidelity (filed separately).