### PR TITLE
feat(registry): bound zot storage growth with a GC/retention policy (salvaged from #1091)

### DIFF
--- a/infra/k8s/zot/base/configmap.yaml
+++ b/infra/k8s/zot/base/configmap.yaml
@@ -3,6 +3,11 @@
 # read/write, no anonymous access. `sync` provides on-demand pull-through of upstream registries so the
 # cluster pulls docker.io/ghcr/gcr/k8s images THROUGH zot (the de-Google lever). S3 credentials are NOT
 # in this file — they come from env (AWS_ACCESS_KEY_ID/SECRET) sourced from the minio-credentials secret.
+#
+# storage.retention + gc bound the registry's growth so pull-through sync and CI pushes cannot fill the
+# MinIO bucket unattended: gc reclaims unreferenced blobs (gcDelay/gcInterval), and the retention policy
+# prunes untagged manifests and referrers while KEEPING `latest`, anything pulled within 90 days
+# (2160h), and the 100 most-recently-pushed tags per repo.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,6 +22,24 @@ data:
         "rootDirectory": "/var/lib/zot",
         "dedupe": false,
         "gc": true,
+        "gcDelay": "1h",
+        "gcInterval": "6h",
+        "retention": {
+          "dryRun": false,
+          "delay": "24h",
+          "policies": [
+            {
+              "repositories": ["**"],
+              "deleteReferrers": true,
+              "deleteUntagged": true,
+              "keepTags": [
+                { "patterns": ["^latest$"] },
+                { "patterns": [".*"], "pulledWithin": "2160h" },
+                { "patterns": [".*"], "mostRecentlyPushedCount": 100 }
+              ]
+            }
+          ]
+        },
         "storageDriver": {
           "name": "s3",
           "rootdirectory": "/zot",


### PR DESCRIPTION
## What

Adds zot storage GC tuning and a retention policy to the sovereign registry so its MinIO-backed bucket cannot grow unbounded:

- `gcDelay: 1h`, `gcInterval: 6h` — reclaim unreferenced blobs on a schedule.
- `storage.retention` policy: prune untagged manifests and referrers, while **keeping** `^latest$`, anything pulled within 90 days (`pulledWithin: 2160h`), and the 100 most-recently-pushed tags per repo (`mostRecentlyPushedCount: 100`). `dryRun: false`, `delay: 24h`.

## Why this is a salvage of #1091

#1091 (`fix/zot-storage-exhaustion`) conflicts with current `main` and must not be rebased/merged. The novel, unsuperseded piece is the zot storage GC/retention policy. This PR carries **only** that policy, grafted onto `main`'s current config.

### Deliberately left behind (superseded / out of scope)
- The **minio PVC cap** change from #1091 — superseded by main's explicit `100Gi`. Not included.
- #1091 refactored zot's config delivery from the inline `zot-config` ConfigMap (`configmap.yaml`) to a standalone `config.json` + `configMapGenerator`. On current `main` the config is delivered inline and the Deployment mounts a ConfigMap named `zot-config`. Introducing a generator named `zot-config` alongside main's existing `configmap.yaml` collides on a duplicate resource id, and the generator's rollout-on-edit behaviour is a separate concern from bounding storage growth. So the GC/retention fields are grafted into main's existing inline config — **config delivery is unchanged**, and only the storage policy differs.

## Validation
- Embedded `config.json` parses (`json.load`): retention policy present, `gcDelay`/`gcInterval` set.
- `kubectl kustomize infra/k8s/zot/base` renders (8 kinds); ConfigMap stays `zot-config`, Deployment still mounts it.

Salvaged from #1091. @mdheller