### PR TITLE
feat(lattice-studio): real DataCite client + concept/version DOI pairing (Zenodo-parity citable identity)

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/datacite.py
+++ b/apps/lattice-studio/src/lattice_studio/datacite.py
@@ -1,0 +1,316 @@
+"""Real DataCite REST client + concept/version DOI pairing for Lattice Studio.
+
+Zenodo parity (and the BEAT): every minted DOI is bound to an *immutable,
+content-addressed artifact* (a zot/MinIO digest) and its SHA-256 receipt, and
+each **version** gets its own DOI linked back to a **concept** DOI — the
+Zenodo/DataCite versioning model (concept DOI ⇄ version DOIs), done natively.
+
+Design constraints honoured here:
+  * consume-not-fork — talks to the real DataCite REST API over ``httpx``
+    (already a dependency); no vendored SDK, no CDN.
+  * SHA-256 is FIPS-180-4 the *algorithm* (``hashlib.sha256``). This is NOT a
+    claim of a FIPS-140 validated crypto *module*.
+  * The DOI prefix and credentials are READ FROM CONFIG/SECRET — never
+    hardcoded. Minting refuses to run against an unregistered placeholder
+    prefix (``10.82044`` / ``10.0000`` / ``10.5072`` demo values), so the
+    code path cannot silently emit fake-but-plausible DOIs.
+
+Nothing here is *live* until a real DataCite prefix is registered (account +
+fee, external/credentialed) and supplied via ``DATACITE_PREFIX``. Until then
+this module runs green against the DataCite **test** API
+(``https://api.test.datacite.org``) or a faithful in-process mock transport.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+# ── configuration boundary ────────────────────────────────────────────────
+# Everything credentialed/external is read here. Nothing below hardcodes a
+# prefix or a credential.
+DATACITE_API_BASE = os.getenv("DATACITE_API_BASE", "https://api.test.datacite.org")
+DATACITE_PREFIX = os.getenv("DATACITE_PREFIX", "")                 # e.g. "10.71234" (REGISTERED). Empty until registered.
+DATACITE_REPOSITORY_ID = os.getenv("DATACITE_REPOSITORY_ID", "")  # DataCite repository account (username)
+DATACITE_PASSWORD = os.getenv("DATACITE_PASSWORD", "")            # repository password / secret
+# Resolver base used inside the DataCite `url` attribute (the landing target).
+DATACITE_RESOLVE_BASE = os.getenv("STUDIO_RESOLVE_BASE", "https://studio.socioprophet.ai/resolve")
+
+# Prefixes that DataCite / IANA reserve for tests & demos, plus our own
+# pre-registration placeholders. Minting a REAL deposition against any of these
+# is refused: they never resolve at doi.org.
+PLACEHOLDER_PREFIXES = frozenset({"10.82044", "10.0000", "10.5072"})
+
+_PREFIX_RE = re.compile(r"^10\.\d{4,9}$")
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class DataCiteError(RuntimeError):
+    """Raised when a deposition cannot be made valid — before any network call."""
+
+
+@dataclass(frozen=True)
+class ImmutableArtifactRef:
+    """A pointer to content-addressed immutable storage (zot OCI or workspace-MinIO).
+
+    ``digest`` is the authoritative SHA-256 content address (``sha256:<64 hex>``).
+    ``receipt_sha256`` is the SHA-256 of the receipt that attests the deposition
+    (hash-chained receipt-gateway record, canonical-JSON). Both are required —
+    a DOI that does not bind to immutable bytes is not a citable identity.
+    """
+
+    storage: str            # "zot" | "workspace-minio"
+    locator: str            # OCI ref or s3 URI, e.g. "zot.internal/lattice/demo-csv@sha256:..."
+    digest: str             # "sha256:<64 hex>"  — content address (FIPS-180-4 algorithm)
+    receipt_sha256: str     # "sha256:<64 hex>"  — SHA-256 of the deposition receipt
+    media_type: str = "application/octet-stream"
+    size_bytes: int | None = None
+
+    def validate(self) -> None:
+        if not self.locator:
+            raise DataCiteError("immutable artifact ref: locator is required")
+        if not _SHA256_RE.match(self.digest or ""):
+            raise DataCiteError(f"immutable artifact ref: digest must be 'sha256:<64 hex>', got {self.digest!r}")
+        if not _SHA256_RE.match(self.receipt_sha256 or ""):
+            raise DataCiteError(
+                f"immutable artifact ref: receipt_sha256 must be 'sha256:<64 hex>', got {self.receipt_sha256!r}"
+            )
+        if self.storage not in ("zot", "workspace-minio"):
+            raise DataCiteError(f"immutable artifact ref: unknown storage backend {self.storage!r}")
+
+    def to_related_identifiers(self, concept_doi: str | None) -> list[dict[str, Any]]:
+        rels: list[dict[str, Any]] = [
+            # bind the DOI to the immutable content address
+            {"relatedIdentifier": self.digest, "relatedIdentifierType": "Handle", "relationType": "IsIdenticalTo"},
+        ]
+        if concept_doi:
+            rels.append(
+                {"relatedIdentifier": concept_doi, "relatedIdentifierType": "DOI", "relationType": "IsVersionOf"}
+            )
+        return rels
+
+
+@dataclass
+class DataCiteConfig:
+    """Resolved config for a mint. Constructed from env by default; overridable in tests."""
+
+    api_base: str = field(default_factory=lambda: DATACITE_API_BASE)
+    prefix: str = field(default_factory=lambda: DATACITE_PREFIX)
+    repository_id: str = field(default_factory=lambda: DATACITE_REPOSITORY_ID)
+    password: str = field(default_factory=lambda: DATACITE_PASSWORD)
+    resolve_base: str = field(default_factory=lambda: DATACITE_RESOLVE_BASE)
+
+    def require_registered_prefix(self) -> str:
+        """Return the prefix, or raise if it is missing/placeholder. TEETH."""
+        prefix = (self.prefix or "").strip()
+        if not prefix:
+            raise DataCiteError(
+                "DATACITE_PREFIX is not set — a real, registered DataCite prefix is required to mint. "
+                "Not live until the prefix is registered (see the tracking issue)."
+            )
+        if prefix in PLACEHOLDER_PREFIXES:
+            raise DataCiteError(
+                f"DATACITE_PREFIX={prefix!r} is a placeholder/test prefix that does not resolve at doi.org. "
+                "Register a real prefix and set DATACITE_PREFIX to it."
+            )
+        if not _PREFIX_RE.match(prefix):
+            raise DataCiteError(f"DATACITE_PREFIX={prefix!r} is not a valid DOI prefix ('10.NNNN').")
+        return prefix
+
+    def require_credentials(self) -> tuple[str, str]:
+        if not self.repository_id or not self.password:
+            raise DataCiteError(
+                "DATACITE_REPOSITORY_ID / DATACITE_PASSWORD are not set — the repository account "
+                "credential (from the DataCite secret) is required to deposit."
+            )
+        return self.repository_id, self.password
+
+
+def suffix_for(kind: str, key: str) -> str:
+    """Deterministic, collision-resistant DOI suffix from a stable key (content-addressed)."""
+    h = hashlib.sha256(f"{kind}:{key}".encode("utf-8")).hexdigest()
+    return f"{kind}.{h[:12]}"
+
+
+def _now_year() -> int:
+    return datetime.now(timezone.utc).year
+
+
+def _datacite_attributes(
+    doi: str,
+    *,
+    title: str,
+    creators: list[str],
+    kind: str,
+    artifact: ImmutableArtifactRef,
+    resolve_base: str,
+    concept_doi: str | None,
+    version: str | None,
+    is_concept: bool,
+) -> dict[str, Any]:
+    """Build a DataCite 4.x metadata payload. `event=publish` requests findable state."""
+    resource_type = "Dataset" if kind in ("dataset", "graph", "data") else "Software" if kind in (
+        "ml-model", "model", "application", "service", "notebook") else "Other"
+    descr = (
+        f"Proof-carrying record. content_digest={artifact.digest}; "
+        f"receipt_sha256={artifact.receipt_sha256}; storage={artifact.storage}; "
+        f"locator={artifact.locator}. Integrity: SHA-256 (FIPS-180-4 algorithm)."
+    )
+    attrs: dict[str, Any] = {
+        "doi": doi,
+        "prefix": doi.split("/", 1)[0],
+        "titles": [{"title": title}],
+        "creators": [{"name": c} for c in creators],
+        "publisher": "SocioProphet Knowledge Commons",
+        "publicationYear": _now_year(),
+        "types": {"resourceTypeGeneral": resource_type},
+        "url": f"{resolve_base}?doi={doi}",
+        "descriptions": [{"descriptionType": "Other", "description": descr}],
+        "relatedIdentifiers": artifact.to_related_identifiers(None if is_concept else concept_doi),
+        "event": "publish",
+    }
+    if version and not is_concept:
+        attrs["version"] = version
+    return attrs
+
+
+@dataclass(frozen=True)
+class MintedDOI:
+    doi: str
+    url: str
+    state: str            # "findable" | "draft" | "registered"
+    kind: str
+    is_concept: bool
+    version: str | None
+    concept_doi: str | None
+    artifact_digest: str
+    receipt_sha256: str
+    attributes: dict[str, Any]
+
+    def resolver_url(self) -> str:
+        return f"https://doi.org/{self.doi}"
+
+
+class DataCiteClient:
+    """Thin async DataCite REST client.
+
+    Pass a custom ``transport`` (e.g. ``httpx.MockTransport``) to run against a
+    faithful in-process mock; pass none to talk to the real API in ``api_base``.
+    """
+
+    def __init__(self, config: DataCiteConfig | None = None, transport: httpx.BaseTransport | None = None):
+        self.config = config or DataCiteConfig()
+        self._transport = transport
+
+    def _auth_header(self) -> dict[str, str]:
+        rid, pw = self.config.require_credentials()
+        token = base64.b64encode(f"{rid}:{pw}".encode("utf-8")).decode("ascii")
+        return {"Authorization": f"Basic {token}", "Content-Type": "application/vnd.api+json"}
+
+    async def _post_doi(self, attributes: dict[str, Any]) -> dict[str, Any]:
+        body = {"data": {"type": "dois", "attributes": attributes}}
+        async with httpx.AsyncClient(
+            base_url=self.config.api_base, transport=self._transport, timeout=30.0
+        ) as client:
+            resp = await client.post("/dois", headers=self._auth_header(), content=json.dumps(body))
+        if resp.status_code not in (200, 201):
+            raise DataCiteError(f"DataCite POST /dois failed: {resp.status_code} {resp.text[:400]}")
+        return resp.json()
+
+    async def get_doi(self, doi: str) -> dict[str, Any] | None:
+        async with httpx.AsyncClient(
+            base_url=self.config.api_base, transport=self._transport, timeout=30.0
+        ) as client:
+            resp = await client.get(f"/dois/{doi}", headers=self._auth_header())
+        if resp.status_code == 404:
+            return None
+        if resp.status_code != 200:
+            raise DataCiteError(f"DataCite GET /dois/{doi} failed: {resp.status_code} {resp.text[:400]}")
+        return resp.json()
+
+    async def _mint(
+        self,
+        *,
+        kind: str,
+        title: str,
+        creators: list[str],
+        artifact: ImmutableArtifactRef,
+        concept_doi: str | None,
+        version: str | None,
+        is_concept: bool,
+        suffix_key: str,
+    ) -> MintedDOI:
+        # TEETH, before any network call: registered prefix + valid immutable artifact.
+        prefix = self.config.require_registered_prefix()
+        artifact.validate()
+        doi = f"{prefix}/{suffix_for(kind, suffix_key)}"
+        attrs = _datacite_attributes(
+            doi, title=title, creators=creators or ["SocioProphet Knowledge Commons"], kind=kind,
+            artifact=artifact, resolve_base=self.config.resolve_base, concept_doi=concept_doi,
+            version=version, is_concept=is_concept,
+        )
+        result = await self._post_doi(attrs)
+        state = ((result.get("data") or {}).get("attributes") or {}).get("state", "findable")
+        return MintedDOI(
+            doi=doi, url=attrs["url"], state=state, kind=kind, is_concept=is_concept,
+            version=version, concept_doi=concept_doi, artifact_digest=artifact.digest,
+            receipt_sha256=artifact.receipt_sha256, attributes=attrs,
+        )
+
+    async def mint_concept_doi(
+        self, *, kind: str, title: str, creators: list[str], artifact: ImmutableArtifactRef, concept_key: str
+    ) -> MintedDOI:
+        """Mint the stable *concept* DOI — the identity that always points at the latest version."""
+        return await self._mint(
+            kind=kind, title=title, creators=creators, artifact=artifact, concept_doi=None,
+            version=None, is_concept=True, suffix_key=f"concept:{concept_key}",
+        )
+
+    async def mint_version_doi(
+        self, *, kind: str, title: str, creators: list[str], artifact: ImmutableArtifactRef,
+        concept_doi: str, version: str, concept_key: str,
+    ) -> MintedDOI:
+        """Mint a *version* DOI bound to a specific immutable artifact, linked to its concept DOI."""
+        if not concept_doi:
+            raise DataCiteError("mint_version_doi requires a concept_doi to link against")
+        return await self._mint(
+            kind=kind, title=title, creators=creators, artifact=artifact, concept_doi=concept_doi,
+            version=version, is_concept=False, suffix_key=f"{concept_key}:{version}",
+        )
+
+    async def mint_concept_and_version(
+        self, *, kind: str, title: str, creators: list[str], concept_key: str, version: str,
+        concept_artifact: ImmutableArtifactRef, version_artifact: ImmutableArtifactRef,
+    ) -> dict[str, MintedDOI]:
+        """Mint a resolvable concept+version PAIR in one call and return both.
+
+        The version DOI carries ``IsVersionOf`` → concept; the concept DOI is
+        updated (best-effort) with ``HasVersion`` → version so the pairing is
+        navigable in both directions.
+        """
+        concept = await self.mint_concept_doi(
+            kind=kind, title=title, creators=creators, artifact=concept_artifact, concept_key=concept_key
+        )
+        version_doi = await self.mint_version_doi(
+            kind=kind, title=title, creators=creators, artifact=version_artifact,
+            concept_doi=concept.doi, version=version, concept_key=concept_key,
+        )
+        # best-effort back-link concept → version (HasVersion)
+        try:
+            back = dict(concept.attributes)
+            rels = list(back.get("relatedIdentifiers") or [])
+            rels.append(
+                {"relatedIdentifier": version_doi.doi, "relatedIdentifierType": "DOI", "relationType": "HasVersion"}
+            )
+            back["relatedIdentifiers"] = rels
+            await self._post_doi(back)
+        except DataCiteError:
+            pass  # pairing is still valid via the version→concept link
+        return {"concept": concept, "version": version_doi}

--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -507,8 +507,60 @@ async def cite(req: CiteRequest, authorization: str = Header(default="")) -> dic
                               "description": f"Proof-carrying record. epistemic_mode={prov['epistemic_mode']}; content_hash={h}; provenance={prov['extractor']}."}],
         },
     }
+    # HONEST boundary: this is a sovereign, DataCite-FORMAT identifier minted locally. It is only a
+    # globally-resolvable doi.org DOI once DATACITE_PREFIX is a registered prefix and the DataCite API
+    # path (/api/studio/datacite/register) is used. Surface that so callers never assume it resolves.
+    datacite_live = bool(os.getenv("DATACITE_PREFIX")) and STUDIO_DOI_PREFIX not in ("10.82044", "10.0000", "10.5072")
     return {"pid": pid, "doi": doi, "resolve": resolve_url, "content_hash": h, "created_at": created,
-            "citation": citation, "bibtex": bibtex, "datacite": datacite, "proof_carrying": True, "node_id": node_id}
+            "citation": citation, "bibtex": bibtex, "datacite": datacite, "proof_carrying": True,
+            "node_id": node_id, "datacite_live": datacite_live,
+            "note": None if datacite_live else "sovereign DOI-format id; not resolvable at doi.org until a DataCite prefix is registered"}
+
+
+class DataCiteRegisterRequest(BaseModel):
+    kind: str = "dataset"              # dataset | ml-model | application | service | notebook | graph
+    concept_key: str                  # stable identity key for the concept (e.g. "demo-csv")
+    version: str                      # this deposition's version (e.g. "1.0.0")
+    title: str
+    creators: list[str] = []
+    # immutable content-addressed binding (zot OCI / workspace-minio) + its SHA-256 receipt
+    storage: str = "zot"              # zot | workspace-minio
+    locator: str                      # OCI ref / s3 URI to the immutable artifact
+    digest: str                       # "sha256:<64 hex>" content address (FIPS-180-4 algorithm)
+    receipt_sha256: str               # "sha256:<64 hex>" SHA-256 of the deposition receipt
+    media_type: str = "application/octet-stream"
+
+
+@app.post("/api/studio/datacite/register")
+async def datacite_register(req: DataCiteRegisterRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """Mint a REAL, globally-resolvable concept+version DOI PAIR via the DataCite REST API, each bound to an
+    immutable content-addressed artifact + its SHA-256 receipt. Fail-closed (503) with a precise reason when
+    DATACITE_PREFIX is unregistered/placeholder or credentials are unset — it is NOT live until the prefix is
+    registered (see the tracking issue). Uses the config/secret; hardcodes no prefix."""
+    _require_write_token(authorization)
+    from lattice_studio.datacite import DataCiteClient, DataCiteError, ImmutableArtifactRef
+
+    artifact = ImmutableArtifactRef(
+        storage=req.storage, locator=req.locator, digest=req.digest,
+        receipt_sha256=req.receipt_sha256, media_type=req.media_type,
+    )
+    client = DataCiteClient()
+    try:
+        pair = await client.mint_concept_and_version(
+            kind=req.kind, title=req.title, creators=req.creators, concept_key=req.concept_key,
+            version=req.version, concept_artifact=artifact, version_artifact=artifact,
+        )
+    except DataCiteError as exc:
+        # config/credential/artifact validity failures are a precondition failure, not a server bug
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    concept, version = pair["concept"], pair["version"]
+    return {
+        "live": True,
+        "concept": {"doi": concept.doi, "resolver": concept.resolver_url(), "state": concept.state},
+        "version": {"doi": version.doi, "resolver": version.resolver_url(), "state": version.state,
+                    "version": version.version, "is_version_of": concept.doi},
+        "content_digest": version.artifact_digest, "receipt_sha256": version.receipt_sha256,
+    }
 
 
 @app.get("/api/studio/resolve")

--- a/apps/lattice-studio/tests/test_datacite.py
+++ b/apps/lattice-studio/tests/test_datacite.py
@@ -1,0 +1,154 @@
+"""Teeth for the DataCite client + concept/version DOI pairing (Lever A).
+
+Proven BOTH ways (a control that fires):
+  1. minting with an UNREGISTERED / placeholder prefix FAILS (no network call);
+  2. minting without a valid IMMUTABLE artifact ref (bad digest / bad receipt) FAILS;
+  3. a valid deposition PASSES and yields a RESOLVABLE concept + version PAIR,
+     with the version DOI linked back to the concept (IsVersionOf) and the
+     concept linked forward (HasVersion) — all against a faithful in-process
+     DataCite REST mock (httpx.MockTransport), never a hardcoded prefix.
+
+The mock speaks the DataCite JSON:API contract (POST /dois, GET /dois/{doi})
+so the client's real HTTP code path is exercised end-to-end.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from lattice_studio.datacite import (
+    DataCiteClient,
+    DataCiteConfig,
+    DataCiteError,
+    ImmutableArtifactRef,
+    PLACEHOLDER_PREFIXES,
+)
+
+GOOD_DIGEST = "sha256:" + "a" * 64
+GOOD_RECEIPT = "sha256:" + "b" * 64
+REGISTERED_PREFIX = "10.71234"  # stand-in for a really-registered prefix (supplied via config, not hardcoded in src)
+
+
+def _artifact(digest: str = GOOD_DIGEST, receipt: str = GOOD_RECEIPT, storage: str = "zot") -> ImmutableArtifactRef:
+    return ImmutableArtifactRef(
+        storage=storage,
+        locator="zot.internal/lattice/demo-csv@" + digest,
+        digest=digest,
+        receipt_sha256=receipt,
+        media_type="text/csv",
+        size_bytes=1234,
+    )
+
+
+def _fake_datacite() -> httpx.MockTransport:
+    """A faithful in-memory DataCite REST endpoint (JSON:API)."""
+    store: dict[str, dict] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # auth must be present — mirrors the real API rejecting anonymous deposits
+        if "authorization" not in {k.lower() for k in request.headers}:
+            return httpx.Response(401, json={"errors": [{"title": "unauthorized"}]})
+        if request.method == "POST" and request.url.path == "/dois":
+            body = json.loads(request.content)
+            attrs = body["data"]["attributes"]
+            doi = attrs["doi"]
+            state = "findable" if attrs.get("event") == "publish" else "draft"
+            attrs = {**attrs, "state": state}
+            store[doi] = {"data": {"id": doi, "type": "dois", "attributes": attrs}}
+            return httpx.Response(201, json=store[doi])
+        if request.method == "GET" and request.url.path.startswith("/dois/"):
+            doi = request.url.path[len("/dois/"):]
+            if doi in store:
+                return httpx.Response(200, json=store[doi])
+            return httpx.Response(404, json={"errors": [{"title": "not found"}]})
+        return httpx.Response(400, json={"errors": [{"title": "bad request"}]})
+
+    return httpx.MockTransport(handler)
+
+
+def _client(prefix: str = REGISTERED_PREFIX) -> DataCiteClient:
+    cfg = DataCiteConfig(
+        api_base="https://api.test.datacite.org",
+        prefix=prefix,
+        repository_id="SPKC.LATTICE",
+        password="secret-from-k8s",
+    )
+    return DataCiteClient(config=cfg, transport=_fake_datacite())
+
+
+# ── TEETH 1: unregistered / placeholder prefix is REJECTED before any network call ──
+def test_mint_without_registered_prefix_fails():
+    for bad in ("", *sorted(PLACEHOLDER_PREFIXES), "not-a-prefix"):
+        client = _client(prefix=bad)
+        with pytest.raises(DataCiteError):
+            asyncio.run(
+                client.mint_concept_doi(
+                    kind="dataset", title="Demo CSV", creators=["SocioProphet"],
+                    artifact=_artifact(), concept_key="demo-csv",
+                )
+            )
+
+
+# ── TEETH 2: a DOI with no valid immutable artifact ref is REJECTED ──
+def test_mint_without_immutable_artifact_ref_fails():
+    client = _client()
+    # bad content digest
+    with pytest.raises(DataCiteError):
+        asyncio.run(
+            client.mint_concept_doi(
+                kind="dataset", title="Demo CSV", creators=["SocioProphet"],
+                artifact=_artifact(digest="not-content-addressed"), concept_key="demo-csv",
+            )
+        )
+    # missing SHA-256 receipt binding
+    with pytest.raises(DataCiteError):
+        asyncio.run(
+            client.mint_concept_doi(
+                kind="dataset", title="Demo CSV", creators=["SocioProphet"],
+                artifact=_artifact(receipt="nope"), concept_key="demo-csv",
+            )
+        )
+
+
+# ── TEETH 3: a valid deposition PASSES with a resolvable concept + version PAIR ──
+def test_valid_deposition_passes_with_resolvable_concept_version_pair():
+    client = _client()
+    pair = asyncio.run(
+        client.mint_concept_and_version(
+            kind="dataset", title="Demo CSV Dataset", creators=["SocioProphet"],
+            concept_key="demo-csv", version="1.0.0",
+            concept_artifact=_artifact(digest="sha256:" + "c" * 64),
+            version_artifact=_artifact(digest="sha256:" + "d" * 64),
+        )
+    )
+    concept, version = pair["concept"], pair["version"]
+
+    # both DOIs are minted under the registered prefix and are distinct
+    assert concept.doi.startswith(REGISTERED_PREFIX + "/")
+    assert version.doi.startswith(REGISTERED_PREFIX + "/")
+    assert concept.doi != version.doi
+    assert concept.is_concept and not version.is_concept
+    assert version.version == "1.0.0"
+
+    # both are findable (published) and resolvable back through the API
+    assert concept.state == "findable" and version.state == "findable"
+    got_concept = asyncio.run(client.get_doi(concept.doi))
+    got_version = asyncio.run(client.get_doi(version.doi))
+    assert got_concept is not None and got_version is not None
+
+    # the version DOI links to the concept (IsVersionOf) ...
+    v_rels = got_version["data"]["attributes"]["relatedIdentifiers"]
+    assert any(r["relationType"] == "IsVersionOf" and r["relatedIdentifier"] == concept.doi for r in v_rels)
+    # ... and binds the immutable content digest
+    assert any(r["relationType"] == "IsIdenticalTo" and r["relatedIdentifier"].startswith("sha256:") for r in v_rels)
+
+    # the concept DOI back-links to the version (HasVersion)
+    c_rels = got_concept["data"]["attributes"]["relatedIdentifiers"]
+    assert any(r["relationType"] == "HasVersion" and r["relatedIdentifier"] == version.doi for r in c_rels)
+
+    # every minted DOI carries its SHA-256 receipt + content digest
+    assert version.receipt_sha256 == GOOD_RECEIPT
+    assert version.artifact_digest == "sha256:" + "d" * 64


