### PR TITLE
deploy(argocd): add held Inception Application (digest-pinned, no traffic)

### DIFF
--- a/adr/ADR-037-inception-deploy-wiring.md
+++ b/adr/ADR-037-inception-deploy-wiring.md
@@ -1,0 +1,89 @@
+# ADR-037 — Inception service: steady-state GitOps deploy wiring
+
+**Status:** Proposed (2026-08-03)
+**Context decision:** "Wire the Cybernetic Genesis *Inception* runtime into the estate's ArgoCD
+steady-state deploy, digest-pinned and held — reviewable, not live."
+
+Companion to ADR-036 (Inception Framework invariants). ADR-036 is the *what runs*; this is the
+*how it deploys*. The build+push half lives in `SocioProphet/cybernetic-genesis`
+(`.github/workflows/image.yml`, `deploy/overlays/prod`, `deploy/DECISIONS.md`).
+
+## Context
+
+Inception's image was built, promoted to estate GAR
+(`us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/inception`, amd64 digest
+`sha256:423b4ae6…`, tag `81fd3cc-amd64`), deployed to live GKE in an `inception-validation`
+namespace, verified Ready + serving, then torn down. The GAR artifact and the self-contained kustomize
+overlay remain. What was missing is the steady-state ArgoCD wiring.
+
+The estate pattern (verified by reading `deploy/argocd/{alert-delivery,pvc-capacity-guard,
+registry-services,socbase-services,runtime-services}.yaml`):
+
+- Application/ApplicationSet manifests live under **`deploy/argocd/`** — the ONLY tree the
+  tofu-created root app-of-apps (`infra/tofu/environments/gcp-gke/argocd.tf`) recurses. Anything under
+  `infra/argocd/` is never reconciled.
+- Every existing Application sets `source.repoURL = prophet-platform` and a kustomize/helm `path`
+  **in this repo**.
+- `project: default`, `destination.server: kubernetes.default.svc`.
+- Each carries `socioprophet.io/tier: foundation|reference` (preflight_deploy_contract.py check 5).
+- Steady-state norm is `syncPolicy.automated:{prune,selfHeal}` + `CreateNamespace=true`.
+- Images are digest/sha-pinned; moving tags (`:latest`) are a hard preflight failure (checks 3/4).
+
+## Decision
+
+Add `deploy/argocd/inception-services.yaml`: a single `kind: Application` following that pattern, with
+two deliberate deviations, each recorded below.
+
+### D1 — External source repo (deviation from repoURL = self)
+
+Inception's deploy manifests are owned by, and versioned in, the public MIT repo
+`SocioProphet/cybernetic-genesis` (self-contained kustomize: `base` + `base-support` +
+`overlays/prod`). So this Application sets `repoURL = cybernetic-genesis`, `path =
+deploy/overlays/prod`. The **digest pin lives with the service that owns it** (that overlay's kustomize
+`images:`), not in prophet-platform.
+
+**Cost of the deviation:** `tools/preflight_deploy_contract.py` is static and walks only in-repo paths,
+so it cannot see the external overlay's digest pin — the anti-`:latest`/anti-phantom guards do not
+extend to Inception's image ref. (The `cybernetic-genesis` repo has its own self-contained check,
+`tools/verify_deploy_self_contained.py`.)
+
+> **Open question 1 (reviewer):** accept the external-repo source, or **vendor** the Inception
+> kustomize base into prophet-platform (repoURL = self) so the estate preflight walks its digest pin
+> too? Vendoring restores full contract coverage at the cost of a second copy that can drift from the
+> upstream repo.
+
+### D2 — Held / manual first sync (deviation from automated norm)
+
+The Application ships with **no `automated:` block** and **no `CreateNamespace`**. Rationale: the
+`inception` namespace does not exist on the cluster (validation ran in `inception-validation`, since
+torn down), and the live-traffic posture is a held, owner-only decision. Automated sync + namespace
+creation on an unmerged-but-later-merged manifest could adopt the service before the owner is ready.
+So first sync is manual and the namespace is owner-provisioned. The target overlay is replicas 1, no
+ingress, no traffic.
+
+> **Open question 2 (reviewer):** on merge, flip to the estate norm `automated:{prune,selfHeal}` +
+> `CreateNamespace=true`, or keep the manual/held gate until you explicitly cut over?
+
+### D3 — tier = reference
+
+Inception is a new runtime service, not part of the interoperability spine, and it is built by its own
+repo's `image.yml`, **not** prophet-platform's `images.yml`. Check 6 requires `foundation` images be
+rebuildable *here*; `reference` is the correct, passing claim. (`preflight_deploy_contract.py` exits 0
+with this manifest added; `inception` raises no new finding.)
+
+## Consequences
+
+- **Reversible & inert.** Merging wires the manifest into the watched tree but, with no `automated`
+  block, nothing syncs until an owner acts. Reverting is a file delete.
+- **Digest-pinned.** No moving tag reaches a node cache; a re-pin is a one-line overlay edit in
+  `cybernetic-genesis`.
+
+## Blocker (owner IAM — NOT in scope of this ADR/PR)
+
+The build side (`cybernetic-genesis/.github/workflows/image.yml`) authenticates to GAR via WIF using
+secret names `GCP_WORKLOAD_IDENTITY_PROVIDER` / `GCP_SERVICE_ACCOUNT`. Those are today **repo-level on
+prophet-platform**; there are **no org-level Actions secrets**, and `cybernetic-genesis` has none. A
+WIF attribute binding admitting the `SocioProphet/cybernetic-genesis` OIDC subject to that service
+account (with `roles/artifactregistry.writer` on the `socioprophet` GAR repo) does not yet exist. This
+does not block the ArgoCD Application (it pulls the already-promoted, validated digest), but it does
+block *future* image builds from that repo. Owner action, out of band.

