### PR TITLE
feat(catalog-gateway): ops SLO gate — the Assay verdict over a readout

### DIFF
--- a/apps/catalog-gateway/app/main.py
+++ b/apps/catalog-gateway/app/main.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 
-from . import ops, readout
+from . import ops, readout, slo
 from .dcat import asset_to_dcat
 from .store import KINDS, SERVICE, get_entry, is_valid_id
 
@@ -68,6 +68,20 @@ def ops_readout_emit(top_n: int = readout.DEFAULT_TOP_N) -> dict:
     scheduled readout job's endpoint). Returns the readout with the emitted event_id."""
     doc, event_id = readout.emit_readout(top_n=max(1, min(top_n, 100)))
     return {"readout": doc, "event_id": event_id}
+
+
+@app.get("/v1/catalog/ops/slo")
+def ops_slo() -> dict:
+    """Grade the current readout against the SLO → the Assay verdict (ok/sad/bad).
+    Read-only: does not crystallize an event (use POST)."""
+    return slo.evaluate()
+
+
+@app.post("/v1/catalog/ops/slo")
+def ops_slo_emit() -> dict:
+    """Evaluate AND crystallize the verdict as a catalog.ops.slo.v0 event."""
+    doc, event_id = slo.emit_slo()
+    return {"slo": doc, "event_id": event_id}
 
 
 @app.get("/v1/catalog/{kind}/{entry_id}/lineage")

