### PR TITLE
fix(rollouts): hellgraph-service slo-gate needs clusterScope: true

### DIFF
--- a/deploy/values/hellgraph-service.yaml
+++ b/deploy/values/hellgraph-service.yaml
@@ -114,8 +114,19 @@ rollout:
         # templateName: field not declared in schema"), so the Rollout was never
         # created and the canary never ran once. Enforced now by
         # tools/check_canary_slo_gate.py.
+        #
+        # clusterScope: true is REQUIRED — slo-gate is a ClusterAnalysisTemplate
+        # (infra/k8s/rollouts/base/analysistemplate-slo.yaml, cluster-scoped per
+        # PR #1229/INV-DEP-9 so the same gate resolves from every wave/service
+        # namespace). Without this flag Argo Rollouts looks for a NAMESPACED
+        # AnalysisTemplate named "slo-gate" instead, finds none, and the Rollout
+        # sits InvalidSpec forever with zero pods — exactly what happened here:
+        # the kind was promoted to cluster-scoped but this reference was never
+        # updated to match, so the outage outlived the fix meant to close it.
+        # Enforced now by tools/check_canary_slo_gate.py's clusterscope check.
         templates:
           - templateName: slo-gate
+            clusterScope: true
         args:
           - { name: service, value: hellgraph-service }
     - setWeight: 50

--- a/tools/check_canary_slo_gate.py
+++ b/tools/check_canary_slo_gate.py
@@ -109,12 +109,23 @@ def _canary_steps_of(doc: dict[str, Any]) -> Any:
     return None
 
 