### PR DESCRIPTION
## Lever A — real citable identity (Zenodo-parity DOI)

Grounded in #1263 (feature 6 "DOI minting" PARTIAL, feature 7 "versioned depositions" PARTIAL).

Before this PR, `apps/lattice-studio` had a deployed `/api/studio/cite` endpoint minting **DataCite-FORMAT** DOIs under an **unregistered placeholder prefix** (`10.82044`; catalog demos `10.0000`) — no DataCite API client, no concept/version pairing, no doi.org resolution.

### What this delivers (buildable now)
- **`datacite.py`** — an async DataCite **REST client** (consume-not-fork, over the existing `httpx` dep; no vendored SDK, no CDN):
  - **concept-DOI / version-DOI pairing** — each version gets its own DOI linked to a concept DOI (`IsVersionOf` / `HasVersion`), the Zenodo versioning model, native.
  - every minted DOI is **bound to an immutable content-addressed artifact** (zot/MinIO `sha256:<64hex>` digest) **+ its SHA-256 receipt**.
  - prefix + credentials **read from config/secret** (`DATACITE_PREFIX`, `DATACITE_REPOSITORY_ID`/`DATACITE_PASSWORD`, `DATACITE_API_BASE`) — **no hardcoded prefix**.
- **`server.py`** — `/api/studio/datacite/register` mints a real concept+version DOI pair (fail-closed `503` with a precise reason until configured); `/api/studio/cite` now reports `datacite_live` honestly.

### Teeth (`test_datacite.py`, faithful in-process DataCite JSON:API mock via `httpx.MockTransport`)
| Test | Result |
|---|---|
| mint with unregistered / placeholder prefix | **FAILS** (before any network call) |
| mint without a valid immutable artifact ref (bad digest / bad receipt) | **FAILS** |
| valid deposition | **PASSES** — resolvable concept+version pair, version→concept `IsVersionOf`, concept→version `HasVersion`, content digest bound |

Observed locally: `3 passed`. Full lattice-studio suite: `251 passed`; the only failures (`test_file_front_door` docx/pdf, SHACL) are **pre-existing** missing-optional-dep failures on `origin/main`, unrelated to this change.

### Precision
SHA-256 here is **FIPS-180-4 the algorithm** (`hashlib.sha256`) — **not** a FIPS-140 validated crypto module claim.

### Not live until the prefix is registered (external / credentialed)
Registering a real DataCite prefix needs a DataCite membership account + fee (external, cannot be done from code). Everything is wired up to that boundary. Registration steps + the exact config/secret the code reads are filed for @mdheller in a tracking issue.

cc @mdheller