### PR TITLE
feat(gitea): mint gitea-signing-key via WIF + backend-flip config (gap #6 provisioning)

### DIFF
--- a/.github/workflows/provision-secrets.yml
+++ b/.github/workflows/provision-secrets.yml
@@ -13,6 +13,8 @@ name: provision-secrets
 #                 COMPUTE_GATEWAY_TOKEN, STUDIO_WRITE_TOKEN, ARCTICDB_GATEWAY_TOKEN,
 #                 WORDOPS_ROOM_FACTORY_TOKEN (the Synapse-issued room-factory service-account token).
 #                 wordops-broker-signing needs NO GitHub secret — it is MINTED here.
+#                 gitea-signing-key needs NO GitHub secret — it is MINTED here (the agentic shell's
+#                 sovereign Gitea backend root; activates ShellBackendAdapter + gitea-sovereign mint).
 #
 # Run: Actions → provision-secrets → Run workflow (optionally scope with `only`).
 # Rotate a token = update the GitHub secret, re-run. A missing value is skipped, not errored.
@@ -176,6 +178,45 @@ jobs:
           kubectl create secret generic "$NAME" -n "$NS" \
             --from-literal=password="$PW" --dry-run=client -o yaml | kubectl apply -f -
           echo "✔ $NAME → namespace/$NS (minted in CI; the value exists nowhere else)"
+
+      # gitea-signing-key is the HMAC root the gitea-sovereign local-authority signs ScopedAgentTokens
+      # with (core/local-authority.js issueLocalGrant). It is what activates the agentic shell's
+      # sovereign Gitea backend (ShellBackendAdapter + gitea-sovereign mint-shell-ops-token). MINTED:
+      # the runner never signs with a human-held key — the authority pod mounts this Secret and issues
+      # short-lived (900s) tokens; the CI mint job calls the authority, it does not hold the root.
+      # CREATE-IF-ABSENT: rotating it invalidates every outstanding grant, so rotation is opt-in via
+      # `rotate` and must be coordinated with an authority restart. 32 hex bytes = a 256-bit HMAC key
+      # (HS256 bootstrap; the schema reserves an Ed25519 upgrade path).
+      - name: Mint gitea-signing-key (create-if-absent)
+        env:
+          ONLY: ${{ inputs.only }}
+          ROTATE: ${{ inputs.rotate }}
+        run: |
+          set -euo pipefail
+          NAME=gitea-signing-key NS=socioprophet
+          if [ -n "$ONLY" ] && ! printf ',%s,' "$ONLY" | grep -q ",$NAME,"; then
+            echo "· skip $NAME (not in 'only' filter)"; exit 0
+          fi
+          EXISTS=$(kubectl get secret "$NAME" -n "$NS" --ignore-not-found -o name || true)
+          FORCE=false
+          if printf ',%s,' "$ROTATE" | grep -q ",$NAME,"; then FORCE=true; fi
+          if [ -n "$EXISTS" ] && [ "$FORCE" != true ]; then
+            echo "✔ $NAME already present in $NS — left untouched (minted secrets are never silently regenerated)"
+            exit 0
+          fi
+          if [ -n "$EXISTS" ] && [ "$FORCE" = true ]; then
+            echo "⚠ ROTATING $NAME. Every outstanding ScopedAgentToken becomes unverifiable the moment"
+            echo "⚠ the authority reloads this key. Restart the gitea-sovereign local-authority in the"
+            echo "⚠ same maintenance window, or in-flight shell sessions will fail token verification."
+          fi
+          # openssl (no pipeline → no SIGPIPE-under-bash-e trap, same reason as clickhouse-admin above)
+          KEY=$(openssl rand -hex 32)
+          [ ${#KEY} -eq 64 ] || { echo "✗ generator produced ${#KEY} chars, refusing"; exit 1; }
+          case "$KEY" in *[!0-9a-f]*) echo "✗ generator produced non-hex output, refusing"; exit 1;; esac
+          echo "::add-mask::$KEY"
+          kubectl create secret generic "$NAME" -n "$NS" \
+            --from-literal=key="$KEY" --dry-run=client -o yaml | kubectl apply -f -
+          echo "✔ $NAME → namespace/$NS (minted in CI; the HMAC root exists nowhere else)"
 
       # nugget-extractor-token is the INBOUND bearer for nugget-extractor POST /v1/extract
       # (the extraction spine's door). Nothing outside the cluster needs to know it, and no

--- a/contracts/adapters/active-backend.json
+++ b/contracts/adapters/active-backend.json
@@ -1,0 +1,10 @@
+{
+  "$comment": "Selects the ShellBackendAdapter manifest the agentic shell drives. Flip 'active' to 'gitea' once gitea-signing-key is provisioned (provision-secrets.yml) AND the Gitea endpoint is live. The shell refuses to select a backend whose manifest is not marked ready.",
+  "version": "0.1",
+  "active": "github",
+  "backends": {
+    "github": { "manifest": "contracts/adapters/github.adapter.json", "ready": true },
+    "gitea": { "manifest": "contracts/adapters/gitea.adapter.json", "ready": false,
+               "blocked_on": ["provision gitea-signing-key (provision-secrets.yml)", "live endpoint gitea.sourceos.dev/api/v1"] }
+  }
+}


### PR DESCRIPTION
The provisioning step that **activates** the sovereign Gitea backend — bound to the estate's canonical WIF secret-provisioning (`provision-secrets.yml`), not a new pattern.

- **`provision-secrets.yml`** — adds `gitea-signing-key` as a **MINTED** secret (`openssl rand -hex 32` = 256-bit HMAC root, create-if-absent, masked, `kubectl apply`), *exactly* the `clickhouse-admin` / `wordops-broker-signing` pattern. **The runner never signs with a human-held key** — the `gitea-sovereign` local-authority pod mounts this Secret and issues 900s `ScopedAgentToken`s; the CI mint job calls the authority, it doesn't hold the root. Rotation is opt-in (invalidates outstanding grants → coordinate with an authority restart).
- **`contracts/adapters/active-backend.json`** — the backend selector: `active=github`, `gitea.ready=false`, `blocked_on=[provision the key, live endpoint]`. Flip to `gitea` when both land; the shell refuses a not-ready backend.

WIF trust + service account are **already configured** (`GCP_WORKLOAD_IDENTITY_PROVIDER` / `GCP_SERVICE_ACCOUNT`), so this needs no new one-time setup. Companion to #1247 (adapter) + gitea-sovereign#21 (mint job).

**This is the last mechanical piece of gap #6.** What remains is genuinely infra: run `provision-secrets` (mints the key), deploy the gitea-sovereign authority + endpoint, then flip `active-backend.json` to `gitea`. Everything above it is built, tested, and consent-gated.