### PR TITLE
feat(resilience): Phase 2 — blast-radius on refactor (L3, INV-DEP-12) + local=CI parity (make preflight, L5)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Example pre-push hook (L5): run `make preflight` before a push so path-breaks and gate
+# failures surface locally, in minutes, instead of in CI after a slow round-trip.
+#
+# This hook is NOT auto-installed. Opt in with:
+#
+#     git config core.hooksPath .githooks
+#
+# To bypass it for a single push (e.g. pushing a WIP branch on purpose):
+#
+#     git push --no-verify
+#
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+echo "pre-push: running \`make preflight\` (local == CI parity) ..."
+if ! make preflight; then
+  echo "pre-push: preflight FAILED — push aborted. Fix the legs above, or bypass with 'git push --no-verify'." >&2
+  exit 1
+fi
+echo "pre-push: preflight passed."

--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -106,6 +106,7 @@ jobs:
           - rollout-analysis-refs-check
           - overlay-self-contained-check
           - manifest-completeness-check
+          - no-dangling-path-refs-check
           - fips-conformance-check
           - imageschemanet-grounding-check
     steps:
@@ -124,6 +125,18 @@ jobs:
           python-version: '3.11'
       - name: Install Python validator dependencies
         run: python -m pip install --upgrade pip pyyaml jsonschema
+      # The blast-radius gate (INV-DEP-12) diffs HEAD against the merge-base with origin/main, so
+      # it needs full history — the default checkout above is shallow (fetch-depth: 1). Deepen
+      # only for this one target so the other ~34 legs keep their cheap shallow clone. The gate
+      # is fail-closed, so an un-deepened repo would turn it RED rather than passing blindly.
+      - name: Deepen history for the blast-radius gate (INV-DEP-12 needs the merge-base)
+        if: matrix.target == 'no-dangling-path-refs-check'
+        run: |
+          set -euo pipefail
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            git fetch --no-tags --unshallow origin || git fetch --no-tags --depth=1000 origin
+          fi
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
       - name: Run target
         run: make ${{ matrix.target }}
 

--- a/Makefile
+++ b/Makefile
@@ -636,3 +636,28 @@ imageschemanet-grounding-check:
 	python3 -m pip install --quiet 'rdflib==7.6.0' 'pytest>=8,<9'
 	python3 tools/imageschema_ground.py
 	python3 -m pytest -q tools/tests/test_imageschema_ground.py
+
+.PHONY: no-dangling-path-refs-check
+# Blast-radius on refactor (INV-DEP-12): a PR that MOVES/RENAMES/DELETES a repo path must not
+# leave any surviving tracked file still referencing the OLD path. That break renders/parses
+# clean and only fails when the path is dereferenced — the same "looks fine, fails later" class
+# as INV-DEP-9/10, here for repo-path refs. It actually happened: moving
+# infra/k8s/search-orchestrator/base/configmap.yaml -> base-support/ silently broke
+# tools/validate_search_orchestrator_academy_deploy.py, which hard-coded the old base/ path;
+# only CI caught it, after push. tools/verify_no_dangling_path_refs.py diffs HEAD against the
+# merge-base with origin/main and fails on a surviving old-path reference (proven both ways by
+# tools/tests/test_verify_no_dangling_path_refs.py). NEEDS FULL GIT HISTORY — in CI, check out
+# with fetch-depth: 0 (or `git fetch --unshallow`); it is fail-closed if it cannot diff.
+no-dangling-path-refs-check:
+	python3 tools/verify_no_dangling_path_refs.py
+
+.PHONY: preflight
+# Local == CI parity (L5): run the fast, hermetic subset of the REQUIRED validate-target-
+# diagnostics matrix locally, in minutes, so path-breaks and gate failures surface BEFORE push
+# instead of only in CI after it. Includes the static ref-resolution + blast-radius gates
+# (INV-DEP-9/10/12) and the tools test suite; EXCLUDES the slow/infra-heavy legs (kind, go
+# build, per-app venvs, docker) and the CI-only real-apply/digest-exists preflight (those still
+# run in CI). Prints a PASS / what-to-fix summary and exits non-zero if any leg fails.
+# See docs/RESILIENCE_ENGINEERING.md. Opt into the pre-push hook: git config core.hooksPath .githooks
+preflight:
+	python3 tools/run_preflight.py

--- a/docs/RESILIENCE_ENGINEERING.md
+++ b/docs/RESILIENCE_ENGINEERING.md
@@ -1,6 +1,7 @@
 # Resilience Engineering — deploy-time failure classes and the layered gates that close them
 
-Status: Phase 1 (L1 + L2) shipped. L3–L6 are declared, not yet built.
+Status: Phase 1 (L1 + L2) and Phase 2 (L3 + L5) shipped. L4, L6, and the cross-cutting
+last-fired gate registry are declared, not yet built.
 
 ## The failure class we are automating away
 