--- a/deploy/argocd/inception-services.yaml
+++ b/deploy/argocd/inception-services.yaml
@@ -1,0 +1,54 @@
+# Argo CD Application — the Cybernetic Genesis **Inception** runtime.
+#
+# Lives in deploy/argocd/, the watched tree: the tofu-created root app-of-apps
+# (infra/tofu/environments/gcp-gke/argocd.tf) recurses deploy/argocd — an Application authored under
+# infra/argocd/ would deploy nothing. Same placement rule as alert-delivery.yaml / pvc-capacity-guard.yaml.
+#
+# DEPARTURE FROM THE HOUSE NORM — external source repo. Every other Application here has
+# repoURL = prophet-platform (kustomize/helm paths in THIS repo). Inception's deploy manifests are
+# owned by, and versioned in, the PUBLIC MIT repo SocioProphet/cybernetic-genesis (self-contained
+# kustomize: base + base-support + overlays/prod). So this Application points its source at THAT repo.
+# The digest pin therefore lives with the service that owns it (cybernetic-genesis
+# deploy/overlays/prod/kustomization.yaml `images:`), not in this file. Tradeoff + the alternative
+# (vendor the base into prophet-platform so preflight_deploy_contract.py can walk it) are in
+# adr/ADR-037-inception-deploy-wiring.md — reviewer decision requested there.
+#
+# HELD POSTURE — deploy-ready, not deployed. This PR is unmerged and nothing here is applied. Even so
+# the manifest is written conservative-by-default so an accidental adoption cannot cut traffic:
+#   * syncPolicy has NO `automated` block — first sync is MANUAL, owner-gated (unlike the estate norm
+#     of automated:{prune,selfHeal}). Flip to automated once the target namespace exists and the
+#     owner approves the first sync.
+#   * NO CreateNamespace — the `inception` namespace is provisioned by the owner out of band, not
+#     minted by a stray sync.
+#   * The overlay it targets is replicas 1, NO ingress, NO traffic.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: inception
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: cybernetic-genesis
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    # Required by tools/preflight_deploy_contract.py check 5. reference, NOT foundation: Inception is
+    # a new runtime service, not part of the interoperability spine, and it is built by its own repo
+    # (cybernetic-genesis/.github/workflows/image.yml), NOT prophet-platform's images.yml — so
+    # foundation (which check 6 requires be rebuildable HERE) would be the wrong, failing claim.
+    socioprophet.io/tier: "reference"
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    # Provisioned by the owner out of band (no CreateNamespace below). The overlay also pins ns=inception.
+    namespace: inception
+  source:
+    # DEPARTURE (see header): external, public MIT repo that owns the Inception deploy manifests.
+    repoURL: https://github.com/SocioProphet/cybernetic-genesis
+    targetRevision: main
+    # Digest pin (sha256:423b4ae6…) is in this overlay's kustomize `images:`, not here.
+    path: deploy/overlays/prod
+  syncPolicy:
+    # DELIBERATELY no `automated:` — held/manual first sync (see header). Estate norm is
+    # automated:{prune,selfHeal}; that is the reviewer's call to enable on merge.
+    syncOptions:
+      - ServerSideApply=true