-def analysis_step_violations(steps: Any, where: str) -> list[str]:
+def analysis_step_violations(
+    steps: Any, where: str, template_kinds: dict[str, str] | None = None
+) -> list[str]:
     """A canary step's ``analysis`` takes a LIST of templates. A bare
     ``templateName`` is schema-invalid: ArgoCD server-side-apply rejects the whole
     Rollout (".spec.strategy.canary.steps[N].analysis.templateName: field not
     declared in schema"), so the Rollout is never created and the canary never runs
-    — silently, because the app can still report Healthy from its other objects."""
+    — silently, because the app can still report Healthy from its other objects.
+
+    Also checks ``clusterScope`` consistency against every AnalysisTemplate /
+    ClusterAnalysisTemplate kind declared elsewhere in the repo (``template_kinds``,
+    from ``collect_template_kinds``). A step referencing a ClusterAnalysisTemplate
+    without ``clusterScope: true`` makes Argo Rollouts look for a namespaced
+    AnalysisTemplate instead, find none, and reject the Rollout as InvalidSpec
+    forever — the bug that outlived PR #1229 (which promoted slo-gate to
+    cluster-scoped but left this reference unset), keeping hellgraph-service at
+    zero pods after the fix everyone thought had already closed the outage."""
     out: list[str] = []
     if not isinstance(steps, list):
         return out
@@ -138,17 +149,82 @@ def analysis_step_violations(steps: Any, where: str) -> list[str]:
                     f"{where}: canary step[{i}].analysis has no non-empty `templates` list "
                     f"(missing or empty) — nothing gates this step."
                 )
+            continue
+        if not template_kinds:
+            continue
+        for t in templates:
+            if not isinstance(t, dict):
+                continue
+            name = t.get("templateName")
+            kind = template_kinds.get(name)
+            if kind is None:
+                continue
+            cluster_scope = bool(t.get("clusterScope", False))
+            if kind == "ClusterAnalysisTemplate" and not cluster_scope:
+                out.append(
+                    f"{where}: canary step[{i}] references '{name}', declared as a "
+                    f"ClusterAnalysisTemplate, without `clusterScope: true` — Argo Rollouts "
+                    f"will look for a namespaced AnalysisTemplate instead, find none, and "
+                    f"reject the Rollout as InvalidSpec with zero pods."
+                )
+            elif kind == "AnalysisTemplate" and cluster_scope:
+                out.append(
+                    f"{where}: canary step[{i}] references '{name}' with `clusterScope: true`, "
+                    f"but it is declared as a namespaced AnalysisTemplate, not a "
+                    f"ClusterAnalysisTemplate — Argo Rollouts will look in the wrong scope "
+                    f"and reject the Rollout as InvalidSpec."
+                )
     return out
 
 
-def scan_text(text: str, where: str) -> list[str]:
-    # Helm/Go-templated files are not plain YAML; they are validated by rendering, not
-    # here (the rendered inputs that matter — deploy/values/*.yaml — are checked
-    # directly). Everything else that names these kinds MUST parse.
-    if "{{" in text and "}}" in text:
-        return []
+def collect_template_kinds(root: Path) -> dict[str, str]:
+    """Map every AnalysisTemplate/ClusterAnalysisTemplate name declared anywhere in
+    the repo to its kind, so canary steps can be checked for clusterScope
+    consistency against the real declaration instead of trusting the reference."""
+    kinds: dict[str, str] = {}
+    for path in sorted(root.rglob("*.y*ml")):
+        s = str(path)
+        if "/node_modules/" in s or "/vendor/" in s or "/.git/" in s:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        if not any(k in text for k in ANALYSIS_KINDS):
+            continue
+        docs, err = _load_docs(text)
+        if err is not None:
+            if any(m in text for m in _HELM_TEMPLATE_MARKERS):
+                continue
+            continue  # unparseable + no Helm markers: not our concern here, scan_text flags it
+        for doc in docs:
+            if doc.get("kind") in ANALYSIS_KINDS:
+                name = (doc.get("metadata") or {}).get("name")
+                if isinstance(name, str):
+                    kinds[name] = doc["kind"]
+    return kinds
+
+
+_HELM_TEMPLATE_MARKERS = ("{{-", "{{.Values", "{{ .Values", "{{include", "{{ include", "{{toYaml", "{{ toYaml", "{{if", "{{ if", "{{range", "{{ range", "{{end", "{{ end")
+
+
+def scan_text(
+    text: str, where: str, template_kinds: dict[str, str] | None = None
+) -> list[str]:
     docs, err = _load_docs(text)
     if err is not None:
+        # A real Helm/go-template file breaks plain YAML parsing by design — it is
+        # validated by rendering, not here. But Argo Rollouts' OWN `{{args.x}}`
+        # metric-templating syntax (used inside quoted strings in AnalysisTemplate
+        # queries) does NOT break YAML parsing, so a bare `{{`/`}}` substring check
+        # here would (and for years silently did) skip the real shipped slo-gate
+        # AnalysisTemplate entirely — a false negative that made
+        # test_shipped_repo_is_clean pass for the wrong reason. Only skip when the
+        # parse actually failed AND the text carries a real Helm control-flow
+        # marker; otherwise a file that names these kinds and won't parse is
+        # flagged, never silently skipped.
+        if any(m in text for m in _HELM_TEMPLATE_MARKERS):
+            return []
         # Fail CLOSED: a file that names a Rollout/AnalysisTemplate but will not parse
         # cannot be certified fail-closed — flag it, never silently skip it.
         return [
@@ -161,11 +237,12 @@ def scan_text(text: str, where: str) -> list[str]:
             out.extend(template_violations(doc, where))
         steps = _canary_steps_of(doc)
         if steps is not None:
-            out.extend(analysis_step_violations(steps, where))
+            out.extend(analysis_step_violations(steps, where, template_kinds))
     return out
 
 
 def scan_repo(root: Path) -> list[str]:
+    template_kinds = collect_template_kinds(root)
     out: list[str] = []
     for path in sorted(root.rglob("*.y*ml")):
         s = str(path)
@@ -178,7 +255,7 @@ def scan_repo(root: Path) -> list[str]:
         # Cheap prefilter — the kind/shape checks inside scan_text are authoritative.
         if not any(k in text for k in ("AnalysisTemplate", "Rollout", "rollout:")):
             continue
-        out.extend(scan_text(text, str(path.relative_to(root))))
+        out.extend(scan_text(text, str(path.relative_to(root)), template_kinds))
     return out
 
 

--- a/tools/tests/test_check_canary_slo_gate.py
+++ b/tools/tests/test_check_canary_slo_gate.py
@@ -153,3 +153,70 @@ def test_non_list_metrics_fails_closed():
     )
     violations = chk.scan_text(doc, "bad-shape.yaml")
     assert any("non-list `spec.metrics`" in v for v in violations)
+
+
+# --- clusterScope consistency: the bug that outlived PR #1229 (kind promoted to
+#     ClusterAnalysisTemplate, but the Rollout step referencing it was never
+#     updated), keeping hellgraph-service at zero pods after the "fix" landed ---
+
+_CLUSTER_KINDS = {"slo-gate": "ClusterAnalysisTemplate"}
+_NAMESPACED_KINDS = {"slo-gate": "AnalysisTemplate"}
+
+
+def test_cluster_template_without_clusterscope_is_rejected():
+    # Exactly deploy/values/hellgraph-service.yaml's shape before this fix: a
+    # ClusterAnalysisTemplate referenced with a bare templateName, no clusterScope.
+    violations = chk.scan_text(_VALUES_TEMPLATES, "hellgraph-service.yaml", _CLUSTER_KINDS)
+    assert any("without `clusterScope: true`" in v for v in violations), violations
+
+
+def test_cluster_template_with_clusterscope_passes():
+    doc = textwrap.dedent(
+        """
+        rollout:
+          enabled: true
+          steps:
+            - setWeight: 20
+            - analysis:
+                templates:
+                  - templateName: slo-gate
+                    clusterScope: true
+                args:
+                  - { name: service, value: hellgraph-service }
+            - setWeight: 100
+        """
+    )
+    assert chk.scan_text(doc, "hellgraph-service.yaml", _CLUSTER_KINDS) == []
+
+
+def test_namespaced_template_with_clusterscope_true_is_rejected():
+    # The opposite mismatch: clusterScope: true pointed at a template that is
+    # actually namespaced — Argo Rollouts would look in the wrong scope either way.
+    doc = textwrap.dedent(
+        """
+        rollout:
+          enabled: true
+          steps:
+            - setWeight: 20
+            - analysis:
+                templates:
+                  - templateName: slo-gate
+                    clusterScope: true
+                args:
+                  - { name: service, value: hellgraph-service }
+            - setWeight: 100
+        """
+    )
+    violations = chk.scan_text(doc, "some-service.yaml", _NAMESPACED_KINDS)
+    assert any("declared as a namespaced AnalysisTemplate" in v for v in violations), violations
+
+
+def test_unknown_template_name_is_not_flagged():
+    # A template this repo doesn't declare (e.g. shared cross-repo) can't be
+    # verified here — must not produce a false positive.
+    assert chk.scan_text(_VALUES_TEMPLATES, "hellgraph-service.yaml", {}) == []
+
+
+def test_collect_template_kinds_matches_live_repo_shape():
+    kinds = chk.collect_template_kinds(Path(chk.ROOT))
+    assert kinds.get("slo-gate") == "ClusterAnalysisTemplate"


### PR DESCRIPTION
## Summary
- PR #1229 promoted `slo-gate` to a `ClusterAnalysisTemplate` but left the Rollout step's reference as a bare `templateName`, so Argo Rollouts kept looking for a namespaced `AnalysisTemplate`, found none, and rejected the Rollout as `InvalidSpec` — hellgraph-service has been at zero pods since, outliving the fix meant to close it. Adds `clusterScope: true` to the reference.
- Extends `tools/check_canary_slo_gate.py` with a clusterScope-consistency check (declared kind vs. reference) so this class of drift can't recur silently, with tests proving it fires both directions.
- Fixes a second, unrelated latent bug found while adding a test: the checker's Helm-template skip heuristic (`{{`/`}}` substring match) also matched Argo Rollouts' own `{{args.service}}` metric-templating syntax, so it was silently skipping the real shipped `slo-gate` template's fail-closed check entirely — `test_shipped_repo_is_clean` was passing for the wrong reason. Now only skips files that actually fail YAML parsing AND carry a real Helm control-flow marker.

## Test plan
- [x] `pytest tools/tests/test_check_canary_slo_gate.py` — 14/14 pass, including new adversarial tests for both clusterScope mismatch directions and confirming the real `slo-gate` template is now actually scanned
- [x] `python3 tools/check_canary_slo_gate.py` against the full repo — clean, no new false positives from the widened parse coverage
- [x] `helm template hellgraph-service charts/socioprophet-service -f deploy/values/hellgraph-service.yaml --show-only templates/rollout.yaml` — confirms `clusterScope: true` renders correctly on the template reference
- [ ] Post-merge: confirm the live Rollout controller stops logging `AnalysisTemplate 'slo-gate' not found` and hellgraph-service pods actually come up