### PR TITLE
fix(secrets): mint arcticdb-gateway-token in CI (was silently skipped)

### DIFF
--- a/.github/workflows/provision-secrets.yml
+++ b/.github/workflows/provision-secrets.yml
@@ -10,11 +10,13 @@ name: provision-secrets
 #   • Variables:  GKE_CLUSTER, GKE_LOCATION  (the prophet-platform GKE Autopilot cluster)
 #   • Secrets:    GCP_WORKLOAD_IDENTITY_PROVIDER, GCP_SERVICE_ACCOUNT  (already set),
 #                 plus the token values: SPARK_RUNNER_TOKEN, LATTICE_FORGE_TOKEN,
-#                 COMPUTE_GATEWAY_TOKEN, STUDIO_WRITE_TOKEN, ARCTICDB_GATEWAY_TOKEN,
+#                 COMPUTE_GATEWAY_TOKEN, STUDIO_WRITE_TOKEN,
 #                 WORDOPS_ROOM_FACTORY_TOKEN (the Synapse-issued room-factory service-account token).
 #                 wordops-broker-signing needs NO GitHub secret — it is MINTED here.
 #                 gitea-signing-key needs NO GitHub secret — it is MINTED here (the agentic shell's
 #                 sovereign Gitea backend root; activates ShellBackendAdapter + gitea-sovereign mint).
+#                 arcticdb-gateway-token needs NO GitHub secret — it is MINTED here (a symmetric
+#                 self-issued bearer; the gateway checks presented bearers against this Secret).
 #
 # Run: Actions → provision-secrets → Run workflow (optionally scope with `only`).
 # Rotate a token = update the GitHub secret, re-run. A missing value is skipped, not errored.
@@ -69,7 +71,6 @@ jobs:
           LATTICE_FORGE_TOKEN: ${{ secrets.LATTICE_FORGE_TOKEN }}
           COMPUTE_GATEWAY_TOKEN: ${{ secrets.COMPUTE_GATEWAY_TOKEN }}
           STUDIO_WRITE_TOKEN: ${{ secrets.STUDIO_WRITE_TOKEN }}
-          ARCTICDB_GATEWAY_TOKEN: ${{ secrets.ARCTICDB_GATEWAY_TOKEN }}
           WORDOPS_ROOM_FACTORY_TOKEN: ${{ secrets.WORDOPS_ROOM_FACTORY_TOKEN }}
           ONLY: ${{ inputs.only }}
         run: |
@@ -94,7 +95,6 @@ jobs:
           sync lattice-forge-token   token "$LATTICE_FORGE_TOKEN"   sovereign-runtime socioprophet
           sync compute-gateway-token token "$COMPUTE_GATEWAY_TOKEN" socioprophet
           sync studio-write-token    token "$STUDIO_WRITE_TOKEN"    socioprophet
-          sync arcticdb-gateway-token token "$ARCTICDB_GATEWAY_TOKEN" socioprophet
           # wordops-room-factory holds the Synapse service-account access token the room-factory
           # uses to createRoom. Synapse ISSUES it, so it originates in a GitHub secret and is
           # synced (not minted). The deploy marks it optional: until present, /rooms fails closed.
@@ -245,6 +245,50 @@ jobs:
           kubectl create secret generic "$NAME" -n "$NS" \
             --from-literal=token="$TOKEN" --dry-run=client -o yaml | kubectl apply -f -
           echo "✔ $NAME → namespace/$NS (minted in CI)"
