### PR TITLE
feat(eval): open/closed division rules + single validate-submission check (MLPerf-parity submission validity)

### DIFF
--- a/schemas/eval/division-rules.json
+++ b/schemas/eval/division-rules.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "spec_id": "eval/division-rules.v1",
+  "title": "SocioProphet Benchmark Submission Rules — Open vs Closed Divisions",
+  "description": "MLPerf-parity submission rules, spec-as-code. Names the OPEN and CLOSED divisions and the validity requirements per division by WIRING the gates that already exist in the estate (Stage-0 governance gate + provider-neutral scoring + no-laundering in tools/isota_tournament.py; clean-eval/contamination certificate; the repro-ledger-entry contract in schemas/eval/repro-ledger-entry.schema.json). A submission is VALID for a division iff every required gate for that division passes. Grounded in issue #1263 feature 2 ('closed vs open division; validity/audit review').",
+  "grounding": {
+    "issue": "SocioProphet/prophet-platform#1263",
+    "existing_mechanisms": {
+      "governance_gate": "tools/isota_tournament.py run_tournament() Stage 0 (fail-closed on governance.{api,rate,auth,cost,observability})",
+      "provider_neutrality": "tools/isota_tournament.py composite() — no provider term in scoring; verdict invariant to provider label permutation",
+      "no_laundering": "tools/isota_tournament.py — promotion rests only on reproduced-by-us facts, disjoint from cited provider numbers; schemas/eval/metric-fact.schema.json {reproduced_by_us, source_trust_class}",
+      "clean_eval_certificate": "pre-exam contamination/clean-eval certificate (Noetica-bench2 contamination_audit.py); asserted here as a required submission artifact",
+      "repro_ledger_entry": "schemas/eval/repro-ledger-entry.schema.json (run_id, environment_hash, methodology_snapshot_hash, seed_policy, replay_artifact_id)"
+    }
+  },
+  "gates": {
+    "governance_gate": "Stage-0 fail-closed governance floor (api, rate, auth, cost, observability all provisioned).",
+    "provider_neutrality": "Scoring carries no provider term; the headline is scored by our runner, not by provider-reported numbers.",
+    "no_laundering": "Every headline/promotion metric fact is reproduced-by-us and disjoint from cited provider numbers (no official_provider trust class as a headline).",
+    "clean_eval_certificate": "A pre-run contamination/clean-eval certificate with status 'clean' that covers the submission's eval corpus.",
+    "repro_ledger_entry": "A repro-ledger entry pinning environment_hash + methodology_snapshot_hash + seed_policy + replay_artifact_id.",
+    "fixed_task_manifest": "The submission runs the canonical benchmark contract unchanged (same dataset_ref / required_metric_definition_ids); deviations are disallowed.",
+    "minimum_trials_met": "trial_count >= the benchmark contract's minimum_trial_count."
+  },
+  "divisions": {
+    "CLOSED": {
+      "intent": "Strict, apples-to-apples comparability (MLPerf 'Closed'). The task manifest is fixed; results are directly comparable and rankable.",
+      "required_gates": [
+        "governance_gate",
+        "provider_neutrality",
+        "no_laundering",
+        "clean_eval_certificate",
+        "repro_ledger_entry",
+        "fixed_task_manifest",
+        "minimum_trials_met"
+      ],
+      "comparable": true
+    },
+    "OPEN": {
+      "intent": "Permits novel methods / modified task manifests (MLPerf 'Open'). Still honest and contamination-free, but NOT directly comparable to CLOSED; deviations must be declared.",
+      "required_gates": [
+        "governance_gate",
+        "provider_neutrality",
+        "no_laundering",
+        "clean_eval_certificate"
+      ],
+      "recommended_gates": [
+        "repro_ledger_entry",
+        "minimum_trials_met"
+      ],
+      "comparable": false
+    }
+  }
+}

