### PR TITLE
feat(catalog-gateway): ops readout — fold captured events into catalog KPIs

### DIFF
--- a/apps/catalog-gateway/app/main.py
+++ b/apps/catalog-gateway/app/main.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 
-from . import ops
+from . import ops, readout
 from .dcat import asset_to_dcat
 from .store import KINDS, SERVICE, get_entry, is_valid_id
 
@@ -50,6 +50,24 @@ def asset_dcat(entry_id: str) -> JSONResponse:
     ops.record_dcat_emitted(entry.get("asset_id") or entry_id, doc.get("dct:accessRights", ""),
                             distribution_class=entry.get("distribution_class"))
     return JSONResponse(content=doc, media_type="application/ld+json")
+
+
+# NOTE: the ops-readout routes are declared BEFORE the generic `/{kind}/{entry_id}`
+# resolver for the same reason as `.dcat.json`: `/v1/catalog/ops/readout` would
+# otherwise bind kind="ops", entry_id="readout" and 404. `ops` is not a catalog kind.
+@app.get("/v1/catalog/ops/readout")
+def ops_readout(top_n: int = readout.DEFAULT_TOP_N) -> dict:
+    """Compute the catalog KPIs by folding the captured operational events. Read-only:
+    does not crystallize a new event (use POST for that)."""
+    return readout.compute_readout(top_n=max(1, min(top_n, 100)))
+
+
+@app.post("/v1/catalog/ops/readout")
+def ops_readout_emit(top_n: int = readout.DEFAULT_TOP_N) -> dict:
+    """Compute AND crystallize the readout as a catalog.ops.readout.v0 event (the
+    scheduled readout job's endpoint). Returns the readout with the emitted event_id."""
+    doc, event_id = readout.emit_readout(top_n=max(1, min(top_n, 100)))
+    return {"readout": doc, "event_id": event_id}
 
 
 @app.get("/v1/catalog/{kind}/{entry_id}/lineage")

