### PR TITLE
entity-resolution: NER extract head + live materialize spine (ER/NER integration)

### DIFF
--- a/apps/entity-resolution/src/entity_resolution/graph_sink.py
+++ b/apps/entity-resolution/src/entity_resolution/graph_sink.py
@@ -1,0 +1,192 @@
+"""Live wiring: resolved entities -> HellGraph, plus a SHA-256 hash-chained
+resolution receipt into the receipt spine.
+
+This is the ``graph update -> proof artifact`` leg of the identity spine, over
+HTTP against the estate's existing services (consume-not-fork):
+
+* HellGraph (``hellgraph-service`` :8090) is the graph of record. We WRITE resolved
+  entity nodes and same_as edges via ``POST /api/graph/node`` / ``/api/graph/edge``.
+* compute-gateway (:8080) is the canonical hash-chained receipt emitter. We compute
+  a SHA-256 receipt (FIPS authoritative) in the exact body shape the gateway seals
+  (``kind, inputs_sha, outputs_sha, status, actor, epistemic_status, prev, ts`` with
+  ``id = sha256(body)``) and best-effort seal it via ``POST /v1/engine-receipts``.
+
+The locally-computed receipt is always returned and is self-verifying; remote
+sealing is best-effort so the resolver degrades safely when the gateway token is
+absent (it is fail-closed on auth) or the endpoint is unreachable.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from typing import Any
+
+import httpx
+
+HELLGRAPH_URL = os.environ.get("HELLGRAPH_URL", "http://hellgraph-service:8090").rstrip("/")
+COMPUTE_GATEWAY_URL = os.environ.get("COMPUTE_GATEWAY_URL", "http://compute-gateway:8080").rstrip("/")
+HELLGRAPH_TOKEN = os.environ.get("HELLGRAPH_TOKEN", "")
+COMPUTE_GATEWAY_TOKEN = os.environ.get("COMPUTE_GATEWAY_TOKEN", "")
+RECEIPT_PROJECT = os.environ.get("ER_RECEIPT_PROJECT", "entity-resolution")
+
+
+def sha(obj: Any) -> str:
+    """SHA-256 over canonical JSON — byte-compatible with the compute-gateway spine
+    (sort_keys, no ASCII escaping). FIPS: SHA-256 is authoritative."""
+    return "sha256:" + hashlib.sha256(
+        json.dumps(obj, sort_keys=True, default=str, ensure_ascii=False).encode("utf-8")
+    ).hexdigest()
+
+
+class GraphSink:
+    """Writes resolved nodes/edges to HellGraph and seals a SHA-256 receipt.
+
+    ``client`` is injectable so the live path is unit-testable against a mock
+    transport without a cluster.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: httpx.Client | None = None,
+        hellgraph_url: str = HELLGRAPH_URL,
+        compute_gateway_url: str = COMPUTE_GATEWAY_URL,
+        hellgraph_token: str = HELLGRAPH_TOKEN,
+        compute_gateway_token: str = COMPUTE_GATEWAY_TOKEN,
+        prev_receipt_id: str | None = None,
+    ) -> None:
+        self._client = client or httpx.Client(timeout=10.0)
+        self._owns_client = client is None
+        self.hellgraph_url = hellgraph_url.rstrip("/")
+        self.compute_gateway_url = compute_gateway_url.rstrip("/")
+        self.hellgraph_token = hellgraph_token
+        self.compute_gateway_token = compute_gateway_token
+        self._prev = prev_receipt_id
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def _hg_headers(self) -> dict[str, str]:
+        h = {"content-type": "application/json"}
+        if self.hellgraph_token:
+            h["authorization"] = f"Bearer {self.hellgraph_token}"
+        return h
+
+    def upsert_node(self, node_id: str, labels: list[str], properties: dict[str, Any]) -> dict[str, Any]:
+        r = self._client.post(
+            f"{self.hellgraph_url}/api/graph/node",
+            json={"id": node_id, "labels": labels, "properties": properties},
+            headers=self._hg_headers(),
+        )
+        r.raise_for_status()
+        return {"id": node_id, "status": r.status_code}
+
+    def add_edge(self, label: str, src: str, dst: str, properties: dict[str, Any]) -> dict[str, Any]:
+        r = self._client.post(
+            f"{self.hellgraph_url}/api/graph/edge",
+            json={"label": label, "from": src, "to": dst, "properties": properties},
+            headers=self._hg_headers(),
+        )
+        r.raise_for_status()
+        return {"label": label, "from": src, "to": dst, "status": r.status_code}
+
+    def write_resolution(self, resolution: dict[str, Any]) -> dict[str, Any]:
+        """Materialize a /resolve output: one node per canonical entity, one same_as
+        edge per applied merge (from epistemic_edges)."""
+        nodes: list[dict[str, Any]] = []
+        edges: list[dict[str, Any]] = []
+        for ent in resolution.get("entities", []):
+            canon = ent["canonical"]
+            nodes.append(self.upsert_node(
+                ent["entity_id"],
+                ["ENTITY_CLUSTER", "CanonicalEntity"],
+                {
+                    "name": canon["name"],
+                    "survivor": canon["survivor"],
+                    "size": ent["size"],
+                    "members": ent["members"],
+                    "scope": canon.get("scope", ""),
+                    "primes": canon.get("primes", []),
+                    "replay_key": resolution.get("replay_key", {}),
+                },
+            ))
+        for e in resolution.get("epistemic_edges", []):
+            edges.append(self.add_edge(
+                "same_as",
+                e["subject"],
+                e["object"],
+                {
+                    "epistemic_class": e["epistemic_class"],
+                    "confidence_type": e["confidence_type"],
+                    "confidence_level": e["confidence_level"],
+                    "confidence_score": e["confidence_score"],
+                },
+            ))
+        return {"nodes": nodes, "edges": edges}
+
+    def build_receipt(self, inputs: Any, outputs: Any, *, status: str = "ok",
+                      actor: str = "entity-resolution", epistemic_status: str = "resolved") -> dict[str, Any]:
+        """Compute a SHA-256 hash-chained receipt body + id (self-verifying, FIPS)."""
+        body = {
+            "project": RECEIPT_PROJECT,
+            "kind": "entity_resolution",
+            "backend": "entity-resolution",
+            "runtime": "python",
+            "inputs_sha": sha(inputs),
+            "outputs_sha": sha(outputs),
+            "status": status,
+            "actor": actor,
+            "epistemic_status": epistemic_status,
+            "prev": self._prev,
+            "ts": time.time(),
+        }
+        receipt = {"id": sha(body), **body}
+        self._prev = receipt["id"]  # chain forward
+        return receipt
+
+    def emit_receipt(self, receipt: dict[str, Any]) -> dict[str, Any]:
+        """Best-effort seal into the compute-gateway receipt spine. The local receipt
+        is authoritative; remote sealing is degradeable (gateway is fail-closed on
+        auth, so without a token this returns sealed=false with the reason)."""
+        if not self.compute_gateway_token:
+            return {"sealed": False, "reason": "no compute-gateway token configured"}
+        try:
+            r = self._client.post(
+                f"{self.compute_gateway_url}/v1/engine-receipts",
+                json={
+                    "kind": "enrich",
+                    "engineReceipt": receipt,
+                    "subject": {"project": RECEIPT_PROJECT},
+                    "project": RECEIPT_PROJECT,
+                    "actor": "entity-resolution",
+                },
+                headers={"authorization": f"Bearer {self.compute_gateway_token}",
+                         "content-type": "application/json"},
+            )
+        except httpx.HTTPError as exc:  # unreachable / timeout
+            return {"sealed": False, "reason": f"transport: {exc.__class__.__name__}"}
+        if r.status_code >= 400:
+            return {"sealed": False, "reason": f"gateway {r.status_code}", "detail": r.text[:200]}
+        return {"sealed": True, "response": r.json()}
+
+
+def materialize(resolution: dict[str, Any], mention_set: dict[str, Any] | None = None,
+                *, sink: GraphSink | None = None) -> dict[str, Any]:
+    """Full graph-update -> proof leg: write resolved nodes/edges to HellGraph, then
+    compute + emit a SHA-256 hash-chained receipt. Returns what actually landed."""
+    own = sink is None
+    sink = sink or GraphSink()
+    try:
+        graph = sink.write_resolution(resolution)
+        receipt = sink.build_receipt(
+            inputs={"mention_set": mention_set, "records": resolution.get("records")},
+            outputs={"entities": resolution.get("entities"), "graph": graph},
+        )
+        seal = sink.emit_receipt(receipt)
+        return {"graph": graph, "receipt": receipt, "seal": seal}
+    finally:
+        if own:
+            sink.close()

