### PR TITLE
feat(resilience): close the program — preflight hermeticity + gate-registry meta-gate (never-fired == suspect)

### DIFF
--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -128,6 +128,7 @@ jobs:
           - manifest-completeness-check
           - no-dangling-path-refs-check
           - evidence-refs-check
+          - gate-registry-check
           - fips-conformance-check
           - imageschemanet-grounding-check
     steps:

--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,18 @@ test-tools:
 	test -d .venv-tools || python3 -m venv .venv-tools
 	. .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest pyyaml jsonschema && pytest -q tools/tests
 
+.PHONY: test-tools-hermetic
+# The hermetic subset of the tools test suite, for `make preflight` (L5). The full `test-tools`
+# runs in CI; the fogstack integration tests it also runs shell out to
+# `kubectl apply --dry-run` and, on a laptop whose kubectl is a gke-gcloud-auth-plugin
+# dispatcher wrapper, that fires the credential plugin even for a client-side dry-run — so an
+# absent or expired cluster credential makes them fail LOCALLY though they are green in CI.
+# Deselecting `fogstack` is the boundary proven green with no cluster (593 pass / 0 fail); it
+# keeps preflight laptop-safe (its purpose) without weakening CI, which still runs everything.
+test-tools-hermetic:
+	test -d .venv-tools || python3 -m venv .venv-tools
+	. .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest pyyaml jsonschema && pytest -q tools/tests -k 'not fogstack'
+
 trustops-art-runner-smoke:
 	PYTHONPATH=apps/trustops-art-runner/src python3 tools/smoke_trustops_art_runner.py
 
@@ -663,6 +675,17 @@ no-dangling-path-refs-check:
 # tools/tests/test_verify_evidence_refs.py. In the validate-target-diagnostics matrix + preflight.
 evidence-refs-check:
 	python3 tools/verify_evidence_refs.py
+
+.PHONY: gate-registry-check
+# Meta-gate (never-fired == suspect): every deploy/resilience gate must PROVE it can fire.
+# tools/gate_registry.yaml registers each gate with a teeth-test that exercises a real failure;
+# tools/check_gate_registry.py fails closed if a registered gate has no negative-case test, and —
+# the ratchet — if ANY tools/verify_*.py is neither registered with teeth nor booked as explicit
+# debt under known_unproven. A control that has only ever passed is theater until it is shown to
+# deny. Pure-python, no kubectl; proven both ways by tools/tests/test_check_gate_registry.py.
+# In the validate-target-diagnostics matrix + preflight.
+gate-registry-check:
+	python3 tools/check_gate_registry.py
 
 .PHONY: preflight
 # Local == CI parity (L5): run the fast, hermetic subset of the REQUIRED validate-target-

--- a/docs/RESILIENCE_ENGINEERING.md
+++ b/docs/RESILIENCE_ENGINEERING.md
@@ -3,7 +3,8 @@
 Status: Phase 1 (L1 + L2), Phase 2 (L3 + L5), and Phase 3 (L4 + L6) shipped. L4
 (evidence-reference verification, INV-DEP-13) is shipped; L6 (auto-remediation) is shipped for the
 RENAME case (`--fix` rewrites the unambiguous old→new references; deletions remain human judgment).
-The cross-cutting last-fired gate registry is declared, not yet built.
+The cross-cutting gate registry (never-fired == suspect) is shipped: every gate must prove it can
+fire. **L1–L6 and the meta-gate are all live.**
 
 ## The failure class we are automating away
 
@@ -36,7 +37,7 @@ continuous gate, not a thing we learn in prod.
 | **L4** | **Evidence-ref verification (INV-DEP-13).** Every claim a release/evidence artifact makes must resolve to real evidence, not a string that looks right — extend the "reference resolves" discipline from cluster objects to the EVIDENCE surface under `releases/`. Every repo-path ref (paths, lock refs, validation-record refs) must exist + parse; every `evidence://`/`file://` URI must resolve; every digest-evidence claim (`bundle_digest`/`rulepack_digest`) must equal `sha256(the file it names)`. `make evidence-refs-check`. | **shipped** |
 | **L5** | **Local == CI parity (`make preflight`).** One target runs the fast, hermetic required-matrix legs locally (validate-repo, drift/standards/topology, the INV-DEP-9/10/11/12 gates, tools tests) so path-breaks and gate failures surface before push, not after. Opt-in `.githooks/pre-push` runs it. Infra-heavy legs (kind, go, docker) stay CI-only. | **shipped** |
 | **L6** | **Auto-remediation.** When a derived gate KNOWS the mechanical fix, offer the patch, not just the refusal. Shipped for the RENAME case of the blast-radius gate (INV-DEP-12): a rename reports its git-detected target, so each surviving reference gets a concrete "→ `<new path>`" suggestion, and `verify_no_dangling_path_refs.py --fix` rewrites the unambiguous full-path references in place. DELETIONS have no safe target and are never auto-rewritten (human judgment). `--fix` is a developer convenience — CI stays report-only, fail-closed. | **shipped (rename); deletion = human judgment** |
