### PR TITLE
infra(wif): let cybernetic-genesis push the Inception image to GAR

### DIFF
--- a/infra/tofu/environments/gcp-gke/main.tf
+++ b/infra/tofu/environments/gcp-gke/main.tf
@@ -47,6 +47,18 @@ resource "google_artifact_registry_repository_iam_member" "ci_push" {
   member     = "serviceAccount:sourceos-ci@socioprophet-platform.iam.gserviceaccount.com"
 }
 
+# Let GitHub Actions in SocioProphet/cybernetic-genesis impersonate the CI push identity via WIF,
+# so its release-train workflow can push the Inception image to GAR (which sourceos-ci already has
+# artifactregistry.writer on, above). Additive per-repo grant, mirroring the existing binding for
+# SocioProphet/prophet-platform. The sourceos-ci SA and the github-pool provider are shared-estate
+# identities defined out-of-band; this resource manages ONLY this repo's impersonation grant.
+# Provider condition (assertion.repository_owner == "SocioProphet") already admits the repo.
+resource "google_service_account_iam_member" "cybernetic_genesis_ci_impersonate" {
+  service_account_id = "projects/socioprophet-platform/serviceAccounts/sourceos-ci@socioprophet-platform.iam.gserviceaccount.com"
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/projects/400078206872/locations/global/workloadIdentityPools/github-pool/attribute.repository/SocioProphet/cybernetic-genesis"
+}
+
 # Dedicated, least-privilege node identity. The project's default compute SA was
 # deleted (hardening), so Autopilot can't fall back to it — and a custom node SA
 # is best practice regardless.


### PR DESCRIPTION
## What
One additive WIF grant so `SocioProphet/cybernetic-genesis` CI can push the Inception image to the estate GAR — the one blocker flagged in #1254 / cybernetic-genesis#7.

## Why this is the whole fix (and why it's small)
Discovered the existing state before changing anything:
- The `github-socioprophet` provider condition is `assertion.repository_owner == "SocioProphet"` — it **already admits** `cybernetic-genesis`. No new pool/provider.
- `sourceos-ci@…` (the shared CI push identity) **already holds** `roles/artifactregistry.writer` on the `socioprophet` GAR repo (see the `ci_push` binding right above this one). No GAR-IAM change.
- The **only** gap: `sourceos-ci`'s `workloadIdentityUser` grants were per-repo (`prophet-platform`, `source-os`×2) and didn't include `cybernetic-genesis`.

So this adds exactly one `google_service_account_iam_member` — an additive per-repo impersonation grant mirroring the existing `prophet-platform` one.

## Live now + tracked as IaC (not drift)
The binding was **applied live** (via `gcloud …add-iam-policy-binding`, verified present) plus the two repo secrets (`GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`) set on cybernetic-genesis — so its CI authenticates as soon as cybernetic-genesis#7 merges (the workflow needs to be on the default branch to mint an OIDC token). This PR commits the same binding so a future `tofu apply` **adopts** it (additive member add is idempotent — a no-op), rather than seeing it as drift.

## Scope / honesty
- Manages **only** this repo's grant. The shared `sourceos-ci` SA and the `github-pool` provider are estate identities defined out-of-band (not in this repo's tofu); referenced by literal, not resource ref.
- `tofu fmt` clean. Full `tofu plan`/`validate` runs in the estate CI on this PR.
- Reversible: remove the resource (and `gcloud …remove-iam-policy-binding`) to revoke.

**Reviewer question:** the other three `sourceos-ci` impersonation grants aren't in this repo's tofu — want me to pull them in here too so all of `sourceos-ci`'s WIF grants are managed in one place, or keep this PR minimal?