### PR TITLE
eval: unified reproduce path + fail-closed reproduce/tolerance gate (chained repro-ledger)

### DIFF
--- a/.github/workflows/reproduce-bench-gate.yml
+++ b/.github/workflows/reproduce-bench-gate.yml
@@ -1,0 +1,51 @@
+# The reproduce/tolerance GATE, fired as a real control: it re-runs a recorded
+# benchmark run and asserts the headline metric reproduces — EXACT for deterministic
+# arms, within the declared epsilon for bounded_nondeterministic arms — and FAILS
+# CLOSED on drift. The teeth are proven both ways (within-tolerance PASSES, injected
+# drift beyond epsilon FAILS). Path-scoped so it actually runs when the gate, the
+# recorded runs, the schemas, or the tests move — a control that never fires is worse
+# than none. SHA-256 here is the FIPS 180-4 algorithm via stdlib hashlib, NOT a FIPS
+# 140-validated module.
+name: reproduce-bench-gate
+
+on:
+  pull_request:
+    paths:
+      - 'tools/reproduce_bench.py'
+      - 'tools/isota_tournament.py'
+      - 'contracts/reproduce/**'
+      - 'schemas/eval/**'
+      - 'tests/platform_stubs/test_reproduce_bench_gate.py'
+      - '.github/workflows/reproduce-bench-gate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'tools/reproduce_bench.py'
+      - 'tools/isota_tournament.py'
+      - 'contracts/reproduce/**'
+      - 'schemas/eval/**'
+      - 'tests/platform_stubs/test_reproduce_bench_gate.py'
+      - '.github/workflows/reproduce-bench-gate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  reproduce-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        # rfc3339-validator lets jsonschema's FormatChecker actually enforce
+        # "format": date-time rather than silently skip it.
+        run: python -m pip install --upgrade pip jsonschema rfc3339-validator pytest
+      - name: Reproduce gate — deterministic arm (exact)
+        run: python tools/reproduce_bench.py --bench isota --run opus-class-r1 --gate
+      - name: Reproduce gate — bounded_nondeterministic arm (within epsilon)
+        run: python tools/reproduce_bench.py --bench isota --run sampled-headline-r1 --gate
+      - name: Teeth — gate PASSES within tolerance and FAILS closed on injected drift
+        run: pytest -q tests/platform_stubs/test_reproduce_bench_gate.py

--- a/Makefile
+++ b/Makefile
@@ -595,6 +595,31 @@ validate-isota-tournament:
 	test -d .venv-tools || python3 -m venv .venv-tools
 	. .venv-tools/bin/activate && python -m pip install --upgrade pip jsonschema rfc3339-validator pytest >/dev/null && python tools/isota_tournament.py && pytest -q tests/platform_stubs/test_isota_tournament.py
 
+.PHONY: reproduce-bench reproduce-bench-gate validate-reproduce-bench-gate
+# UNIFIED one-command reproduce path over the three suite runners (isota / mmlu /
+# hellgraph). Dispatches BENCH=<name> RUN=<id> to the correct runner and MANDATES a
+# content-addressed, hash-chained repro-ledger-entry per run.
+#   make reproduce-bench BENCH=isota RUN=opus-class-r1
+reproduce-bench:
+	test -d .venv-tools || python3 -m venv .venv-tools
+	. .venv-tools/bin/activate && python -m pip install --upgrade pip jsonschema rfc3339-validator >/dev/null && python tools/reproduce_bench.py --bench $(BENCH) --run $(RUN)
+
+# Same dispatch, but FAIL CLOSED on metric drift: deterministic arms require an exact
+# reproduce, bounded_nondeterministic arms must fall within the declared epsilon.
+#   make reproduce-bench-gate BENCH=isota RUN=opus-class-r1
+reproduce-bench-gate:
+	test -d .venv-tools || python3 -m venv .venv-tools
+	. .venv-tools/bin/activate && python -m pip install --upgrade pip jsonschema rfc3339-validator >/dev/null && python tools/reproduce_bench.py --bench $(BENCH) --run $(RUN) --gate
+
+# The teeth: the reproduce/tolerance gate proven both ways (within-tolerance PASSES,
+# injected drift beyond epsilon FAILS). Mirrors .github/workflows/reproduce-bench-gate.yml.
+validate-reproduce-bench-gate:
+	test -d .venv-tools || python3 -m venv .venv-tools
+	. .venv-tools/bin/activate && python -m pip install --upgrade pip jsonschema rfc3339-validator pytest >/dev/null && \
+		python tools/reproduce_bench.py --bench isota --run opus-class-r1 --gate && \
+		python tools/reproduce_bench.py --bench isota --run sampled-headline-r1 --gate && \
+		pytest -q tests/platform_stubs/test_reproduce_bench_gate.py
+
 .PHONY: canary-slo-gate-check
 # Fail-closed Argo Rollouts SLO gates: an empty Prometheus series must ABORT a
 # canary, not promote it ("no data" != "healthy"). tools/check_canary_slo_gate.py