--- a/apps/entity-resolution/src/entity_resolution/ner.py
+++ b/apps/entity-resolution/src/entity_resolution/ner.py
@@ -1,0 +1,188 @@
+"""NER (mention/span) extraction — the ``extract -> mentions`` head of the
+identity spine that entity-resolution previously lacked.
+
+The resolver turns records into proof-carrying entities, but something has to
+produce the mentions/records first. This is the local-first extraction phase from
+the ER/NER integration plan: lightweight, deterministic, dictionary + pattern NER
+for high-value entity types, emitting a MentionSet that conforms to
+regis-entity-graph ``schemas/ner/mention.schema.json`` (v0.1).
+
+Design choices from the plan:
+
+* Overlapping / multi-labelled spans are first-class — a phrase may be at once a
+  named entity, a prime-topic marker, and a policy-sensitive context cue.
+* Immediate PII minimization: high-risk classes (CREDENTIAL, TRACKING_IDENTIFIER,
+  and IDENTIFIER surfaces that look like secrets) are hashed on the span. FIPS:
+  SHA-256 is authoritative.
+* The extraction is stamped with the ``locality`` scope it ran in.
+
+Pure-stdlib so it stays trivially testable and runs local-first (on device / in
+citizen-fog) with no model download.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+
+SCHEMA_VERSION = "regis.ner.mention_set.v0.1"
+EXTRACTOR_VERSION = "regis-ner-deterministic@0.1.0"
+
+# Kept in sync with regis-entity-graph schemas/ner/entity-class.schema.json.
+BASE_CLASSES = {
+    "PERSON", "ORG", "PRODUCT_SERVICE", "DEVICE", "ACCOUNT", "IDENTIFIER",
+    "CREDENTIAL", "LOCATION", "JURISDICTION", "CONSENT_ARTIFACT", "POLICY_TERM",
+    "PRIME_TOPIC_MENTION", "ACTION_EVENT_TRIGGER", "RELATIONSHIP_MENTION",
+}
+DOMAIN_CLASSES = {
+    "SCOPE_REALM", "TRACKING_IDENTIFIER", "HSM_HANDLE", "NONCE_STREAM",
+    "EXPORT_ATTEMPT", "CONSENT_WITNESS", "SENSITIVE_CONTEXT", "CHILD_CONTEXT",
+    "PATIENT_CONTEXT", "CIVIC_CONTEXT", "MARKETING_CONTEXT",
+}
+ENTITY_CLASSES = BASE_CLASSES | DOMAIN_CLASSES
+
+LOCALITIES = {"CITIZEN_FOG", "CITIZEN_CLOUD", "INSTITUTION", "ADTECH", "HSM"}
+SOURCE_TYPES = {"document", "form", "log", "network_event", "message", "page"}
+
+# Classes whose surface value is a secret/identifier and must be minimized (hashed).
+PII_MINIMIZE = {"CREDENTIAL", "TRACKING_IDENTIFIER", "HSM_HANDLE", "NONCE_STREAM"}
+
+# Deterministic high-value patterns. Each entry: (regex, entity_class, secondary_classes, confidence).
+_PATTERNS: list[tuple[re.Pattern[str], str, tuple[str, ...], float]] = [
+    (re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"), "IDENTIFIER", ("ACCOUNT",), 0.97),
+    (re.compile(r"\b\d{3}-\d{2}-\d{4}\b"), "IDENTIFIER", ("SENSITIVE_CONTEXT",), 0.95),
+    (re.compile(r"\b(?:tid|trk|track|gaid|idfa)[-_][A-Za-z0-9]{6,}\b", re.I), "TRACKING_IDENTIFIER", ("MARKETING_CONTEXT",), 0.93),
+    (re.compile(r"\b(?:sk|pk|tok|bearer|apikey)[-_][A-Za-z0-9]{8,}\b", re.I), "CREDENTIAL", ("SENSITIVE_CONTEXT",), 0.9),
+    (re.compile(r"\bhsm://[A-Za-z0-9/_-]+\b"), "HSM_HANDLE", (), 0.9),
+]
+
+# Context-cue dictionary — words that mark a policy-sensitive context. These deliberately
+# OVERLAP any entity spans they sit inside (the plan's overlapping-span requirement).
+_CONTEXT_CUES: list[tuple[re.Pattern[str], str, tuple[str, ...]]] = [
+    (re.compile(r"\b(?:pediatric|paediatric|child|minor|kid|infant)\b", re.I), "CHILD_CONTEXT", ()),
+    (re.compile(r"\b(?:patient|clinic|clinical|hospital|ward|diagnosis|medical)\b", re.I), "PATIENT_CONTEXT", ("SENSITIVE_CONTEXT",)),
+    (re.compile(r"\b(?:vote|voter|ballot|election|civic|census)\b", re.I), "CIVIC_CONTEXT", ()),
+    (re.compile(r"\b(?:consent|opt-?in|opt-?out|authoriz\w+)\b", re.I), "CONSENT_ARTIFACT", ()),
+    (re.compile(r"\b(?:ad|ads|advert\w*|campaign|retarget\w*)\b", re.I), "MARKETING_CONTEXT", ()),
+]
+
+
+def sha256_hex(value: str) -> str:
+    """FIPS: SHA-256 is the authoritative digest for minimized PII surfaces."""
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _mk_pii(text: str) -> dict[str, Any]:
+    return {"minimized": True, "hash_alg": "SHA-256", "value_hash": sha256_hex(text)}
+
+
+def extract_mentions(
+    text: str,
+    *,
+    source_id: str,
+    source_type: str = "document",
+    locality: str = "CITIZEN_FOG",
+    event_ir_id: str | None = None,
+    gazetteer: dict[str, str] | None = None,
+    scope_realm: str = "FOG",
+) -> dict[str, Any]:
+    """Extract a regis-conformant MentionSet from ``text``.
+
+    ``gazetteer`` maps a surface form -> entity_class (e.g. {"Mercy General": "ORG"})
+    for dictionary NER of known high-value entities. Pattern NER covers identifiers,
+    credentials, tracking ids and HSM handles deterministically. Context cues are
+    added as OVERLAPPING mentions so downstream disambiguation sees them.
+    """
+    if source_type not in SOURCE_TYPES:
+        raise ValueError(f"unknown source_type {source_type}")
+    if locality not in LOCALITIES:
+        raise ValueError(f"unknown locality {locality}")
+
+    mentions: list[dict[str, Any]] = []
+    counter = 0
+
+    def add(start: int, end: int, klass: str, secondary: tuple[str, ...], conf: float) -> None:
+        nonlocal counter
+        counter += 1
+        surface = text[start:end]
+        m: dict[str, Any] = {
+            "mention_id": f"m{counter}",
+            "span": {"start": start, "end": end, "text": surface},
+            "entity_class": klass,
+            "confidence": round(conf, 4),
+            "scope_realm": scope_realm,
+            "provenance": {
+                "source_event_ids": [event_ir_id] if event_ir_id else [],
+                "artifact_ids": [],
+            },
+        }
+        secondary_clean = [c for c in secondary if c != klass]
+        if secondary_clean:
+            m["secondary_classes"] = sorted(set(secondary_clean))
+        if klass in PII_MINIMIZE:
+            m["pii"] = _mk_pii(surface)
+        mentions.append(m)
+
+    # 1. Deterministic pattern NER (identifiers / credentials / trackers).
+    for pat, klass, secondary, conf in _PATTERNS:
+        for match in pat.finditer(text):
+            add(match.start(), match.end(), klass, secondary, conf)
+
+    # 2. Dictionary NER over the gazetteer (case-insensitive, all occurrences).
+    for surface, klass in (gazetteer or {}).items():
+        if klass not in ENTITY_CLASSES:
+            raise ValueError(f"gazetteer maps to unknown entity_class {klass}")
+        for match in re.finditer(re.escape(surface), text, flags=re.I):
+            add(match.start(), match.end(), klass, (), 0.85)
+
+    # 3. Context cues — emitted as overlapping mentions.
+    for pat, klass, secondary, in ((p, k, s) for p, k, s in _CONTEXT_CUES):
+        for match in pat.finditer(text):
+            add(match.start(), match.end(), klass, secondary, 0.8)
+
+    mentions.sort(key=lambda m: (m["span"]["start"], m["span"]["end"], m["entity_class"]))
+    # Re-number after the sort so ids are stable/positional.
+    for i, m in enumerate(mentions, start=1):
+        m["mention_id"] = f"m{i}"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "source_ref": {
+            "source_id": source_id,
+            "source_type": source_type,
+            **({"event_ir_id": event_ir_id} if event_ir_id else {}),
+        },
+        "locality": locality,
+        "extractor_version": EXTRACTOR_VERSION,
+        "overlaps_allowed": True,
+        "mentions": mentions,
+    }
+
+
+def mentions_to_records(mention_set: dict[str, Any]) -> list[dict[str, Any]]:
+    """Bridge NER -> ER: fold PERSON/ORG mentions into resolver Record inputs so the
+    same request can flow extract -> resolve. Context/identifier mentions ride along
+    as attributes/primes rather than becoming their own entities."""
+    records: list[dict[str, Any]] = []
+    src = mention_set["source_ref"]["source_id"]
+    for m in mention_set["mentions"]:
+        if m["entity_class"] in ("PERSON", "ORG"):
+            attrs: dict[str, str] = {}
+            for other in mention_set["mentions"]:
+                if other is m:
+                    continue
+                if other["entity_class"] in ("IDENTIFIER", "ACCOUNT") and "email" not in attrs and "@" in other["span"]["text"]:
+                    attrs["email"] = other["span"]["text"].lower()
+            primes = sorted({
+                p
+                for other in mention_set["mentions"]
+                for p in other.get("prime_topic_support", [])
+            })
+            records.append({
+                "id": f"{src}:{m['mention_id']}",
+                "name": m["span"]["text"],
+                "attributes": attrs,
+                "scope": m.get("scope_realm", ""),
+                "primes": primes,
+            })
+    return records

--- a/apps/entity-resolution/src/entity_resolution/server.py
+++ b/apps/entity-resolution/src/entity_resolution/server.py
@@ -1,21 +1,33 @@
 """entity-resolution service — the real ER resolver (regis had only a validator).
 
   GET  /healthz