-| — | **Last-fired gate registry (cross-cutting).** A control that has never fired is suspect. Every gate here records when it last actually FAILED on something (the negative fixtures included), so a gate that has only ever passed is flagged for an adversarial review rather than trusted. L1's negative fixture is the first entry. | future |
+| **meta** | **Gate registry — never-fired == suspect (cross-cutting).** `tools/gate_registry.yaml` registers every gate with the teeth-test that proves it can DENY; `tools/check_gate_registry.py` fails closed if a registered gate has no negative-case test, and — the ratchet — if any `tools/verify_*.py` is neither registered with teeth nor booked as explicit debt under `known_unproven`. On first run it surfaced 3 estate gates with no teeth (fogstack signature ×2, probe-contract), now booked as acknowledged debt. A new gate cannot land without proving it fires or being visibly recorded as debt. | **shipped** |
 
 ## How the invariants + ephemeral-apply map onto it
 

--- a/docs/standards/deploy-wave-invariants-v0.md
+++ b/docs/standards/deploy-wave-invariants-v0.md
@@ -285,3 +285,4 @@ still fails).
 | 14 | Local == CI parity: the fast required matrix, run locally (L5) | `make preflight` |
 | 15 | Every release/evidence reference resolves to a real, well-formed artifact (INV-DEP-13) | `python3 tools/verify_evidence_refs.py` (+ `python3 -m pytest -q tools/tests/test_verify_evidence_refs.py`) |
 | 16 | Blast-radius auto-remediation for renames (L6): suggestion + in-place fix, deletions untouched | `python3 tools/verify_no_dangling_path_refs.py --fix` (+ `python3 -m pytest -q tools/tests/test_verify_no_dangling_path_refs.py`) |
+| 17 | Meta-gate — every gate proves it can fire; no unregistered/teeth-less gate (never-fired == suspect) | `make gate-registry-check` (+ `python3 -m pytest -q tools/tests/test_check_gate_registry.py`) |