--- a/contracts/reproduce/isota/opus-class-r1.run.json
+++ b/contracts/reproduce/isota/opus-class-r1.run.json
@@ -1,0 +1,21 @@
+{
+  "run_id": "opus-class-r1",
+  "bench": "isota",
+  "round_id": "isota-2026Q3-r1",
+  "version": "v1",
+  "determinism": "deterministic",
+  "headline_metric_id": "md.isota.tournament_composite",
+  "headline_value": 88.79,
+  "seed_policy": "none (pure composite over pinned axis scores)",
+  "rerun": {
+    "kind": "isota_composite",
+    "args": {
+      "scores": {
+        "case_action": 89, "groundedness": 93, "citation": 91, "tool_use": 90,
+        "instruction": 92, "retrieval": 88, "cost": 62, "latency": 74, "observability": 85
+      }
+    }
+  },
+  "external_command": "python3 tools/isota_tournament.py --results build/eval/opus-class.results.json",
+  "notes": "Deterministic arm: iSOTA Sherlock-weighted composite for the opus-class candidate. Re-run must reproduce EXACTLY (epsilon ignored)."
+}

--- a/contracts/reproduce/isota/sampled-headline-r1.run.json
+++ b/contracts/reproduce/isota/sampled-headline-r1.run.json
@@ -1,0 +1,17 @@
+{
+  "run_id": "sampled-headline-r1",
+  "bench": "isota",
+  "round_id": "isota-2026Q3-r1",
+  "version": "v1",
+  "determinism": "bounded_nondeterministic",
+  "epsilon": 0.05,
+  "headline_metric_id": "md.isota.sampled_headline",
+  "headline_value": 79.522944,
+  "seed_policy": "SEED=1729 pinned",
+  "rerun": {
+    "kind": "isota_seeded_headline",
+    "args": {"seed": 1729, "n": 256, "base": 80.0}
+  },
+  "external_command": "SEED=1729 python3 tools/isota_tournament.py --results build/eval/sampled.results.json",
+  "notes": "Bounded-nondeterministic arm (stand-in for a sampled eval mean). Pinned seed reproduces within epsilon=0.05; the gate exercises the tolerance path, not exact match."
+}

--- a/contracts/reproduce/mmlu/st026-seed1729.run.json
+++ b/contracts/reproduce/mmlu/st026-seed1729.run.json
@@ -1,0 +1,14 @@
+{
+  "run_id": "st026-seed1729",
+  "bench": "mmlu",
+  "round_id": "mmlu-st026-r1",
+  "version": "v1",
+  "determinism": "bounded_nondeterministic",
+  "epsilon": 0.02,
+  "headline_metric_id": "md.mmlu.route_accuracy",
+  "headline_value": 0.0,
+  "seed_policy": "MMLU_SEED=1729 pinned; clean-eval contamination certificate attached",
+  "rerun": {"kind": "external"},
+  "external_command": "bash agent-machine/scripts/run-exam.sh   # MMLU_SEED=1729 MMLU_ARMS=baseline,brain,compute,route",
+  "notes": "External arm (Noetica MMLU/ST026 exam). DISPATCH-ONLY: the in-process gate records the dispatch and the one-command reproduce path; it does NOT fabricate a reproduced number. headline_value=0.0 is a placeholder until the exam headline is captured out-of-band and pinned. Full in-process collapse is filed as a follow-up issue."
+}

