### PR TITLE
feat(embeddings): route hellgraph/health-twin/sherlock through the receipt-gateway

### DIFF
--- a/deploy/values/health-twin.yaml
+++ b/deploy/values/health-twin.yaml
@@ -19,7 +19,9 @@ config:
   HT_HOLMES_URL: "http://holmes.socioprophet.svc.cluster.local:8091"               # claim grounding (anti-Watson)
   HT_HELLGRAPH_URL: "http://hellgraph-service.socioprophet.svc.cluster.local:8090" # land + hybrid semantic search
   HT_OWL_URL: "http://owl-reasoner.socioprophet.svc.cluster.local:8080"            # TTL → entailments
-  HT_EMBEDDINGS_URL: "http://embeddings.socioprophet.svc.cluster.local:8080/v1/embeddings"
+  # Routed through the receipt-gateway (deploy/values/receipt-gateway.yaml) so every embedding call is
+  # receipted; it forwards transparently to the `embeddings` service and returns the same response.
+  HT_EMBEDDINGS_URL: "http://receipt-gateway.socioprophet.svc.cluster.local:8898/v1/embeddings"
   # The estate's medical BRAIN (Noetica agent-machine, 125k USMLE-textbook chunks): grounds Ask/Explain
   # in cited medical texts via /api/study/retrieve. Degrades to the local sourced KB if unreachable.
   NOETICA_AM_URL: "http://agent-machine.socioprophet.svc.cluster.local:8080"

--- a/deploy/values/hellgraph-service.yaml
+++ b/deploy/values/hellgraph-service.yaml
@@ -27,7 +27,10 @@ config:
   # nomic-embed-text's 768-dim vectors as-is), so no fixed vector-size var is needed here — unlike
   # memoryd's MEMORYMESH_VECTOR_SIZE. The fogstack (federal/standard) tiers override EMBEDDINGS_URL
   # to "" in the appset so a sovereign tier never reaches this socioprophet-namespace service.
-  EMBEDDINGS_URL: "http://embeddings.socioprophet.svc.cluster.local:8080/v1/embeddings"
+  # Routed through the receipt-gateway (deploy/values/receipt-gateway.yaml) so every embedding call is
+  # receipted; it forwards transparently to the `embeddings` service. The fogstack "" override still wins
+  # (an empty EMBEDDINGS_URL disables the call entirely), so this only affects the socioprophet tier.
+  EMBEDDINGS_URL: "http://receipt-gateway.socioprophet.svc.cluster.local:8898/v1/embeddings"
   EMBEDDINGS_MODEL: "nomic-embed-text"
   # Load the ~55k KBpedia reference concepts at startup (the RC ABox under KKO, vendored gzipped in
   # the image). Activates the KKO coherence ranker in /api/graph/enrich and gives semantic entity

--- a/deploy/values/sherlock-engine.yaml
+++ b/deploy/values/sherlock-engine.yaml
@@ -11,7 +11,9 @@ config:
   # NOTE: consumed once the engine's dense-rerank path lands; declared here so the binding is explicit.
   QDRANT_URL: "http://mesh-qdrant.socioprophet.svc.cluster.local:6333"
   QDRANT_COLLECTION: "sherlock-corpus"
-  EMBEDDINGS_URL: "http://embeddings.socioprophet.svc.cluster.local:8080/v1/embeddings"
+  # Routed through the receipt-gateway (deploy/values/receipt-gateway.yaml) so every embedding call is
+  # receipted; it forwards transparently to the `embeddings` service and returns the same response.
+  EMBEDDINGS_URL: "http://receipt-gateway.socioprophet.svc.cluster.local:8898/v1/embeddings"
   EMBEDDINGS_MODEL: "nomic-embed-text"
   # KMASS baseline (2026-08-01) found the tantivy index was create_in_ram over a static
   # in-image fixture with no ingest path -- corpus resets to the same 12 docs on every


### PR DESCRIPTION
## Why
Follow-up to #1233 (memoryd → receipt-gateway). The remaining estate consumers that embed against the sovereign `embeddings` service still called it directly, so their embeddings weren't receipted. This routes them through the gateway too — **every** embedding call in the estate now carries a hash-chained `InferenceReceipt` ("proceed till the whole thing has receipts").

## What
No app code change — the gateway forwards transparently and returns the identical `/v1/embeddings` response:
- **hellgraph-service** — `EMBEDDINGS_URL → receipt-gateway:8898` (the fogstack `""` override still wins, so only the socioprophet tier is affected).
- **health-twin** — `HT_EMBEDDINGS_URL → receipt-gateway:8898`.
- **sherlock-engine** — `EMBEDDINGS_URL → receipt-gateway:8898`.

## Verification
- `helm template` renders each consumer's embeddings URL at the gateway.
- `preflight_deploy_contract` (exit 0) + YAML lint pass.

## Scaling note (follow-up filed)
The receipt-gateway is now the shared embed path for 4 services on a **single-writer, single-replica** ledger (RWO PVC + `Recreate` — the hash chain wants one writer). Fine for current volume; a scaling/SPOF revisit (replicas + ledger design) is tracked separately.