### PR TITLE
feat(shell): first-class AgenticTask object + state machine (gaps #1/#4/#5)

### DIFF
--- a/.github/workflows/agentic-task-contract.yml
+++ b/.github/workflows/agentic-task-contract.yml
@@ -1,0 +1,33 @@
+name: AgenticTask contract
+on:
+  pull_request:
+    paths:
+      - "contracts/AgenticTask.v0.1.json"
+      - "contracts/TypedInterrupt.v0.1.json"
+      - "contracts/ShellEvidencePacket.v0.1.json"
+      - "tools/agentic_task.py"
+      - "tools/validate_agentic_task.py"
+      - "tools/tests/test_agentic_task.py"
+      - "examples/agentic_task_example.json"
+  push:
+    branches: [main]
+    paths:
+      - "contracts/AgenticTask.v0.1.json"
+      - "tools/agentic_task.py"
+      - "tools/validate_agentic_task.py"
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - run: python -m pip install jsonschema pytest
+      - name: Validator self-test (fail-closed semantics + tamper detection)
+        run: python3 tools/validate_agentic_task.py
+      - name: Validate the example task
+        run: python3 tools/validate_agentic_task.py examples/agentic_task_example.json
+      - name: State-machine tests
+        run: python3 -m pytest tools/tests/test_agentic_task.py -q

--- a/contracts/AgenticTask.v0.1.json
+++ b/contracts/AgenticTask.v0.1.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/AgenticTask.v0.1.json",
+  "title": "AgenticTask",
+  "description": "The first-class task object for the agentic supervisory shell: an explicit, persisted object with scope, policy envelope, autonomy level, budget, lifecycle state, staged actions, evidence, and approval requirements. This is the object the shell organizes supervision around (objective bar, status strip, worksets, timeline). audit_log entries reference AutonomyAdmissionReceipt seals — the task's decisions are backed by the estate's hash-sealed autonomy receipts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "task_id", "goal", "scope", "autonomy_level", "owner", "state", "created_at", "updated_at", "hash", "hash_algo"],
+  "properties": {
+    "version": { "const": "0.1" },
+    "task_id": { "type": "string", "pattern": "^urn:srcos:task:[0-9a-f-]{8,}$" },
+    "goal": { "type": "string", "minLength": 1, "description": "the operator's stated objective (natural language + structured tokens)" },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "explicit scope selector — what the task may touch",
+      "properties": {
+        "orgs": { "type": "array", "items": { "type": "string" } },
+        "repos": { "type": "array", "items": { "type": "string" } },
+        "groups": { "type": "array", "items": { "type": "string" } },
+        "selector": { "type": "string", "description": "natural-language or structured scope query" }
+      }
+    },
+    "policies": { "type": "array", "items": { "type": "string" }, "description": "policy-envelope refs (consent-plane / policy-fabric); e.g. policy://sourceos/terminal/v1" },
+    "autonomy_level": { "type": "string", "pattern": "^L[0-5]$", "description": "canonical autonomy ladder L0-L5, aligned with AutonomyAdmissionReceipt" },
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "wall_seconds": { "type": "integer", "minimum": 0 },
+        "tokens": { "type": "integer", "minimum": 0 },
+        "usd": { "type": "number", "minimum": 0 }
+      }
+    },
+    "owner": { "type": "string", "description": "responsible principal (human:* or urn:srcos:agent:*)" },
+    "state": {
+      "type": "string",
+      "enum": ["drafting", "ready", "running", "waiting_for_evidence", "waiting_for_approval", "blocked", "completed", "aborted", "rolled_back"]
+    },
+    "created_at": { "type": "string", "format": "date-time" },
+    "updated_at": { "type": "string", "format": "date-time" },
+    "actions": {
+      "type": "array",
+      "description": "recommended/staged actions with their own lifecycle + risk tier",
+      "items": { "$ref": "#/$defs/recommendedAction" }
+    },
+    "outputs": { "type": "array", "items": { "type": "object" }, "description": "produced artifacts (issue drafts, MRs, diffs, reports)" },
+    "audit_log": {
+      "type": "array",
+      "description": "ordered, append-only audit entries; receipt_ref links to an AutonomyAdmissionReceipt seal",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["at", "event"],
+        "properties": {
+          "at": { "type": "string", "format": "date-time" },
+          "event": { "type": "string", "description": "e.g. state:running, action:approved, interrupt:critical" },
+          "from": { "type": "string" },
+          "to": { "type": "string" },
+          "actor": { "type": "string" },
+          "receipt_ref": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+          "reason": { "type": "string" }
+        }
+      }
+    },
+    "confidence_summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "score": { "type": "number", "minimum": 0, "maximum": 1 },
+        "uncertainty": { "type": "number", "minimum": 0, "maximum": 1 },
+        "basis": { "type": "string" }
+      }
+    },
+    "approval_requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tier", "requires_human"],
+      "properties": {
+        "tier": { "type": "string", "enum": ["low", "medium", "high"] },
+        "requires_human": { "type": "boolean" },
+        "reason": { "type": "string", "description": "WHY this tier (the shell must always state it)" }
+      }
+    },
+    "hash": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "hash_algo": { "const": "sha256" }
+  },
+  "$defs": {
+    "recommendedAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action_id", "capability", "state", "risk_tier"],
+      "properties": {
+        "action_id": { "type": "string" },
+        "capability": { "type": "string", "description": "e.g. issue.draft, mr.open, dependency.update, config.prod-change" },
+        "args": { "type": "object" },
+        "state": {
+          "type": "string",
+          "enum": ["proposed", "staged", "approved", "executing", "succeeded", "failed", "reverted"]
+        },
+        "risk_tier": { "type": "string", "enum": ["low", "medium", "high"] },
+        "why": { "type": "string", "description": "WHY the action fell into its risk tier (mandatory per the approval model)" },
+        "evidence_refs": { "type": "array", "items": { "type": "string" }, "description": "ShellEvidencePacket evidence_ids supporting this action" },
+        "blast_radius": { "type": "string" },
+        "rollback_path": { "type": "string" }
+      }
+    }
+  }
+}

