### PR TITLE
fix(ci): evaluate the docs-only detector from the base ref so a PR can't certify its own modification (salvaged from #1087)

### DIFF
--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -51,13 +51,33 @@ jobs:
           # The rule lives in tools/ci_docs_only.py so it is unit-tested; a skip rule that
           # only exists in YAML is a skip rule nobody can test.
           #
+          # The detector CODE is read from the BASE REF, never from the PR checkout.
+          # `python3 tools/ci_docs_only.py` ran the pull request's OWN copy of the detector,
+          # and the detector is not on its own inert allowlist — so a PR could edit it to
+          # print "true" unconditionally and thereby skip app-test and smoke for its entire
+          # diff. The detector would be certifying its own modification. origin/$BASE is the
+          # copy that has already been reviewed and merged. (The changed-file LIST above
+          # still comes from the PR diff; only the detector CODE comes from base.)
+          #
+          # Consequence worth stating: a PR that improves the detector does not get the
+          # improvement applied to itself. That is the correct direction — the change takes
+          # effect once merged, and until then the PR runs the full matrix anyway.
+          #
+          # Reading base fails safe like everything else here: if origin/$BASE has no
+          # detector (or git show errors) we run the full matrix rather than trust the PR's.
+          DETECTOR="$(mktemp)"
+          trap 'rm -f "$DETECTOR"' EXIT
+          if ! git show "origin/$BASE:tools/ci_docs_only.py" > "$DETECTOR" 2>/dev/null; then
+            echo "cannot read the detector from origin/$BASE — running everything"
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
           # The detector is NOT allowed to fail this job. Skipping tests must require a
           # positive "true"; anything else — a crash, a missing interpreter, an
           # unrecognised answer — falls back to running the full matrix. Letting the job
           # fail instead would still be safe for coverage (the dependents run on an empty
           # output), but it paints the workflow red while the required gate stays green,
           # which teaches people to ignore red.
-          if ! RESULT="$(printf '%s\n' "$CHANGED" | python3 tools/ci_docs_only.py 2>&1)"; then
+          if ! RESULT="$(printf '%s\n' "$CHANGED" | python3 "$DETECTOR" 2>&1)"; then
             echo "detector failed, running everything. output: $RESULT"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"; exit 0
           fi


### PR DESCRIPTION
## What

The `changes` job in `validate-target-diagnostics.yml` decides whether app-test/smoke legs may be skipped by running `tools/ci_docs_only.py` on the PR's changed-file list. It ran the **PR's own** copy of the detector. Since `tools/ci_docs_only.py` is not on its own inert allowlist, a PR could rewrite the detector to print `true` unconditionally and skip app-test + smoke for its entire diff — the detector certifying its own modification.

This changes **only** the detection step: read the detector CODE from `origin/$BASE` (the already-reviewed, merged copy) via `git show` into a temp file and run that. The changed-file **list** still comes from the PR diff (`origin/$BASE...HEAD`); only the detector code comes from base.

```
DETECTOR="$(mktemp)"; trap 'rm -f "$DETECTOR"' EXIT
if ! git show "origin/$BASE:tools/ci_docs_only.py" > "$DETECTOR" 2>/dev/null; then
  echo "cannot read the detector from origin/$BASE — running everything"
  echo "docs_only=false" >> "$GITHUB_OUTPUT"; exit 0
fi
... printf '%s\n' "$CHANGED" | python3 "$DETECTOR" ...
```

`origin/$BASE` is already fetched earlier in the same step (`git fetch --no-tags --quiet origin "$BASE"`, checkout is `fetch-depth: 0`).

## Fail-safe semantics preserved
All of main's existing fail-safe behaviour is intact: not a PR → full matrix; empty diff → full matrix; detector crash/unrecognised output → full matrix. New failure mode added, same direction: if `origin/$BASE` has no detector or `git show` errors → `docs_only=false` → full matrix. Skipping still requires a positive `true`.

`tools/ci_docs_only.py` reads only stdin at runtime (`sys.stdin.read()`), no other repo files, so running the base copy against the PR's changed-file list is self-contained.

## Salvage of #1087 — what is / isn't carried
#1087 (`fix/copilot-ci-docs-only-selfcert`) conflicts with `main`. Main **already** has the docs-only detector (`tools/ci_docs_only.py`, denylist impl) — this PR keeps it unchanged and does **not** replace it. Only the novel base-ref workflow guard is salvaged.

### Deliberately left behind
- #1087's edits to `tools/ci_docs_only.py` and its test — not needed; the guard runs main's existing detector from base.
- #1087's unrelated `arcticdb-gateway` app-test matrix leg — out of scope for this fix.

## Validation
- `actionlint`: no new findings vs `main` (the one pre-existing SC2086 in a different job is unchanged).
- `bash -n` on the extracted detect step: clean.
- Guard simulation with main's detector: attack list `[tools/ci_docs_only.py, apps/zone-router/src/evil.py]` → `false` (full matrix); pure-docs list `[docs/x.md, README.md]` → `true` (skip preserved).
- No unit test added: the workflow's shell logic has no existing test harness (the Python suite covers the detector function, which is unmodified). Verification is the manual checks above.

Salvaged from #1087. @mdheller