@@ -29,9 +30,9 @@ continuous gate, not a thing we learn in prod.
 |---|---|---|
 | **L1** | **Ephemeral real-apply preflight.** Stand up a hermetic `kind` cluster, install argo-rollouts CRDs + controller, ACTUALLY apply each promote overlay to a throwaway namespace, and assert the create/spec failure class does not occur. The effect-canary as a continuous gate. | **shipped** |
 | **L2** | **Derived reference completeness (INV-DEP-11).** One checker that derives and resolves the reference types the point-gates do NOT cover (Secrets, image digest-pinning), so a novel ref type can't reach prod before someone hand-writes a gate for it. | **shipped** |
-| L3 | **Blast-radius-on-refactor.** When a shared resource (a base, a ClusterAnalysisTemplate, a support kustomization) changes, compute which overlays/waves it affects and re-render/apply exactly those — refuse a refactor whose blast radius is unproven. | future |
+| **L3** | **Blast-radius-on-refactor (INV-DEP-12).** A git-diff-aware gate: when a PR deletes or renames a path, fail if any tracked file still references the old path — the exact break that moving `base/configmap.yaml` → `base-support/` caused (the academy-deploy validator hardcoded the old path). `make no-dangling-path-refs-check`. | **shipped** |
 | L4 | **Evidence-ref verification.** Every claim a gate makes (a digest exists, a series is present, a receipt is sealed) must resolve to real evidence, not a string that looks right — extend the "reference resolves" discipline from cluster objects to evidence artifacts. | future |
-| L5 | **Local == CI parity.** The commands a developer runs locally must be byte-for-byte the commands CI runs (`pytest` == `python -m pytest`, same make target, same interpreter), so "green on my machine" and "green in CI" cannot diverge. | future |
+| **L5** | **Local == CI parity (`make preflight`).** One target runs the fast, hermetic required-matrix legs locally (validate-repo, drift/standards/topology, the INV-DEP-9/10/11/12 gates, tools tests) so path-breaks and gate failures surface before push, not after. Opt-in `.githooks/pre-push` runs it. Infra-heavy legs (kind, go, docker) stay CI-only. | **shipped** |
 | L6 | **Auto-remediation.** When a derived gate knows the fix (render the missing SA, pin the floating tag), offer/produce the patch, not just the refusal. | future |
 | — | **Last-fired gate registry (cross-cutting).** A control that has never fired is suspect. Every gate here records when it last actually FAILED on something (the negative fixtures included), so a gate that has only ever passed is flagged for an adversarial review rather than trusted. L1's negative fixture is the first entry. | future |
 
@@ -64,3 +65,55 @@ a resolvable overlay (must pass) and a dangling ref (must fail). L1 carries a ne
 overlay does not render — and the workflow applies ONLY that fixture and fails the job unless the
 detector reports the `FailedCreate` (returns non-zero). A gate that has only ever passed proves
 nothing; the fixture is the standing proof that this one can still fail.
+
+## Runbook — the shipped Phase 2 gates
+
+## L3 — `make no-dangling-path-refs-check` (INV-DEP-12)
+
+Blast-radius on refactor. A git-diff-aware gate: it computes the paths a PR **deleted or
+renamed-away** (`git diff --diff-filter=DR` against the merge-base with `origin/main`) and fails
+if any surviving tracked file still references one of those old paths.
+
+- **The incident it prevents.** `infra/k8s/search-orchestrator/base/configmap.yaml` was correctly
+  factored out to `.../base-support/configmap.yaml`, but
+  `tools/validate_search_orchestrator_academy_deploy.py` had the old `base/` path hard-coded. The
+  move was invisible to that consumer; the validator only went red in CI, after push. This gate
+  catches that shape in the diff.
+- **No false positives.** It matches the full old path or a path suffix of ≥ 2 segments
+  (`base/configmap.yaml`), on path boundaries — never a bare shared basename like
+  `kustomization.yaml`, which unrelated files legitimately share.
+- **Fail-closed.** If git is unavailable or the diff cannot be computed, it exits non-zero. In CI
+  it needs full history, so its matrix leg checks out with `fetch-depth: 0`.
+- **Testable seam.** The core is `scan(removed_paths, tree_files)` — pure, git-free, unit-tested
+  both ways in `tools/tests/test_verify_no_dangling_path_refs.py`.
+
+## L5 — `make preflight` (local == CI parity)
+
+Runs the fast, hermetic subset of the required `validate-target-diagnostics` matrix locally, in
+minutes, so a developer catches path-breaks and gate failures **before** pushing. Each leg is the
+same `make` target CI runs, so a green preflight predicts a green matrix for those legs.
+
+```
+make preflight
+```
+
+Included legs: `validate-repo`, `drift-check`, `standards-check`, `topology-check`,
+`rollout-analysis-refs-check`, `overlay-self-contained-check`, `no-dangling-path-refs-check`,
+`test-tools`. It prints a PASS / what-to-fix summary and exits non-zero if any leg fails.
+
+**Deliberately excluded** (they stay in CI, never in preflight): the L1 real-apply / digest-exists
+preflight and the `wave-promote` GATE chain (need registry/cluster credentials); `kind`,
+`test-go`, the per-app venv suites (`app-test-diagnostics`), `docker`, and the smoke matrix. These
+are infra-heavy or non-hermetic — running them on a laptop would make preflight slow and flaky,
+defeating its purpose. They remain fully covered by the required CI matrix.
+
+### Opt into the pre-push hook
+
+`.githooks/pre-push` runs `make preflight` before every push. It is **not** auto-installed; opt in
+per clone:
+
+```
+git config core.hooksPath .githooks
+```
+
+Bypass for a single push (e.g. a deliberate WIP branch) with `git push --no-verify`.