--- a/schemas/eval/reproduce-run-record.schema.json
+++ b/schemas/eval/reproduce-run-record.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schema://eval/reproduce-run-record.schema.json",
+  "title": "ReproduceRunRecord",
+  "description": "A recorded benchmark run that the reproduce/tolerance gate re-runs and asserts against. The headline metric must reproduce within epsilon for bounded_nondeterministic arms, or EXACTLY for deterministic arms. Rounds are versioned (round_id + version).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "run_id",
+    "bench",
+    "round_id",
+    "version",
+    "determinism",
+    "headline_metric_id",
+    "headline_value",
+    "rerun"
+  ],
+  "properties": {
+    "run_id": {"type": "string", "minLength": 1},
+    "bench": {"type": "string", "minLength": 1, "description": "Dispatch key into the reproduce dispatch table (e.g. isota, mmlu, hellgraph)."},
+    "round_id": {"type": "string", "minLength": 1, "description": "Versioned round identifier; stamped onto every repro-ledger spine record."},
+    "version": {"type": "string", "minLength": 1, "description": "Round schema/methodology version, e.g. v1."},
+    "determinism": {
+      "enum": ["deterministic", "bounded_nondeterministic"],
+      "description": "deterministic -> exact match required; bounded_nondeterministic -> abs(observed-recorded) <= epsilon."
+    },
+    "epsilon": {"type": "number", "minimum": 0, "description": "Declared tolerance. REQUIRED (and > 0 in practice) for bounded_nondeterministic; ignored for deterministic (exact match)."},
+    "headline_metric_id": {"type": "string", "minLength": 1},
+    "headline_value": {"type": "number", "description": "The recorded headline value the gate must reproduce."},
+    "seed_policy": {"type": "string", "description": "How seeds are pinned for this run (e.g. MMLU_SEED=1729)."},
+    "rerun": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["kind"],
+      "description": "How the gate re-derives the observed headline. kind selects the in-process re-runner in the dispatch table.",
+      "properties": {
+        "kind": {"type": "string", "minLength": 1},
+        "args": {"type": "object", "additionalProperties": true}
+      }
+    },
+    "external_command": {"type": "string", "description": "Documentary: the one-command path a human runs to reproduce out-of-band (e.g. bash agent-machine/scripts/run-exam.sh). External arms are dispatched, not executed in-process by the gate."},
+    "notes": {"type": "string"}
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"determinism": {"const": "bounded_nondeterministic"}}},
+      "then": {"required": ["epsilon"]}
+    }
+  ]
+}

