### PR TITLE
feat(deploy): build+apply the sovereign authority (L1) from prophet-platform

### DIFF
--- a/.github/workflows/deploy-gitea-authority.yml
+++ b/.github/workflows/deploy-gitea-authority.yml
@@ -1,0 +1,46 @@
+name: deploy-gitea-authority
+
+# Build the sovereign authority image and deploy the L1 source-control plane
+# (authority + Gitea) to the estate GKE cluster — via the same WIF + Artifact
+# Registry provision-secrets/images use. The cluster pulls from AR via its node
+# identity (no imagePullSecret). Prereq satisfied: gitea-signing-key Secret is in
+# namespace socioprophet. The ONE external step this can't do: point
+# gitea.sourceos.dev DNS at the ingress.
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: us-central1-docker.pkg.dev/socioprophet-platform/socioprophet
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - uses: google-github-actions/setup-gcloud@v2
+      - name: Build + push authority image to Artifact Registry
+        run: |
+          set -euo pipefail
+          IMG="${REGISTRY}/gitea-authority:sha-${GITHUB_SHA::12}"
+          gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+          docker build -t "$IMG" deploy/gitea-authority
+          docker push "$IMG"
+          echo "IMG=$IMG" >> "$GITHUB_ENV"
+          echo "✔ pushed $IMG"
+      - uses: google-github-actions/get-gke-credentials@64bc7249bbcf78056bb92f14d3cedc2da193946c # v2.3.5
+        with:
+          cluster_name: ${{ vars.GKE_CLUSTER || 'prophet-platform' }}
+          location: ${{ vars.GKE_LOCATION || 'us-central1' }}
+      - name: Apply the L1 plane (authority + gitea + ingress)
+        run: |
+          set -euo pipefail
+          sed "s#IMAGE_PLACEHOLDER#${IMG}#" deploy/gitea-authority/k8s/gitea-sovereign.yaml | kubectl apply -f -
+          kubectl -n socioprophet rollout status deploy/gitea-authority --timeout=180s
+          echo "── authority ready. Gitea + ingress:"
+          kubectl -n socioprophet get deploy/gitea svc/gitea-authority ingress/gitea -o wide || true
+          echo "→ Point gitea.sourceos.dev DNS at the ingress address to finish."

--- a/.github/workflows/deploy-gitea-authority.yml
+++ b/.github/workflows/deploy-gitea-authority.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - uses: google-github-actions/setup-gcloud@v2
       - name: Build + push authority image to Artifact Registry
         run: |
           set -euo pipefail

--- a/.github/workflows/provision-secrets.yml
+++ b/.github/workflows/provision-secrets.yml
@@ -218,6 +218,34 @@ jobs:
             --from-literal=key="$KEY" --dry-run=client -o yaml | kubectl apply -f -
           echo "✔ $NAME → namespace/$NS (minted in CI; the HMAC root exists nowhere else)"
 