--- a/schemas/eval/submission.schema.json
+++ b/schemas/eval/submission.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schema://eval/submission.schema.json",
+  "title": "BenchmarkSubmission",
+  "description": "A single benchmark submission evaluated by tools/validate_submission.py against schemas/eval/division-rules.json. Carries the evidence each gate reads.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["submission_id", "division", "candidate_id", "benchmark_contract_id", "governance", "provider_neutrality", "metric_facts", "clean_eval_certificate"],
+  "properties": {
+    "submission_id": {"type": "string", "minLength": 1},
+    "division": {"enum": ["OPEN", "CLOSED"]},
+    "candidate_id": {"type": "string", "minLength": 1},
+    "benchmark_contract_id": {"type": "string", "minLength": 1},
+    "governance": {
+      "type": "object",
+      "description": "Stage-0 governance floor flags (same keys as isota_tournament).",
+      "additionalProperties": true,
+      "properties": {
+        "api": {"type": "boolean"},
+        "rate": {"type": "boolean"},
+        "auth": {"type": "boolean"},
+        "cost": {"type": "boolean"},
+        "observability": {"type": "boolean"}
+      }
+    },
+    "provider_neutrality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scored_by", "provider_terms_in_scoring"],
+      "properties": {
+        "scored_by": {"enum": ["internal_runner", "provider_reported", "independent_harness"]},
+        "provider_terms_in_scoring": {"type": "boolean"}
+      }
+    },
+    "metric_facts": {
+      "type": "array",
+      "minItems": 1,
+      "description": "Headline metric facts. No-laundering reads reproduced_by_us + source_trust_class from each (schema://eval/metric-fact.schema.json).",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["metric_definition_id", "reproduced_by_us", "source_trust_class", "is_headline"],
+        "properties": {
+          "metric_definition_id": {"type": "string"},
+          "reproduced_by_us": {"type": "boolean"},
+          "source_trust_class": {
+            "enum": ["internal_reproduced", "internal_live", "independent_harness", "official_provider", "crowd_preference", "third_party_analytics"]
+          },
+          "is_headline": {"type": "boolean"},
+          "trial_count": {"type": "integer", "minimum": 0}
+        }
+      }
+    },
+    "clean_eval_certificate": {
+      "type": ["object", "null"],
+      "description": "Pre-run contamination/clean-eval certificate. null or status!='clean' fails the gate.",
+      "additionalProperties": true,
+      "properties": {
+        "certificate_id": {"type": "string"},
+        "status": {"enum": ["clean", "contaminated", "unknown"]},
+        "corpus_ref": {"type": "string"},
+        "checked_at": {"type": "string"}
+      }
+    },
+    "repro_ledger_entry": {
+      "type": ["object", "null"],
+      "description": "Conforms to schema://eval/repro-ledger-entry.schema.json when present.",
+      "additionalProperties": true
+    },
+    "task_manifest": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "unchanged": {"type": "boolean", "description": "true iff the canonical benchmark contract task manifest was run unmodified"},
+        "declared_deviations": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "minimum_trial_count": {"type": "integer", "minimum": 1}
+  }
+}