--- a/apps/catalog-gateway/app/readout.py
+++ b/apps/catalog-gateway/app/readout.py
@@ -1,0 +1,149 @@
+"""Catalog operational plane — analysis layer (the readout).
+
+`ops.py` CAPTURES what the gateway does (one `catalog.*.v0` event per resolve / DCAT
+emission). This module FOLDS that event stream into catalog KPIs — the numbers a
+steward actually reads: resolve hit/miss, the hot entries, registration candidates
+(entries people ask for that don't exist yet), DCAT coverage, and cold sources.
+
+Two entry points, one computation:
+  * `compute_readout()` — pure fold over the captured events + the catalog listing.
+    Deterministic for a given file-state: given the same events it returns the same
+    KPIs (ties broken by id), so it is testable and diffable. `generated_at` is the
+    only clock-dependent field and is metadata, not a KPI.
+  * `emit_readout()` — crystallizes the readout as a `catalog.ops.readout.v0` event
+    into the SAME shared file-state, so the analysis layer is itself observable and a
+    downstream SLO gate (WO-2) can read a readout the same way it reads any event.
+
+The readout is derived, not authoritative: it never mutates the catalog or the event
+log, and an empty event stream yields a well-formed zero readout (not an error).
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from . import ops
+from .store import KINDS, list_ids
+
+SCHEMA_VERSION = "crystal-atlas.catalog.ops.readout.v0"
+DEFAULT_TOP_N = 10
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _load_events() -> list[dict[str, Any]]:
+    """Read every captured operational event (best-effort per file). A malformed or
+    unreadable event is skipped, never fatal — the readout must survive a partially
+    corrupt log rather than blind the steward to the events that ARE readable."""
+    d: Path = ops._events_dir()
+    if not d.is_dir():
+        return []
+    out: list[dict[str, Any]] = []
+    for p in sorted(d.glob("*.event.json")):
+        try:
+            obj = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if isinstance(obj, dict) and isinstance(obj.get("event"), dict):
+            out.append(obj)
+    return out
+
+
+def _rank(counter: Counter, top_n: int) -> list[tuple[str, int]]:
+    # deterministic: count desc, then key asc — never rely on Counter insertion order
+    return sorted(counter.items(), key=lambda kv: (-kv[1], kv[0]))[:top_n]
+
+
+def compute_readout(top_n: int = DEFAULT_TOP_N) -> dict[str, Any]:
+    events = _load_events()
+    resolves = [e["event"] for e in events if e.get("event_type") == "catalog.resolved.v0"]
+    dcats = [e["event"] for e in events if e.get("event_type") == "catalog.dcat.emitted.v0"]
+
+    hits = sum(1 for r in resolves if r.get("hit") is True)
+    misses = sum(1 for r in resolves if r.get("hit") is False)
+    total = hits + misses
+
+    # per-kind resolve breakdown
+    by_kind: dict[str, dict[str, int]] = {}
+    for r in resolves:
+        k = r.get("kind", "unknown")
+        b = by_kind.setdefault(k, {"total": 0, "hits": 0, "misses": 0})
+        b["total"] += 1
+        b["hits"] += 1 if r.get("hit") is True else 0
+        b["misses"] += 1 if r.get("hit") is False else 0
+
+    # hot entries (most-resolved) and top misses (registration candidates)
+    hot = Counter(f'{r.get("kind","?")}/{r.get("entry_id","?")}' for r in resolves)
+    miss_c = Counter(f'{r.get("kind","?")}/{r.get("entry_id","?")}'
+                     for r in resolves if r.get("hit") is False)
+
+    def _split(key: str) -> dict[str, str]:
+        kind, _, entry_id = key.partition("/")
+        return {"kind": kind, "entry_id": entry_id}
+
+    hot_entries = [{**_split(k), "resolves": n} for k, n in _rank(hot, top_n)]
+    top_misses = [{**_split(k), "misses": n} for k, n in _rank(miss_c, top_n)]
+
+    # DCAT coverage: distinct assets that emitted a DCAT doc / distinct assets HIT
+    dcat_assets = {d.get("asset_id") for d in dcats if d.get("asset_id")}
+    resolved_assets = {r.get("entry_id") for r in resolves
+                       if r.get("kind") == "asset" and r.get("hit") is True and r.get("entry_id")}
+    covered = dcat_assets & resolved_assets
+    coverage = round(len(covered) / len(resolved_assets), 4) if resolved_assets else None
+
+    # cold sources: cataloged sources that were never HIT in this window (candidates
+    # for deprecation review — they exist but nobody reads them)
+    cataloged_sources = set(list_ids("source"))
+    hit_sources = {r.get("entry_id") for r in resolves
+                   if r.get("kind") == "source" and r.get("hit") is True and r.get("entry_id")}
+    cold_sources = sorted(cataloged_sources - hit_sources)
+
+    emitted = [e["event"].get("emitted_at") for e in events if e["event"].get("emitted_at")]
+    emitted_sorted = sorted(x for x in emitted if isinstance(x, str))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "readout_id": "ro_" + uuid.uuid4().hex[:16],
+        "generated_at": _now(),
+        "producer": ops.PRODUCER,
+        "window": {
+            "events_scanned": len(events),
+            "first_event_at": emitted_sorted[0] if emitted_sorted else None,
+            "last_event_at": emitted_sorted[-1] if emitted_sorted else None,
+        },
+        "resolve": {
+            "total": total,
+            "hits": hits,
+            "misses": misses,
+            "hit_rate": round(hits / total, 4) if total else None,
+            "by_kind": {k: by_kind[k] for k in sorted(by_kind)},
+        },
+        "hot_entries": hot_entries,
+        "top_misses": top_misses,
+        "dcat": {
+            "emissions": len(dcats),
+            "distinct_assets": len(dcat_assets),
+            "coverage_of_resolved_assets": coverage,
+        },
+        "sources": {
+            "cataloged": len(cataloged_sources),
+            "read_in_window": len(cataloged_sources & hit_sources),
+            "cold": cold_sources,
+        },
+    }
+
+
+def emit_readout(top_n: int = DEFAULT_TOP_N) -> tuple[dict[str, Any], str | None]:
+    """Compute the readout AND crystallize it as a `catalog.ops.readout.v0` event.
+    Returns (readout, event_id). event_id is None if capture is off or the write
+    fails — the computed readout is still returned (the fold never depends on the
+    write succeeding). Intended for the scheduled readout job / SLO gate (WO-2)."""
+    readout = compute_readout(top_n)
+    event_id = ops.emit(SCHEMA_VERSION, dict(readout))
+    return readout, event_id

--- a/apps/catalog-gateway/app/store.py
+++ b/apps/catalog-gateway/app/store.py
@@ -40,6 +40,18 @@ def is_valid_id(entry_id: str) -> bool:
     return bool(_SAFE_ID.match(entry_id or "")) and ".." not in entry_id
 
 
+def list_ids(kind: str) -> list[str]:
+    """Return the ids of every catalog entry of `kind` (sorted, deterministic).
+    Empty on an unknown kind or an absent catalog root — never raises. This is the
+    denominator source for coverage KPIs (e.g. which cataloged sources are cold)."""
+    if kind not in KINDS:
+        return []
+    d = catalog_root() / kind
+    if not d.is_dir():
+        return []
+    return sorted(p.stem for p in d.glob("*.json") if p.is_file())
+
+
 def get_entry(kind: str, entry_id: str) -> dict[str, Any] | None:
     """Return the catalog entry, or None if the kind/id is invalid or absent.
     Fails closed on a bad id (path-traversal attempt) — returns None, never reads