--- a/tests/platform_stubs/test_reproduce_bench_gate.py
+++ b/tests/platform_stubs/test_reproduce_bench_gate.py
@@ -1,0 +1,149 @@
+"""Teeth for the unified reproduce path + fail-closed tolerance gate.
+
+A control that never fires is suspect, so the gate is proven BOTH ways:
+
+  POSITIVE — a within-tolerance re-run PASSES (deterministic exact; bounded within
+             epsilon), and the gate CLI exits 0.
+  NEGATIVE — an injected drift beyond epsilon makes the gate FAIL, and the gate CLI
+             exits non-zero (fail-closed).
+
+Plus: every emitted repro-ledger-entry validates against the real schema, the spine
+is content-addressed + hash-chained (tamper-evident), and round_id/version are
+stamped on every record.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_DIR = ROOT / "schemas" / "eval"
+
+
+def _rb():
+    path = ROOT / "tools" / "reproduce_bench.py"
+    spec = importlib.util.spec_from_file_location("reproduce_bench", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _det_record():
+    return _rb().load_record(ROOT / "contracts" / "reproduce" / "isota" / "opus-class-r1.run.json")
+
+
+def _bnd_record():
+    return _rb().load_record(ROOT / "contracts" / "reproduce" / "isota" / "sampled-headline-r1.run.json")
+
+
+# ---------------------------------------------------------------- POSITIVE ----
+def test_positive_deterministic_rerun_reproduces_exactly_and_passes():
+    rb = _rb()
+    rec = _det_record()
+    observed = rb.observe(rec)                 # real in-process re-run of the composite
+    passed, detail = rb.reproduce_gate(rec, observed)
+    assert passed is True
+    assert detail["delta"] == 0.0              # exact
+    assert detail["rule"] == "exact"
+    assert observed == rec["headline_value"]
+
+
+def test_positive_bounded_within_epsilon_passes():
+    rb = _rb()
+    rec = _bnd_record()
+    observed = rb.observe(rec)                 # pinned seed -> reproduces
+    passed, detail = rb.reproduce_gate(rec, observed)
+    assert passed is True
+    assert detail["delta"] <= rec["epsilon"]
+    assert detail["rule"] == "within_epsilon"
+
+
+def test_positive_bounded_at_epsilon_boundary_passes():
+    rb = _rb()
+    rec = _bnd_record()
+    observed = rec["headline_value"] + rec["epsilon"]   # exactly at tolerance
+    passed, detail = rb.reproduce_gate(rec, observed)
+    assert passed is True
+    assert detail["delta"] == pytest.approx(rec["epsilon"])
+
+
+# ---------------------------------------------------------------- NEGATIVE ----
+def test_negative_deterministic_any_drift_fails():
+    rb = _rb()
+    rec = _det_record()
+    observed = rec["headline_value"] + 0.01    # tiny drift, but arm is exact
+    passed, detail = rb.reproduce_gate(rec, observed)
+    assert passed is False
+    assert detail["rule"] == "exact"
+
+
+def test_negative_bounded_drift_beyond_epsilon_fails():
+    rb = _rb()
+    rec = _bnd_record()
+    observed = rec["headline_value"] + rec["epsilon"] * 2 + 1e-6  # beyond tolerance
+    passed, detail = rb.reproduce_gate(rec, observed)
+    assert passed is False
+    assert detail["delta"] > rec["epsilon"]
+
+
+def test_negative_unknown_determinism_fails_closed():
+    rb = _rb()
+    rec = _bnd_record()
+    rec = {**rec, "determinism": "wat"}
+    passed, detail = rb.reproduce_gate(rec, rec["headline_value"])
+    assert passed is False                     # never a silent pass
+    assert detail["rule"] == "unknown_determinism_fail_closed"
+
+
+# --------------------------------------------------- CLI exit codes (teeth) ---
+def test_cli_gate_passes_exit_zero_on_within_tolerance():
+    rb = _rb()
+    rc = rb.main(["--bench", "isota", "--run", "opus-class-r1", "--gate"])
+    assert rc == 0
+
+
+def test_cli_gate_fails_exit_nonzero_on_injected_drift():
+    rb = _rb()
+    rec = _det_record()
+    drifted = rec["headline_value"] + 5.0
+    rc = rb.main(["--bench", "isota", "--run", "opus-class-r1", "--gate",
+                  "--inject-observed", str(drifted)])
+    assert rc == 1                             # FAIL CLOSED
+
+
+# ------------------------------------------------- ledger + chain + schema ----
+def test_repro_ledger_entry_validates_and_is_chained(tmp_path):
+    rb = _rb()
+    rec = _det_record()
+    ledger = tmp_path / "repro-ledger.jsonl"
+    # emit two entries; the second must chain to the first.
+    s1 = rb.emit_ledger_entry(rec, rec["headline_value"], True,
+                              rb.reproduce_gate(rec, rec["headline_value"])[1], ledger=ledger)
+    s2 = rb.emit_ledger_entry(rec, rec["headline_value"], True,
+                              rb.reproduce_gate(rec, rec["headline_value"])[1], ledger=ledger)
+    schema = json.loads((SCHEMA_DIR / "repro-ledger-entry.schema.json").read_text())
+    jsonschema.validate(s1["entry"], schema)
+    jsonschema.validate(s2["entry"], schema)
+    assert s1["prev_entry_digest"] == ""                       # genesis
+    assert s2["prev_entry_digest"] == s1["entry_digest"]       # chained
+    assert s1["round_id"] == rec["round_id"] and s1["version"] == rec["version"]  # stamped
+    assert rb.verify_ledger(ledger) is True
+
+
+def test_ledger_tamper_is_detected(tmp_path):
+    rb = _rb()
+    rec = _det_record()
+    ledger = tmp_path / "repro-ledger.jsonl"
+    rb.emit_ledger_entry(rec, rec["headline_value"], True,
+                         rb.reproduce_gate(rec, rec["headline_value"])[1], ledger=ledger)
+    assert rb.verify_ledger(ledger) is True
+    # flip the recorded outcome without recomputing the digest -> chain breaks.
+    line = json.loads(ledger.read_text().splitlines()[0])
+    line["reproduce_outcome"]["observed"] = 999.0
+    ledger.write_text(json.dumps(line, sort_keys=True) + "\n")
+    assert rb.verify_ledger(ledger) is False

--- a/tools/reproduce_bench.py
+++ b/tools/reproduce_bench.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""reproduce_bench — the UNIFIED one-command reproduce path + fail-closed
+reproduce/tolerance gate for the eval fabric.
+
+WHY. Today there are three separate reproduce paths — `run-exam.sh` (Noetica MMLU
+/ ST026), `cargo run -p hellgraph-bench`, and `tools/isota_tournament.py`. This is
+the single dispatch front door over them, and the control that makes a *reproduced*
+number defensible:
+
+  make reproduce-bench BENCH=<name> RUN=<id>            # reproduce + emit ledger
+  make reproduce-bench-gate BENCH=<name> RUN=<id>       # + FAIL CLOSED on drift
+
+WHAT IT GUARANTEES.
+  1. DISPATCH. One entrypoint routes BENCH -> the correct suite runner (dispatch
+     table below). In-repo arms are re-derived in-process (real computation);
+     external arms (MMLU exam, hellgraph) carry the exact one-command reproduce
+     path and are dispatched, never faked.
+  2. LEDGER, MANDATED. Every run emits a `repro-ledger-entry` (schema
+     schemas/eval/repro-ledger-entry.schema.json) that is content-addressed and
+     CHAINED to a receipt spine (append-only JSONL, prev_entry_digest links each
+     record to its predecessor). round_id + version are stamped (versioned rounds).
+  3. TOLERANCE GATE, FAIL-CLOSED. The gate re-runs a recorded run and asserts the
+     headline metric reproduces: EXACT for `deterministic` arms, within the declared
+     `epsilon` for `bounded_nondeterministic` arms. Drift beyond tolerance -> the
+     gate returns non-zero. A control that never fires is suspect, so the teeth are
+     proven both ways in tests/platform_stubs/test_reproduce_bench_gate.py.
+
+Hashing note: SHA-256 is the FIPS 180-4 *algorithm* via Python's stdlib hashlib.
+This is NOT a FIPS 140-validated cryptographic module. We describe it precisely.
+
+License: MIT (matches repo LICENSE).
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import platform
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = ROOT / "schemas" / "eval"
+RECORDS_DIR = ROOT / "contracts" / "reproduce"
+LEDGER_ROOT = ROOT / "build" / "reproduce"
+
+
+# ---------------------------------------------------------------------------
+# consume-not-fork: reuse the real isota_tournament composite as an in-repo,
+# deterministic headline metric. We import the existing module, we do not
+# reimplement its scoring.
+# ---------------------------------------------------------------------------
+def _isota():
+    path = ROOT / "tools" / "isota_tournament.py"
+    spec = importlib.util.spec_from_file_location("isota_tournament", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# in-process re-runners: given a record's rerun.args, produce the OBSERVED
+# headline value. These are REAL computations, deterministic given their inputs.
+# ---------------------------------------------------------------------------
+def _rerun_isota_composite(args: dict) -> float:
+    """Observed = the iSOTA Sherlock-weighted composite over the recorded axis
+    scores. Pure deterministic function of its inputs -> a deterministic arm."""
+    scores = args["scores"]
+    return float(_isota().composite(scores))
+
+
+def _rerun_isota_seeded_headline(args: dict) -> float:
+    """Observed = a seeded, bounded-nondeterministic headline (a stand-in for a
+    sampled eval mean). The seed is PINNED, so with the pinned seed the value
+    reproduces within epsilon; the arm is declared bounded_nondeterministic so the
+    gate exercises the epsilon tolerance path rather than exact match."""
+    seed = int(args["seed"])
+    n = int(args.get("n", 64))
+    base = float(args.get("base", 80.0))
+    # deterministic PRNG from a pinned seed: a small LCG averaged over n draws,
+    # centered on `base`. Same seed -> same value (reproducible); different seed
+    # -> a value that can exceed epsilon (drift is detectable).
+    state = (seed * 6364136223846793005 + 1442695040888963407) & ((1 << 64) - 1)
+    acc = 0.0
+    for _ in range(n):
+        state = (state * 6364136223846793005 + 1442695040888963407) & ((1 << 64) - 1)
+        acc += ((state >> 33) / float(1 << 31)) - 1.0  # in [-1, 1)
+    return round(base + acc / n, 6)
+
+
+def _rerun_external(args: dict) -> float:  # pragma: no cover - guarded by tests
+    raise RuntimeError(
+        "external arm: reproduce out-of-band via the recorded external_command; "
+        "the in-process gate dispatches but does not execute external suites"
+    )
+
+
+# ---------------------------------------------------------------------------
+# DISPATCH TABLE — one front door over the three reproduce paths.
+#   in_process: the re-runner kind -> callable used by the gate.
+#   command:    the canonical one-command reproduce path (documentary / human).
+# ---------------------------------------------------------------------------
+DISPATCH: dict[str, dict] = {
+    "isota": {
+        "command": "python3 tools/isota_tournament.py --results <results.json>",
+        "in_process": {
+            "isota_composite": _rerun_isota_composite,
+            "isota_seeded_headline": _rerun_isota_seeded_headline,
+        },
+    },
+    "mmlu": {
+        # Noetica MMLU / ST026 exam — pinned seed, clean-eval certificate attached.
+        "command": "bash agent-machine/scripts/run-exam.sh   # MMLU_SEED pinned",
+        "in_process": {"external": _rerun_external},
+    },
+    "hellgraph": {
+        "command": "cargo run -p hellgraph-bench",
+        "in_process": {"external": _rerun_external},
+    },
+}
+
+
+def canonical_digest(obj: object) -> str:
+    """Content address via SHA-256 (FIPS 180-4 algorithm; NOT a FIPS 140 module)
+    over the canonical JSON encoding (sorted keys, tight separators)."""
+    encoded = json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest() if path.exists() else ""
+
+
+def load_record(path: Path) -> dict:
+    """Load a ReproduceRunRecord and validate it spec-first."""
+    schema = json.loads((SCHEMA_DIR / "reproduce-run-record.schema.json").read_text())
+    record = json.loads(path.read_text())
+    Draft202012Validator(schema, format_checker=FormatChecker()).validate(record)
+    if record["bench"] not in DISPATCH:
+        raise KeyError("unknown bench %r; known: %s" % (record["bench"], sorted(DISPATCH)))
+    return record
+
+
+def record_path(bench: str, run_id: str) -> Path:
+    return RECORDS_DIR / bench / ("%s.run.json" % run_id)
+
+
+def observe(record: dict, override: float | None = None) -> float:
+    """Produce the OBSERVED headline value by re-running the arm in-process.
+    `override` lets teeth inject a drifted/within-tolerance observation."""
+    if override is not None:
+        return float(override)
+    bench = record["bench"]
+    kind = record["rerun"]["kind"]
+    fn = DISPATCH[bench]["in_process"].get(kind)
+    if fn is None:
+        raise KeyError("no in-process re-runner %r for bench %r" % (kind, bench))
+    return fn(record["rerun"].get("args", {}))
+
+
+def reproduce_gate(record: dict, observed: float) -> tuple[bool, dict]:
+    """The teeth. Compare observed vs recorded headline.
+
+      deterministic            -> EXACT match required.
+      bounded_nondeterministic -> abs(observed - recorded) <= epsilon.
+
+    Returns (passed, detail). FAIL CLOSED: any drift beyond tolerance -> passed
+    False; a malformed determinism class -> passed False (never a silent pass)."""
+    recorded = float(record["headline_value"])
+    mode = record["determinism"]
+    delta = abs(observed - recorded)
+    detail = {
+        "headline_metric_id": record["headline_metric_id"],
+        "recorded": recorded,
+        "observed": observed,
+        "delta": delta,
+        "determinism": mode,
+        "round_id": record["round_id"],
+        "version": record["version"],
+    }
+    if mode == "deterministic":
+        passed = observed == recorded
+        detail["tolerance"] = 0.0
+        detail["rule"] = "exact"
+    elif mode == "bounded_nondeterministic":
+        eps = float(record.get("epsilon", 0.0))
+        passed = delta <= eps
+        detail["tolerance"] = eps
+        detail["rule"] = "within_epsilon"
+    else:  # fail closed on an unknown class
+        passed = False
+        detail["tolerance"] = 0.0
+        detail["rule"] = "unknown_determinism_fail_closed"
+    detail["passed"] = passed
+    return passed, detail
+
+
+def _environment_hash() -> str:
+    env = {
+        "python": platform.python_version(),
+        "impl": platform.python_implementation(),
+        "system": platform.system(),
+        "machine": platform.machine(),
+    }
+    return canonical_digest(env)
+
+
+def _methodology_snapshot_hash(record: dict) -> str:
+    """Content address the methodology: the runner source + the record itself.
+    A change to either changes the snapshot hash -> the round must be re-versioned."""
+    runner_src = _sha256_file(ROOT / "tools" / "reproduce_bench.py")
+    isota_src = _sha256_file(ROOT / "tools" / "isota_tournament.py")
+    return canonical_digest({
+        "reproduce_bench_sha256": runner_src,
+        "isota_tournament_sha256": isota_src,
+        "record": record,
+    })
+
+
+def ledger_path_for(bench: str) -> Path:
+    return LEDGER_ROOT / bench / "repro-ledger.jsonl"
+
+
+def _prev_digest(ledger: Path) -> str:
+    if not ledger.exists():
+        return ""
+    lines = [ln for ln in ledger.read_text().splitlines() if ln.strip()]
+    if not lines:
+        return ""
+    return json.loads(lines[-1])["entry_digest"]
+
+
+def emit_ledger_entry(record: dict, observed: float, passed: bool, detail: dict,
+                      ledger: Path | None = None, ts: str | None = None) -> dict:
+    """Emit a repro-ledger-entry (schema-valid) wrapped in a content-addressed,
+    hash-chained spine record, and append it to the append-only ledger.
+
+    The inner `entry` conforms to schemas/eval/repro-ledger-entry.schema.json
+    (additionalProperties:false -> we do NOT fork the contract). round_id, version
+    and the reproduce outcome live on the OUTER spine record, which is chained to
+    its predecessor via prev_entry_digest (SHA-256 / FIPS 180-4 algorithm)."""
+    ts = ts or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    ledger = ledger or ledger_path_for(record["bench"])
+
+    entry = {  # <- validates against repro-ledger-entry.schema.json
+        "repro_ledger_entry_id": "rle.%s.%s.%s" % (record["bench"], record["run_id"], ts),
+        "run_id": record["run_id"],
+        "environment_hash": _environment_hash(),
+        "methodology_snapshot_hash": _methodology_snapshot_hash(record),
+        "seed_policy": record.get("seed_policy", "n/a"),
+        "notes": "reproduce gate %s (%s)" % ("PASS" if passed else "FAIL", detail["rule"]),
+    }
+    _validate_repro_ledger_entry(entry)
+
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    prev = _prev_digest(ledger)
+    spine = {
+        "kind": "repro_ledger_spine_record",
+        "schema_version": "0.1",
+        "ts": ts,
+        "bench": record["bench"],
+        "round_id": record["round_id"],   # stamped: versioned rounds
+        "version": record["version"],     # stamped: versioned rounds
+        "reproduce_outcome": {
+            "passed": passed,
+            "recorded": detail["recorded"],
+            "observed": detail["observed"],
+            "delta": detail["delta"],
+            "tolerance": detail["tolerance"],
+            "rule": detail["rule"],
+            "headline_metric_id": detail["headline_metric_id"],
+        },
+        "entry": entry,
+        "prev_entry_digest": prev,
+    }
+    # content address: the digest covers the whole spine record incl. prev link.
+    spine["entry_digest"] = canonical_digest(spine)
+    with ledger.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(spine, sort_keys=True) + "\n")
+    return spine
+
+
+def verify_ledger(ledger: Path) -> bool:
+    """True iff the spine chain is intact and every entry is content-addressed
+    correctly (tamper-evident)."""
+    if not ledger.exists():
+        return True
+    prev = ""
+    for ln in ledger.read_text().splitlines():
+        if not ln.strip():
+            continue
+        rec = json.loads(ln)
+        if rec.get("prev_entry_digest", "") != prev:
+            return False
+        claimed = rec.pop("entry_digest")
+        if canonical_digest(rec) != claimed:
+            return False
+        rec["entry_digest"] = claimed
+        prev = claimed
+    return True
+
+
+def _validate_repro_ledger_entry(entry: dict) -> None:
+    schema = json.loads((SCHEMA_DIR / "repro-ledger-entry.schema.json").read_text())
+    Draft202012Validator(schema, format_checker=FormatChecker()).validate(entry)
+
+
+def run(bench: str, run_id: str, gate: bool, inject: float | None = None) -> int:
+    """Unified reproduce path. Loads the recorded run, re-runs it, MANDATES a
+    chained repro-ledger-entry, and (if gate) fails closed on drift."""
+    rp = record_path(bench, run_id)
+    if not rp.exists():
+        print("ERROR: no recorded run %s for bench %s (expected %s)" % (run_id, bench, rp), file=sys.stderr)
+        return 2
+    record = load_record(rp)
+    print("dispatch: BENCH=%s RUN=%s -> %s" % (bench, run_id, DISPATCH[bench]["command"]))
+
+    try:
+        observed = observe(record, override=inject)
+    except RuntimeError as e:
+        # external arm: dispatch-only. Emit a ledger entry recording the dispatch,
+        # do NOT fabricate a reproduced number.
+        print("external arm (dispatch-only): %s" % e)
+        detail = {"headline_metric_id": record["headline_metric_id"], "recorded": float(record["headline_value"]),
+                  "observed": float("nan"), "delta": float("nan"), "determinism": record["determinism"],
+                  "tolerance": 0.0, "rule": "external_dispatch_only", "round_id": record["round_id"],
+                  "version": record["version"], "passed": None}
+        emit_ledger_entry(record, float("nan"), False, {**detail, "rule": "external_dispatch_only"})
+        print("  reproduce out-of-band:  %s" % record.get("external_command", DISPATCH[bench]["command"]))
+        return 0  # dispatch succeeded; reproduction is out-of-band
+
+    passed, detail = reproduce_gate(record, observed)
+    spine = emit_ledger_entry(record, observed, passed, detail)
+    print("repro-ledger: %s  (entry_digest=%s prev=%s)"
+          % (ledger_path_for(bench), spine["entry_digest"][:12], (spine["prev_entry_digest"] or "GENESIS")[:12]))
+    print("  round=%s version=%s  metric=%s" % (record["round_id"], record["version"], detail["headline_metric_id"]))
+    print("  recorded=%.6f observed=%.6f delta=%.6g tolerance=%s rule=%s"
+          % (detail["recorded"], detail["observed"], detail["delta"], detail["tolerance"], detail["rule"]))
+    if not verify_ledger(ledger_path_for(bench)):
+        print("ERROR: repro-ledger chain verification FAILED (tamper-evident)", file=sys.stderr)
+        return 3
+    if gate:
+        if passed:
+            print("GATE PASS: headline reproduced within tolerance.")
+            return 0
+        print("GATE FAIL (fail-closed): metric drift exceeds tolerance.", file=sys.stderr)
+        return 1
+    print("reproduce %s (gate not enforced): %s" % ("PASS" if passed else "DRIFT", detail["rule"]))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Unified benchmark reproduce path + tolerance gate.")
+    ap.add_argument("--bench", required=True, help="dispatch key: %s" % ", ".join(sorted(DISPATCH)))
+    ap.add_argument("--run", required=True, help="recorded run id (contracts/reproduce/<bench>/<run>.run.json)")
+    ap.add_argument("--gate", action="store_true", help="FAIL CLOSED on metric drift beyond tolerance")
+    ap.add_argument("--inject-observed", type=float, default=None,
+                    help="TEETH: inject an observed headline value (bypasses re-run) to prove the gate bites")
+    args = ap.parse_args(argv)
+    return run(args.bench, args.run, gate=args.gate, inject=args.inject_observed)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why
The #1 reproducibility superiority lever: BEAT MLPerf on reproducibility by making a *reproduced* number defensible. Today there are THREE separate reproduce paths — `run-exam.sh` (Noetica MMLU/ST026), `cargo run -p hellgraph-bench`, and `tools/isota_tournament.py`. This gives them ONE front door plus the control that fails closed on metric drift, with a per-run repro-ledger chained to a receipt spine.

## What (buildable-now slice)
- **Unified entrypoint** — `make reproduce-bench BENCH=<name> RUN=<id>` (and `reproduce-bench-gate` for the enforced variant). `tools/reproduce_bench.py` holds a dispatch table over the three runners. In-repo arms are re-derived in-process (real computation — it *consumes* `isota_tournament.composite`, does not fork it); external arms (MMLU exam, hellgraph) carry the exact one-command reproduce path and are dispatched, never faked.
- **Mandated repro-ledger** — every run emits a `repro-ledger-entry` (`schemas/eval/repro-ledger-entry.schema.json`, unmodified — `additionalProperties:false`, so we wrap it rather than fork it) inside a content-addressed, hash-chained spine record (append-only JSONL, `prev_entry_digest` links each record; tamper-evident). `round_id` + `version` stamped on every record (versioned rounds).
- **Fail-closed tolerance gate** — re-runs a recorded run and asserts the headline metric reproduces: EXACT for `deterministic` arms, within the declared `epsilon` for `bounded_nondeterministic` arms. Drift beyond tolerance (or an unknown determinism class) → non-zero exit.
- **New contracts** — `schemas/eval/reproduce-run-record.schema.json` (the recorded-run schema) + recorded runs under `contracts/reproduce/`.
- **CI** — `.github/workflows/reproduce-bench-gate.yml`, path-scoped so the control actually fires.

## Teeth (proven both ways, locally)
`tests/platform_stubs/test_reproduce_bench_gate.py` — 10 tests, all green:
- POSITIVE: deterministic re-run reproduces exactly (delta 0) → PASS, exit 0; bounded re-run within epsilon → PASS; at the epsilon boundary → PASS.
- NEGATIVE: any drift on a deterministic arm → FAIL; drift beyond epsilon on a bounded arm → FAIL; unknown determinism → fail-closed; CLI injected drift → exit 1.
- Ledger: entry is schema-valid, spine is chained (genesis + prev links), tamper flips `verify_ledger` to False.

Observed locally:
- `--bench isota --run opus-class-r1 --gate` → recorded 88.79 == observed 88.79, delta 0, rule=exact → **GATE PASS (exit 0)**.
- same with `--inject-observed 93.79` → delta 5, tolerance 0 → **GATE FAIL (exit 1)**.
- `--bench isota --run sampled-headline-r1 --gate` → delta 0 ≤ epsilon 0.05 → **PASS**; `--inject-observed 79.722944` → delta 0.2 > 0.05 → **FAIL (exit 1)**.

## Constraints honored
consume-not-fork (imports isota, unmodified schema); MIT; SHA-256 described as the **FIPS 180-4 algorithm** via stdlib hashlib, **not** a FIPS 140 module; isolated worktree off `main`; rebased.

## Remaining (filed separately)
Full in-process collapse of the external MMLU and hellgraph runners (so their headline metrics are re-derived by the gate, not dispatch-only) → follow-up issue with acceptance criteria.