+  POST /extract/mentions     { text, source_id, source_type?, locality?, gazetteer? } → a regis-conformant
+                             MentionSet (NER head of the spine: overlapping/multi-labelled spans, FIPS PII hashing)
   POST /resolve              { records[] , as_of? } → entities + golden_records + concordance +
                              proof-carrying decision ledger, all pinned with a deterministic replay_key
   POST /resolve/incremental  { prior_golden[], new_records[], as_of? } → delta: which new records attached
                              to an existing entity vs formed new ones, without re-resolving the estate (O(new))
+  POST /resolve/materialize  { records[]?, text?+source_id? , as_of? } → resolve, then WRITE resolved
+                             nodes/edges to HellGraph and emit a SHA-256 hash-chained receipt (live spine).
 """
 from __future__ import annotations
 
 from typing import Any
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from pydantic import BaseModel
 
+from .graph_sink import GraphSink, materialize
+from .ner import extract_mentions, mentions_to_records
 from .resolver import Record, resolve, resolve_incremental
 
 app = FastAPI(title="entity-resolution", version="0.1.0")
+
+
+def get_sink() -> GraphSink:
+    """The live HellGraph + receipt sink. Overridden in tests via
+    app.dependency_overrides[get_sink] to inject a mock-transport sink."""
+    return GraphSink()
 
 
 class RecordIn(BaseModel):
@@ -37,13 +49,48 @@ class IncrementalRequest(BaseModel):
     as_of: str | None = None
 
 
+class ExtractRequest(BaseModel):
+    text: str
+    source_id: str
+    source_type: str = "document"
+    locality: str = "CITIZEN_FOG"
+    event_ir_id: str | None = None
+    gazetteer: dict[str, str] = {}
+    scope_realm: str = "FOG"
+
+
+class MaterializeRequest(BaseModel):
+    # Either supply records directly, or supply text+source_id to run extract -> resolve first.
+    records: list[RecordIn] = []
+    text: str | None = None
+    source_id: str | None = None
+    source_type: str = "document"
+    locality: str = "CITIZEN_FOG"
+    gazetteer: dict[str, str] = {}
+    as_of: str | None = None
+
+
 def _rec(r: RecordIn) -> Record:
     return Record(id=r.id, name=r.name, attributes=r.attributes, scope=r.scope, primes=frozenset(r.primes))
+
+
+def _rec_dict(d: dict[str, Any]) -> Record:
+    return Record(id=d["id"], name=d["name"], attributes=d.get("attributes", {}),
+                  scope=d.get("scope", ""), primes=frozenset(d.get("primes", [])))
 
 
 @app.get("/healthz")
 def healthz() -> dict[str, Any]:
     return {"ok": True, "service": "entity-resolution"}
+
+
+@app.post("/extract/mentions")
+def extract_endpoint(req: ExtractRequest) -> dict[str, Any]:
+    return extract_mentions(
+        req.text, source_id=req.source_id, source_type=req.source_type,
+        locality=req.locality, event_ir_id=req.event_ir_id,
+        gazetteer=req.gazetteer or None, scope_realm=req.scope_realm,
+    )
 
 
 @app.post("/resolve")
@@ -54,3 +101,32 @@ def resolve_endpoint(req: ResolveRequest) -> dict[str, Any]:
 @app.post("/resolve/incremental")
 def resolve_incremental_endpoint(req: IncrementalRequest) -> dict[str, Any]:
     return resolve_incremental(req.prior_golden, [_rec(r) for r in req.new_records], as_of=req.as_of)
+
+
+@app.post("/resolve/materialize")
+def resolve_materialize_endpoint(req: MaterializeRequest,
+                                 sink: GraphSink = Depends(get_sink)) -> dict[str, Any]:
+    """Live spine: extract (optional) -> resolve -> write to HellGraph -> emit SHA-256 receipt.
+
+    The sink is injected via Depends(get_sink); tests override get_sink to supply a
+    mock-transport sink, production builds one from HELLGRAPH_URL/COMPUTE_GATEWAY_URL.
+    """
+    mention_set: dict[str, Any] | None = None
+    if req.text is not None and req.source_id:
+        mention_set = extract_mentions(
+            req.text, source_id=req.source_id, source_type=req.source_type,
+            locality=req.locality, gazetteer=req.gazetteer or None,
+        )
+        records = [_rec_dict(d) for d in mentions_to_records(mention_set)]
+    else:
+        records = [_rec(r) for r in req.records]
+
+    resolution = resolve(records, as_of=req.as_of)
+    landed = materialize(resolution, mention_set, sink=sink)
+    return {
+        "resolution": resolution,
+        "mention_set": mention_set,
+        "graph": landed["graph"],
+        "receipt": landed["receipt"],
+        "seal": landed["seal"],
+    }

--- a/apps/entity-resolution/tests/test_ner_and_materialize.py
+++ b/apps/entity-resolution/tests/test_ner_and_materialize.py
@@ -1,0 +1,163 @@
+"""NER extraction + live materialize-path teeth.
+
+The materialize test proves the LIVE PATH end to end against a mock transport
+(request in -> resolved entity out -> node/edge written to HellGraph -> SHA-256
+hash-chained receipt landed), not just the resolver in isolation.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+from fastapi.testclient import TestClient
+
+from entity_resolution.graph_sink import GraphSink, materialize, sha
+from entity_resolution.ner import ENTITY_CLASSES, extract_mentions, mentions_to_records
+from entity_resolution.resolver import resolve
+from entity_resolution.server import app, get_sink
+
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------- NER (extract) --
+
+def test_extract_emits_overlapping_multilabel_spans():
+    # The ORG gazetteer phrase contains the "pediatric"/"clinic" context cues, so the
+    # ORG span and the CHILD_CONTEXT/PATIENT_CONTEXT cue spans overlap the same region.
+    text = "Emma visited Mercy Pediatric Clinic today."
+    ms = extract_mentions(text, source_id="msg-1", source_type="message",
+                          gazetteer={"Emma": "PERSON", "Mercy Pediatric Clinic": "ORG"})
+    assert ms["schema_version"] == "regis.ner.mention_set.v0.1"
+    assert ms["overlaps_allowed"] is True
+    spans = [(m["span"]["start"], m["span"]["end"]) for m in ms["mentions"]]
+    # "Mercy General" (ORG) and "pediatric"(CHILD_CONTEXT)/"patient ward" cues overlap the same region
+    overlap = any(a is not b and a[0] < b[1] and b[0] < a[1] for i, a in enumerate(spans) for b in spans[i + 1:])
+    assert overlap, "extractor must produce overlapping spans"
+    classes = {m["entity_class"] for m in ms["mentions"]}
+    assert "ORG" in classes and "PATIENT_CONTEXT" in classes and "CHILD_CONTEXT" in classes
+
+
+def test_all_emitted_classes_are_in_taxonomy():
+    text = "contact sk-ABCDEFGH12 track_9f8e7d6c user@example.com pediatric patient consent"
+    ms = extract_mentions(text, source_id="doc-1")
+    for m in ms["mentions"]:
+        assert m["entity_class"] in ENTITY_CLASSES
+        for s in m.get("secondary_classes", []):
+            assert s in ENTITY_CLASSES
+
+
+def test_high_risk_surfaces_are_fips_hashed():
+    ms = extract_mentions("token sk-DEADBEEF99 and tracker trk_aa11bb22cc",
+                          source_id="net-1", source_type="network_event", locality="ADTECH")
+    hashed = [m for m in ms["mentions"] if "pii" in m]
+    assert hashed, "credential/tracking surfaces must be minimized"
+    for m in hashed:
+        assert m["pii"]["minimized"] is True
+        assert m["pii"]["hash_alg"] == "SHA-256"
+        assert len(m["pii"]["value_hash"]) == 64
+        # value_hash is the SHA-256 of the surface text (verifiable)
+        import hashlib
+        assert m["pii"]["value_hash"] == hashlib.sha256(m["span"]["text"].encode()).hexdigest()
+
+
+def test_extract_endpoint():
+    r = client.post("/extract/mentions", json={
+        "text": "Acme Corp opted-in to the ad campaign",
+        "source_id": "p-1", "source_type": "page",
+        "gazetteer": {"Acme Corp": "ORG"},
+    })
+    assert r.status_code == 200
+    body = r.json()
+    assert body["mentions"] and any(m["entity_class"] == "ORG" for m in body["mentions"])
+
+
+def test_ner_to_er_bridge():
+    ms = extract_mentions("Acme Corp and Acme Corp", source_id="d1",
+                          gazetteer={"Acme Corp": "ORG"})
+    recs = mentions_to_records(ms)
+    assert len(recs) == 2 and all(r["name"] == "Acme Corp" for r in recs)
+
+
+# ------------------------------------------------------- live materialize path --
+
+def _mock_sink(recorder: list[dict]) -> GraphSink:
+    def handler(request: httpx.Request) -> httpx.Response:
+        recorder.append({"url": str(request.url), "body": json.loads(request.content)})
+        if request.url.path == "/api/graph/node":
+            return httpx.Response(200, json={"ok": True, "node": json.loads(request.content)})
+        if request.url.path == "/api/graph/edge":
+            return httpx.Response(200, json={"ok": True})
+        if request.url.path == "/v1/engine-receipts":
+            return httpx.Response(200, json={"receiptId": "sha256:sealed", "memoized": False})
+        return httpx.Response(404)
+
+    return GraphSink(client=httpx.Client(transport=httpx.MockTransport(handler)),
+                     compute_gateway_token="test-token")
+
+
+def test_materialize_writes_graph_and_seals_receipt_direct():
+    recorder: list[dict] = []
+    from entity_resolution.resolver import Record
+    # two Acme records that merge → one entity + one same_as edge
+    res = resolve([Record("a", "Acme Corp", {"city": "NYC"}), Record("b", "Acme Corp", {"city": "NYC"})],
+                  as_of="2026-08-03T00:00:00+00:00")
+    landed = materialize(res, mention_set=None, sink=_mock_sink(recorder))
+
+    node_calls = [c for c in recorder if c["url"].endswith("/api/graph/node")]
+    edge_calls = [c for c in recorder if c["url"].endswith("/api/graph/edge")]
+    receipt_calls = [c for c in recorder if c["url"].endswith("/v1/engine-receipts")]
+    assert node_calls, "a resolved entity node must be written to HellGraph"
+    assert edge_calls, "the merge must be written as a same_as edge"
+    assert receipt_calls, "a receipt must be sealed to the gateway"
+
+    receipt = landed["receipt"]
+    assert receipt["id"].startswith("sha256:")
+    assert receipt["inputs_sha"].startswith("sha256:") and receipt["outputs_sha"].startswith("sha256:")
+    assert receipt["outputs_sha"] == sha({"entities": res["entities"], "graph": landed["graph"]})
+    assert landed["seal"]["sealed"] is True
+
+
+def test_materialize_endpoint_live_path_with_text():
+    recorder: list[dict] = []
+    app.dependency_overrides[get_sink] = lambda: _mock_sink(recorder)
+    try:
+        r = client.post("/resolve/materialize", json={
+            "text": "Acme Corp merged with Acme Corp",
+            "source_id": "doc-live-1",
+            "gazetteer": {"Acme Corp": "ORG"},
+            "as_of": "2026-08-03T00:00:00+00:00",
+        })
+    finally:
+        app.dependency_overrides.pop(get_sink, None)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # request in -> resolved entity out
+    assert body["mention_set"]["schema_version"] == "regis.ner.mention_set.v0.1"
+    assert body["resolution"]["entities"], "must resolve at least one entity"
+    # -> node landed in HellGraph + receipt landed
+    assert body["graph"]["nodes"], "resolved node must land in HellGraph"
+    assert body["receipt"]["id"].startswith("sha256:")
+    assert any(c["url"].endswith("/api/graph/node") for c in recorder)
+
+
+def test_receipt_chain_links_prev():
+    recorder: list[dict] = []
+    sink = _mock_sink(recorder)
+    from entity_resolution.resolver import Record
+    res = resolve([Record("a", "Acme Corp", {"city": "NYC"}), Record("b", "Acme Corp", {"city": "NYC"})])
+    r1 = sink.build_receipt(inputs={"n": 1}, outputs={"n": 1})
+    r2 = sink.build_receipt(inputs={"n": 2}, outputs={"n": 2})
+    assert r1["prev"] is None
+    assert r2["prev"] == r1["id"], "receipts must hash-chain via prev"
+
+
+def test_seal_degrades_without_token():
+    recorder: list[dict] = []
+    def handler(request: httpx.Request) -> httpx.Response:
+        recorder.append({"url": str(request.url)})
+        return httpx.Response(200, json={"ok": True})
+    sink = GraphSink(client=httpx.Client(transport=httpx.MockTransport(handler)),
+                     compute_gateway_token="")  # no token → fail-closed gateway
+    receipt = sink.build_receipt(inputs={"n": 1}, outputs={"n": 1})
+    seal = sink.emit_receipt(receipt)
+    assert seal["sealed"] is False and "token" in seal["reason"]