--- a/apps/catalog-gateway/tests/test_readout.py
+++ b/apps/catalog-gateway/tests/test_readout.py
@@ -1,0 +1,143 @@
+"""Catalog operational-plane analysis-layer tests (the readout fold)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from app.main import app  # noqa: E402
+
+client = TestClient(app)
+
+ASSET = {
+    "asset_id": "asset-ro-1", "asset_kind": "dataset", "tenant_id": "t",
+    "distribution_class": "public_derived", "source_refs": ["src-1"],
+    "created_at": "2026-08-01T00:00:00Z", "updated_at": "2026-08-01T00:00:00Z",
+}
+SOURCE_HOT = {"source_id": "src-1", "tenant_id": "t"}
+SOURCE_COLD = {"source_id": "src-cold", "tenant_id": "t"}
+
+
+def _seed(monkeypatch, tmp_path):
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path))
+    monkeypatch.setenv("CATALOG_OPS_CAPTURE", "true")
+    root = tmp_path / "prophet-platform" / "catalog"
+    (root / "asset").mkdir(parents=True, exist_ok=True)
+    (root / "source").mkdir(parents=True, exist_ok=True)
+    (root / "asset" / "asset-ro-1.json").write_text(json.dumps(ASSET), encoding="utf-8")
+    (root / "source" / "src-1.json").write_text(json.dumps(SOURCE_HOT), encoding="utf-8")
+    (root / "source" / "src-cold.json").write_text(json.dumps(SOURCE_COLD), encoding="utf-8")
+
+
+def _drive(monkeypatch, tmp_path):
+    """Produce a known event mix: 2 hits on the asset, 1 hit on src-1, 3 misses on the
+    same absent id, and 1 DCAT emission."""
+    _seed(monkeypatch, tmp_path)
+    assert client.get("/v1/catalog/asset/asset-ro-1").status_code == 200
+    assert client.get("/v1/catalog/asset/asset-ro-1").status_code == 200
+    assert client.get("/v1/catalog/source/src-1").status_code == 200
+    for _ in range(3):
+        assert client.get("/v1/catalog/asset/ghost").status_code == 404
+    assert client.get("/v1/catalog/asset/asset-ro-1.dcat.json").status_code == 200
+
+
+def test_zero_readout_is_well_formed(monkeypatch, tmp_path):
+    # No events, no catalog → a valid zero readout, never an error.
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path))
+    from app import readout
+    r = readout.compute_readout()
+    assert r["schema_version"] == "crystal-atlas.catalog.ops.readout.v0"
+    assert r["window"]["events_scanned"] == 0
+    assert r["resolve"] == {"total": 0, "hits": 0, "misses": 0, "hit_rate": None, "by_kind": {}}
+    assert r["hot_entries"] == [] and r["top_misses"] == []
+    assert r["dcat"]["coverage_of_resolved_assets"] is None
+    assert r["sources"]["cataloged"] == 0 and r["sources"]["cold"] == []
+
+
+def test_resolve_hit_miss_and_rate(monkeypatch, tmp_path):
+    _drive(monkeypatch, tmp_path)
+    from app import readout
+    r = readout.compute_readout()
+    # 2 asset hits + 1 source hit = 3 hits; 3 ghost misses; total 6; rate 0.5
+    assert r["resolve"]["hits"] == 3
+    assert r["resolve"]["misses"] == 3
+    assert r["resolve"]["total"] == 6
+    assert r["resolve"]["hit_rate"] == 0.5
+    assert r["resolve"]["by_kind"]["asset"] == {"total": 5, "hits": 2, "misses": 3}
+    assert r["resolve"]["by_kind"]["source"] == {"total": 1, "hits": 1, "misses": 0}
+
+
+def test_hot_entries_and_top_misses_ranking(monkeypatch, tmp_path):
+    _drive(monkeypatch, tmp_path)
+    from app import readout
+    r = readout.compute_readout()
+    hot = r["hot_entries"]
+    # asset/asset-ro-1 (3 resolves: 2 hit + ... no, ghost is separate) — asset-ro-1
+    # has 2 resolves, ghost has 3, src-1 has 1. ghost is hottest by resolve count.
+    assert hot[0] == {"kind": "asset", "entry_id": "ghost", "resolves": 3}
+    assert {"kind": "asset", "entry_id": "asset-ro-1", "resolves": 2} in hot
+    # top misses = registration candidates: only ghost missed (3x)
+    assert r["top_misses"] == [{"kind": "asset", "entry_id": "ghost", "misses": 3}]
+
+
+def test_dcat_coverage(monkeypatch, tmp_path):
+    _drive(monkeypatch, tmp_path)
+    from app import readout
+    r = readout.compute_readout()
+    # 1 DCAT emission for asset-ro-1, which was also HIT → coverage 1/1 = 1.0
+    assert r["dcat"]["emissions"] == 1
+    assert r["dcat"]["distinct_assets"] == 1
+    assert r["dcat"]["coverage_of_resolved_assets"] == 1.0
+
+
+def test_cold_sources(monkeypatch, tmp_path):
+    _drive(monkeypatch, tmp_path)
+    from app import readout
+    r = readout.compute_readout()
+    # 2 cataloged sources; src-1 was read, src-cold never → cold = [src-cold]
+    assert r["sources"]["cataloged"] == 2
+    assert r["sources"]["read_in_window"] == 1
+    assert r["sources"]["cold"] == ["src-cold"]
+
+
+def test_emit_crystallizes_a_readout_event(monkeypatch, tmp_path):
+    _drive(monkeypatch, tmp_path)
+    from app import readout
+    doc, event_id = readout.emit_readout()
+    assert event_id is not None
+    ev_dir = tmp_path / "prophet-platform" / "events" / "catalog-gateway"
+    written = [json.loads(p.read_text()) for p in ev_dir.glob("*.event.json")]
+    readouts = [e for e in written if e["event_type"] == "crystal-atlas.catalog.ops.readout.v0"]
+    assert len(readouts) == 1
+    assert readouts[0]["event"]["readout_id"] == doc["readout_id"]
+    # the crystallized readout does not count itself as a resolve/dcat KPI
+    assert readouts[0]["event"]["resolve"]["total"] == 6
+
+
+def test_readout_is_deterministic_for_fixed_events(monkeypatch, tmp_path):
+    _drive(monkeypatch, tmp_path)
+    from app import readout
+    a = readout.compute_readout()
+    b = readout.compute_readout()
+    # KPIs identical run-to-run; only the id + generated_at differ.
+    for key in ("resolve", "hot_entries", "top_misses", "dcat", "sources"):
+        assert a[key] == b[key]
+
+
+def test_route_get_and_post(monkeypatch, tmp_path):
+    _drive(monkeypatch, tmp_path)
+    g = client.get("/v1/catalog/ops/readout")
+    assert g.status_code == 200
+    assert g.json()["resolve"]["total"] == 6
+    p = client.post("/v1/catalog/ops/readout")
+    assert p.status_code == 200
+    body = p.json()
+    assert body["event_id"] is not None
+    assert body["readout"]["resolve"]["hits"] == 3
+    # the GET route must not be shadowed by the generic /{kind}/{entry_id} resolver
+    assert "ops" not in [h["kind"] for h in g.json()["hot_entries"]]

--- a/contracts/crystal-atlas/events/catalog.ops.readout.v0.schema.json
+++ b/contracts/crystal-atlas/events/catalog.ops.readout.v0.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/crystal-atlas/catalog_ops_readout.schema.json",
+  "title": "catalog.ops.readout.v0",
+  "description": "Analysis-layer record: a fold of the captured catalog.resolved.v0 / catalog.dcat.emitted.v0 events into catalog KPIs (resolve hit/miss, hot entries, registration-candidate misses, DCAT coverage, cold sources). Derived and non-authoritative; crystallized into the shared file-state so the readout is itself observable and SLO-gateable (WO-2).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "readout_id", "generated_at", "producer", "window", "resolve", "hot_entries", "top_misses", "dcat", "sources"],
+  "properties": {
+    "schema_version": { "const": "crystal-atlas.catalog.ops.readout.v0" },
+    "readout_id": { "type": "string", "minLength": 8 },
+    "generated_at": { "type": "string" },
+    "producer": { "type": "string" },
+    "event_id": { "type": "string" },
+    "emitted_at": { "type": "string" },
+    "window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["events_scanned", "first_event_at", "last_event_at"],
+      "properties": {
+        "events_scanned": { "type": "integer", "minimum": 0 },
+        "first_event_at": { "type": ["string", "null"] },
+        "last_event_at": { "type": ["string", "null"] }
+      }
+    },
+    "resolve": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["total", "hits", "misses", "hit_rate", "by_kind"],
+      "properties": {
+        "total": { "type": "integer", "minimum": 0 },
+        "hits": { "type": "integer", "minimum": 0 },
+        "misses": { "type": "integer", "minimum": 0 },
+        "hit_rate": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+        "by_kind": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["total", "hits", "misses"],
+            "properties": {
+              "total": { "type": "integer", "minimum": 0 },
+              "hits": { "type": "integer", "minimum": 0 },
+              "misses": { "type": "integer", "minimum": 0 }
+            }
+          }
+        }
+      }
+    },
+    "hot_entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "entry_id", "resolves"],
+        "properties": {
+          "kind": { "type": "string" },
+          "entry_id": { "type": "string" },
+          "resolves": { "type": "integer", "minimum": 1 }
+        }
+      }
+    },
+    "top_misses": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "entry_id", "misses"],
+        "properties": {
+          "kind": { "type": "string" },
+          "entry_id": { "type": "string" },
+          "misses": { "type": "integer", "minimum": 1 }
+        }
+      }
+    },
+    "dcat": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["emissions", "distinct_assets", "coverage_of_resolved_assets"],
+      "properties": {
+        "emissions": { "type": "integer", "minimum": 0 },
+        "distinct_assets": { "type": "integer", "minimum": 0 },
+        "coverage_of_resolved_assets": { "type": ["number", "null"], "minimum": 0, "maximum": 1 }
+      }
+    },
+    "sources": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cataloged", "read_in_window", "cold"],
+      "properties": {
+        "cataloged": { "type": "integer", "minimum": 0 },
+        "read_in_window": { "type": "integer", "minimum": 0 },
+        "cold": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What
The catalog operational plane had a **capture** layer (`ops.py` — one `catalog.*.v0` event per resolve / DCAT emission) but no **analysis** layer. `ops.py`'s own docstring pointed at a *"scheduled readout [that] folds these into catalog KPIs"* — which did not exist. This is WO-1: that readout.

## Deliverables
- **`app/readout.py`** — `compute_readout()` folds the captured event stream into the KPIs a steward actually reads:
  - resolve **hit/miss + rate**, and a **per-kind** breakdown
  - **hot_entries** (most-resolved) and **top_misses** (*registration candidates* — entries people ask for that don't exist yet)
  - **DCAT coverage** of resolved assets
  - **cold sources** (cataloged but never read — deprecation-review candidates)
- **`contracts/crystal-atlas/events/catalog.ops.readout.v0.schema.json`** — the record contract (readout validated against it).
- **`store.list_ids(kind)`** — deterministic catalog listing (the coverage denominator).
- **Routes**: `GET /v1/catalog/ops/readout` (compute) + `POST` (compute & **crystallize** as a `catalog.ops.readout.v0` event), declared before the generic `/{kind}/{entry_id}` resolver so `ops/readout` isn't swallowed.
- **`tests/test_readout.py`** — 8 tests.

## Properties
- **Deterministic** for a given file-state (ties broken by id) → testable + diffable; `generated_at` is the only clock-dependent field and is metadata, not a KPI.
- **Derived + non-authoritative**: never mutates the catalog or the event log; a corrupt/absent event is skipped, and an empty stream yields a well-formed **zero readout**, never an error.
- The crystallized readout does **not** count itself as a resolve/DCAT KPI.

## Verify
```
cd apps/catalog-gateway && python3 -m pytest tests/ -q   # 20 passed (8 new + 12 existing)
```

Next: **WO-2** folds the readout into an SLO verdict (ok/sad/bad per the Assay); **WO-3/4** surface it in the cockpit.