### PR DESCRIPTION
## What this does

Wires the **Cybernetic Genesis Inception** runtime into the estate's steady-state ArgoCD tree. Companion to the build+push PR on `cybernetic-genesis` (SocioProphet/cybernetic-genesis#7).

**Unmerged, unapplied, reversible.** With no `automated` block, merging wires the manifest into the watched tree but syncs nothing until an owner acts.

### Changes
- **`deploy/argocd/inception-services.yaml`** — a single `kind: Application` in the watched tree (the tofu root app recurses `deploy/argocd`), `project: default`, `socioprophet.io/tier: reference`, pointing at the Inception overlay that carries the `sha256:423b4ae6…` GAR digest pin.
- **`adr/ADR-037-inception-deploy-wiring.md`** — the reasoning, both deviations, reviewer open-questions, and the owner-IAM blocker.

## Pattern matched
Read `deploy/argocd/{alert-delivery,pvc-capacity-guard,registry-services,socbase-services,runtime-services}.yaml`. House pattern: Application manifests under `deploy/argocd/` (only tree the root app-of-apps recurses; `infra/argocd/` is never reconciled), `project: default`, `destination.server: kubernetes.default.svc`, a required `socioprophet.io/tier` annotation, digest/sha-pinned images. This manifest follows all of it, `preflight_deploy_contract.py` **exits 0** with it added, and `inception` raises no new finding.

## Two deliberate deviations — please decide

1. **External source repo.** Every other Application here sets `repoURL = prophet-platform`. Inception's deploy manifests live in the public MIT repo `cybernetic-genesis` (self-contained kustomize), so this sets `repoURL = cybernetic-genesis`, `path = deploy/overlays/prod` — the digest pin lives with the service that owns it. **Cost:** the static `preflight_deploy_contract.py` walks only in-repo paths, so it can't see the external overlay's pin. **Q1: accept the external source, or vendor the base into prophet-platform (repoURL = self) for full contract coverage at the price of a copy that can drift?** (ADR-037 D1)
2. **Held / manual first sync.** No `automated:` block, no `CreateNamespace`. The `inception` namespace doesn't exist (validation ran in `inception-validation`, torn down) and cutover is a held, owner-only decision. **Q2: on merge, flip to the estate norm `automated:{prune,selfHeal}` + `CreateNamespace=true`, or keep the manual gate until you cut over?** (ADR-037 D2)

## tier = reference
Inception is built by its own repo's `image.yml`, not this repo's `images.yml`; check 6 requires `foundation` images be rebuildable here, so `reference` is the correct, passing claim.

## Blocker — owner IAM (does NOT block this PR)
The build side (cybernetic-genesis#7) needs a WIF binding admitting the `SocioProphet/cybernetic-genesis` OIDC subject to the estate service account (`GCP_WORKLOAD_IDENTITY_PROVIDER`/`GCP_SERVICE_ACCOUNT` are repo-level on prophet-platform; no org-level secrets; cybernetic-genesis has none). This Application pulls the already-validated, already-promoted digest, so it is unaffected — but future image builds from that repo are blocked until the owner adds the binding. Out of band; I did not touch IAM/WIF.

## Verification
- `python3 tools/preflight_deploy_contract.py` → exit 0; `inception` not flagged.
- Companion overlay: `kubectl kustomize deploy/overlays/prod` (in cybernetic-genesis#7) renders 8 objects, image = `…/inception@sha256:423b4ae6…`, replicas 1, netpol scoped to ns `inception`.