--- a/contracts/ShellEvidencePacket.v0.1.json
+++ b/contracts/ShellEvidencePacket.v0.1.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/ShellEvidencePacket.v0.1.json",
+  "title": "ShellEvidencePacket",
+  "description": "Evidence backing a task/action finding, in the supervisory-shell shape (resource -> claim -> confidence -> freshness -> policy relevance). Distinct from prophet-platform's science-claim evidence_packet; this is the trust-surface (right-inspector) evidence the operator inspects before approving an action.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "evidence_id", "resource_id", "source_type", "source_pointer", "extracted_claim", "confidence", "freshness"],
+  "properties": {
+    "version": { "const": "0.1" },
+    "evidence_id": { "type": "string" },
+    "resource_id": { "type": "string", "description": "the repo/service/entity this evidence is about" },
+    "source_type": { "type": "string", "enum": ["ci", "security-scan", "dependency", "ownership", "activity", "docs", "policy", "other"] },
+    "source_pointer": { "type": "string", "description": "URL / path / query that produced the claim (reproducible)" },
+    "extracted_claim": { "type": "string", "minLength": 1 },
+    "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+    "freshness": { "type": "string", "format": "date-time", "description": "when the underlying signal was observed" },
+    "policy_relevance": { "type": "array", "items": { "type": "string" }, "description": "policy refs this evidence bears on" }
+  }
+}

--- a/contracts/TypedInterrupt.v0.1.json
+++ b/contracts/TypedInterrupt.v0.1.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/contracts/TypedInterrupt.v0.1.json",
+  "title": "TypedInterrupt",
+  "description": "A typed interrupt raised by the agentic shell. All interrupts are typed; only a `critical` interrupt may invade the operator's focus (messenger-style overlays and unrelated surfaces must never cover the decision workspace during task review). Generalizes the estate's single ESCALATE primitive into the spec's FYI/Review/Blocked/Critical taxonomy.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "interrupt_id", "type", "invades_focus", "task_ref", "created_at", "message"],
+  "properties": {
+    "version": { "const": "0.1" },
+    "interrupt_id": { "type": "string" },
+    "type": { "type": "string", "enum": ["fyi", "review_requested", "blocked", "critical"] },
+    "invades_focus": { "type": "boolean", "description": "MUST be false unless type=critical" },
+    "task_ref": { "type": "string", "pattern": "^urn:srcos:task:[0-9a-f-]{8,}$" },
+    "action_ref": { "type": "string" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "message": { "type": "string", "minLength": 1 },
+    "requires_ack": { "type": "boolean" }
+  }
+}