--- a/deploy/values/entity-resolution.yaml
+++ b/deploy/values/entity-resolution.yaml
@@ -5,3 +5,17 @@ image: { repository: entity-resolution, tag: latest }
 service: { port: 8080, portName: http }
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }
 networkPolicy: { enabled: true, ports: [8080] }
+
+# Live spine wiring (added with the NER extract + /resolve/materialize endpoints):
+#   /resolve/materialize writes resolved nodes/edges to HellGraph and seals a
+#   SHA-256 hash-chained resolution receipt into the compute-gateway spine.
+config:
+  HELLGRAPH_URL: "http://hellgraph-service.socioprophet.svc.cluster.local:8090"
+  COMPUTE_GATEWAY_URL: "http://compute-gateway.socioprophet.svc.cluster.local:8080"
+  ER_RECEIPT_PROJECT: "entity-resolution"
+# compute-gateway is fail-closed on auth. Without this token, graph writes + the
+# local SHA-256 receipt still land; only remote sealing degrades (seal.sealed=false).
+# Provision the Secret out of band: kubectl -n socioprophet create secret generic \
+#   entity-resolution-receipt-token --from-literal=token=<GATEWAY_TOKEN>
+secretEnv:
+  COMPUTE_GATEWAY_TOKEN: { secretName: entity-resolution-receipt-token, key: token, optional: true }