--- a/docs/standards/deploy-wave-invariants-v0.md
+++ b/docs/standards/deploy-wave-invariants-v0.md
@@ -173,6 +173,40 @@ any apply.
 
 ---
 
+## INV-DEP-12 — A refactor MUST NOT leave a dangling repo-path reference (blast-radius on move/rename/delete)
+
+A PR that MOVES, RENAMES, or DELETES a repo path MUST NOT leave any surviving tracked file still
+referencing that path by its **old** name. A hard-coded path is just a string: renaming the file
+it points at does not touch the string, so the reference silently rots. Nothing in the diff of
+the *moved* file can reveal the break — it only surfaces when something dereferences the path at
+run time. This is the same "renders/parses clean, fails on use" class as INV-DEP-9 (a namespaced
+cluster ref), lifted to *repo-path* references.
+
+*Rationale.* `infra/k8s/search-orchestrator/base/configmap.yaml` was correctly factored out to
+`.../base-support/configmap.yaml` so the prod blue-green overlay could render it. But
+`tools/validate_search_orchestrator_academy_deploy.py` had the old `.../base/configmap.yaml`
+path hard-coded in its required-files list. The move was invisible to that consumer; the
+validator only went RED in CI, AFTER push. A diff-time gate would have caught it before the push
+(and `make preflight`, L5, runs it locally).
+
+*Fail-closed / no-false-positive distinction.* The check computes the paths deleted or
+renamed-away between HEAD and the merge-base with `origin/main`, then searches the CURRENT tree
+(tracked files only) for a surviving literal reference to each old path — matching the full path
+OR a path suffix of ≥ 2 segments (e.g. `base/configmap.yaml`), on path boundaries, and NEVER a
+bare shared basename (`kustomization.yaml`) which two unrelated files can legitimately share. A
+surviving reference to a now-missing path FAILS with `file:line` and the missing path. If git is
+unavailable, or the merge-base / diff cannot be computed, the gate FAILS — a gate that cannot
+compute blast-radius must not pass. (In CI this needs full history: check out with
+`fetch-depth: 0`.)
+
+*Enforced by.* `tools/verify_no_dangling_path_refs.py` (pure `scan()` seam, proven both ways by
+`tools/tests/test_verify_no_dangling_path_refs.py` — a still-referenced removed path fails, an
+all-references-updated rename and a bare-basename collision are both clean); `make
+no-dangling-path-refs-check` in the required `validate-target-diagnostics` matrix (with
+`fetch-depth: 0`); and locally via `make preflight`. See also `docs/RESILIENCE_ENGINEERING.md`.
+
+---
+
 ## Conformance checklist
 
 | # | Check | Command |
@@ -187,3 +221,7 @@ any apply.
 | 8 | Digest-exists (incl. GAR) + lock-provenance gates, both ways (INV-DEP-6/7) | `python3 -m pytest -q tools/tests/test_verify_pinned_digest_exists.py tools/tests/test_apply_search_orchestrator_image_lock.py` |
 | 9 | First-party refs point at a pullable registry — GAR/zot, not ghcr (INV-DEP-8) | `python3 tools/preflight_deploy_contract.py` |
 | 10 | Overlays self-contained — every Rollout analysis ref resolves (INV-DEP-9) | `python3 tools/verify_rollout_analysis_refs.py` (+ `python3 -m pytest -q tools/tests/test_verify_rollout_analysis_refs.py`) |
+| 11 | Workloads self-contained — every SA/ConfigMap/PVC a pod names is rendered (INV-DEP-10) | `python3 tools/verify_overlay_self_contained.py` (+ `python3 -m pytest -q tools/tests/test_verify_overlay_self_contained.py`) |
+| 12 | Workloads complete — every Secret rendered/allowlisted + every image digest-pinned (INV-DEP-11) | `python3 tools/verify_manifest_completeness.py` (+ `python3 -m pytest -q tools/tests/test_verify_manifest_completeness.py`) |
+| 13 | No dangling repo-path reference after a move/rename/delete (INV-DEP-12) | `python3 tools/verify_no_dangling_path_refs.py` (+ `python3 -m pytest -q tools/tests/test_verify_no_dangling_path_refs.py`) |
+| 14 | Local == CI parity: the fast required matrix, run locally (L5) | `make preflight` |