--- a/tools/check_gate_registry.py
+++ b/tools/check_gate_registry.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Meta-gate: every deploy/resilience gate must PROVE it can fire (never-fired == suspect).
+
+The estate's oldest failure mode is a control that passes because it cannot fail — enforcement
+theater. This meta-gate reads `tools/gate_registry.yaml` and fails closed unless every registered
+gate demonstrates teeth:
+
+  * pytest gate  -> its tool file and teeth-test exist, and the teeth-test contains at least
+    `min_negative_tests` NEGATIVE-case test functions (a test whose name marks a failure it
+    expects the gate to catch: fail/missing/dangling/broken/malformed/mismatch/bogus/not_/
+    unresolved/fabricated/invalid/absent). A gate with no negative case has never been shown to
+    deny anything.
+  * workflow gate -> its workflow file and negative fixture exist, and the workflow carries the
+    toothless-guard marker (it applies the broken fixture and fails unless the detector fires).
+
+The ratchet: EVERY `tools/verify_*.py` must be either registered under `gates` or explicitly
+booked under `known_unproven` (acknowledged debt). A verify tool in neither fails this gate — a
+new gate cannot land without proving it can fire or being visibly recorded as debt.
+
+Teeth both ways in tools/tests/test_check_gate_registry.py: the shipped registry passes; a gate
+whose teeth-test has no negative case fails; an unregistered verify tool fails.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "tools" / "gate_registry.yaml"
+
+# A test function name signals a negative (failure-expecting) case if it contains one of these.
+_NEGATIVE_MARKERS = (
+    "fail", "missing", "dangling", "broken", "malformed", "mismatch", "bogus",
+    "not_", "unresolved", "fabricated", "invalid", "absent", "reject", "deny", "unmet",
+)
+_DEF_RE = re.compile(r"^\s*def (test_\w+)", re.MULTILINE)
+
+
+def negative_test_count(text: str) -> int:
+    return sum(
+        1 for name in _DEF_RE.findall(text)
+        if any(m in name.lower() for m in _NEGATIVE_MARKERS)
+    )
+
+
+def _read(path: Path) -> tuple[str | None, str | None]:
+    try:
+        return path.read_text(encoding="utf-8"), None
+    except (OSError, UnicodeDecodeError) as e:
+        return None, f"{type(e).__name__}: {e}"
+
+
+def check(registry_obj: dict, root: Path) -> list[str]:
+    """Return violation strings. Empty == every gate proves it can fire. Fail-closed."""
+    problems: list[str] = []
+    if not isinstance(registry_obj, dict):
+        return ["gate_registry.yaml did not parse to a mapping"]
+
+    gates = registry_obj.get("gates") or []
+    known_unproven = registry_obj.get("known_unproven") or []
+    registered_tools: set[str] = set()
+
+    for g in gates:
+        gid = g.get("id", "<no-id>")
+        kind = g.get("kind")
+        if kind == "pytest":
+            tool = g.get("tool", "")
+            teeth = g.get("teeth_test", "")
+            minneg = int(g.get("min_negative_tests", 1))
+            registered_tools.add(tool)
+            if not (root / tool).is_file():
+                problems.append(f"{gid}: tool {tool!r} does not exist")
+            tt = root / teeth
+            if not tt.is_file():
+                problems.append(f"{gid}: teeth-test {teeth!r} does not exist — gate has no proof it can fire")
+                continue
+            text, err = _read(tt)
+            if err:
+                problems.append(f"{gid}: teeth-test unreadable ({err})")
+                continue
+            n = negative_test_count(text)
+            if n < minneg:
+                problems.append(
+                    f"{gid}: teeth-test {teeth!r} has {n} negative-case test(s), needs >= {minneg} "
+                    f"— an all-green gate proves nothing (never-fired == suspect)"
+                )
+        elif kind == "workflow":
+            wf = g.get("workflow", "")
+            fixture = g.get("negative_fixture", "")
+            marker = g.get("toothless_guard_marker", "toothless")
+            if not (root / wf).is_file():
+                problems.append(f"{gid}: workflow {wf!r} does not exist")
+            elif marker not in (_read(root / wf)[0] or ""):
+                problems.append(f"{gid}: workflow {wf!r} missing toothless-guard marker {marker!r}")
+            if fixture and not (root / fixture).is_dir():
+                problems.append(f"{gid}: negative fixture {fixture!r} does not exist")
+        else:
+            problems.append(f"{gid}: unknown gate kind {kind!r}")
+
+    # Ratchet: every verify_*.py must be registered or explicitly booked as debt.
+    debt_tools = {d.get("tool", "") for d in known_unproven}
+    for vf in sorted((root / "tools").glob("verify_*.py")):
+        rel = f"tools/{vf.name}"
+        if rel not in registered_tools and rel not in debt_tools:
+            problems.append(
+                f"{rel}: a verify_*.py gate that is neither registered in gate_registry.yaml with a "
+                f"teeth-test nor booked under known_unproven — register it (with proof it can fire) "
+                f"or acknowledge it as debt"
+            )
+
+    # Debt tools must actually exist (a stale debt entry hides a removed gate).
+    for d in known_unproven:
+        t = d.get("tool", "")
+        if not (root / t).is_file():
+            problems.append(f"known_unproven references {t!r} which does not exist — remove the stale debt entry")
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--registry", default=str(REGISTRY))
+    args = ap.parse_args(argv)
+    text, err = _read(Path(args.registry))
+    if err:
+        print(f"gate-registry check FAILED: cannot read {args.registry}: {err}", file=sys.stderr)
+        return 1
+    try:
+        obj = yaml.safe_load(text)
+    except yaml.YAMLError as e:
+        print(f"gate-registry check FAILED: {args.registry} is not valid YAML: {e}", file=sys.stderr)
+        return 1
+    problems = check(obj, ROOT)
+    if problems:
+        print("gate-registry check FAILED — a gate cannot prove it fires (never-fired == suspect):", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        return 1
+    gates = obj.get("gates") or []
+    debt = obj.get("known_unproven") or []
+    print(f"OK: {len(gates)} gate(s) each prove they can fire (registered teeth).")
+    if debt:
+        print(f"  acknowledged debt (teeth owed): {', '.join(d.get('tool','?') for d in debt)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/gate_registry.yaml
+++ b/tools/gate_registry.yaml
@@ -1,0 +1,78 @@
+# Gate registry — the meta-gate for "never-fired == suspect".
+#
+# A control that has never actually caught anything is suspect (feedback_control_that_cannot_fail):
+# the estate's oldest failure is a gate that passes because it can't fail, not because the thing it
+# guards is sound. This registry makes "provably fireable" a REQUIREMENT: every deploy/resilience
+# gate must be registered here WITH a teeth-test that exercises a real failure (a negative case that
+# proves the gate denies). tools/check_gate_registry.py fails closed if:
+#   * a registered pytest gate's tool or teeth-test is missing, or the teeth-test has no negative case;
+#   * a registered workflow gate's negative fixture / toothless-guard is missing;
+#   * ANY tools/verify_*.py exists that is neither registered below NOR listed in known_unproven.
+# That last rule is the ratchet: a NEW gate cannot land without either proving it can fire or being
+# explicitly booked as debt in full view of review.
+
+gates:
+  - id: INV-DEP-6
+    name: A promoted digest exists in the registry the nodes pull from
+    kind: pytest
+    tool: tools/verify_pinned_digest_exists.py
+    teeth_test: tools/tests/test_verify_pinned_digest_exists.py
+    min_negative_tests: 1
+
+  - id: INV-DEP-9
+    name: Rollout analysis refs resolve (namespaced/clusterScope)
+    kind: pytest
+    tool: tools/verify_rollout_analysis_refs.py
+    teeth_test: tools/tests/test_verify_rollout_analysis_refs.py
+    min_negative_tests: 1
+
+  - id: INV-DEP-10
+    name: Overlay self-contained — SA/ConfigMap/PVC rendered in-overlay
+    kind: pytest
+    tool: tools/verify_overlay_self_contained.py
+    teeth_test: tools/tests/test_verify_overlay_self_contained.py
+    min_negative_tests: 1
+
+  - id: INV-DEP-11
+    name: Manifest completeness — Secrets resolve + images digest-pinned
+    kind: pytest
+    tool: tools/verify_manifest_completeness.py
+    teeth_test: tools/tests/test_verify_manifest_completeness.py
+    min_negative_tests: 1
+
+  - id: INV-DEP-12
+    name: No dangling repo-path reference after a move/rename/delete
+    kind: pytest
+    tool: tools/verify_no_dangling_path_refs.py
+    teeth_test: tools/tests/test_verify_no_dangling_path_refs.py
+    min_negative_tests: 1
+
+  - id: INV-DEP-13
+    name: Evidence references resolve to real, well-formed artifacts
+    kind: pytest
+    tool: tools/verify_evidence_refs.py
+    teeth_test: tools/tests/test_verify_evidence_refs.py
+    min_negative_tests: 1
+
+  - id: L1-ephemeral-apply
+    name: Ephemeral real-apply preflight (live create/spec-admission)
+    kind: workflow
+    workflow: .github/workflows/ephemeral-apply-preflight.yml
+    negative_fixture: infra/k8s/search-orchestrator/overlays/_selftest-broken
+    # The workflow applies ONLY the broken fixture and fails the job unless the detector reports
+    # the FailedCreate — the standing proof the effect-canary can still fire.
+    toothless_guard_marker: toothless
+
+# Acknowledged debt: gates that exist but have NOT yet proven they can fire (no teeth-test with a
+# negative case). Surfaced by this registry rather than hidden. Each owes a teeth-test; until then
+# it is treated as unproven, not trusted. Adding an entry here is a deliberate, reviewable act.
+known_unproven:
+  - tool: tools/verify_fogstack_manifest_signature.py
+    reason: signature verifier; no negative-case test proving it rejects a bad/absent signature yet
+    teeth_owed: true
+  - tool: tools/verify_fogstack_release_seal_signature.py
+    reason: release-seal signature verifier; no negative-case test proving rejection yet
+    teeth_owed: true
+  - tool: tools/verify_probe_contract.py
+    reason: probe-contract verifier; no negative-case test proving it rejects a violating probe yet
+    teeth_owed: true

--- a/tools/run_preflight.py
+++ b/tools/run_preflight.py
@@ -8,10 +8,14 @@ preflight means those legs will be green in CI too.
 
 INCLUDED (fast + hermetic, laptop-runnable in minutes):
   * validate-repo, drift-check, standards-check, topology-check   — repo/standards/topology gates
-  * rollout-analysis-refs-check, overlay-self-contained-check     — static ref-resolution (INV-DEP-9/10)
+  * rollout-analysis-refs-check, overlay-self-contained-check,
+    manifest-completeness-check                                   — static ref-resolution (INV-DEP-9/10/11)
   * no-dangling-path-refs-check                                   — blast-radius on refactor (INV-DEP-12)
   * evidence-refs-check                                           — evidence-reference verification (INV-DEP-13)
-  * test-tools                                                    — the tools/ pytest suite
+  * gate-registry-check                                           — meta-gate: every gate proves it can fire
+  * test-tools-hermetic                                           — the tools/ pytest suite, `-k 'not fogstack'`
+                                                                     (the fogstack integration tests need a
+                                                                     cluster; they run in CI's full test-tools)
 
 DELIBERATELY EXCLUDED — these stay in CI, never in preflight:
   * the ephemeral real-apply / digest-exists preflight and the wave-promote GATE chain (need
@@ -43,7 +47,12 @@ LEGS: list[str] = [
     "manifest-completeness-check",
     "no-dangling-path-refs-check",
     "evidence-refs-check",
-    "test-tools",
+    "gate-registry-check",
+    # Hermetic subset (`-k 'not fogstack'`): the fogstack integration tests in the full
+    # `test-tools` shell out to `kubectl apply --dry-run`, which fails locally on a
+    # gke-gcloud-auth-plugin kubectl when no cluster credential is present (green in CI).
+    # Preflight must be laptop-safe; CI still runs the full `test-tools`.
+    "test-tools-hermetic",
 ]
 
 # Legs that shell out to `kubectl kustomize` to render overlays. Without kubectl they fail

--- a/tools/tests/test_check_gate_registry.py
+++ b/tools/tests/test_check_gate_registry.py
@@ -1,0 +1,88 @@
+"""Teeth for the gate-registry meta-gate (never-fired == suspect).
+
+The meta-gate must PASS the shipped registry (every registered gate has a teeth-test with a
+negative case) and FAIL when a gate can't prove it fires — a teeth-test with no negative case, a
+missing teeth-test, or a verify_*.py registered nowhere. A meta-gate that only ever passes would
+be the very theater it exists to catch.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_gate_registry as chk  # noqa: E402
+
+
+def test_shipped_registry_passes():
+    import yaml
+    obj = yaml.safe_load((chk.ROOT / "tools" / "gate_registry.yaml").read_text())
+    assert chk.check(obj, chk.ROOT) == []
+
+
+def test_negative_test_counter_recognizes_failure_cases():
+    src = (
+        "def test_resolves_ok(): ...\n"
+        "def test_dangling_ref_fails(): ...\n"
+        "def test_malformed_yaml_fails_closed(): ...\n"
+    )
+    assert chk.negative_test_count(src) == 2  # dangling_ref_fails, malformed_yaml_fails_closed
+
+
+def test_gate_with_no_negative_case_is_flagged(tmp_path):
+    # A pytest gate whose teeth-test has ONLY positive tests -> flagged.
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "tools" / "tests").mkdir()
+    (tmp_path / "tools" / "verify_thing.py").write_text("# a gate\n")
+    (tmp_path / "tools" / "tests" / "test_verify_thing.py").write_text(
+        "def test_happy_path(): assert True\n"  # no negative case
+    )
+    obj = {
+        "gates": [{
+            "id": "X", "kind": "pytest",
+            "tool": "tools/verify_thing.py",
+            "teeth_test": "tools/tests/test_verify_thing.py",
+            "min_negative_tests": 1,
+        }],
+        "known_unproven": [],
+    }
+    problems = chk.check(obj, tmp_path)
+    assert any("negative-case" in p for p in problems), problems
+
+
+def test_unregistered_verify_tool_is_flagged(tmp_path):
+    # A verify_*.py present but in neither gates nor known_unproven -> ratchet fails.
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "tools" / "verify_orphan.py").write_text("# unregistered gate\n")
+    obj = {"gates": [], "known_unproven": []}
+    problems = chk.check(obj, tmp_path)
+    assert any("verify_orphan.py" in p and "neither registered" in p for p in problems), problems
+
+
+def test_known_unproven_tool_satisfies_ratchet_but_must_exist(tmp_path):
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "tools" / "verify_orphan.py").write_text("# gate\n")
+    # booked as debt -> ratchet satisfied, no violation for verify_orphan
+    ok = chk.check({"gates": [], "known_unproven": [{"tool": "tools/verify_orphan.py"}]}, tmp_path)
+    assert not any("verify_orphan.py" in p for p in ok), ok
+    # but a debt entry for a NON-existent tool is a stale entry -> flagged
+    stale = chk.check({"gates": [], "known_unproven": [{"tool": "tools/verify_ghost.py"}]}, tmp_path)
+    assert any("verify_ghost.py" in p and "stale" in p for p in stale), stale
+
+
+def test_missing_teeth_test_is_flagged(tmp_path):
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "tools" / "verify_thing.py").write_text("# gate\n")
+    obj = {"gates": [{
+        "id": "X", "kind": "pytest",
+        "tool": "tools/verify_thing.py",
+        "teeth_test": "tools/tests/test_verify_thing.py",  # does not exist
+        "min_negative_tests": 1,
+    }], "known_unproven": []}
+    problems = chk.check(obj, tmp_path)
+    assert any("no proof it can fire" in p for p in problems), problems
+
+
+def test_malformed_registry_fails_closed():
+    assert chk.check("not a mapping", chk.ROOT)  # non-empty violations


### PR DESCRIPTION
Closes out the resilience-engineering program. L1–L6 already landed (#1232, #1235, #1242); this adds the two remaining pieces.

## 1. Preflight hermeticity (L5 fix)
`make preflight` ran the full `test-tools`, which includes fogstack integration tests that shell out to `kubectl apply --dry-run`. On a laptop whose kubectl is a gke-gcloud-auth-plugin dispatcher, that fires the credential plugin **even for a client-side dry-run** — so an absent/expired cluster cred makes 8 tests fail locally though they're green in CI. That's a false failure breaking preflight's laptop-safe contract (**preflight caught its own non-hermeticity** — exactly the "green on my machine ≠ green in CI" divergence L5 exists to kill).

New `test-tools-hermetic` (`pytest -k 'not fogstack'`, the boundary proven green with no cluster: **593 pass / 0 fail**) is what preflight runs; **CI still runs the full `test-tools`**. Preflight: 65s + FAIL → **20s, all 11 legs PASS**.

## 2. Gate registry meta-gate — never-fired == suspect
The estate's oldest failure is a control that passes because it *can't* fail. `tools/gate_registry.yaml` registers every deploy/resilience gate with the teeth-test that proves it can **deny**; `tools/check_gate_registry.py` fails closed if:
- a registered gate has no negative-case test, or
- **(the ratchet)** any `tools/verify_*.py` is neither registered with teeth nor booked as explicit debt under `known_unproven`.

A new gate can't land without proving it fires or being visibly recorded as debt. **First run surfaced 3 estate gates with no teeth** (`verify_fogstack_manifest_signature`, `verify_fogstack_release_seal_signature`, `verify_probe_contract`) — now booked as acknowledged debt (teeth owed), no longer silently trusted.

Proven both ways: `tools/tests/test_check_gate_registry.py` (7 tests) — the shipped registry passes; a teeth-less gate is flagged; an unregistered `verify_*.py` fails the ratchet. `make gate-registry-check` in the required matrix + preflight.

## Program status
L1 real-apply · L2 completeness · L3 blast-radius · L4 evidence-refs · L5 preflight · L6 auto-remediate · **meta-gate** — all live. Full preflight green in 20s.

## Follow-up (surfaced, not blocking)
The 3 teeth-less gates owe negative-case tests — tracked in `known_unproven`.