### PR TITLE
feat(ecosystem-sim): Wave-2 — scenario solver (Layer B) on the Wave-1 gate

### DIFF
--- a/.github/workflows/ecosystem-sim-wave2.yml
+++ b/.github/workflows/ecosystem-sim-wave2.yml
@@ -1,0 +1,34 @@
+name: ecosystem-sim-wave2
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'tools/scenario_solver.py'
+      - 'tools/causal_identification.py'
+      - 'tools/tests/test_scenario_solver.py'
+      - 'docs/ECOSYSTEM_SIM_WAVE2.md'
+      - '.github/workflows/ecosystem-sim-wave2.yml'
+  pull_request:
+    paths:
+      - 'tools/scenario_solver.py'
+      - 'tools/causal_identification.py'
+      - 'tools/tests/test_scenario_solver.py'
+      - 'docs/ECOSYSTEM_SIM_WAVE2.md'
+      - '.github/workflows/ecosystem-sim-wave2.yml'
+
+jobs:
+  ecosystem-sim-wave2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install
+        run: python -m pip install --upgrade pip && pip install pytest
+      - name: Wave-2 solver tests (gate + distribution + replay)
+        run: PYTHONPATH=tools pytest -q tools/tests/test_scenario_solver.py

--- a/docs/ECOSYSTEM_SIM_WAVE2.md
+++ b/docs/ECOSYSTEM_SIM_WAVE2.md
@@ -1,0 +1,39 @@
+# Ecosystem Simulation Substrate — Wave 2 (solver, Layer B)
+
+Builds on the merged Wave-1 causal spine (#1220, `tools/causal_identification.py`).
+Wave 1 is Layer A (*may we claim this*); Wave 2 is Layer B (*what is the value*),
+and it runs **only** through `causal_identification.gate` — no number without a
+cleared estimand.
+
+## `tools/scenario_solver.py`
+
+- **ParameterFact** — a parameter as a fact: value + `interval` (uncertainty) + `n`
+  + provenance + `epistemic_level` + `as_of`. Uncertainty propagates into output.
+- **solve(spec)**:
+  1. `identify()` the estimand. If **not clearable**, REFUSE the point estimate —
+     return non-causal `bounds`, `blocking_structure`, and `measurement_to_identify`
+     (no distribution).
+  2. If cleared, Monte-Carlo propagate parameter uncertainty (deterministic per
+     `seed`) → a **Distribution** (`p05/p50/p95/mean`). Never a scalar.
+- **content_address** over `{graph_snapshot_hash, intervention_set, solver_version,
+  assumption_set, reaction_level, parameter_vintage, seed}` → certified scenarios
+  **replay bit-identically** (the liability shield, spec §7).
+- **Reaction level** is declared on every result; **L0** (static competitors) is
+  labelled `upper_bound_on_own_move` — never a forecast; **L1** dampens via a
+  `competitor_reaction` parameter. `propagation` is pluggable so the real Wave-2/4
+  solvers (discrete-event supply, choice model, best-response) drop in unchanged.
+
+## Acceptance coverage (spec §12)
+
+| Criterion | Test |
+|---|---|
+| No point estimate for an unidentified estimand | `test_unidentified_refuses_point_estimate` |
+| Every output a distribution with propagated uncertainty | `test_identified_returns_a_distribution_not_a_scalar`, `test_parameter_uncertainty_propagates` |
+| Certified scenarios replay bit-identically | `test_deterministic_replay_is_bit_identical` |
+| Reaction level declared; L0 labelled a bound | `test_L0_is_labelled_a_bound_and_L1_reacts` |
+
+## Next
+
+Wave-2 remainder: discrete-event supply propagation + choice model as concrete
+`propagation` plugins; scenario-artifact persistence. Wave 3: precomputed
+sensitivity, read-set delta invalidation, staleness decay.

--- a/tools/scenario_solver.py
+++ b/tools/scenario_solver.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Scenario solver — Ecosystem Simulation Substrate, Wave 2 (Layer B).
+
+Builds on the merged Wave-1 identification spine (`causal_identification`). Layer
+A decides *may we claim this*; this is Layer B — *what is the value* — and it runs
+**only** on an estimand Layer A has cleared (enforced via `gate`).
+
+Wave-2 guarantees (spec §4, §7, §12):
+  * No point estimate for an unidentified estimand — refuse, return non-causal
+    bounds + the blocking structure + the measurement that would identify it.
+  * Every solved output is a **distribution** carrying propagated parameter
+    uncertainty — never a single number.
+  * Certified scenarios are **content-addressed** over
+    {graph_snapshot_hash, intervention_set, solver_version, assumption_set,
+     reaction_level, parameter_vintage, seed} and **replay bit-identically**.
+  * Competitor reaction level is declared; L0 (static competitors) is labelled a
+    bound, never a forecast.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+import statistics
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from causal_identification import Dag, IdentificationReport, gate, identify
+
+SOLVER_VERSION = "scenario_solver/0.2.0"
+_DEFAULT_SAMPLES = 512
+
+# Reaction levels (spec §6). L0 is a bound, never sold as a forecast.
+REACTION_LEVELS = {"L0", "L1", "L2", "L3"}
+
+
+@dataclass
+class ParameterFact:
+    """A model parameter as a fact: a value with uncertainty and provenance."""
+
+    name: str
+    value: float
+    interval: tuple[float, float]  # (lo, hi) — parameter uncertainty
+    n: int
+    provenance: str
+    epistemic_level: str
+    as_of: str
+
+    def sample(self, rng: random.Random) -> float:
+        lo, hi = self.interval
+        return self.value if hi <= lo else rng.uniform(lo, hi)
+
+
+@dataclass
+class ScenarioSpec:
+    """A scenario: an estimand, an intervention, and the parameters it needs."""
+
+    estimand_id: str
+    dag: Dag
+    treatment: str
+    outcome: str
+    intervention: dict[str, float]  # e.g. {"magnitude": -0.08}
+    parameters: dict[str, ParameterFact]
+    graph_snapshot_hash: str
+    parameter_vintage: str
+    reaction_level: str = "L0"
+    assumption_set: frozenset[str] = frozenset()
+    seed: int = 0
+    n_samples: int = _DEFAULT_SAMPLES
+
+
+@dataclass
+class Distribution:
+    """A scenario output distribution (never a scalar)."""
+
+    mean: float
+    p05: float
+    p50: float
+    p95: float
+    n_samples: int
+
+
+@dataclass
+class ScenarioResult:
+    content_address: str
+    estimand_id: str
+    identification_status: str
+    reaction_level: str
+    refused: bool
+    adjustment_set: list[str] = field(default_factory=list)
+    assumptions: list[str] = field(default_factory=list)
+    distribution: Optional[Distribution] = None
+    label: Optional[str] = None  # e.g. "upper_bound_on_own_move" for L0
+    bounds: Optional[tuple[float, float]] = None
+    blocking_structure: list[str] = field(default_factory=list)
+    measurement_to_identify: list[str] = field(default_factory=list)
+
+
+def _default_propagation(sample: dict[str, float], intervention: dict[str, float], reaction_level: str) -> float:
+    """Model-agnostic default transfer: magnitude x elasticity, damped by reaction.
+
+    Real solvers (discrete-event / choice / best-response) plug in via the
+    `propagation` argument; this default just exercises uncertainty propagation.
+    L0 holds competitors static (no damping) → an upper bound on the own-move effect.
+    """
+    magnitude = intervention.get("magnitude", 0.0)
+    elasticity = sample.get("elasticity", 1.0)
+    reaction = 0.0 if reaction_level == "L0" else sample.get("competitor_reaction", 0.0)
+    return magnitude * elasticity * (1.0 - reaction)
+
+
+def content_address(spec: ScenarioSpec) -> str:
+    """Content address over the certifying inputs (spec §7). Deterministic."""
+    payload = {
+        "graph_snapshot_hash": spec.graph_snapshot_hash,
+        "intervention_set": spec.intervention,
+        "solver_version": SOLVER_VERSION,
+        "assumption_set": sorted(spec.assumption_set),
+        "reaction_level": spec.reaction_level,
+        "parameter_vintage": spec.parameter_vintage,
+        "seed": spec.seed,
+    }
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(blob).hexdigest()
+
+
+def _bounds(spec: ScenarioSpec, propagation: Callable) -> tuple[float, float]:
+    """Non-causal interval bounds from parameter extremes (for the refusal path)."""
+    lows = {k: p.interval[0] for k, p in spec.parameters.items()}
+    highs = {k: p.interval[1] for k, p in spec.parameters.items()}
+    a = propagation(lows, spec.intervention, spec.reaction_level)
+    b = propagation(highs, spec.intervention, spec.reaction_level)
+    return (min(a, b), max(a, b))
+
+
+def solve(spec: ScenarioSpec, *, propagation: Callable = _default_propagation) -> ScenarioResult:
+    """Identify, then (only if cleared) propagate parameter uncertainty."""
+    if spec.reaction_level not in REACTION_LEVELS:
+        raise ValueError(f"unknown reaction_level {spec.reaction_level!r}")
+
+    report: IdentificationReport = identify(
+        spec.dag, spec.treatment, spec.outcome, spec.estimand_id,
+        assume_unconfounded=set(spec.assumption_set),
+    )
+    addr = content_address(spec)
+
+    if not report.clearable:
+        # REFUSE the point estimate. Return non-causal bounds + what to measure.
+        return ScenarioResult(
+            content_address=addr,
+            estimand_id=spec.estimand_id,
+            identification_status=report.status,
+            reaction_level=spec.reaction_level,
+            refused=True,
+            bounds=_bounds(spec, propagation),
+            blocking_structure=report.blocking_structure,
+            measurement_to_identify=report.measurement_to_identify,
+            label="non_causal_bounds_only",
+        )
+
+    # Cleared: Monte-Carlo propagate parameter uncertainty (deterministic per seed).
+    def _run() -> list[float]:
+        rng = random.Random(spec.seed)
+        out: list[float] = []
+        for _ in range(spec.n_samples):
+            sample = {name: spec.parameters[name].sample(rng) for name in sorted(spec.parameters)}
+            out.append(propagation(sample, spec.intervention, spec.reaction_level))
+        return out
+
+    samples = gate(report, _run)  # Layer-B runs only through the Layer-A gate
+    samples.sort()
+    dist = Distribution(
+        mean=statistics.fmean(samples),
+        p05=samples[max(0, int(0.05 * (len(samples) - 1)))],
+        p50=samples[int(0.50 * (len(samples) - 1))],
+        p95=samples[int(0.95 * (len(samples) - 1))],
+        n_samples=len(samples),
+    )
+    return ScenarioResult(
+        content_address=addr,
+        estimand_id=spec.estimand_id,
+        identification_status=report.status,
+        reaction_level=spec.reaction_level,
+        refused=False,
+        adjustment_set=report.adjustment_set,
+        assumptions=report.assumptions,
+        distribution=dist,
+        label="upper_bound_on_own_move" if spec.reaction_level == "L0" else None,
+    )

--- a/tools/tests/test_scenario_solver.py
+++ b/tools/tests/test_scenario_solver.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOLS))
+
+import scenario_solver as ss  # type: ignore
+from causal_identification import Dag  # type: ignore
+
+
+def _pf(name, value, lo, hi):
+    return ss.ParameterFact(name=name, value=value, interval=(lo, hi), n=30,
+                            provenance="test", epistemic_level="empirical", as_of="2026-08-01T00:00:00+00:00")
+
+
+def _identified_dag():
+    # T<-C->Y and T->Y: backdoor via measured confounder C -> identifiable.
+    return Dag(nodes={"T", "Y", "C"}, edges=[("C", "T"), ("C", "Y"), ("T", "Y")], measured={"T", "Y", "C"})
+
+
+def _unidentified_dag():
+    # T<-U->Y with U unmeasured: unblockable backdoor -> not identifiable.
+    return Dag(nodes={"T", "Y", "U"}, edges=[("U", "T"), ("U", "Y"), ("T", "Y")], measured={"T", "Y"})
+
+
+def _spec(dag, *, reaction="L0", elast=(0.9, 1.1), seed=0):
+    return ss.ScenarioSpec(
+        estimand_id="reprice-Y", dag=dag, treatment="T", outcome="Y",
+        intervention={"magnitude": -0.08},
+        parameters={"elasticity": _pf("elasticity", 1.0, *elast),
+                    "competitor_reaction": _pf("competitor_reaction", 0.3, 0.2, 0.4)},
+        graph_snapshot_hash="g:abc", parameter_vintage="2026-08-01", reaction_level=reaction, seed=seed,
+    )
+
+
+def test_unidentified_refuses_point_estimate():
+    r = ss.solve(_spec(_unidentified_dag()))
+    assert r.refused is True
+    assert r.distribution is None                     # NO point estimate / distribution
+    assert r.identification_status == "not_identified"
+    assert r.bounds is not None                       # non-causal bounds instead
+    assert r.blocking_structure                       # tells the customer why
+    assert r.label == "non_causal_bounds_only"
+
+
+def test_identified_returns_a_distribution_not_a_scalar():
+    r = ss.solve(_spec(_identified_dag()))
+    assert r.refused is False
+    assert r.distribution is not None
+    d = r.distribution
+    assert d.p05 <= d.p50 <= d.p95                    # a distribution, never a single number
+    assert d.n_samples == 512
+    assert "C" in r.adjustment_set                    # identified by adjusting for C
+
+
+def test_parameter_uncertainty_propagates():
+    narrow = ss.solve(_spec(_identified_dag(), elast=(0.99, 1.01))).distribution
+    wide = ss.solve(_spec(_identified_dag(), elast=(0.5, 1.5))).distribution
+    assert (wide.p95 - wide.p05) > (narrow.p95 - narrow.p05)  # wider input -> wider output
+
+
+def test_deterministic_replay_is_bit_identical():
+    r1 = ss.solve(_spec(_identified_dag(), seed=7))
+    r2 = ss.solve(_spec(_identified_dag(), seed=7))
+    assert r1.content_address == r2.content_address
+    assert r1.distribution == r2.distribution        # replays exactly
+    # different seed -> same content address only if seed is part of it (it is) -> differs
+    r3 = ss.solve(_spec(_identified_dag(), seed=8))
+    assert r3.content_address != r1.content_address
+
+
+def test_L0_is_labelled_a_bound_and_L1_reacts():
+    l0 = ss.solve(_spec(_identified_dag(), reaction="L0"))
+    l1 = ss.solve(_spec(_identified_dag(), reaction="L1"))
+    assert l0.label == "upper_bound_on_own_move"      # L0 never sold as a forecast
+    assert l1.label != "upper_bound_on_own_move"
+    # L1 competitor reaction dampens the own-move effect.
+    assert abs(l1.distribution.p50) < abs(l0.distribution.p50)
+
+
+def test_content_address_reacts_to_certifying_inputs():
+    base = ss.solve(_spec(_identified_dag())).content_address
+    # changing the reaction level changes the certified identity
+    assert ss.solve(_spec(_identified_dag(), reaction="L1")).content_address != base
+
+
+def test_unknown_reaction_level_rejected():
+    with pytest.raises(ValueError):
+        ss.solve(_spec(_identified_dag(), reaction="L9"))


### PR DESCRIPTION
Builds on merged Wave-1 (#1220). Layer B (*what is the value*) runs **only** through `causal_identification.gate` — no number without a cleared estimand.

- **ParameterFact** carries uncertainty (value+interval+n+provenance+epistemic_level+as_of).
- **solve()**: unidentified → **refuse** the point estimate (non-causal bounds + blocking structure + measurement-to-identify, no distribution); cleared → Monte-Carlo propagate uncertainty (deterministic per seed) → **Distribution** (never a scalar).
- **content_address** over {graph_snapshot_hash, intervention_set, solver_version, assumption_set, reaction_level, parameter_vintage, seed} → **bit-identical replay**.
- Reaction level declared; **L0 labelled a bound**, L1 dampens; `propagation` pluggable for real solvers.

7 tests (all §12 acceptance points that apply at this layer). Merge after CI green **and Copilot evaluated** (no --auto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)