### PR DESCRIPTION
Lands the ER/NER integration plan **live** by folding the missing pieces into the existing `entity-resolution` service (consume-not-fork: it is the natural home, already deployed and wired in `images.yml` + `deploy/argocd/platform-services.yaml`). No parallel `er-gateway` was created — that would be estate bloat.

Pairs with the contract PR SocioProphet/regis-entity-graph#16 (the NER `MentionSet` schema this service emits).

## What lands
- **NER head** (`ner.py`): deterministic/dictionary extractor → regis-conformant `MentionSet` (overlapping/multi-labelled spans, locality scope stamp, FIPS SHA-256 PII minimization of CREDENTIAL/TRACKING_IDENTIFIER/HSM/NONCE surfaces). `POST /extract/mentions`.
- **Live spine** (`graph_sink.py` + `POST /resolve/materialize`): extract → resolve → **write resolved nodes/edges to HellGraph** (`POST /api/graph/node|edge`) → **emit a SHA-256 hash-chained resolution receipt** into the compute-gateway spine (`POST /v1/engine-receipts`). Local receipt is authoritative; remote sealing degrades safely when the gateway token is absent (fail-closed) or unreachable.
- **Deploy as code** (`deploy/values/entity-resolution.yaml`): `HELLGRAPH_URL` / `COMPUTE_GATEWAY_URL` config + optional `COMPUTE_GATEWAY_TOKEN` secretEnv (missing secret degrades sealing, never crashes the pod). Image build/argocd wiring already exists for this service; gitops-promote sha-pins on merge.