--- a/tests/platform_stubs/test_validate_submission.py
+++ b/tests/platform_stubs/test_validate_submission.py
@@ -1,0 +1,150 @@
+"""Teeth for validate-submission — the single MLPerf-parity submission-validity check (Lever B).
+
+Proven BOTH ways (controls that fire), grounded in issue #1263 feature 2:
+  1. a COMPLIANT submission PASSES (CLOSED + OPEN);
+  2. a submission missing the clean-eval certificate is REJECTED;
+  3. a provider-neutrality violation is REJECTED;
+  4. the OPEN division is genuinely more permissive than CLOSED (an
+     OPEN-valid submission missing only the repro-ledger + fixed-manifest
+     is REJECTED under CLOSED) — the division split is not vacuous;
+  5. the submission descriptor + division rules validate against their schemas.
+"""
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_DIR = ROOT / "schemas" / "eval"
+
+
+def _mod():
+    path = ROOT / "tools" / "validate_submission.py"
+    spec = importlib.util.spec_from_file_location("validate_submission", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = mod  # dataclass field resolution needs the module registered
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _compliant_closed() -> dict:
+    """A submission that passes every CLOSED gate."""
+    return {
+        "submission_id": "sub-001",
+        "division": "CLOSED",
+        "candidate_id": "cand.internal-runner",
+        "benchmark_contract_id": "bc.sherlock.stage2",
+        "governance": {"api": True, "rate": True, "auth": True, "cost": True, "observability": True},
+        "provider_neutrality": {"scored_by": "internal_runner", "provider_terms_in_scoring": False},
+        "metric_facts": [
+            {"metric_definition_id": "md.isota.tournament_composite", "reproduced_by_us": True,
+             "source_trust_class": "internal_reproduced", "is_headline": True, "trial_count": 30},
+        ],
+        "clean_eval_certificate": {"certificate_id": "ce-1", "status": "clean",
+                                    "corpus_ref": "corpus://sherlock", "checked_at": "2026-08-03T00:00:00Z"},
+        "repro_ledger_entry": {"repro_ledger_entry_id": "rl-1", "run_id": "run-1",
+                                "environment_hash": "sha256:" + "e" * 64,
+                                "methodology_snapshot_hash": "sha256:" + "f" * 64,
+                                "seed_policy": "fixed:1729", "replay_artifact_id": "replay-1"},
+        "task_manifest": {"unchanged": True, "declared_deviations": []},
+        "minimum_trial_count": 30,
+    }
+
+
+# ── TEETH 1: compliant submissions PASS (both divisions) ──
+def test_compliant_closed_passes():
+    mod = _mod()
+    verdict = mod.validate_submission(_compliant_closed())
+    assert verdict.valid is True, verdict.to_dict()
+    assert verdict.failed_gates() == []
+
+
+def test_compliant_open_passes():
+    mod = _mod()
+    sub = _compliant_closed()
+    sub["division"] = "OPEN"
+    verdict = mod.validate_submission(sub)
+    assert verdict.valid is True, verdict.to_dict()
+
+
+# ── TEETH 2: missing clean-eval certificate is REJECTED ──
+def test_missing_clean_eval_certificate_is_rejected():
+    mod = _mod()
+    for div in ("CLOSED", "OPEN"):
+        sub = _compliant_closed()
+        sub["division"] = div
+        sub["clean_eval_certificate"] = None
+        verdict = mod.validate_submission(sub)
+        assert verdict.valid is False, div
+        assert "clean_eval_certificate" in verdict.failed_gates(), div
+
+    # a contaminated (non-clean) cert is also rejected — the control is not just "presence"
+    sub = _compliant_closed()
+    sub["clean_eval_certificate"]["status"] = "contaminated"
+    assert mod.validate_submission(sub).valid is False
+
+
+# ── TEETH 3: provider-neutrality violation is REJECTED ──
+def test_provider_neutrality_violation_is_rejected():
+    mod = _mod()
+    # scored by provider-reported numbers
+    sub = _compliant_closed()
+    sub["provider_neutrality"] = {"scored_by": "provider_reported", "provider_terms_in_scoring": False}
+    v1 = mod.validate_submission(sub)
+    assert v1.valid is False and "provider_neutrality" in v1.failed_gates()
+
+    # provider term leaked into scoring
+    sub2 = _compliant_closed()
+    sub2["provider_neutrality"] = {"scored_by": "internal_runner", "provider_terms_in_scoring": True}
+    v2 = mod.validate_submission(sub2)
+    assert v2.valid is False and "provider_neutrality" in v2.failed_gates()
+
+
+# ── TEETH 3b: no-laundering — a cited (not-reproduced) headline is REJECTED ──
+def test_laundered_cited_headline_is_rejected():
+    mod = _mod()
+    sub = _compliant_closed()
+    sub["metric_facts"] = [
+        {"metric_definition_id": "md.gpqa", "reproduced_by_us": False,
+         "source_trust_class": "official_provider", "is_headline": True, "trial_count": 30},
+    ]
+    v = mod.validate_submission(sub)
+    assert v.valid is False and "no_laundering" in v.failed_gates()
+
+
+# ── TEETH 4: the OPEN/CLOSED split is not vacuous ──
+def test_open_more_permissive_than_closed():
+    mod = _mod()
+    # drop the two CLOSED-only gates: repro-ledger + fixed task manifest
+    sub = _compliant_closed()
+    sub["repro_ledger_entry"] = None
+    sub["task_manifest"] = {"unchanged": False, "declared_deviations": ["novel retrieval head"]}
+
+    closed = copy.deepcopy(sub); closed["division"] = "CLOSED"
+    open_ = copy.deepcopy(sub); open_["division"] = "OPEN"
+
+    v_closed = mod.validate_submission(closed)
+    v_open = mod.validate_submission(open_)
+    assert v_closed.valid is False and set(v_closed.failed_gates()) >= {"repro_ledger_entry", "fixed_task_manifest"}
+    assert v_open.valid is True, v_open.to_dict()
+
+
+# ── TEETH 5: descriptor + rules validate against their schemas ──
+def test_submission_and_rules_validate_against_schema():
+    submission_schema = json.loads((SCHEMA_DIR / "submission.schema.json").read_text())
+    jsonschema.validate(_compliant_closed(), submission_schema)
+
+    rules = json.loads((SCHEMA_DIR / "division-rules.json").read_text())
+    assert set(rules["divisions"]) == {"OPEN", "CLOSED"}
+    # every required gate a division names must be implemented by the validator
+    mod = _mod()
+    implemented = set(mod.GATE_FUNCS) | {"minimum_trials_met"}
+    for div, spec in rules["divisions"].items():
+        for gate in spec["required_gates"]:
+            assert gate in implemented, f"{div} requires unimplemented gate {gate}"

--- a/tools/validate_submission.py
+++ b/tools/validate_submission.py
@@ -1,0 +1,209 @@
+"""validate-submission — the single MLPerf-parity submission-validity check.
+
+WIRES the gates that already exist across the estate into ONE pass/fail verdict
+per division, driven by the spec-as-code in ``schemas/eval/division-rules.json``:
+
+  * governance_gate      — Stage-0 fail-closed floor (isota_tournament.py)
+  * provider_neutrality  — scored by our runner, no provider term in scoring
+  * no_laundering        — every headline fact is reproduced-by-us, disjoint
+                           from cited provider numbers (metric-fact schema)
+  * clean_eval_certificate — a pre-run contamination/clean-eval cert, status 'clean'
+  * repro_ledger_entry   — env + methodology + seed pinning (repro-ledger schema)
+  * fixed_task_manifest  — canonical benchmark contract run unchanged (CLOSED only)
+  * minimum_trials_met   — trial_count >= contract minimum
+
+A submission is VALID for its division iff every REQUIRED gate for that
+division passes. Nothing here re-implements a gate's policy; it reads the
+evidence each gate already defines and composes one verdict.
+
+Usage:
+    python tools/validate_submission.py <submission.json> [--min-trials N]
+    # exit 0 = VALID, exit 1 = REJECTED, exit 2 = malformed input
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = ROOT / "schemas" / "eval"
+DIVISION_RULES_PATH = SCHEMA_DIR / "division-rules.json"
+
+# Governance floor keys — identical to isota_tournament.py Stage 0 (single source of truth for the flags).
+GOVERNANCE_KEYS = ("api", "rate", "auth", "cost", "observability")
+# Trust classes that count as reproduced-by-us (not a cited provider number).
+INTERNAL_TRUST = frozenset({"internal_reproduced", "internal_live", "independent_harness"})
+
+
+def load_division_rules() -> dict[str, Any]:
+    return json.loads(DIVISION_RULES_PATH.read_text())
+
+
+@dataclass
+class GateResult:
+    gate: str
+    passed: bool
+    reason: str
+
+
+@dataclass
+class SubmissionVerdict:
+    submission_id: str
+    division: str
+    valid: bool
+    required_gates: list[str]
+    results: list[GateResult] = field(default_factory=list)
+
+    def failed_gates(self) -> list[str]:
+        return [r.gate for r in self.results if r.gate in self.required_gates and not r.passed]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "submission_id": self.submission_id,
+            "division": self.division,
+            "valid": self.valid,
+            "required_gates": self.required_gates,
+            "gate_results": [{"gate": r.gate, "passed": r.passed, "reason": r.reason} for r in self.results],
+            "failed_required_gates": self.failed_gates(),
+        }
+
+
+# ── individual gate checks (each reads the evidence the gate already defines) ──
+def _gate_governance(sub: dict) -> GateResult:
+    gov = sub.get("governance") or {}
+    missing = [k for k in GOVERNANCE_KEYS if gov.get(k) is not True]
+    ok = not missing
+    return GateResult("governance_gate", ok,
+                      "all Stage-0 floor flags provisioned" if ok else f"governance floor not met: missing {missing}")
+
+
+def _gate_provider_neutrality(sub: dict) -> GateResult:
+    pn = sub.get("provider_neutrality") or {}
+    scored_by = pn.get("scored_by")
+    terms = pn.get("provider_terms_in_scoring")
+    ok = scored_by in ("internal_runner", "independent_harness") and terms is False
+    if scored_by == "provider_reported":
+        reason = "scored by provider-reported numbers (not provider-neutral)"
+    elif terms is not False:
+        reason = "provider terms present in scoring"
+    else:
+        reason = "scored by neutral runner, no provider term in scoring"
+    return GateResult("provider_neutrality", ok, reason)
+
+
+def _gate_no_laundering(sub: dict) -> GateResult:
+    facts = sub.get("metric_facts") or []
+    headline = [f for f in facts if f.get("is_headline")]
+    if not headline:
+        return GateResult("no_laundering", False, "no headline metric fact to stand on")
+    laundered = [
+        f.get("metric_definition_id", "?")
+        for f in headline
+        if not (f.get("reproduced_by_us") is True and f.get("source_trust_class") in INTERNAL_TRUST)
+    ]
+    ok = not laundered
+    return GateResult("no_laundering", ok,
+                      "all headline facts reproduced-by-us, disjoint from cited" if ok
+                      else f"laundered headline facts (cited/not-reproduced): {laundered}")
+
+
+def _gate_clean_eval(sub: dict) -> GateResult:
+    cert = sub.get("clean_eval_certificate")
+    if not cert:
+        return GateResult("clean_eval_certificate", False, "no clean-eval/contamination certificate")
+    ok = cert.get("status") == "clean"
+    return GateResult("clean_eval_certificate", ok,
+                      "clean-eval certificate present and clean" if ok
+                      else f"clean-eval certificate status={cert.get('status')!r} (must be 'clean')")
+
+
+def _gate_repro_ledger(sub: dict) -> GateResult:
+    entry = sub.get("repro_ledger_entry")
+    if not entry:
+        return GateResult("repro_ledger_entry", False, "no repro-ledger entry")
+    required = ("run_id", "environment_hash", "methodology_snapshot_hash")
+    missing = [k for k in required if not entry.get(k)]
+    ok = not missing
+    return GateResult("repro_ledger_entry", ok,
+                      "repro-ledger entry pins env + methodology" if ok
+                      else f"repro-ledger entry incomplete: missing {missing}")
+
+
+def _gate_fixed_manifest(sub: dict) -> GateResult:
+    manifest = sub.get("task_manifest") or {}
+    ok = manifest.get("unchanged") is True
+    return GateResult("fixed_task_manifest", ok,
+                      "canonical task manifest run unchanged" if ok
+                      else "task manifest deviated (not allowed in CLOSED)")
+
+
+def _gate_minimum_trials(sub: dict, min_trials: int | None) -> GateResult:
+    floor = min_trials if min_trials is not None else sub.get("minimum_trial_count")
+    if not floor:
+        return GateResult("minimum_trials_met", False, "no minimum_trial_count declared")
+    headline = [f for f in (sub.get("metric_facts") or []) if f.get("is_headline")]
+    worst = min((f.get("trial_count", 0) for f in headline), default=0)
+    ok = worst >= floor
+    return GateResult("minimum_trials_met", ok,
+                      f"trial_count {worst} >= {floor}" if ok else f"trial_count {worst} < required {floor}")
+
+
+GATE_FUNCS = {
+    "governance_gate": _gate_governance,
+    "provider_neutrality": _gate_provider_neutrality,
+    "no_laundering": _gate_no_laundering,
+    "clean_eval_certificate": _gate_clean_eval,
+    "repro_ledger_entry": _gate_repro_ledger,
+    "fixed_task_manifest": _gate_fixed_manifest,
+}
+
+
+def validate_submission(sub: dict, rules: dict | None = None, min_trials: int | None = None) -> SubmissionVerdict:
+    """Run every gate; a submission is VALID iff all REQUIRED gates for its division pass."""
+    rules = rules or load_division_rules()
+    division = sub.get("division")
+    div_spec = (rules.get("divisions") or {}).get(division)
+    if div_spec is None:
+        raise ValueError(f"unknown division {division!r} (expected one of {list((rules.get('divisions') or {}))})")
+    required = list(div_spec.get("required_gates", []))
+
+    results: list[GateResult] = []
+    for name, fn in GATE_FUNCS.items():
+        results.append(fn(sub))
+    results.append(_gate_minimum_trials(sub, min_trials))
+
+    valid = all(r.passed for r in results if r.gate in required)
+    return SubmissionVerdict(
+        submission_id=sub.get("submission_id", "?"), division=division,
+        valid=valid, required_gates=required, results=results,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="validate a benchmark submission against the division rules")
+    ap.add_argument("submission", type=Path, help="path to a submission JSON")
+    ap.add_argument("--min-trials", type=int, default=None, help="override the minimum trial floor")
+    args = ap.parse_args(argv)
+    try:
+        sub = json.loads(args.submission.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"malformed submission: {exc}", file=sys.stderr)
+        return 2
+    try:
+        verdict = validate_submission(sub, min_trials=args.min_trials)
+    except ValueError as exc:
+        print(f"invalid submission: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(verdict.to_dict(), indent=2))
+    status = "VALID" if verdict.valid else "REJECTED"
+    print(f"\n{status}: {verdict.submission_id} [{verdict.division}]"
+          + ("" if verdict.valid else f" — failed required gates: {verdict.failed_gates()}"), file=sys.stderr)
+    return 0 if verdict.valid else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Lever B — division rules + submission validity (MLPerf-parity), enforced

Grounded in #1263 (feature 2 "closed vs open division; validity/audit review" — PARTIAL: "strong adjacent mechanisms, no 'division' naming ... publish one open-vs-closed division-rules + submission-validity doc that names and wires the gates that already exist").

The gates already existed (Stage-0 governance gate + provider-neutral scoring + no-laundering in `tools/isota_tournament.py`; the clean-eval/contamination certificate; the `repro-ledger-entry` contract). What was missing: a **named** open-vs-closed division spec and a **single** submission-validity check. This PR adds both.

### What this delivers (buildable now)
- **`schemas/eval/division-rules.json`** — spec-as-code naming **OPEN** vs **CLOSED** and the required gates per division:
  - **CLOSED** (strict, comparable, MLPerf 'Closed'): governance + provider-neutrality + no-laundering + clean-eval cert + repro-ledger + fixed task manifest + minimum trials.
  - **OPEN** (permits novel methods, non-comparable, MLPerf 'Open'): governance + provider-neutrality + no-laundering + clean-eval cert.
- **`schemas/eval/submission.schema.json`** — the submission descriptor carrying the evidence each gate reads.
- **`tools/validate_submission.py`** — `validate-submission`: wires the existing gates into ONE pass/fail verdict per division. CLI exits `0=VALID`, `1=REJECTED`, `2=malformed`.

### Teeth (`tests/platform_stubs/test_validate_submission.py`) — `7 passed`
| Test | Result |
|---|---|
| compliant submission (CLOSED + OPEN) | **PASSES** |
| missing clean-eval certificate (both divisions) / contaminated cert | **REJECTED** |
| provider-neutrality violation (provider-reported scoring / provider term leaked) | **REJECTED** |
| laundered cited (`official_provider`, not reproduced) headline | **REJECTED** |
| OPEN genuinely more permissive than CLOSED (drop repro-ledger + fixed manifest) | OPEN **PASSES**, CLOSED **REJECTED** |

Shown locally both ways via the CLI:
```
$ validate_submission.py ok.json   ->  VALID: sub-ok [CLOSED]           exit=0
$ validate_submission.py bad.json  ->  REJECTED — failed: [clean_eval_certificate]  exit=1
```
No regression: existing `test_isota_tournament.py` still `9 passed`.

### Beyond the buildable slice (filed for @mdheller)
Public ranked/tiered leaderboard round surface + OAIS preservation/curation vault — filed as a separate tracking issue.

cc @mdheller