+
+      # arcticdb-gateway-token is the INBOUND bearer for the arcticdb-gateway. server.py checks the
+      # presented `Authorization: Bearer` against GATEWAY_TOKEN with secrets.compare_digest — a
+      # SYMMETRIC self-issued bearer: nothing outside the cluster issues it and no human needs it,
+      # so it is MINTED here. (It was previously mis-declared SYNCED; with no GitHub value ever set,
+      # `sync` failed OPEN and silently skipped it — the pod sat in CreateContainerConfigError and
+      # the ArgoCD app Degraded, a control that failed quietly. Minting is create-if-absent, so the
+      # Secret is always produced.)
+      #
+      # CREATE-IF-ABSENT with plain rotation: no persisted copy on a data volume, so rotating is
+      # safe — callers holding the old bearer get 401 until they re-read the Secret; restart
+      # arcticdb-gateway after a rotation (the value is read into the process env at start).
+      - name: Mint arcticdb-gateway-token (create-if-absent)
+        env:
+          ONLY: ${{ inputs.only }}
+          ROTATE: ${{ inputs.rotate }}
+        run: |
+          set -euo pipefail
+          NAME=arcticdb-gateway-token NS=socioprophet
+          if [ -n "$ONLY" ] && ! printf ',%s,' "$ONLY" | grep -q ",$NAME,"; then
+            echo "· skip $NAME (not in 'only' filter)"; exit 0
+          fi
+
+          EXISTS=$(kubectl get secret "$NAME" -n "$NS" --ignore-not-found -o name || true)
+          FORCE=false
+          if printf ',%s,' "$ROTATE" | grep -q ",$NAME,"; then FORCE=true; fi
+
+          if [ -n "$EXISTS" ] && [ "$FORCE" != true ]; then
+            echo "✔ $NAME already present in $NS — left untouched (minted secrets are never silently regenerated)"
+            exit 0
+          fi
+          if [ -n "$EXISTS" ] && [ "$FORCE" = true ]; then
+            echo "⚠ ROTATING $NAME. Callers holding the old bearer will get 401; restart arcticdb-gateway."
+          fi
+
+          # openssl (no pipeline → no SIGPIPE-under-bash-e trap, same reason as clickhouse-admin above)
+          TOK=$(openssl rand -hex 32)
+          [ ${#TOK} -eq 64 ] || { echo "✗ generator produced ${#TOK} chars, refusing"; exit 1; }
+          case "$TOK" in *[!0-9a-f]*) echo "✗ generator produced non-hex output, refusing"; exit 1;; esac
+          echo "::add-mask::$TOK"
+
+          kubectl create secret generic "$NAME" -n "$NS" \
+            --from-literal=token="$TOK" --dry-run=client -o yaml | kubectl apply -f -
+          echo "✔ $NAME → namespace/$NS (minted in CI; the value exists nowhere else)"
 
       # nugget-extractor-token is the INBOUND bearer for nugget-extractor POST /v1/extract
       # (the extraction spine's door). Nothing outside the cluster needs to know it, and no

--- a/deploy/values/arcticdb-gateway.yaml
+++ b/deploy/values/arcticdb-gateway.yaml
@@ -28,8 +28,8 @@ config:
 # POST /v1/write is fail-closed: with no token configured it returns 503 rather than
 # accepting anonymous mutations. This secret is therefore a DEPLOY PREREQUISITE — without
 # it every write is refused (which is the correct failure, but it is a failure).
-# Provisioned by .github/workflows/provision-secrets.yml from the ARCTICDB_GATEWAY_TOKEN
-# repo secret. Reads are unaffected.
+# Provisioned by .github/workflows/provision-secrets.yml, which MINTS it in CI
+# (create-if-absent; a symmetric self-issued bearer, no GitHub secret). Reads are unaffected.
 secretEnv:
   GATEWAY_TOKEN: { secretName: arcticdb-gateway-token, key: token }
 


### PR DESCRIPTION
## What
Reclassify `arcticdb-gateway-token` from **SYNCED** to **MINTED (create-if-absent)** in `provision-secrets.yml`, mirroring `authority-caller-token` / `nugget-extractor-token`.

## Why (root cause, verified live on the prophet-platform cluster)
- Pod `arcticdb-gateway` (ns `socioprophet`) was stuck in `CreateContainerConfigError` → `secret "arcticdb-gateway-token" not found`; ArgoCD `svc-arcticdb-gateway` = **Synced/Degraded**.
- `provision-secrets.yml` declared it SYNCED (`sync arcticdb-gateway-token token "$ARCTICDB_GATEWAY_TOKEN" socioprophet`), but the GitHub Actions secret `ARCTICDB_GATEWAY_TOKEN` was **never populated**, and `sync()` **fails open**: `if [ -z "$val" ]; then echo "· skip"; return 0`. So it was silently skipped — a *control that failed quietly*.
- There is **no external-secrets/sealed-secrets operator** in the cluster; the other four `*-gateway`-style tokens exist only because their GitHub values were set.

## Why minting is correct & safe
`apps/arcticdb-gateway/src/arcticdb_gateway/server.py`:
```py
token = os.getenv("GATEWAY_TOKEN", "")
if not secrets.compare_digest(_bearer(authorization), token): ...
```
Symmetric self-issued bearer — value is arbitrary as long as server + in-cluster clients share the same Secret; no external issuer. grep found no other consumer, and since the Secret has **never existed**, no client depends on any prior value.

## Teeth
`create-if-absent` (never silently regenerates), hex-charset + length assertions, `::add-mask::`, rotation only via the `rotate` input. YAML validated.

## Activation (deliberately NOT auto-run here)
Minting a production secret + mutating the cluster is left to a human:
```
gh workflow run provision-secrets.yml -R SocioProphet/prophet-platform -f only=arcticdb-gateway-token
```
After it runs: `kubectl -n socioprophet get secret arcticdb-gateway-token` should exist, the pod should go `Running`, and ArgoCD `svc-arcticdb-gateway` should return to Healthy.

## Follow-up (separate, not in this PR)
The `sync()` fail-open on an empty *required* secret is the deeper "control that cannot fail" gap — worth a loud warning / fail-closed for required entries. Can file as an issue if wanted.