## Teeth
`apps/entity-resolution` suite: **27 passed** (14 pre-existing + 13 new). The live-path test proves **request in → resolved entity out → node/edge written to HellGraph → SHA-256 receipt sealed** against a mock transport (records the actual `/api/graph/node`, `/api/graph/edge`, `/v1/engine-receipts` calls; asserts `receipt.id`/`inputs_sha`/`outputs_sha` are `sha256:` and receipts hash-chain via `prev`).

## Live cluster state (verify-artifact discipline — read before merging)
Probed the running `socioprophet` namespace:
- `compute-gateway`: **Running**, reachable; but the **deployed image predates `/v1/engine-receipts`** (returns 404) — image lags source.
- `hellgraph-service`: **Service exists with 0 endpoints / no deployment / no pods** — the graph-of-record is not running, so the graph-write leg cannot be live-probed yet.
- `entity-resolution`: pod Running on the **old image** (pre-this-PR).

Full in-cluster end-to-end therefore cannot be demonstrated pre-merge; it requires (a) this PR merged → image build → argocd sync, (b) HellGraph brought up, (c) compute-gateway rolled to a build with `/v1/engine-receipts` + the receipt-token secret provisioned. Tracked as issues assigned @mdheller.

Constraints honored: consume-not-fork, MIT/Apache-only (no new deps — httpx already present), FIPS SHA-256, no Co-Authored-By, branch+rebase before PR, image pinned via existing gitops-promote (not :latest at runtime).