--- a/apps/catalog-gateway/app/slo.py
+++ b/apps/catalog-gateway/app/slo.py
@@ -1,0 +1,110 @@
+"""Catalog operational plane — SLO gate (the verdict).
+
+WO-1 (readout.py) turns the captured event stream into KPIs. This turns the KPIs
+into a JUDGEMENT: the Assay verdict (ok / sad / bad) a gate can act on, not just a
+number a human squints at.
+
+Each objective grades one KPI against two thresholds (ok / sad; below sad = bad).
+The overall verdict is the WORST applicable objective — MEET / min semantics, the
+same fail-closed rule the estate uses for Truth = Law × Evidence: a single bad
+objective makes the whole readout bad, no averaging a failure away.
+
+Small-sample honesty: an objective with fewer than `min_n` observations returns
+`insufficient_data` rather than a confident grade, and does NOT drag the overall
+verdict — you cannot fail an SLO you have no evidence for, nor pass it. When every
+objective is insufficient/na the overall verdict is `insufficient_data` too.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from . import ops, readout
+
+SCHEMA_VERSION = "crystal-atlas.catalog.ops.slo.v0"
+
+# rank for MEET(min): a higher number is worse, so overall = max(rank) → worst verdict.
+_GRADED = {"ok": 0, "sad": 1, "bad": 2}
+_MIN_N_DEFAULT = 30  # estate rule: a grade needs n>=30 observations or it is not evidence
+
+# Default SLO objectives. Each: (kind, ok_threshold, sad_threshold, direction).
+# direction "high" = higher is better (value>=ok → ok); "low" = lower is better.
+DEFAULT_SLO: dict[str, dict[str, Any]] = {
+    "resolve_hit_rate": {"ok": 0.90, "sad": 0.70, "direction": "high"},
+    "dcat_coverage":    {"ok": 0.80, "sad": 0.50, "direction": "high"},
+    "cold_source_ratio":{"ok": 0.20, "sad": 0.50, "direction": "low"},
+}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _grade(value: float | None, ok: float, sad: float, direction: str, n: int,
+           min_n: int) -> tuple[str, str]:
+    """Return (verdict, note). insufficient_data when value is unknown or n<min_n."""
+    if value is None:
+        return "insufficient_data", "no observations"
+    if n < min_n:
+        return "insufficient_data", f"n={n} < min_n={min_n}"
+    if direction == "high":
+        if value >= ok:
+            return "ok", ""
+        return ("sad", "") if value >= sad else ("bad", "")
+    # direction == "low": lower is better
+    if value <= ok:
+        return "ok", ""
+    return ("sad", "") if value <= sad else ("bad", "")
+
+
+def evaluate(ro: dict[str, Any] | None = None, *, slo: dict[str, dict[str, Any]] | None = None,
+             min_n: int = _MIN_N_DEFAULT) -> dict[str, Any]:
+    """Grade a readout against the SLO. Computes a fresh readout if none is passed."""
+    ro = ro if ro is not None else readout.compute_readout()
+    slo = slo or DEFAULT_SLO
+
+    resolve_total = ro["resolve"]["total"]
+    cataloged_sources = ro["sources"]["cataloged"]
+    cold = len(ro["sources"]["cold"])
+
+    # objective input values + their sample sizes
+    cold_ratio = round(cold / cataloged_sources, 4) if cataloged_sources else None
+    inputs = {
+        "resolve_hit_rate": (ro["resolve"]["hit_rate"], resolve_total),
+        "dcat_coverage": (ro["dcat"]["coverage_of_resolved_assets"], ro["dcat"]["distinct_assets"]),
+        "cold_source_ratio": (cold_ratio, cataloged_sources),
+    }
+
+    objectives: list[dict[str, Any]] = []
+    for name in sorted(slo):
+        cfg = slo[name]
+        value, n = inputs.get(name, (None, 0))
+        verdict, note = _grade(value, cfg["ok"], cfg["sad"], cfg["direction"], n, min_n)
+        objectives.append({
+            "name": name, "verdict": verdict, "value": value, "n": n,
+            "thresholds": {"ok": cfg["ok"], "sad": cfg["sad"], "direction": cfg["direction"]},
+            "note": note,
+        })
+
+    graded = [o["verdict"] for o in objectives if o["verdict"] in _GRADED]
+    overall = max(graded, key=lambda v: _GRADED[v]) if graded else "insufficient_data"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "slo_id": "slo_" + uuid.uuid4().hex[:16],
+        "generated_at": _now(),
+        "producer": ops.PRODUCER,
+        "readout_ref": ro.get("readout_id"),
+        "verdict": overall,
+        "objectives": objectives,
+        "window": dict(ro["window"]),
+    }
+
+
+def emit_slo(*, slo: dict[str, dict[str, Any]] | None = None,
+             min_n: int = _MIN_N_DEFAULT) -> tuple[dict[str, Any], str | None]:
+    """Evaluate AND crystallize the verdict as a catalog.ops.slo.v0 event."""
+    doc = evaluate(slo=slo, min_n=min_n)
+    event_id = ops.emit(SCHEMA_VERSION, dict(doc))
+    return doc, event_id

--- a/apps/catalog-gateway/tests/test_slo.py
+++ b/apps/catalog-gateway/tests/test_slo.py
@@ -1,0 +1,130 @@
+"""Catalog operational-plane SLO-gate tests (the Assay verdict over a readout)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from app.main import app  # noqa: E402
+from app import slo  # noqa: E402
+
+client = TestClient(app)
+
+
+def _readout(*, hit_rate, resolve_total, coverage, distinct_assets, cataloged, cold):
+    """Synthesize just the fields slo.evaluate() reads."""
+    return {
+        "readout_id": "ro_test",
+        "resolve": {"total": resolve_total, "hits": 0, "misses": 0,
+                    "hit_rate": hit_rate, "by_kind": {}},
+        "dcat": {"emissions": 0, "distinct_assets": distinct_assets,
+                 "coverage_of_resolved_assets": coverage},
+        "sources": {"cataloged": cataloged, "read_in_window": 0, "cold": cold},
+        "window": {"events_scanned": 0, "first_event_at": None, "last_event_at": None},
+    }
+
+
+def test_all_green_is_ok():
+    ro = _readout(hit_rate=0.95, resolve_total=40, coverage=0.9, distinct_assets=40,
+                  cataloged=40, cold=[f"s{i}" for i in range(4)])  # cold ratio 0.1
+    r = slo.evaluate(ro)
+    assert r["verdict"] == "ok"
+    assert {o["name"]: o["verdict"] for o in r["objectives"]} == {
+        "resolve_hit_rate": "ok", "dcat_coverage": "ok", "cold_source_ratio": "ok"}
+
+
+def test_worst_objective_wins_meet_min():
+    # hit_rate ok, coverage sad, cold_ratio bad → overall bad (min semantics)
+    ro = _readout(hit_rate=0.95, resolve_total=40, coverage=0.6, distinct_assets=40,
+                  cataloged=40, cold=[f"s{i}" for i in range(30)])  # cold ratio 0.75 → bad
+    r = slo.evaluate(ro)
+    verdicts = {o["name"]: o["verdict"] for o in r["objectives"]}
+    assert verdicts["resolve_hit_rate"] == "ok"
+    assert verdicts["dcat_coverage"] == "sad"
+    assert verdicts["cold_source_ratio"] == "bad"
+    assert r["verdict"] == "bad"  # worst wins, no averaging
+
+
+def test_sad_when_worst_is_sad():
+    ro = _readout(hit_rate=0.75, resolve_total=40, coverage=0.9, distinct_assets=40,
+                  cataloged=40, cold=["s0"])  # cold ratio ~0.025 ok, hit_rate 0.75 sad
+    r = slo.evaluate(ro)
+    assert r["verdict"] == "sad"
+
+
+def test_insufficient_data_below_min_n():
+    # only 10 resolves and 5 assets → hit_rate + coverage objectives are insufficient;
+    # cataloged=5 → cold_ratio also insufficient → overall insufficient_data.
+    ro = _readout(hit_rate=1.0, resolve_total=10, coverage=1.0, distinct_assets=5,
+                  cataloged=5, cold=[])
+    r = slo.evaluate(ro)
+    assert r["verdict"] == "insufficient_data"
+    assert all(o["verdict"] == "insufficient_data" for o in r["objectives"])
+    assert any("n=10 < min_n=30" in o["note"] for o in r["objectives"])
+
+
+def test_insufficient_does_not_drag_the_graded_verdict():
+    # hit_rate graded ok (n=40); coverage insufficient (n=5) → overall follows the
+    # graded objective (ok), the insufficient one neither passes nor fails.
+    ro = _readout(hit_rate=0.95, resolve_total=40, coverage=1.0, distinct_assets=5,
+                  cataloged=40, cold=[])
+    r = slo.evaluate(ro)
+    assert r["verdict"] == "ok"
+    cov = next(o for o in r["objectives"] if o["name"] == "dcat_coverage")
+    assert cov["verdict"] == "insufficient_data"
+
+
+def test_none_value_is_insufficient():
+    ro = _readout(hit_rate=None, resolve_total=0, coverage=None, distinct_assets=0,
+                  cataloged=0, cold=[])
+    r = slo.evaluate(ro)
+    assert r["verdict"] == "insufficient_data"
+
+
+def test_low_direction_boundary():
+    # cold ratio exactly at ok threshold (0.20) → ok (<=); just above → sad
+    ok = slo.evaluate(_readout(hit_rate=0.95, resolve_total=40, coverage=0.9,
+                               distinct_assets=40, cataloged=100,
+                               cold=[f"s{i}" for i in range(20)]))  # 0.20
+    assert next(o for o in ok["objectives"] if o["name"] == "cold_source_ratio")["verdict"] == "ok"
+    sad = slo.evaluate(_readout(hit_rate=0.95, resolve_total=40, coverage=0.9,
+                                distinct_assets=40, cataloged=100,
+                                cold=[f"s{i}" for i in range(21)]))  # 0.21
+    assert next(o for o in sad["objectives"] if o["name"] == "cold_source_ratio")["verdict"] == "sad"
+
+
+def _drive_events(monkeypatch, tmp_path):
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path))
+    monkeypatch.setenv("CATALOG_OPS_CAPTURE", "true")
+    d = tmp_path / "prophet-platform" / "catalog" / "asset"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "a1.json").write_text(json.dumps({"asset_id": "a1", "asset_kind": "dataset",
+                                            "tenant_id": "t", "distribution_class": "public_derived",
+                                            "created_at": "2026-08-01T00:00:00Z",
+                                            "updated_at": "2026-08-01T00:00:00Z"}), encoding="utf-8")
+    assert client.get("/v1/catalog/asset/a1").status_code == 200
+
+
+def test_emit_crystallizes_slo_event(monkeypatch, tmp_path):
+    _drive_events(monkeypatch, tmp_path)
+    doc, event_id = slo.emit_slo()
+    assert event_id is not None
+    ev = tmp_path / "prophet-platform" / "events" / "catalog-gateway"
+    written = [json.loads(p.read_text()) for p in ev.glob("*.event.json")]
+    slos = [e for e in written if e["event_type"] == "crystal-atlas.catalog.ops.slo.v0"]
+    assert len(slos) == 1 and slos[0]["event"]["slo_id"] == doc["slo_id"]
+
+
+def test_route_get_and_post(monkeypatch, tmp_path):
+    _drive_events(monkeypatch, tmp_path)
+    g = client.get("/v1/catalog/ops/slo")
+    assert g.status_code == 200
+    # 1 resolve → below min_n → insufficient_data, not a false pass/fail
+    assert g.json()["verdict"] == "insufficient_data"
+    p = client.post("/v1/catalog/ops/slo")
+    assert p.status_code == 200 and p.json()["event_id"] is not None