--- a/tools/run_preflight.py
+++ b/tools/run_preflight.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""`make preflight` (L5): local == CI parity.
+
+Runs the fast, hermetic subset of the REQUIRED `validate-target-diagnostics` matrix locally so
+a developer catches path-breaks and gate failures BEFORE pushing, instead of only in CI after a
+slow round-trip. Each leg is an existing `make` target, run exactly as CI runs it, so a green
+preflight means those legs will be green in CI too.
+
+INCLUDED (fast + hermetic, laptop-runnable in minutes):
+  * validate-repo, drift-check, standards-check, topology-check   — repo/standards/topology gates
+  * rollout-analysis-refs-check, overlay-self-contained-check     — static ref-resolution (INV-DEP-9/10)
+  * no-dangling-path-refs-check                                   — blast-radius on refactor (INV-DEP-12)
+  * test-tools                                                    — the tools/ pytest suite
+
+DELIBERATELY EXCLUDED — these stay in CI, never in preflight:
+  * the ephemeral real-apply / digest-exists preflight and the wave-promote GATE chain (need
+    cluster/registry credentials),
+  * kind, `go build`/test-go, per-app venvs (app-test-diagnostics), docker and the smoke matrix.
+  These are infra-heavy or non-hermetic; running them on a laptop would make preflight slow and
+  flaky, defeating its purpose. They remain fully covered by the required CI matrix.
+
+Prints a PASS / what-to-fix summary and exits non-zero if any leg fails.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Order matters only for readability: cheapest gates first, the pytest suite last.
+LEGS: list[str] = [
+    "validate-repo",
+    "drift-check",
+    "standards-check",
+    "topology-check",
+    "rollout-analysis-refs-check",
+    "overlay-self-contained-check",
+    "manifest-completeness-check",
+    "no-dangling-path-refs-check",
+    "test-tools",
+]
+
+# Legs that shell out to `kubectl kustomize` to render overlays. Without kubectl they fail
+# closed (correct in CI), but locally we want to tell the developer WHY rather than dump a
+# confusing traceback.
+_NEEDS_KUBECTL = {
+    "rollout-analysis-refs-check",
+    "overlay-self-contained-check",
+    "manifest-completeness-check",
+}
+
+
+def _run_leg(target: str) -> tuple[bool, float, str]:
+    start = time.monotonic()
+    proc = subprocess.run(
+        ["make", target],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    dur = time.monotonic() - start
+    ok = proc.returncode == 0
+    output = (proc.stdout or "") + (proc.stderr or "")
+    return ok, dur, output
+
+
+def main() -> int:
+    kubectl = shutil.which("kubectl") is not None
+    print("make preflight (L5) — local == CI parity for the fast, hermetic required matrix")
+    print(f"  running {len(LEGS)} leg(s) from {ROOT}\n")
+    if not kubectl:
+        print(
+            "  NOTE: kubectl not found — the overlay-render gates (INV-DEP-9/10) will fail "
+            "closed. Install kubectl to run them locally (`brew install kubectl`).\n"
+        )
+
+    results: list[tuple[str, bool, float]] = []
+    failures: list[tuple[str, str]] = []
+    for target in LEGS:
+        label = target + (" (needs kubectl)" if target in _NEEDS_KUBECTL and not kubectl else "")
+        print(f"  -> {label} ...", flush=True)
+        ok, dur, output = _run_leg(target)
+        results.append((target, ok, dur))
+        status = "PASS" if ok else "FAIL"
+        print(f"     {status} ({dur:.1f}s)")
+        if not ok:
+            failures.append((target, output))
+
+    print("\n" + "=" * 72)
+    total = sum(d for _, _, d in results)
+    for target, ok, dur in results:
+        mark = "PASS" if ok else "FAIL"
+        print(f"  [{mark}] {target:<32} {dur:6.1f}s")
+    print(f"  total: {total:.1f}s")
+    print("=" * 72)
+
+    if not failures:
+        print(
+            "\nPREFLIGHT PASSED. The fast required-matrix legs are green locally. The infra-heavy "
+            "legs (kind, test-go, per-app venvs, docker, smoke) and the CI-only real-apply / "
+            "digest-exists preflight still run in CI."
+        )
+        return 0
+
+    print(f"\nPREFLIGHT FAILED — {len(failures)} leg(s) need attention:\n")
+    for target, output in failures:
+        print(f"----- {target} -----")
+        tail = "\n".join(output.rstrip().splitlines()[-25:])
+        print(tail if tail else "(no output captured)")
+        print()
+    print("Fix the leg(s) above, then re-run `make preflight`. Do not push until it is green.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_verify_no_dangling_path_refs.py
+++ b/tools/tests/test_verify_no_dangling_path_refs.py
@@ -1,0 +1,155 @@
+"""Teeth for the blast-radius-on-refactor gate (INV-DEP-12).
+
+Proven both ways, and against the exact incident that motivated it: a moved file whose OLD
+path is still hard-coded somewhere must FLAG; a move whose references were all updated must be
+CLEAN; a bare shared basename (two `kustomization.yaml`) must NOT be a false positive; and a
+rename whose consumers point at the NEW path must be CLEAN. A gate that has only ever passed
+proves nothing.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import verify_no_dangling_path_refs as chk  # noqa: E402
+
+
+# (a) A removed path still referenced by another file -> flagged, with file:line + missing path.
+def test_removed_path_still_referenced_is_flagged():
+    removed = ["infra/k8s/search-orchestrator/base/configmap.yaml"]
+    tree = {
+        "tools/validate_search_orchestrator_academy_deploy.py": (
+            "REQUIRED = [\n"
+            '    "infra/k8s/search-orchestrator/base/configmap.yaml",\n'
+            "]\n"
+        ),
+    }
+    violations = chk.scan(removed, tree)
+    assert len(violations) == 1, violations
+    v = violations[0]
+    assert "tools/validate_search_orchestrator_academy_deploy.py:2" in v
+    assert "infra/k8s/search-orchestrator/base/configmap.yaml" in v
+
+
+# The real 2026-08-02 incident: the file was MOVED to base-support/, but a consumer kept the
+# old base/ path. That is a rename-away whose old path survives as a hard-coded ref.
+def test_academy_deploy_incident_shape_is_flagged():
+    removed = ["infra/k8s/search-orchestrator/base/configmap.yaml"]
+    tree = {
+        "tools/validate_search_orchestrator_academy_deploy.py": (
+            '"infra/k8s/search-orchestrator/base/configmap.yaml": ["expected-key"],\n'
+        ),
+        # the new location exists and is referenced correctly elsewhere — irrelevant to the flag
+        "infra/k8s/search-orchestrator/base-support/kustomization.yaml": (
+            "resources:\n  - configmap.yaml\n"
+        ),
+    }
+    violations = chk.scan(removed, tree)
+    assert any("base/configmap.yaml" in v for v in violations), violations
+
+
+# (b) A removed path with all references updated to the new path -> clean.
+def test_all_references_updated_is_clean():
+    removed = ["infra/k8s/search-orchestrator/base/configmap.yaml"]
+    tree = {
+        "tools/validate_search_orchestrator_academy_deploy.py": (
+            '"infra/k8s/search-orchestrator/base-support/configmap.yaml": ["expected-key"],\n'
+        ),
+    }
+    assert chk.scan(removed, tree) == []
+
+
+# (c) A bare-basename collision (two files named kustomization.yaml) -> NOT flagged.
+def test_bare_basename_collision_is_not_flagged():
+    removed = ["infra/k8s/search-orchestrator/base/kustomization.yaml"]
+    tree = {
+        # a DIFFERENT kustomization.yaml, referenced by its own distinct path
+        "infra/k8s/rollouts/base/kustomization.yaml": "resources:\n  - rollout.yaml\n",
+        # a file that references the surviving one by a distinct 2-segment suffix
+        "infra/k8s/rollouts/overlays/prod/kustomization.yaml": (
+            "resources:\n  - ../../base\n"
+        ),
+        # and a doc that mentions the bare basename in prose
+        "docs/DEPLOY.md": "each overlay has its own kustomization.yaml file\n",
+    }
+    assert chk.scan(removed, tree) == []
+
+
+# The bare basename alone must never match, even when it is the removed file's basename.
+def test_bare_basename_alone_never_matches():
+    removed = ["a/b/kustomization.yaml"]
+    tree = {"x/y/z.md": "see kustomization.yaml for details\n"}
+    assert chk.scan(removed, tree) == []
+
+
+# (d) A rename where the NEW path is referenced -> clean (only the OLD path is in `removed`).
+def test_rename_with_new_path_referenced_is_clean():
+    removed = ["infra/k8s/foo/old/deployment.yaml"]  # the rename-away old path
+    tree = {
+        "tools/consumer.py": '"infra/k8s/foo/new/deployment.yaml"\n',
+    }
+    assert chk.scan(removed, tree) == []
+
+
+# A >=2-segment suffix reference (not the full path) is still caught.
+def test_two_segment_suffix_is_matched():
+    removed = ["infra/k8s/search-orchestrator/base/pvc.yaml"]
+    tree = {"scripts/deploy.sh": "kubectl apply -f base/pvc.yaml\n"}
+    violations = chk.scan(removed, tree)
+    assert any("base/pvc.yaml" in v for v in violations) or any("pvc.yaml" in v for v in violations)
+    assert violations, "a distinctive >=2-segment suffix must be caught"
+
+
+# Path boundaries: a needle must not match inside a longer segment or a different extension.
+def test_no_partial_segment_false_positive():
+    removed = ["k8s/base/configmap.yaml"]
+    tree = {
+        "a.txt": "xk8s/base/configmap.yaml\n",          # left-glued
+        "b.txt": "k8s/base/configmap.yaml.bak\n",         # right-glued (different file)
+        "c.txt": "k8s/base/configmap.yamlish\n",          # right-glued word
+    }
+    assert chk.scan(removed, tree) == []
+
+
+def test_binary_text_none_is_skipped():
+    removed = ["a/b/c.yaml"]
+    # a tuple-iterable tree with a None (binary) entry that "contains" the path bytes-wise
+    tree = [("bin/blob", None), ("ok.md", "a/b/c.yaml\n")]
+    violations = chk.scan(removed, tree)
+    assert len(violations) == 1 and "ok.md:1" in violations[0]
+
+
+def test_removed_file_does_not_flag_itself():
+    removed = ["a/b/c.yaml"]
+    # if the removed file is (wrongly) passed in the tree, it must not self-flag
+    tree = {"a/b/c.yaml": "self reference a/b/c.yaml\n"}
+    assert chk.scan(removed, tree) == []
+
+
+def test_empty_removed_is_clean():
+    assert chk.scan([], {"any.py": "infra/k8s/x/y.yaml\n"}) == []
+
+
+def test_iterable_of_pairs_tree_supported():
+    removed = ["a/b/c.yaml"]
+    tree = iter([("f.py", "ref a/b/c.yaml here\n")])
+    violations = chk.scan(removed, tree)
+    assert len(violations) == 1
+
+
+# Fail-closed plumbing: a bogus base ref cannot be diffed, so main() must NOT return 0.
+def test_main_fails_closed_on_unresolvable_base(capsys):
+    rc = chk.main(["--base-ref", "definitely/not/a/ref/zzz"])
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "INV-DEP-12" in err
+
+
+# _parse_name_status_z parses D and R records from `git diff --name-status -z` output.
+def test_parse_name_status_z_handles_delete_and_rename():
+    # D old1 ; R100 old2 -> new2 ; D old3
+    payload = "D\0old/one.yaml\0R100\0old/two.yaml\0new/two.yaml\0D\0old/three.yaml\0"
+    removed = chk._parse_name_status_z(payload)
+    assert removed == ["old/one.yaml", "old/two.yaml", "old/three.yaml"]

--- a/tools/verify_no_dangling_path_refs.py
+++ b/tools/verify_no_dangling_path_refs.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Blast-radius on refactor (INV-DEP-12): a PR that MOVES/RENAMES/DELETES a repo path
+must not leave any surviving tracked file still referencing that path by its old name.
+
+A refactor that relocates a file is invisible to the file it moved — but every tool,
+workflow, manifest, or doc that hard-coded the OLD path is now pointing at nothing. The
+render/parse still succeeds (the string is just a string); the break only surfaces when
+something dereferences the path at run time. That is the same "looks fine, fails later"
+class the deploy self-containment gates (INV-DEP-9/10) close for cluster refs — here for
+*repo-path* refs.
+
+This actually happened. `infra/k8s/search-orchestrator/base/configmap.yaml` was factored out
+to `.../base-support/configmap.yaml` so the prod blue-green overlay could render it. The move
+was correct, but `tools/validate_search_orchestrator_academy_deploy.py` had the old
+`.../base/configmap.yaml` path hard-coded in its required-files list. Nothing in the diff of
+the moved file could reveal it; the validator only went red in CI, AFTER push. This gate would
+have caught it in the diff, before push (and `make preflight`, L5, runs it locally).
+
+Design / seam:
+  * `scan(removed_paths, tree_files)` is the pure, git-free core. `removed_paths` is the list
+    of old paths a PR deleted or renamed away; `tree_files` is the CURRENT tree as a mapping
+    (or iterable of pairs) of {repo-relative path: text}. It returns human-readable violation
+    strings, each carrying `file:line` and the missing path — unit-testable without a repo.
+  * The git plumbing (`compute_removed_paths`, `read_tracked_files`, `main`) is a thin wrapper
+    that computes the removed set from `git diff` against the merge-base and feeds the tracked
+    tree to `scan`.
+
+Matching rule (avoid false positives): a surviving reference counts only when the text contains
+the FULL removed path OR a path suffix of >= 2 segments (e.g. `base/configmap.yaml`). A bare,
+common basename (`kustomization.yaml`, `configmap.yaml`) is NEVER matched on its own — two
+unrelated files can share a basename, and flagging that would be noise. References are matched
+on path boundaries so `base/configmap.yaml` does not hit inside `xbase/configmap.yaml` or
+`base/configmap.yaml.bak`.
+
+Fail-closed: if git is unavailable, or the merge-base / diff cannot be computed, the gate exits
+non-zero with a clear message. A gate that cannot compute blast-radius must not silently pass.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, Mapping
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# A file bigger than this, or one carrying a NUL byte, is treated as binary/opaque and skipped
+# for reference scanning. Path references live in text (YAML, Python, Markdown, shell).
+_MAX_TEXT_BYTES = 2_000_000
+
+
+def _needles(removed_path: str) -> list[str]:
+    """The literal strings whose presence counts as a surviving reference to `removed_path`:
+    the full path plus every path suffix of >= 2 segments. A single trailing segment (a bare
+    basename) is deliberately excluded — it is not distinctive enough to flag."""
+    parts = [p for p in removed_path.split("/") if p]
+    if not parts:
+        return []
+    needles: list[str] = []
+    # i == 0 is the full path; suffixes down to (but not including) the bare last segment.
+    for i in range(len(parts) - 1):
+        needles.append("/".join(parts[i:]))
+    if len(parts) == 1:
+        # A top-level path (e.g. `go.work`) has no >=2-segment suffix; the full path IS the
+        # only distinctive form, so match it exactly.
+        needles.append(parts[0])
+    return needles
+
+
+def _compile(needle: str) -> re.Pattern[str]:
+    # Bound the match on path characters so a needle does not match inside a longer path
+    # segment or a different extension: `base/configmap.yaml` must not hit `xbase/...` (left)
+    # or `.../configmap.yaml.bak` (right).
+    return re.compile(r"(?<![\w./-])" + re.escape(needle) + r"(?![\w./-])")
+
+
+def scan(removed_paths: Iterable[str], tree_files) -> list[str]:
+    """Return violation messages for every removed path still referenced in the current tree.
+
+    `tree_files`: a mapping {path: text} or an iterable of (path, text) pairs. A `text` of
+    None is skipped (binary/unreadable). Each violation carries `file:line` and the missing
+    path, deduped per (removed_path, file, line)."""
+    removed = [p for p in dict.fromkeys(removed_paths) if p]  # de-dupe, keep order, drop empties
+    if not removed:
+        return []
+    removed_set = set(removed)
+    patterns = {p: [_compile(n) for n in _needles(p)] for p in removed}
+
+    if isinstance(tree_files, Mapping):
+        items = tree_files.items()
+    else:
+        items = tree_files
+
+    seen: set[tuple[str, str, int]] = set()
+    violations: list[str] = []
+    for path, text in items:
+        if text is None:
+            continue
+        # A file the PR itself removed is not in the current tree; if a caller passes one
+        # anyway, never let it flag itself.
+        if path in removed_set:
+            continue
+        lines = text.splitlines()
+        for removed_path in removed:
+            pats = patterns[removed_path]
+            for lineno, line in enumerate(lines, start=1):
+                if any(pat.search(line) for pat in pats):
+                    key = (removed_path, path, lineno)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    violations.append(
+                        f"{path}:{lineno}: references '{removed_path}', but that path was "
+                        f"DELETED or RENAMED away in this PR and no longer exists — update or "
+                        f"remove the reference (blast-radius of the refactor)."
+                    )
+    return violations
+
+
+# --------------------------------------------------------------------------------------------
+# git plumbing — a thin wrapper around scan().
+# --------------------------------------------------------------------------------------------
+class GitError(RuntimeError):
+    pass
+
+
+def _git(args: list[str], root: Path) -> str:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as e:
+        raise GitError("git executable not found — cannot compute blast-radius") from e
+    if proc.returncode != 0:
+        raise GitError(f"`git {' '.join(args)}` failed (exit {proc.returncode}): {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def merge_base(root: Path, base_ref: str) -> str:
+    """The merge-base of HEAD and `base_ref`. Robust when `base_ref` is already the base."""
+    out = _git(["merge-base", "HEAD", base_ref], root).strip()
+    if not out:
+        raise GitError(f"could not determine merge-base of HEAD and {base_ref}")
+    return out
+
+
+def compute_removed_paths(root: Path, base: str, head: str = "HEAD") -> list[str]:
+    """Old paths DELETED (D) or RENAMED-away (R) between `base` and `head`."""
+    out = _git(["diff", "--diff-filter=DR", "--name-status", "-z", base, head], root)
+    return _parse_name_status_z(out)
+
+
+def _parse_name_status_z(out: str) -> list[str]:
+    """Parse `git diff --name-status -z` output. NUL-separated fields: a D record is
+    `status\\0path`; an R record is `Rnnn\\0oldpath\\0newpath`. We collect the OLD path."""
+    fields = out.split("\0")
+    removed: list[str] = []
+    i = 0
+    while i < len(fields):
+        status = fields[i]
+        if not status:
+            i += 1
+            continue
+        code = status[0]
+        if code == "R":
+            if i + 2 < len(fields):
+                removed.append(fields[i + 1])  # old path
+            i += 3
+        elif code == "D":
+            if i + 1 < len(fields):
+                removed.append(fields[i + 1])
+            i += 2
+        else:
+            # Any other status shouldn't appear under --diff-filter=DR; skip its single path.
+            i += 2
+    return [p for p in removed if p]
+
+
+def read_tracked_files(root: Path):
+    """Yield (path, text|None) for every tracked file. Binary or oversized files yield None."""
+    out = _git(["ls-files", "-z"], root)
+    for rel in out.split("\0"):
+        if not rel:
+            continue
+        fp = root / rel
+        try:
+            data = fp.read_bytes()
+        except (OSError, ValueError):
+            yield rel, None
+            continue
+        if b"\0" in data[:8192] or len(data) > _MAX_TEXT_BYTES:
+            yield rel, None
+            continue
+        yield rel, data.decode("utf-8", errors="replace")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument(
+        "--base-ref",
+        default="origin/main",
+        help="ref to diff against for removed/renamed paths (default: origin/main)",
+    )
+    args = ap.parse_args(argv)
+
+    try:
+        base = merge_base(ROOT, args.base_ref)
+        removed = compute_removed_paths(ROOT, base)
+    except GitError as e:
+        # Fail-closed: a gate that cannot compute blast-radius must not pass.
+        print(f"no-dangling-path-refs check FAILED (INV-DEP-12): {e}", file=sys.stderr)
+        print(
+            "  This gate needs full git history to diff HEAD against the merge-base with "
+            f"{args.base_ref}. In CI, check out with fetch-depth: 0 (or `git fetch --unshallow`).",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not removed:
+        print("OK: no paths deleted or renamed in this PR — nothing to check for dangling refs.")
+        return 0
+
+    violations = scan(removed, read_tracked_files(ROOT))
+    if violations:
+        print("no-dangling-path-refs check FAILED (INV-DEP-12):", file=sys.stderr)
+        print(
+            f"  {len(removed)} path(s) were removed/renamed; the following tracked files still "
+            f"reference an old path that no longer exists:",
+            file=sys.stderr,
+        )
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        return 1
+
+    print(
+        f"OK: {len(removed)} path(s) removed/renamed, and no surviving tracked file references "
+        f"any of them by the old path."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What & why

Phase 2 of the resilience-engineering program. Phase 1 shipped the static ref-resolution deploy gates (INV-DEP-9/10) and the CI real-apply / digest-exists preflight. Two failure modes stayed unautomated; this PR closes both — and pulls them earlier in the loop (diff-time, on a laptop).

### L3 — blast-radius on refactor (`INV-DEP-12`, `tools/verify_no_dangling_path_refs.py`)

A refactor that MOVES/RENAMES/DELETES a repo path silently breaks any tool/workflow/manifest/doc that hard-coded the **old** path. A hard-coded path is just a string, so the moved file's own diff can't reveal the break — it renders/parses clean and only fails when the path is *dereferenced*. Same "looks fine, fails later" class as INV-DEP-9/10, here for repo-path refs.

**The incident it prevents.** `infra/k8s/search-orchestrator/base/configmap.yaml` was correctly factored out to `.../base-support/configmap.yaml`, but `tools/validate_search_orchestrator_academy_deploy.py` had the old `base/` path hard-coded in its required-files list. The move was invisible to that consumer; the validator only went RED in CI, **after push**. This gate catches that exact shape in the diff, before push (and `make preflight` runs it locally).

Design:
- Computes paths DELETED / RENAMED-away between HEAD and the merge-base with `origin/main` (`git diff --diff-filter=DR`), then searches the current tree (tracked files only) for a surviving reference to each old path.
- Matches the **full path OR a path suffix of ≥ 2 segments** (`base/configmap.yaml`), on path boundaries — **never** a bare shared basename like `kustomization.yaml` (no false positives).
- Pure `scan(removed_paths, tree_files)` seam — unit-tested **without git**, both ways.
- **Fail-closed**: if git/merge-base/diff can't be computed, it exits non-zero. A gate that can't compute blast-radius must not silently pass.
- Wired into the required `validate-target-diagnostics` matrix; because it needs full history, that one leg deepens the (otherwise shallow) checkout (`git fetch --unshallow` + fetch `origin/main`) — the other ~34 legs keep their cheap shallow clone.

### L5 — local == CI parity (`make preflight`, `tools/run_preflight.py`)

The required-gate matrix only ran remotely, so path-breaks/gate-failures cost a full push→CI round-trip to discover. `make preflight` runs the **fast, hermetic subset** of that matrix locally, in minutes: `validate-repo`, `drift-check`, `standards-check`, `topology-check`, `rollout-analysis-refs-check`, `overlay-self-contained-check`, `no-dangling-path-refs-check`, `test-tools`. It prints a PASS / what-to-fix summary and exits non-zero on any failure.

It **mirrors the required matrix minus the infra-heavy legs**: `kind`, `test-go`, per-app venv suites, `docker`, the smoke matrix, and the CI-only real-apply / digest-exists preflight (needs registry/cluster creds) all stay in CI. An opt-in `.githooks/pre-push` runs `make preflight` before every push (`git config core.hooksPath .githooks`; bypass with `git push --no-verify`).

### Docs
- New `docs/RESILIENCE_ENGINEERING.md`: the L0/L1/L3/L5 layer table + runbook for `make preflight` and INV-DEP-12.
- `docs/standards/deploy-wave-invariants-v0.md`: new INV-DEP-12 section + conformance-table rows (11/12/13).

## Verification (local)
- `make no-dangling-path-refs-check` → exit 0 on the clean tree; a throwaway commit deleting a still-referenced file made it FAIL with `file:line` + the missing path (then discarded).
- `tools/tests/test_verify_no_dangling_path_refs.py` → 14 passed (both ways + bare-basename false-positive guard + rename-clean + fail-closed).
- `make preflight` → all 8 legs PASS (~46s).
- No regression in INV-DEP-9/10 (both green in preflight); `actionlint` on the workflow shows only a pre-existing SC2086 (line 223 on main), none from the new step.

Do not merge — for coordinator review.