### PR TITLE
feat(storage): prune old mesh-qdrant snapshots (retention), grafted onto #1207's backup fix (salvaged from #1114)

### DIFF
--- a/infra/k8s/mesh-qdrant/base/backup-cronjob.yaml
+++ b/infra/k8s/mesh-qdrant/base/backup-cronjob.yaml
@@ -20,6 +20,13 @@ spec:
           containers:
             - name: qdrant-snapshot
               image: curlimages/curl:8.6.0
+              env:
+                # Retention: keep the newest N snapshots per collection; older ones are
+                # DELETEd each run (see the pruning block below). Snapshots are full copies
+                # living on the same volume they back up, so unbounded accumulation would
+                # eventually take out the thing it is backing up.
+                - name: RETAIN
+                  value: "7"
               args:
                 - /bin/sh
                 - -c
@@ -52,6 +59,27 @@ spec:
                       echo "Snapshotting collection: $col"
                       # Not piped -- set -e already catches a bare failing command like this.
                       curl -sf -X POST "http://mesh-qdrant:6333/collections/${col}/snapshots"
+
+                      # Retention (salvaged from #1114): main's #1207 only ever POSTed -- it
+                      # never called DELETE /collections/{c}/snapshots/{s}, so snapshots would
+                      # accumulate forever. Keep the newest $RETAIN, delete the rest. Reuse the
+                      # same no-jq grep/sed extraction as the collections list above; snapshot
+                      # names carry a timestamp and sort chronologically, so the oldest sort
+                      # first. Pruning is best-effort: a failed listing or DELETE is logged and
+                      # skipped, never fatal -- creating a snapshot matters more than reclaiming
+                      # the old one, and the snapshot above already succeeded.
+                      SNAPS=$(curl -sf "http://mesh-qdrant:6333/collections/${col}/snapshots" | grep -o '"name":"[^"]*"' | sed 's/"name":"//;s/"$//' || true)
+                      TOTAL=$(printf '%s\n' "$SNAPS" | grep -c . || true)
+                      if [ "$TOTAL" -gt "$RETAIN" ]; then
+                        DROP=$((TOTAL - RETAIN))
+                        echo "Retention: $col has $TOTAL snapshots, deleting $DROP oldest (keep $RETAIN)"
+                        printf '%s\n' "$SNAPS" | sort | head -n "$DROP" | while read -r snap; do
+                          [ -z "$snap" ] && continue
+                          echo "Retention: deleting $col/$snap"
+                          curl -sf -X DELETE "http://mesh-qdrant:6333/collections/${col}/snapshots/${snap}" \
+                            || echo "WARN: could not delete $col/$snap" >&2
+                        done
+                      fi
                     done
                   fi
                   echo "Backup run complete"


### PR DESCRIPTION
## What

Adds per-collection **retention** to the mesh-qdrant snapshot CronJob so snapshots stop accumulating forever:

- New `RETAIN` env (default `"7"`) — keep the newest N snapshots per collection.
- After each `POST .../snapshots`, list that collection's snapshots, sort chronologically (names carry a timestamp), and `DELETE` everything beyond `RETAIN`.

## Why this is a salvage of #1114

#1114 (`feat/storage-retention`) conflicts with `main` and must not be rebased/merged. Meanwhile #1207 already reworked this file (fixed the service name `qdrant`→`mesh-qdrant`, dropped `jq`, added explicit curl exit-capture). The genuinely novel, unsuperseded piece of #1114 is the **retention/DELETE** behaviour — main's #1207 job only ever `POST`ed and never `DELETE`d, so snapshots (full copies on the same volume they back up) would grow unbounded.

This grafts **only** the retention logic onto #1207's current script:
- Keeps the `mesh-qdrant` service name and the no-`jq` `grep`/`sed` extraction — and **reuses that exact extraction** for the snapshot list, adding no new dependency.
- Reverts none of #1207's fixes.
- Pruning is **best-effort**: a failed listing or `DELETE` is logged (`WARN`) and skipped, never fatal — creating the snapshot matters more than reclaiming an old one, and the snapshot POST already succeeded above.

### Deliberately left behind
- #1114's **`readyz`-refusal** — redundant here. main already fails the job loudly on an unreachable `mesh-qdrant` (`RESPONSE=$(curl -sf .../collections) || { exit 1; }`); adopting #1114's `|| true` + `readyz` path would require reverting that deliberate #1207 structure.
- #1114's **evidence-receipt JSON emission** — a separate concern that changes the job's stdout contract; out of scope for a retention change. Can be a follow-up.
- #1114's **`statefulset.yaml`** snapshots-path change — competes with main's literal; left as main set it.
- #1114's `args:`→`command:` entrypoint change and the other files in that branch — out of scope; #1207's structure is kept verbatim.

## Validation
- `yq` parses the CronJob; `RETAIN` env present.
- Embedded script: `sh -n` and `dash -n` clean.
- Retention math exercised against a mock list: 12 snapshots, `RETAIN=7` → deletes the 5 oldest; empty list → skips.
- No actual `jq` invocation (the word appears only in main's explanatory comments).
- `kubectl kustomize infra/k8s/mesh-qdrant/base` renders (4 kinds) with the `RETAIN` env and `DELETE` call present.

Salvaged from #1114; grafted onto #1207. @mdheller