--- a/contracts/crystal-atlas/events/catalog.ops.slo.v0.schema.json
+++ b/contracts/crystal-atlas/events/catalog.ops.slo.v0.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.dev/schemas/crystal-atlas/catalog_ops_slo.schema.json",
+  "title": "catalog.ops.slo.v0",
+  "description": "SLO-gate record: the Assay verdict (ok/sad/bad) for a catalog.ops.readout.v0, graded per-objective against ok/sad thresholds. Overall verdict is the WORST applicable objective (MEET/min, fail-closed). Objectives with fewer than min_n observations return insufficient_data and neither pass nor fail the gate.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "slo_id", "generated_at", "producer", "verdict", "objectives", "window"],
+  "properties": {
+    "schema_version": { "const": "crystal-atlas.catalog.ops.slo.v0" },
+    "slo_id": { "type": "string", "minLength": 8 },
+    "generated_at": { "type": "string" },
+    "producer": { "type": "string" },
+    "event_id": { "type": "string" },
+    "emitted_at": { "type": "string" },
+    "readout_ref": { "type": ["string", "null"] },
+    "verdict": { "type": "string", "enum": ["ok", "sad", "bad", "insufficient_data"] },
+    "objectives": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "verdict", "value", "n", "thresholds", "note"],
+        "properties": {
+          "name": { "type": "string" },
+          "verdict": { "type": "string", "enum": ["ok", "sad", "bad", "insufficient_data"] },
+          "value": { "type": ["number", "null"] },
+          "n": { "type": "integer", "minimum": 0 },
+          "thresholds": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["ok", "sad", "direction"],
+            "properties": {
+              "ok": { "type": "number" },
+              "sad": { "type": "number" },
+              "direction": { "type": "string", "enum": ["high", "low"] }
+            }
+          },
+          "note": { "type": "string" }
+        }
+      }
+    },
+    "window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["events_scanned", "first_event_at", "last_event_at"],
+      "properties": {
+        "events_scanned": { "type": "integer", "minimum": 0 },
+        "first_event_at": { "type": ["string", "null"] },
+        "last_event_at": { "type": ["string", "null"] }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What
WO-2. WO-1 produced catalog KPIs; this grades them into a **judgement a gate can act on** — the Assay verdict (`ok` / `sad` / `bad`).

## Design
- **`app/slo.py`** — `evaluate()` grades each KPI against `ok`/`sad` thresholds.
  - **Overall = the WORST applicable objective** (MEET / min, fail-closed) — the same rule the estate uses for Truth = Law × Evidence. A single `bad` objective makes the readout `bad`; no averaging a failure away.
  - **Small-sample honesty**: an objective with `n < min_n` (30 — the estate min-n rule) returns `insufficient_data` and neither passes nor fails the gate; you cannot grade an SLO you have no evidence for. When all objectives are insufficient, so is the overall verdict.
  - Default objectives: `resolve_hit_rate` (≥0.90 ok / ≥0.70 sad), `dcat_coverage` (≥0.80 / ≥0.50), `cold_source_ratio` (≤0.20 / ≤0.50). Thresholds are injectable.
- **`contracts/crystal-atlas/events/catalog.ops.slo.v0.schema.json`** — the verdict record (validated).
- **Routes**: `GET /v1/catalog/ops/slo` (evaluate) + `POST` (evaluate & crystallize as `catalog.ops.slo.v0`), before the generic resolver.
- **`tests/test_slo.py`** — 11 tests (all-green, worst-wins, sad, insufficient<min_n, insufficient-doesn't-drag, none→insufficient, low-direction boundary, crystallization, routes).

## Stacking
Based on **#1279** (WO-1): `evaluate()` folds a readout, so it depends on `readout.py`. **Merge #1279 first**, then this retargets to `main` automatically. 29 tests pass across the suite.

```
cd apps/catalog-gateway && python3 -m pytest tests/ -q   # 29 passed
```