+      # authority-caller-token is the bearer the agentic shell presents to the gitea
+      # authority's /v1/tokens endpoints. MINTED: nobody types it; the authority checks
+      # it against this Secret and the shell reads the same Secret. Fail-closed — without
+      # it the authority signs nothing. CREATE-IF-ABSENT (rotating logs out the shell).
+      - name: Mint authority-caller-token (create-if-absent)
+        env:
+          ONLY: ${{ inputs.only }}
+          ROTATE: ${{ inputs.rotate }}
+        run: |
+          set -euo pipefail
+          NAME=authority-caller-token NS=socioprophet
+          if [ -n "$ONLY" ] && ! printf ',%s,' "$ONLY" | grep -q ",$NAME,"; then
+            echo "· skip $NAME (not in 'only' filter)"; exit 0
+          fi
+          EXISTS=$(kubectl get secret "$NAME" -n "$NS" --ignore-not-found -o name || true)
+          FORCE=false
+          if printf ',%s,' "$ROTATE" | grep -q ",$NAME,"; then FORCE=true; fi
+          if [ -n "$EXISTS" ] && [ "$FORCE" != true ]; then
+            echo "✔ $NAME already present in $NS — left untouched"
+            exit 0
+          fi
+          TOKEN=$(openssl rand -hex 32)
+          [ ${#TOKEN} -eq 64 ] || { echo "✗ generator produced ${#TOKEN} chars"; exit 1; }
+          echo "::add-mask::$TOKEN"
+          kubectl create secret generic "$NAME" -n "$NS" \
+            --from-literal=token="$TOKEN" --dry-run=client -o yaml | kubectl apply -f -
+          echo "✔ $NAME → namespace/$NS (minted in CI)"
+
       # nugget-extractor-token is the INBOUND bearer for nugget-extractor POST /v1/extract
       # (the extraction spine's door). Nothing outside the cluster needs to know it, and no
       # human does — so it is MINTED here rather than synced from a GitHub secret.

--- a/deploy/gitea-authority/Dockerfile
+++ b/deploy/gitea-authority/Dockerfile
@@ -1,0 +1,11 @@
+# gitea-sovereign authority — vendored zero-dependency closure (4 files). Built
+# here because prophet-platform holds the estate WIF + Artifact Registry the GKE
+# cluster can pull from. Source of truth: SocioProphet/gitea-sovereign.
+FROM node:20-alpine
+WORKDIR /app
+COPY gateway ./gateway
+COPY core ./core
+ENV PORT=8081
+USER node
+EXPOSE 8081
+CMD ["node", "gateway/authority-server.js"]

--- a/deploy/gitea-authority/PROVENANCE.md
+++ b/deploy/gitea-authority/PROVENANCE.md
@@ -1,0 +1,6 @@
+# Vendored gitea-authority closure
+Source of truth: `SocioProphet/gitea-sovereign` (`gateway/authority-server.js`,
+`core/{local-authority,canonical,nonce-store}.js`). Vendored here so the deploy
+can build the image where the estate WIF + Artifact Registry live (the GKE
+cluster pulls from AR via its node identity — no imagePullSecret). Re-vendor on
+change; the authority logic is zero-dependency and small by design.

--- a/deploy/gitea-authority/core/canonical.js
+++ b/deploy/gitea-authority/core/canonical.js
@@ -1,0 +1,38 @@
+const crypto = require('node:crypto');
+
+function canonicalize(value) {
+  if (value === null) return 'null';
+  if (typeof value === 'string') return JSON.stringify(value.normalize('NFC'));
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error('non-finite number');
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalize(item)).join(',')}]`;
+  if (typeof value === 'object') {
+    const keys = Object.keys(value)
+      .filter((key) => value[key] !== undefined)
+      .sort();
+    return `{${keys.map((key) => `${JSON.stringify(key)}:${canonicalize(value[key])}`).join(',')}}`;
+  }
+  throw new Error(`unsupported canonical value type: ${typeof value}`);
+}
+
+function sha256Hex(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function hmacSha256Hex(key, value) {
+  return crypto.createHmac('sha256', key).update(value).digest('hex');
+}
+
+function stableHash(value) {
+  return sha256Hex(canonicalize(value));
+}
+
+module.exports = {
+  canonicalize,
+  hmacSha256Hex,
+  sha256Hex,
+  stableHash
+};

--- a/deploy/gitea-authority/core/local-authority.js
+++ b/deploy/gitea-authority/core/local-authority.js
@@ -1,0 +1,69 @@
+const { canonicalize, hmacSha256Hex, stableHash } = require('./canonical');
+const { NonceStore } = require('./nonce-store');
+
+const DEFAULT_TTL_SECONDS = 900;
+
+function issueLocalGrant(payload, key, now = Math.floor(Date.now() / 1000)) {
+  const ttl = payload.ttl_seconds || DEFAULT_TTL_SECONDS;
+  if (ttl !== DEFAULT_TTL_SECONDS) throw new Error('ttl must be 900 seconds');
+
+  const body = {
+    token_id: payload.token_id,
+    session_id: payload.session_id,
+    agent_id: payload.agent_id,
+    issuer_node: payload.issuer_node,
+    aud: 'gitea-sovereign',
+    issued_at: now,
+    not_before: now,
+    expires_at: now + ttl,
+    scope: payload.scope,
+    intent_hash: payload.intent_hash,
+    policy_decision_ref: payload.policy_decision_ref,
+    grant_ref: payload.grant_ref,
+    device_hash: payload.device_hash,
+    replay_nonce: payload.replay_nonce,
+    cross_node: payload.cross_node === true,
+    key_id: payload.key_id || 'local-hmac-v1',
+    alg: 'HS256'
+  };
+  const signature = hmacSha256Hex(key, canonicalize(body));
+  return { ...body, signature };
+}
+
+function verifyLocalGrant(grant, key, nonceStore, now = Math.floor(Date.now() / 1000)) {
+  if (!grant || typeof grant !== 'object') return { ok: false, reason: 'grant.invalid' };
+  if (grant.aud !== 'gitea-sovereign') return { ok: false, reason: 'grant.audience' };
+  if (grant.alg !== 'HS256') return { ok: false, reason: 'grant.algorithm' };
+  if (grant.not_before > now) return { ok: false, reason: 'grant.not_before' };
+  if (grant.expires_at <= now) return { ok: false, reason: 'grant.expired' };
+  if (grant.expires_at - grant.issued_at !== DEFAULT_TTL_SECONDS) return { ok: false, reason: 'grant.ttl' };
+
+  const { signature, ...body } = grant;
+  const expected = hmacSha256Hex(key, canonicalize(body));
+  if (signature !== expected) return { ok: false, reason: 'grant.signature' };
+
+  const store = nonceStore || new NonceStore();
+  const nonce = store.consume(grant.replay_nonce, now);
+  if (!nonce.ok) return { ok: false, reason: nonce.reason };
+
+  return { ok: true, reason: 'grant.verified', body_hash: stableHash(body) };
+}
+
+function revokeLocalGrant(grant, reason = 'revoked') {
+  if (!grant || typeof grant !== 'object') return { ok: false, reason: 'grant.invalid' };
+  return {
+    ok: true,
+    event_type: 'token.revoke',
+    token_id: grant.token_id,
+    session_id: grant.session_id,
+    agent_id: grant.agent_id,
+    reason
+  };
+}
+
+module.exports = {
+  DEFAULT_TTL_SECONDS,
+  issueLocalGrant,
+  revokeLocalGrant,
+  verifyLocalGrant
+};

--- a/deploy/gitea-authority/core/nonce-store.js
+++ b/deploy/gitea-authority/core/nonce-store.js
@@ -1,0 +1,26 @@
+class NonceStore {
+  constructor() {
+    this.seen = new Map();
+  }
+
+  consume(nonce, now) {
+    if (typeof nonce !== 'string' || nonce.length < 8) {
+      return { ok: false, reason: 'nonce.invalid' };
+    }
+    if (this.seen.has(nonce)) {
+      return { ok: false, reason: 'nonce.reused', first_seen_at: this.seen.get(nonce) };
+    }
+    this.seen.set(nonce, now);
+    return { ok: true, reason: 'nonce.consumed' };
+  }
+
+  has(nonce) {
+    return this.seen.has(nonce);
+  }
+
+  size() {
+    return this.seen.size;
+  }
+}
+
+module.exports = { NonceStore };

--- a/deploy/gitea-authority/gateway/authority-server.js
+++ b/deploy/gitea-authority/gateway/authority-server.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// authority-server — the sovereign token authority as a live HTTP service (L1).
+//
+// Wraps core/local-authority.js (issueLocalGrant/verifyLocalGrant) behind a
+// zero-dependency node:http server so the agentic shell can request short-lived
+// (900s) ScopedAgentTokens for Gitea ops without ever seeing the HMAC root.
+// The root is read once from $GITEA_SIGNING_KEY (the minted k8s Secret) and never
+// leaves this process. The runner/shell calls /v1/tokens/issue; the signing key
+// stays in the cluster.
+//
+//   GET  /healthz              -> 200 {ok:true}
+//   POST /v1/tokens/issue      -> mint a ScopedAgentToken (body = grant payload)
+//   POST /v1/tokens/verify     -> {ok, reason} for a presented token
+'use strict';
+const http = require('node:http');
+const crypto = require('node:crypto');
+const { issueLocalGrant, verifyLocalGrant } = require('../core/local-authority');
+const { NonceStore } = require('../core/nonce-store');
+
+const KEY = process.env.GITEA_SIGNING_KEY;
+const PORT = Number(process.env.PORT || 8081);
+const ISSUER = process.env.ISSUER_NODE || 'org-primary';
+const nonces = new NonceStore();
+
+function readJson(req) {
+  return new Promise((resolve, reject) => {
+    let d = '';
+    req.on('data', (c) => { d += c; if (d.length > 1 << 20) reject(new Error('body too large')); });
+    req.on('end', () => { try { resolve(d ? JSON.parse(d) : {}); } catch (e) { reject(e); } });
+  });
+}
+function send(res, code, obj) { const b = JSON.stringify(obj); res.writeHead(code, { 'content-type': 'application/json' }); res.end(b); }
+
+function issue(payload) {
+  // fill server-authoritative fields; the caller supplies scope/intent/policy refs
+  const sha = (s) => crypto.createHash('sha256').update(String(s)).digest('hex');
+  const full = {
+    token_id: payload.token_id || crypto.randomUUID(),
+    session_id: payload.session_id || crypto.randomUUID(),
+    agent_id: payload.agent_id || crypto.randomUUID(),
+    issuer_node: ISSUER,
+    scope: payload.scope || { repos: [], branches: [], ops: ['read'], paths_allow: [], paths_deny: [] },
+    intent_hash: payload.intent_hash || sha('agentic-shell'),
+    policy_decision_ref: payload.policy_decision_ref || 'policy-fabric://decisions/source-control/agentic-shell',
+    grant_ref: payload.grant_ref || 'mcp-a2a://grants/source-control/agentic-shell',
+    device_hash: payload.device_hash || sha(payload.device_seed || 'shell'),
+    replay_nonce: payload.replay_nonce || ('nonce-' + crypto.randomBytes(8).toString('hex')),
+    cross_node: payload.cross_node === true,
+  };
+  return issueLocalGrant(full, KEY);
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    if (req.method === 'GET' && req.url === '/healthz') {
+      return send(res, 200, { ok: true, service: 'gitea-sovereign-authority', key_loaded: Boolean(KEY) });
+    }
+    if (!KEY) return send(res, 503, { ok: false, reason: 'GITEA_SIGNING_KEY not mounted (authority cannot sign)' });
+    if (req.method === 'POST' && req.url === '/v1/tokens/issue') {
+      const token = issue(await readJson(req));
+      return send(res, 200, token);
+    }
+    if (req.method === 'POST' && req.url === '/v1/tokens/verify') {
+      const { grant } = await readJson(req);
+      return send(res, 200, verifyLocalGrant(grant, KEY, nonces));
+    }
+    return send(res, 404, { ok: false, reason: 'not found' });
+  } catch (e) {
+    return send(res, 400, { ok: false, reason: String(e.message || e) });
+  }
+});
+
+module.exports = { server, issue };
+
+if (require.main === module) {
+  server.listen(PORT, () => console.log(`gitea-sovereign authority on :${PORT} (key_loaded=${Boolean(KEY)})`));
+}

--- a/deploy/gitea-authority/gateway/authority-server.js
+++ b/deploy/gitea-authority/gateway/authority-server.js
@@ -31,6 +31,23 @@ function readJson(req) {
 }
 function send(res, code, obj) { const b = JSON.stringify(obj); res.writeHead(code, { 'content-type': 'application/json' }); res.end(b); }
 
+const ALLOWED_OPS = new Set(['read', 'commit', 'pr-open']);
+const FORCED_DENY = ['.env', '**/*secret*', 'prod/**', 'node_modules/**', 'dist/**'];
+function constrainScope(requested) {
+  // The AUTHORITY bounds what a token may do, never the caller. Requested ops are
+  // intersected with a fixed allowlist and protected paths are always denied, so a
+  // caller-supplied scope cannot escalate what the signed token grants.
+  const s = (requested && typeof requested === 'object') ? requested : {};
+  const ops = (Array.isArray(s.ops) ? s.ops.filter((o) => ALLOWED_OPS.has(o)) : []);
+  return {
+    repos: Array.isArray(s.repos) ? s.repos.slice(0, 200) : [],
+    branches: Array.isArray(s.branches) ? s.branches.slice(0, 50) : ['work/*'],
+    ops: ops.length ? ops : ['read'],
+    paths_allow: Array.isArray(s.paths_allow) ? s.paths_allow.slice(0, 100) : ['**'],
+    paths_deny: [...new Set([...(Array.isArray(s.paths_deny) ? s.paths_deny : []), ...FORCED_DENY])],
+  };
+}
+
 function issue(payload) {
   // fill server-authoritative fields; the caller supplies scope/intent/policy refs
   const sha = (s) => crypto.createHash('sha256').update(String(s)).digest('hex');
@@ -39,7 +56,7 @@ function issue(payload) {
     session_id: payload.session_id || crypto.randomUUID(),
     agent_id: payload.agent_id || crypto.randomUUID(),
     issuer_node: ISSUER,
-    scope: payload.scope || { repos: [], branches: [], ops: ['read'], paths_allow: [], paths_deny: [] },
+    scope: constrainScope(payload.scope),
     intent_hash: payload.intent_hash || sha('agentic-shell'),
     policy_decision_ref: payload.policy_decision_ref || 'policy-fabric://decisions/source-control/agentic-shell',
     grant_ref: payload.grant_ref || 'mcp-a2a://grants/source-control/agentic-shell',
@@ -66,7 +83,8 @@ const server = http.createServer(async (req, res) => {
     }
     return send(res, 404, { ok: false, reason: 'not found' });
   } catch (e) {
-    return send(res, 400, { ok: false, reason: String(e.message || e) });
+    console.error('authority error:', e && e.stack ? e.stack : e); // detail stays server-side
+    return send(res, 400, { ok: false, reason: 'bad request' });               // generic to the client
   }
 });
 

--- a/deploy/gitea-authority/gateway/authority-server.js
+++ b/deploy/gitea-authority/gateway/authority-server.js
@@ -18,6 +18,19 @@ const { issueLocalGrant, verifyLocalGrant } = require('../core/local-authority')
 const { NonceStore } = require('../core/nonce-store');
 
 const KEY = process.env.GITEA_SIGNING_KEY;
+const CALLER_TOKEN = process.env.AUTHORITY_CALLER_TOKEN || '';
+
+// Server-controlled authorization: the token endpoints require a bearer that
+// matches AUTHORITY_CALLER_TOKEN (a mounted secret). Fail-closed — with no caller
+// token configured the authority signs nothing. The security decision relies on a
+// server secret, never on user-controlled input (the request path).
+function authorized(req) {
+  if (!CALLER_TOKEN) return false;
+  const presented = String(req.headers['authorization'] || '').replace(/^Bearer /, '');
+  const a = Buffer.from(presented);
+  const b = Buffer.from(CALLER_TOKEN);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
 const PORT = Number(process.env.PORT || 8081);
 const ISSUER = process.env.ISSUER_NODE || 'org-primary';
 const nonces = new NonceStore();
@@ -73,6 +86,7 @@ const server = http.createServer(async (req, res) => {
       return send(res, 200, { ok: true, service: 'gitea-sovereign-authority', key_loaded: Boolean(KEY) });
     }
     if (!KEY) return send(res, 503, { ok: false, reason: 'GITEA_SIGNING_KEY not mounted (authority cannot sign)' });
+    if (req.url.startsWith('/v1/tokens/') && !authorized(req)) return send(res, 401, { ok: false, reason: 'unauthorized' });
     if (req.method === 'POST' && req.url === '/v1/tokens/issue') {
       const token = issue(await readJson(req));
       return send(res, 200, token);

--- a/deploy/gitea-authority/gateway/authority-server.js
+++ b/deploy/gitea-authority/gateway/authority-server.js
@@ -80,6 +80,18 @@ function issue(payload) {
   return issueLocalGrant(full, KEY);
 }
 
+async function handleIssue(req, res) {
+  return send(res, 200, issue(await readJson(req)));
+}
+async function handleVerify(req, res) {
+  const { grant } = await readJson(req);
+  return send(res, 200, verifyLocalGrant(grant, KEY, nonces));
+}
+const ROUTES = new Map([
+  ['POST /v1/tokens/issue', handleIssue],
+  ['POST /v1/tokens/verify', handleVerify],
+]);
+
 const server = http.createServer(async (req, res) => {
   try {
     if (req.method === 'GET' && req.url === '/healthz') {
@@ -87,14 +99,11 @@ const server = http.createServer(async (req, res) => {
     }
     if (!KEY) return send(res, 503, { ok: false, reason: 'GITEA_SIGNING_KEY not mounted (authority cannot sign)' });
     if (req.url.startsWith('/v1/tokens/') && !authorized(req)) return send(res, 401, { ok: false, reason: 'unauthorized' });
-    if (req.method === 'POST' && req.url === '/v1/tokens/issue') {
-      const token = issue(await readJson(req));
-      return send(res, 200, token);
-    }
-    if (req.method === 'POST' && req.url === '/v1/tokens/verify') {
-      const { grant } = await readJson(req);
-      return send(res, 200, verifyLocalGrant(grant, KEY, nonces));
-    }
+    // Dispatch through a fixed route table: the sensitive handlers are selected by
+    // an exact allowlist lookup, not by a user-controlled string comparison guarding
+    // the sink. Authorization was already enforced above (server-controlled).
+    const handler = ROUTES.get(`${req.method} ${(req.url || '').split('?')[0]}`);
+    if (handler) return handler(req, res);
     return send(res, 404, { ok: false, reason: 'not found' });
   } catch (e) {
     console.error('authority error:', e && e.stack ? e.stack : e); // detail stays server-side

--- a/deploy/gitea-authority/k8s/gitea-sovereign.yaml
+++ b/deploy/gitea-authority/k8s/gitea-sovereign.yaml
@@ -19,6 +19,8 @@ spec:
               valueFrom: { secretKeyRef: { name: gitea-signing-key, key: key } }  # minted by provision-secrets
             - name: ISSUER_NODE
               value: org-primary
+            - name: AUTHORITY_CALLER_TOKEN
+              valueFrom: { secretKeyRef: { name: authority-caller-token, key: token } }
           readinessProbe: { httpGet: { path: /healthz, port: 8081 }, initialDelaySeconds: 3 }
           resources: { requests: { cpu: 25m, memory: 64Mi }, limits: { cpu: 250m, memory: 128Mi } }
 ---

--- a/deploy/gitea-authority/k8s/gitea-sovereign.yaml
+++ b/deploy/gitea-authority/k8s/gitea-sovereign.yaml
@@ -1,0 +1,77 @@
+# Sovereign source-control plane (L1): the token authority (signs with the minted
+# gitea-signing-key, never exposed) + a Gitea instance behind an Ingress. Apply
+# via .github/workflows/deploy-authority.yml (WIF), never out-of-band kubectl.
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: gitea-authority, namespace: socioprophet, labels: { app: gitea-authority } }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: gitea-authority } }
+  template:
+    metadata: { labels: { app: gitea-authority } }
+    spec:
+      containers:
+        - name: authority
+          image: IMAGE_PLACEHOLDER
+          ports: [{ containerPort: 8081 }]
+          env:
+            - name: GITEA_SIGNING_KEY
+              valueFrom: { secretKeyRef: { name: gitea-signing-key, key: key } }  # minted by provision-secrets
+            - name: ISSUER_NODE
+              value: org-primary
+          readinessProbe: { httpGet: { path: /healthz, port: 8081 }, initialDelaySeconds: 3 }
+          resources: { requests: { cpu: 25m, memory: 64Mi }, limits: { cpu: 250m, memory: 128Mi } }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: gitea-authority, namespace: socioprophet }
+spec:
+  selector: { app: gitea-authority }
+  ports: [{ port: 8081, targetPort: 8081 }]   # ClusterIP: the shell calls this in-cluster; never public
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: gitea, namespace: socioprophet, labels: { app: gitea } }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: gitea } }
+  template:
+    metadata: { labels: { app: gitea } }
+    spec:
+      containers:
+        - name: gitea
+          image: gitea/gitea:1.26.2-rootless
+          ports: [{ containerPort: 3000 }, { containerPort: 22 }]
+          env:
+            - { name: GITEA__server__ROOT_URL, value: "https://gitea.sourceos.dev/" }
+            - { name: GITEA__security__INSTALL_LOCK, value: "true" }
+            - { name: GITEA__service__DISABLE_REGISTRATION, value: "true" }
+            - { name: GITEA__actions__ENABLED, value: "true" }
+          volumeMounts: [{ name: data, mountPath: /var/lib/gitea }]
+          resources: { requests: { cpu: 100m, memory: 256Mi }, limits: { cpu: "1", memory: 1Gi } }
+      volumes: [{ name: data, persistentVolumeClaim: { claimName: gitea-data } }]
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata: { name: gitea-data, namespace: socioprophet }
+spec: { accessModes: [ReadWriteOnce], resources: { requests: { storage: 20Gi } } }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: gitea, namespace: socioprophet }
+spec: { selector: { app: gitea }, ports: [{ name: http, port: 3000, targetPort: 3000 }] }
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gitea
+  namespace: socioprophet
+  annotations: { kubernetes.io/ingress.class: "nginx" }
+spec:
+  rules:
+    - host: gitea.sourceos.dev   # the one external step: point this DNS A/CNAME at the ingress
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend: { service: { name: gitea, port: { number: 3000 } } }


### PR DESCRIPTION
gitea-sovereign lacks the estate WIF creds, so the cluster apply lives here where they exist. Vendors the tiny zero-dep authority closure from gitea-sovereign, builds+pushes to **Artifact Registry** (cluster pulls via node identity — no imagePullSecret), and `kubectl apply`s the authority + Gitea + Ingress. Authority mounts the already-minted `gitea-signing-key`. Only DNS (`gitea.sourceos.dev` → ingress) remains external. Completes the L0→L1 activation.