--- a/examples/agentic_task_example.json
+++ b/examples/agentic_task_example.json
@@ -1,0 +1,99 @@
+{
+  "version": "0.1",
+  "task_id": "urn:srcos:task:586b338634674f6b8907771cfc21e0ec",
+  "goal": "Audit all repos in Developers for failing CI, stale dependencies, and missing owners. Draft issues but do not open them.",
+  "scope": {
+    "orgs": [
+      "SocioProphet"
+    ],
+    "selector": "group:Developers"
+  },
+  "policies": [
+    "policy://sourceos/terminal/v1",
+    "consent-plane/001"
+  ],
+  "autonomy_level": "L2",
+  "budget": {
+    "wall_seconds": 900
+  },
+  "owner": "human:mdheller",
+  "state": "waiting_for_approval",
+  "created_at": "2026-08-03T02:51:55.018823Z",
+  "updated_at": "2026-08-03T02:51:55.019152Z",
+  "actions": [
+    {
+      "action_id": "act:94372dcccea8",
+      "capability": "issue.draft",
+      "args": {},
+      "state": "staged",
+      "risk_tier": "low",
+      "why": "drafting an issue is reversible and does not open it",
+      "evidence_refs": [
+        "ev:ci-fail-001"
+      ]
+    },
+    {
+      "action_id": "act:f80602280da5",
+      "capability": "dependency.update",
+      "args": {},
+      "state": "proposed",
+      "risk_tier": "medium",
+      "why": "touches build config; needs contextual review",
+      "evidence_refs": [
+        "ev:dep-stale-002"
+      ]
+    }
+  ],
+  "outputs": [],
+  "audit_log": [
+    {
+      "at": "2026-08-03T02:51:55.018823Z",
+      "event": "state:drafting",
+      "to": "drafting",
+      "actor": "human:mdheller"
+    },
+    {
+      "at": "2026-08-03T02:51:55.019055Z",
+      "event": "action:staged",
+      "to": "staged",
+      "actor": "system",
+      "reason": "drafting an issue is reversible and does not open it"
+    },
+    {
+      "at": "2026-08-03T02:51:55.019091Z",
+      "event": "action:proposed",
+      "to": "proposed",
+      "actor": "system",
+      "reason": "touches build config; needs contextual review"
+    },
+    {
+      "at": "2026-08-03T02:51:55.019118Z",
+      "event": "state:ready",
+      "from": "drafting",
+      "to": "ready",
+      "actor": "human:mdheller"
+    },
+    {
+      "at": "2026-08-03T02:51:55.019136Z",
+      "event": "state:running",
+      "from": "ready",
+      "to": "running",
+      "actor": "system"
+    },
+    {
+      "at": "2026-08-03T02:51:55.019152Z",
+      "event": "state:waiting_for_approval",
+      "from": "running",
+      "to": "waiting_for_approval",
+      "actor": "system",
+      "reason": "medium-risk action staged"
+    }
+  ],
+  "approval_requirements": {
+    "tier": "medium",
+    "requires_human": true,
+    "reason": "a medium-risk action requires contextual review"
+  },
+  "hash_algo": "sha256",
+  "hash": "sha256:7a7b13d83a18e3fc4cb530d07131106987e8b2e158a0142e6f089723476b0707"
+}

--- a/tools/agentic_task.py
+++ b/tools/agentic_task.py
@@ -1,0 +1,189 @@
+"""agentic_task — the AgenticTask object model + state machine.
+
+The first-class task object for the agentic supervisory shell, with a fail-closed
+lifecycle: only legal state transitions, an action lifecycle, risk-tier ->
+approval derivation ("always state WHY"), and typed interrupts where only a
+`critical` interrupt may invade operator focus. Every mutation re-seals the task
+with a sha256 hash; `audit_log` entries can carry an AutonomyAdmissionReceipt
+seal, so the task's decisions are backed by the estate's hash-sealed receipts.
+
+Conforms to contracts/AgenticTask.v0.1.json, TypedInterrupt.v0.1.json.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+# ---- lifecycle (fail-closed transition tables) ------------------------------
+TASK_TRANSITIONS: dict[str, set[str]] = {
+    "drafting": {"ready", "aborted"},
+    "ready": {"running", "aborted"},
+    "running": {"waiting_for_evidence", "waiting_for_approval", "blocked", "completed", "aborted"},
+    "waiting_for_evidence": {"running", "blocked", "aborted"},
+    "waiting_for_approval": {"running", "blocked", "completed", "aborted"},
+    "blocked": {"running", "aborted"},
+    "completed": {"rolled_back"},
+    "aborted": set(),
+    "rolled_back": set(),
+}
+ACTION_TRANSITIONS: dict[str, set[str]] = {
+    "proposed": {"staged", "failed"},
+    "staged": {"approved", "failed", "reverted"},
+    "approved": {"executing", "reverted"},
+    "executing": {"succeeded", "failed"},
+    "succeeded": {"reverted"},
+    "failed": set(),
+    "reverted": set(),
+}
+RISK_TIERS = ("low", "medium", "high")
+INTERRUPT_TYPES = ("fyi", "review_requested", "blocked", "critical")
+_LEVEL_RE = re.compile(r"^L[0-5]$")
+
+_APPROVAL_REASON = {
+    "low": "only low-risk actions (auto-stage, batch approval)",
+    "medium": "a medium-risk action requires contextual review",
+    "high": "a high-risk action requires explicit approval + richer evidence",
+}
+
+
+class TaskError(Exception):
+    """Raised on an illegal transition or malformed input (fail-closed)."""
+
+
+def _utc() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _seal(obj: Any) -> str:
+    return "sha256:" + hashlib.sha256(json.dumps(obj, sort_keys=True, default=str).encode()).hexdigest()
+
+
+def _reseal(task: dict[str, Any]) -> None:
+    task.pop("hash", None)
+    task["hash_algo"] = "sha256"
+    task["hash"] = _seal({k: v for k, v in task.items() if k != "hash"})
+
+
+# ---- factory + transitions --------------------------------------------------
+def new_task(goal: str, owner: str, autonomy_level: str = "L1",
+             scope: dict | None = None, policies: list[str] | None = None,
+             budget: dict | None = None) -> dict[str, Any]:
+    if not goal:
+        raise TaskError("goal is required")
+    if not _LEVEL_RE.match(autonomy_level):
+        raise TaskError(f"autonomy_level must match L0-L5, got {autonomy_level!r}")
+    now = _utc()
+    task = {
+        "version": "0.1",
+        "task_id": f"urn:srcos:task:{uuid.uuid4().hex}",
+        "goal": goal,
+        "scope": scope or {},
+        "policies": policies or [],
+        "autonomy_level": autonomy_level,
+        "budget": budget or {},
+        "owner": owner,
+        "state": "drafting",
+        "created_at": now,
+        "updated_at": now,
+        "actions": [],
+        "outputs": [],
+        "audit_log": [{"at": now, "event": "state:drafting", "to": "drafting", "actor": owner}],
+        "approval_requirements": {"tier": "low", "requires_human": False, "reason": _APPROVAL_REASON["low"]},
+    }
+    _reseal(task)
+    return task
+
+
+def transition(task: dict[str, Any], to_state: str, actor: str = "system",
+               reason: str = "", receipt_ref: str | None = None) -> dict[str, Any]:
+    frm = task["state"]
+    if to_state not in TASK_TRANSITIONS.get(frm, set()):
+        raise TaskError(f"illegal task transition {frm} -> {to_state}")
+    task["state"] = to_state
+    task["updated_at"] = _utc()
+    entry: dict[str, Any] = {"at": task["updated_at"], "event": f"state:{to_state}",
+                             "from": frm, "to": to_state, "actor": actor}
+    if reason:
+        entry["reason"] = reason
+    if receipt_ref:
+        entry["receipt_ref"] = receipt_ref
+    task["audit_log"].append(entry)
+    _reseal(task)
+    return task
+
+
+def add_action(task: dict[str, Any], capability: str, risk_tier: str, why: str,
+               args: dict | None = None, evidence_refs: list[str] | None = None) -> dict[str, Any]:
+    if risk_tier not in RISK_TIERS:
+        raise TaskError(f"risk_tier must be one of {RISK_TIERS}")
+    if not why:
+        raise TaskError("every action must state WHY it fell into its risk tier")
+    action = {
+        "action_id": f"act:{uuid.uuid4().hex[:12]}",
+        "capability": capability,
+        "args": args or {},
+        # low-risk actions auto-stage; medium/high stay proposed pending review
+        "state": "staged" if risk_tier == "low" else "proposed",
+        "risk_tier": risk_tier,
+        "why": why,
+        "evidence_refs": evidence_refs or [],
+    }
+    task["actions"].append(action)
+    task["audit_log"].append({"at": _utc(), "event": f"action:{action['state']}",
+                              "to": action["state"], "actor": "system", "reason": why})
+    _derive_approval(task)
+    task["updated_at"] = _utc()
+    _reseal(task)
+    return action
+
+
+def transition_action(task: dict[str, Any], action_id: str, to_state: str,
+                      actor: str = "system") -> dict[str, Any]:
+    a = next((x for x in task["actions"] if x["action_id"] == action_id), None)
+    if a is None:
+        raise TaskError(f"no such action {action_id}")
+    if to_state not in ACTION_TRANSITIONS.get(a["state"], set()):
+        raise TaskError(f"illegal action transition {a['state']} -> {to_state}")
+    frm = a["state"]
+    a["state"] = to_state
+    task["audit_log"].append({"at": _utc(), "event": f"action:{to_state}",
+                              "from": frm, "to": to_state, "actor": actor})
+    task["updated_at"] = _utc()
+    _reseal(task)
+    return a
+
+
+def _derive_approval(task: dict[str, Any]) -> None:
+    tiers = {a["risk_tier"] for a in task["actions"]}
+    tier = "high" if "high" in tiers else "medium" if "medium" in tiers else "low"
+    task["approval_requirements"] = {"tier": tier, "requires_human": tier != "low",
+                                     "reason": _APPROVAL_REASON[tier]}
+
+
+def make_interrupt(task: dict[str, Any], itype: str, message: str,
+                   action_ref: str | None = None) -> dict[str, Any]:
+    """Build a TypedInterrupt. `invades_focus` is true ONLY for `critical` — the
+    rule is enforced here by construction, not left to the caller."""
+    if itype not in INTERRUPT_TYPES:
+        raise TaskError(f"interrupt type must be one of {INTERRUPT_TYPES}")
+    if not message:
+        raise TaskError("interrupt requires a message")
+    return {
+        "version": "0.1",
+        "interrupt_id": f"int:{uuid.uuid4().hex[:12]}",
+        "type": itype,
+        "invades_focus": itype == "critical",
+        "task_ref": task["task_id"],
+        "action_ref": action_ref,
+        "created_at": _utc(),
+        "message": message,
+        "requires_ack": itype in {"review_requested", "critical"},
+    }
+
+
+def verify_seal(task: dict[str, Any]) -> bool:
+    return task.get("hash") == _seal({k: v for k, v in task.items() if k != "hash"})

--- a/tools/tests/test_agentic_task.py
+++ b/tools/tests/test_agentic_task.py
@@ -1,0 +1,77 @@
+"""AgenticTask state machine — fail-closed lifecycle, risk->approval, typed
+interrupts (critical-only focus), seal + tamper detection. Offline."""
+from __future__ import annotations
+import sys
+from pathlib import Path
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+import agentic_task as at  # noqa: E402
+from validate_agentic_task import semantic_checks, validate_interrupt  # noqa: E402
+import pytest  # noqa: E402
+
+
+def test_legal_lifecycle_and_seal():
+    t = at.new_task("audit repos", owner="human:x", autonomy_level="L2")
+    assert t["state"] == "drafting" and at.verify_seal(t)
+    at.transition(t, "ready"); at.transition(t, "running")
+    at.transition(t, "waiting_for_approval"); at.transition(t, "completed")
+    assert t["state"] == "completed"
+    assert semantic_checks(t) == []
+
+
+def test_illegal_transition_fails_closed():
+    t = at.new_task("g", owner="o")
+    at.transition(t, "ready"); at.transition(t, "running")
+    with pytest.raises(at.TaskError):
+        at.transition(t, "drafting")  # not a legal successor of running
+
+
+def test_low_risk_autostages_high_derives_approval():
+    t = at.new_task("g", owner="o")
+    lo = at.add_action(t, "issue.draft", "low", why="reversible")
+    assert lo["state"] == "staged"
+    assert t["approval_requirements"] == {"tier": "low", "requires_human": False,
+                                          "reason": at._APPROVAL_REASON["low"]}
+    hi = at.add_action(t, "config.prod-change", "high", why="prod impact")
+    assert hi["state"] == "proposed"
+    assert t["approval_requirements"]["tier"] == "high"
+    assert t["approval_requirements"]["requires_human"] is True
+
+
+def test_action_lifecycle():
+    t = at.new_task("g", owner="o")
+    a = at.add_action(t, "mr.open", "medium", why="touches build config")  # -> proposed
+    with pytest.raises(at.TaskError):
+        at.transition_action(t, a["action_id"], "approved")  # must be STAGED first
+    at.transition_action(t, a["action_id"], "staged")
+    at.transition_action(t, a["action_id"], "approved")
+    at.transition_action(t, a["action_id"], "executing")
+    at.transition_action(t, a["action_id"], "succeeded")
+    with pytest.raises(at.TaskError):
+        at.transition_action(t, a["action_id"], "executing")  # succeeded is not a predecessor
+
+
+def test_action_requires_why():
+    t = at.new_task("g", owner="o")
+    with pytest.raises(at.TaskError):
+        at.add_action(t, "x", "low", why="")
+
+
+def test_typed_interrupt_focus_rule():
+    t = at.new_task("g", owner="o")
+    fyi = at.make_interrupt(t, "fyi", "heads up")
+    crit = at.make_interrupt(t, "critical", "prod down")
+    assert fyi["invades_focus"] is False and crit["invades_focus"] is True
+    assert validate_interrupt(fyi) == [] and validate_interrupt(crit) == []
+    # a hand-forged non-critical claiming focus is rejected
+    assert validate_interrupt({"type": "fyi", "invades_focus": True})
+
+
+def test_tamper_detected():
+    t = at.new_task("g", owner="o")
+    t["goal"] = "tampered"
+    assert "hash seal does not verify" in semantic_checks(t)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tools/validate_agentic_task.py
+++ b/tools/validate_agentic_task.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Validate an AgenticTask (and optionally a TypedInterrupt) against its contract
++ fail-closed semantics: legal replayable state history, action lifecycle,
+approval tier == max action risk tier, and the hash seal. Proven both ways by
+the self-test below.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "contracts" / "AgenticTask.v0.1.json"
+INTERRUPT_SCHEMA = ROOT / "contracts" / "TypedInterrupt.v0.1.json"
+
+sys.path.insert(0, str(ROOT / "tools"))
+from agentic_task import (  # noqa: E402
+    ACTION_TRANSITIONS, TASK_TRANSITIONS, _APPROVAL_REASON, verify_seal,
+)
+
+
+class ValidationError(Exception):
+    pass
+
+
+def _fail(msg: str) -> None:
+    raise ValidationError(msg)
+
+
+def semantic_checks(task: dict[str, Any]) -> list[str]:
+    errs: list[str] = []
+    # 1. replay the audit_log's state transitions — every hop must be legal
+    state = None
+    for e in task.get("audit_log", []):
+        if not e.get("event", "").startswith("state:"):
+            continue
+        to = e.get("to")
+        if state is None:
+            if to != "drafting":
+                errs.append(f"first state must be 'drafting', got {to!r}")
+        elif to not in TASK_TRANSITIONS.get(state, set()):
+            errs.append(f"illegal state transition in audit_log: {state} -> {to}")
+        state = to
+    if state is not None and state != task.get("state"):
+        errs.append(f"task.state {task.get('state')!r} disagrees with audit_log tail {state!r}")
+
+    # 2. action lifecycle + low-risk auto-stage
+    for a in task.get("actions", []):
+        if a["state"] not in ACTION_TRANSITIONS:
+            errs.append(f"action {a['action_id']}: unknown state {a['state']!r}")
+        if not a.get("why"):
+            errs.append(f"action {a['action_id']}: missing WHY (risk rationale)")
+        if a["risk_tier"] == "low" and a["state"] == "proposed":
+            errs.append(f"action {a['action_id']}: low-risk actions auto-stage, must not be 'proposed'")
+
+    # 3. approval tier == max action risk tier, and requires_human derived
+    tiers = {a["risk_tier"] for a in task.get("actions", [])}
+    want = "high" if "high" in tiers else "medium" if "medium" in tiers else "low"
+    ap = task.get("approval_requirements", {})
+    if ap.get("tier") != want:
+        errs.append(f"approval_requirements.tier {ap.get('tier')!r} != max action tier {want!r}")
+    if ap.get("requires_human") != (want != "low"):
+        errs.append("approval_requirements.requires_human must be (tier != low)")
+    if not ap.get("reason"):
+        errs.append("approval_requirements must state WHY (reason)")
+
+    # 4. hash seal
+    if not verify_seal(task):
+        errs.append("hash seal does not verify")
+    return errs
+
+
+def validate_interrupt(rec: dict[str, Any]) -> list[str]:
+    errs: list[str] = []
+    if rec.get("type") != "critical" and rec.get("invades_focus"):
+        errs.append("only a 'critical' interrupt may invade focus (invades_focus=true)")
+    if rec.get("type") == "critical" and not rec.get("invades_focus"):
+        errs.append("a 'critical' interrupt must set invades_focus=true")
+    return errs
+
+
+def _schema_validate(inst: dict, schema_path: Path) -> str | None:
+    try:
+        import jsonschema  # type: ignore
+    except ImportError:
+        return None
+    try:
+        jsonschema.validate(inst, json.loads(schema_path.read_text()))
+    except Exception as exc:  # jsonschema.ValidationError
+        return str(exc).splitlines()[0]
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    if argv:
+        inst = json.loads(Path(argv[0]).read_text())
+        serr = _schema_validate(inst, SCHEMA)
+        errs = ([f"schema: {serr}"] if serr else []) + semantic_checks(inst)
+        if errs:
+            print("FAIL:", file=sys.stderr)
+            for e in errs:
+                print("  -", e, file=sys.stderr)
+            return 1
+        print("OK: AgenticTask valid (schema + fail-closed semantics + seal).")
+        return 0
+
+    # self-test: build via the engine, prove valid; prove an illegal transition is refused
+    import agentic_task as at
+    t = at.new_task("Audit all repos for failing CI", owner="human:mdheller", autonomy_level="L2")
+    at.add_action(t, "issue.draft", "low", why="drafting an issue is reversible and low-impact")
+    at.transition(t, "ready", actor="human:mdheller")
+    at.transition(t, "running")
+    assert semantic_checks(t) == [], semantic_checks(t)
+    try:
+        at.transition(t, "drafting")  # running -> drafting is illegal
+        print("FAIL: self-test — illegal transition was allowed", file=sys.stderr)
+        return 1
+    except at.TaskError:
+        pass
+    # tamper detection
+    t["goal"] = "tampered"
+    assert "hash seal does not verify" in semantic_checks(t)
+    print("OK: self-test — engine-built task valid, illegal transition refused, tamper detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Plugs the **biggest gap** in the "Agentic GitLab-Style Shell v0.1" estate evaluation: the estate has the governance **engine room** (autonomy receipts, ALLOW/DENY/ESCALATE policy engine, consent-plane) but **no first-class Task object** — the thing the shell organizes supervision around. This adds that object model, to SOTA, backed by the receipts we already emit.

## Contracts (JSON Schema 2020-12)
- **AgenticTask.v0.1** — `task_id/goal/scope/policies/autonomy_level(L0-L5)/budget/owner/state/created/updated/actions/outputs/audit_log/confidence_summary/approval_requirements` + sha256 seal. `audit_log` entries carry **AutonomyAdmissionReceipt** seals → task decisions are backed by the estate's hash-sealed receipts.
- **TypedInterrupt.v0.1** — FYI / Review / Blocked / Critical; **only critical may invade focus** (generalizes the estate's single ESCALATE primitive). *[gap #5]*
- **ShellEvidencePacket.v0.1** — `resource → claim → confidence → freshness → policy_relevance`, the trust-surface evidence shape (reconciles the science-claim mismatch). *[gap #4]*

## Engine — `tools/agentic_task.py` (fail-closed state machine)
Legal task + action transition tables (Proposed→Staged→Approved→Executing→…, low-risk **auto-stage**), risk-tier → approval derivation that **always states WHY**, typed interrupts with the **critical-only focus rule enforced by construction**, sha256 re-seal on every mutation.

## Proof
- `validate_agentic_task.py` self-test: engine-built task valid · illegal transition refused · **tamper detected** (seal breaks).
- 7 pytest cases (lifecycle, illegal transitions fail-closed, low-auto-stage/high-derives-approval, action lifecycle Staged-before-Approved, why-required, interrupt focus rule, tamper).
- Generated conformant **example** (Workflow A: group-health audit) validates.
- Dedicated CI workflow.

This is gap #1 (+#4/#5) of six. Health-matrix aggregator (#2) follows; shell UI (#3) and Gitea backend wiring (#6) are the larger remaining pieces.