### PR TITLE
feat(lattice-studio/viz): credit-risk & economic-capital visualization thesis

### DIFF
--- a/apps/dashboard-shell/cockpit-surfaces.json
+++ b/apps/dashboard-shell/cockpit-surfaces.json
@@ -1,0 +1,27 @@
+{
+  "$comment": "Cockpit surfaces the dashboard-shell composes into navigation. Reviewed 2026-08-03; risk/profit visualization wave.",
+  "surfaces": [
+    {
+      "id": "credit-risk-thesis",
+      "title": "Credit Risk & Economic Capital",
+      "group": "Risk & Profit",
+      "kind": "viz",
+      "source": "apps/lattice-studio/viz/credit-risk-thesis.html",
+      "summary": "13-module thesis: EL (PD·LGD·EAD), Vasicek Monte-Carlo loss sim, risk measures, capital stack, EP waterfalls, FTP, recovery, EAD, aggregation, DCF, credit-model taxonomy, and Ross recovery (state-price → real-world measure + futures/options curves).",
+      "data_source": "illustrative; production = diligence.risk.pack/#1293 + economic-prophet (recovery surface, ep.variance)",
+      "wiring_issue": 1294,
+      "status": "review"
+    },
+    {
+      "id": "profit-risk-drilldown",
+      "title": "Economic Profit & Risk — drilldown",
+      "group": "Risk & Profit",
+      "kind": "viz",
+      "source": "apps/lattice-studio/viz/profit-risk-drilldown.html",
+      "summary": "EP & RAROC additive drilldown Firm→LOB→Segment→Product→Client→Transaction, with EP-variance waterfall and economic-capital loss distribution.",
+      "data_source": "illustrative; production = economic-prophet + diligence.risk.pack",
+      "wiring_issue": 1294,
+      "status": "review"
+    }
+  ]
+}

--- a/apps/lattice-studio/viz/README.md
+++ b/apps/lattice-studio/viz/README.md
@@ -1,0 +1,30 @@
+# Credit-risk & economic-capital visualization wave
+
+Interactive, reproducible-from-source explanatory visualizations for the profit-and-risk domain —
+Bostock / NYT-mortgage-calculator caliber. Self-contained HTML/SVG/Canvas, theme-aware, accessible.
+**No captured third-party images or branding** (the McKinsey/BIS/OCC figures are reference only) —
+per the estate "diagram is a witness" rule.
+
+| File | What it is |
+|---|---|
+| `credit-risk-thesis.html` | 12-module thesis — EL calculator, **Vasicek Monte-Carlo portfolio-loss simulation**, risk measures (VaR/ES/σ/spectral + coherence), regulatory-vs-economic capital stack, EP & EP-variance waterfalls, matched-maturity FTP, recovery-by-seniority + PD↔RR, EAD race-to-default, risk-aggregation diversification, DCF life-cycle fade, credit-model taxonomy. |
+| `profit-risk-drilldown.html` | Economic-Profit & RAROC drilldown — additive roll-up Firm→LOB→Segment→Product→Client→Transaction, EP-variance waterfall, economic-capital loss distribution. |
+
+## The Bostock interaction model (how these are built)
+
+1. **Direct manipulation, immediate feedback.** Every input is a slider or a click; the model recomputes
+   live (a shared five-lever portfolio — PD, LGD, EAD, ρ, confidence — flows through EL → simulation →
+   risk measures → capital, so one gesture ripples across screens). No "apply" button.
+2. **Teach by manipulating, not by captioning.** The lesson is in what moves: raise ρ and the loss tail
+   visibly fattens while the mean holds — you *see* why correlation, not average PD, drives capital.
+3. **No chart-junk.** Recessive grid/axes, thin marks, direct labels over legends, one idea per view.
+4. **Honest by construction.** Illustrative data is labeled as such; the math is real (Vasicek single-factor,
+   Ninv/normal-CDF, Monte-Carlo over 6k economies). Colorblind-safe: blue/orange not red/green; status
+   carries icon + label; palette validated for CVD + contrast in both light and dark.
+
+## Data source (production)
+
+Illustrative defaults today. In production these are **witnesses over governed facts**: PD·LGD·EAD and
+the loss tail from `diligence.risk.pack` / internal-model #1293, EP & variance from `economic-prophet`
+(as `ep.variance.decomposed.v0`), peer benchmark from the corporate-intelligence plane (#1284) —
+surfaced through this `lattice-studio` viz layer and `dashboard-bff`. Wiring tracked in #1294.

--- a/apps/lattice-studio/viz/README.md
+++ b/apps/lattice-studio/viz/README.md
@@ -28,3 +28,7 @@ Illustrative defaults today. In production these are **witnesses over governed f
 the loss tail from `diligence.risk.pack` / internal-model #1293, EP & variance from `economic-prophet`
 (as `ep.variance.decomposed.v0`), peer benchmark from the corporate-intelligence plane (#1284) —
 surfaced through this `lattice-studio` viz layer and `dashboard-bff`. Wiring tracked in #1294.
+
+## Ross recovery — witness over economic-prophet
+
+The **Ross recovery & curves** module ports `economic-prophet/src/open_ep_framework/recovery.py` **exactly** (`planning_recovery` RR^P, `market_implied_recovery` RR^Q, `recovery_wedge` ΔRR) — product_spec §6 (Ross / Arrow-Debreu). On top it runs the actual **Ross Recovery Theorem**: option-implied Arrow-Debreu state prices → the Perron eigenproblem `Pφ = δφ` recovers the real-world measure P and the pricing kernel φ from the risk-neutral Q. It surfaces the futures/forward curve and the option call-price curve, and the values that pop out (real-world vs risk-neutral PD, the risk premium, recovered discount δ). Verified: recovered δ = true discount; risk-neutral PD > real-world PD.

--- a/apps/lattice-studio/viz/credit-risk-thesis.html
+++ b/apps/lattice-studio/viz/credit-risk-thesis.html
@@ -105,6 +105,7 @@
     <section class="module" id="m-var"></section>
     <section class="module" id="m-ftp"></section>
     <section class="module" id="m-recovery"></section>
+    <section class="module" id="m-ross"></section>
     <section class="module" id="m-ead"></section>
     <section class="module" id="m-agg"></section>
     <section class="module" id="m-models"></section>
@@ -169,7 +170,8 @@ const NAVS=[
            ["m-sim","Portfolio simulation","Monte-Carlo loss distribution"],
            ["m-measures","Risk measures","VaR · ES · σ · spectral"],
            ["m-ead","EAD — race to default","LEQ / CCF, revolving vs term"],
-           ["m-recovery","Recovery &amp; PD↔RR","seniority, default-recovery link"]]],
+           ["m-recovery","Recovery &amp; PD↔RR","seniority, default-recovery link"],
+           ["m-ross","Ross recovery &amp; curves","state-price → real-world"]]],
   ["CAPITAL",[["m-capital","Capital stack","regulatory vs economic"],
            ["m-agg","Risk aggregation","summation → copula diversification"],
            ["m-var","EP variance","price/volume/cost/capital drivers"]]],
@@ -209,7 +211,8 @@ const DESC={
  "m-recovery":"Loss given default is one minus recovery, and recovery is neither constant nor independent of default — it falls exactly when defaults rise.",
  "m-ead":"Exposure at default is the weakest link in the Basel machinery. Revolving lines fill up as a borrower deteriorates (the 'race to default'); term loans amortise away.",
  "m-dcf":"Value fades. A franchise earns above its cost of capital for a while, then competition erodes the ROIC−WACC spread — and a naive perpetuity assumption mis-prices exactly that fade.",
- "m-models":"A field guide. Credit-risk models fall into statistical, structural, reduced-form and value-at-risk families, differing above all in how they treat recovery and its link to default."
+ "m-models":"A field guide. Credit-risk models fall into statistical, structural, reduced-form and value-at-risk families, differing above all in how they treat recovery and its link to default.",
+ "m-ross":"The Ross Recovery Theorem in action — the same tech built into the economic-prophet repo. Option prices give Arrow–Debreu state prices (the risk-neutral measure Q); Ross's eigenvalue recovery pulls the real-world measure P and the pricing kernel back out. The wedge between the two <em>is</em> the risk premium — and, for a defaulted claim, the wedge between market-implied recovery RR^Q and planning recovery RR^P."
 };
 
 // ============ shared rail wiring ============
@@ -527,8 +530,109 @@ function m_dcf(){const box=document.getElementById("m-dcf");
    <div class="cap">A franchise earns a positive <b>ROIC−WACC</b> spread, but competition fades it toward zero. Freezing the last explicit year into a perpetuity (the red cliff) assumes the fade never happens — over-valuing exactly the mature businesses whose advantage is eroding (Mauboussin). The honest curve returns to zero economic profit.</div></div>`;
 }
 
+// ---------- Ross recovery (economic-prophet: open_ep_framework/recovery.py, product_spec §6) ----------
+const RS={seniority:0.6,collateral:0.5,jurisdiction:0.6,macro:"base",liq:"normal",horizon:540,statePrice:0.5};
+const _MACRO={benign:0.03,base:0.0,stressed:-0.06,crisis:-0.12},_LIQ={normal:0.0,tight:-0.03,frozen:-0.08};
+function planningRR(s){let b=0.15+0.35*s.seniority+0.25*s.collateral+0.15*s.jurisdiction; // exact port
+  b+=_MACRO[s.macro]+_LIQ[s.liq];const drag=Math.min(s.horizon/3650,0.25);return Math.max(0,Math.min(0.95,b-drag));}
+function marketRR(s){const rp=0.05+0.25*s.statePrice;return Math.max(0,Math.min(0.95,planningRR(s)-rp));}
+function perron(P,it){const n=P.length;let v=new Array(n).fill(1),lam=1;
+  for(let k=0;k<it;k++){const w=new Array(n).fill(0);for(let i=0;i<n;i++)for(let j=0;j<n;j++)w[i]+=P[i][j]*v[j];
+    lam=Math.max(...w);for(let i=0;i<n;i++)v[i]=w[i]/lam;}return{lam,v};}
+function m_ross(){const box=document.getElementById("m-ross");const s=RS;
+  const rrP=planningRR(s),rrQ=marketRR(s),wedge=rrQ-rrP;
+  // ---- Ross state-price recovery over a Markov chain of terminal states ----
+  const n=13,st=[];for(let i=0;i<n;i++)st.push(0.55+i*(0.9/(n-1)));       // asset-value ratio 0.55..1.45
+  const gamma=1.6+2.2*s.statePrice+(s.macro==="crisis"?1.4:s.macro==="stressed"?0.7:0); // risk aversion
+  const volP=0.11+0.06*s.statePrice+(s.macro==="crisis"?0.06:s.macro==="stressed"?0.03:0);
+  const disc=Math.exp(-0.03),kappa=0.35;
+  const npdf=(x,m,sg)=>Math.exp(-((x-m)*(x-m))/(2*sg*sg))/(sg*Math.sqrt(2*Math.PI));
+  const phiT=st.map(x=>Math.exp(gamma*(1-x)));                            // true kernel: marginal utility ↑ in bad states
+  // true real-world transition F (mean-reverting to 1) and Arrow-Debreu prices P = disc·F·φj/φi
+  const F=[],P=[];for(let i=0;i<n;i++){const mean=st[i]+kappa*(1-st[i]);let row=[],sum=0;
+    for(let j=0;j<n;j++){const f=npdf(st[j],mean,volP);row.push(f);sum+=f;}row=row.map(x=>x/sum);F.push(row);
+    P.push(row.map((f,j)=>disc*f*phiT[j]/phiT[i]));}
+  // RECOVER: Pφ=δφ (Perron) → δ, kernel; then real-world F_rec and risk-neutral Q
+  const {lam:delta,v:phi}=perron(P,220);
+  const Q=P.map(r=>{const s2=r.reduce((a,b)=>a+b,0);return r.map(x=>x/s2);}); // risk-neutral transition
+  const c=Math.floor(n/2);const qMarg=Q[c],pMarg=F[c];                    // one-step-from-centre marginals
+  // credit mapping: default = asset ratio below 0.75
+  const dThr=0.75;let pdQ=0,pdP=0;for(let j=0;j<n;j++){if(st[j]<dThr){pdQ+=qMarg[j];pdP+=pMarg[j];}}
+  const kNorm=phi.map(x=>x/phi[c]);
+  // futures curve: E^Q[S_T] iterating Q^T from centre
+  const fut=[];let dist=new Array(n).fill(0);dist[c]=1;for(let T=1;T<=8;T++){const nd=new Array(n).fill(0);
+    for(let i=0;i<n;i++)for(let j=0;j<n;j++)nd[j]+=dist[i]*Q[i][j];dist=nd;fut.push(st.reduce((a,v,j)=>a+v*dist[j],0));}
+  // option smile: C(K)=disc·Σ qMarg·max(S−K,0)
+  const strikes=st.slice(1,n-1),calls=strikes.map(K=>disc*qMarg.reduce((a,q,j)=>a+q*Math.max(st[j]-K,0),0));
+
+  // ---- SVG builders ----
+  function densChart(title,series,extra){const W=440,H=190,pL=8,pR=8,pB=26,pT=10;const s2=svg(W,H);
+    const mx=Math.max(...series.flatMap(z=>z.d));const X=i=>pL+i/(n-1)*(W-pL-pR),Y=v=>H-pB-(v/mx)*(H-pB-pT);
+    s2.add(`<line class="axis" x1="${pL}" y1="${H-pB}" x2="${W-pR}" y2="${H-pB}"/>`);
+    // default threshold shade
+    const tx=pL+ (0.75-0.55)/0.9*(W-pL-pR);
+    s2.add(`<rect x="${pL}" y="${pT}" width="${tx-pL}" height="${H-pB-pT}" fill="var(--neg)" opacity="0.06"/><text class="tick" x="${pL+4}" y="${pT+8}" fill="var(--neg)">default states</text>`);
+    series.forEach(z=>{let p="";z.d.forEach((v,i)=>p+=(i?"L":"M")+X(i)+" "+Y(v)+" ");
+      s2.add(`<path d="${p}" fill="none" stroke="${z.c}" stroke-width="2.2"/>`);});
+    st.forEach((v,i)=>{if(i%3===0)s2.add(`<text class="tick" x="${X(i)}" y="${H-pB+13}" text-anchor="middle">${v.toFixed(2)}</text>`);});
+    if(extra)extra(s2,X,Y);return s2.html();}
+  const dens=densChart("",[{d:qMarg,c:"var(--neg)"},{d:pMarg,c:"var(--pos)"}]);
+  // kernel chart
+  function line(title,xs,ys,col,fmtY){const W=440,H=170,pL=34,pR=10,pB=24,pT=10;const s2=svg(W,H);
+    const lo=Math.min(...ys),hi=Math.max(...ys),pad=(hi-lo)*0.12||1;const X=i=>pL+i/(xs.length-1)*(W-pL-pR),Y=v=>H-pB-((v-lo+pad)/((hi-lo)+2*pad))*(H-pB-pT);
+    s2.add(`<line class="axis" x1="${pL}" y1="${H-pB}" x2="${W-pR}" y2="${H-pB}"/>`);let p="";ys.forEach((v,i)=>p+=(i?"L":"M")+X(i)+" "+Y(v)+" ");
+    s2.add(`<path d="${p}" fill="none" stroke="${col}" stroke-width="2.4"/>`);
+    xs.forEach((v,i)=>{if(i%2===0)s2.add(`<text class="tick" x="${X(i)}" y="${H-pB+13}" text-anchor="middle">${fmtY?v.toFixed(0):v.toFixed(2)}</text>`);});
+    return s2.html();}
+  const kernel=line("",st,kNorm,"var(--pos2)");
+  const futures=line("",[1,2,3,4,5,6,7,8],fut,"var(--accent)",true);
+  const smile=(function(){const W=440,H=170,pL=34,pR=10,pB=24,pT=10;const s2=svg(W,H);const mx=Math.max(...calls);
+    const X=i=>pL+i/(strikes.length-1)*(W-pL-pR),Y=v=>H-pB-(v/mx)*(H-pB-pT);
+    s2.add(`<line class="axis" x1="${pL}" y1="${H-pB}" x2="${W-pR}" y2="${H-pB}"/>`);let p="";calls.forEach((v,i)=>p+=(i?"L":"M")+X(i)+" "+Y(v)+" ");
+    calls.forEach((v,i)=>s2.add(`<circle cx="${X(i)}" cy="${Y(v)}" r="2.6" fill="var(--neg2)"/>`));
+    s2.add(`<path d="${p}" fill="none" stroke="var(--neg2)" stroke-width="2"/>`);
+    strikes.forEach((v,i)=>{if(i%2===0)s2.add(`<text class="tick" x="${X(i)}" y="${H-pB+13}" text-anchor="middle">${v.toFixed(2)}</text>`);});
+    return s2.html();})();
+
+  const seg=(id,opts,cur)=>`<span class="seg">${opts.map(o=>`<button data-k="${id}" data-v="${o}" aria-pressed="${o===cur}">${o}</button>`).join("")}</span>`;
+  const sld=(id,lab,min,max,step,val,suf)=>`<div class="ctl"><label>${lab} <b class="num">${val}${suf||''}</b></label><input type="range" data-rs="${id}" min="${min}" max="${max}" step="${step}" value="${val}"></div>`;
+  box.innerHTML=`
+   <div class="rail" style="display:flex">
+     ${sld('seniority','Seniority',0,1,0.05,s.seniority,'')}${sld('collateral','Collateral',0,1,0.05,s.collateral,'')}
+     ${sld('jurisdiction','Jurisdiction',0,1,0.05,s.jurisdiction,'')}${sld('horizon','Workout days',30,3650,10,s.horizon,'')}
+     ${sld('statePrice','Market state price',0,1,0.05,s.statePrice,'')}
+     <div class="ctl"><label>Macro regime</label>${seg('macro',['benign','base','stressed','crisis'],s.macro)}</div>
+     <div class="ctl"><label>Liquidity</label>${seg('liq',['normal','tight','frozen'],s.liq)}</div>
+     <div class="railhint">Mirrors <code>open_ep_framework/recovery.py</code> exactly. Recovery is a <b>state-contingent surface</b>, not a scalar (product_spec §6).</div>
+   </div>
+   <div class="tiles">
+     <div class="tile"><div class="k">RR&#7526; planning (real-world)</div><div class="v num" style="color:var(--pos)">${(rrP*100).toFixed(1)}%</div><div class="d">planning_recovery()</div></div>
+     <div class="tile"><div class="k">RR&#7561; market-implied</div><div class="v num" style="color:var(--neg)">${(rrQ*100).toFixed(1)}%</div><div class="d">market_implied_recovery()</div></div>
+     <div class="tile"><div class="k">Wedge ΔRR = RR&#7561;−RR&#7526;</div><div class="v num" style="color:var(--accent)">${(wedge*100).toFixed(1)}pp</div><div class="d">the recovery risk premium</div></div>
+     <div class="tile"><div class="k">Recovered discount δ</div><div class="v num">${delta.toFixed(4)}</div><div class="d">Perron root of P</div></div>
+   </div>
+   <div class="panel"><div class="ph">Ross recovery — risk-neutral Q vs recovered real-world P</div>
+     <div class="legend"><span><i style="background:var(--neg)"></i>Q — risk-neutral (from option state prices)</span><span><i style="background:var(--pos)"></i>P — real-world (Ross-recovered)</span></div>
+     ${dens}
+     <div class="tiles" style="margin-top:12px">
+       <div class="tile"><div class="k">Risk-neutral PD (Q)</div><div class="v num" style="color:var(--neg)">${(pdQ*100).toFixed(1)}%</div></div>
+       <div class="tile"><div class="k">Real-world PD (P)</div><div class="v num" style="color:var(--pos)">${(pdP*100).toFixed(1)}%</div></div>
+       <div class="tile"><div class="k">Risk premium (Q−P)</div><div class="v num" style="color:var(--accent)">${((pdQ-pdP)*100).toFixed(1)}pp</div></div>
+     </div>
+     <div class="cap">The market prices the bad tail as if it were <b>${(pdQ/Math.max(pdP,1e-6)).toFixed(1)}× more likely</b> than it truly is — that gap is the credit risk premium the pricing kernel demands. Ross's theorem recovers the true probabilities P and the kernel from the observed state prices alone, with no assumed risk aversion.</div>
+   </div>
+   <div class="grid2" style="display:grid;grid-template-columns:1fr 1fr;gap:14px">
+     <div class="panel"><div class="ph">Pricing kernel φ (recovered)</div>${kernel}<div class="cap">Marginal utility — high in bad (low) states. The "values that pop out" of the eigenvector.</div></div>
+     <div class="panel"><div class="ph">Options → call-price curve C(K)</div>${smile}<div class="cap">Calls integrated against the Q state prices (Breeden–Litzenberger runs this in reverse: option curvature <em>is</em> the state-price density above).</div></div>
+   </div>
+   <div class="panel"><div class="ph">Futures / forward curve E&#7561;[S&#8348;]</div>${futures}
+     <div class="cap">Forward value across horizon under the risk-neutral measure — ${fut[7]>fut[0]?'contango':'backwardation'} from the recovered dynamics. In production these curves and the RR^P/RR^Q/ΔRR values are the same ones <code>economic-prophet</code> emits; here they recompute live from the surface above.</div></div>`;
+  box.querySelectorAll("input[data-rs]").forEach(inp=>inp.addEventListener("input",()=>{RS[inp.dataset.rs]=+inp.value;m_ross();}));
+  box.querySelectorAll(".seg button").forEach(b=>b.addEventListener("click",()=>{RS[b.dataset.k]=b.dataset.v;m_ross();}));
+}
+
 const RENDER={"m-el":m_el,"m-sim":m_sim,"m-measures":m_measures,"m-capital":m_capital,"m-ep":m_ep,"m-var":m_var,
-  "m-ftp":m_ftp,"m-recovery":m_recovery,"m-ead":m_ead,"m-agg":m_agg,"m-models":m_models,"m-dcf":m_dcf};
+  "m-ftp":m_ftp,"m-recovery":m_recovery,"m-ead":m_ead,"m-agg":m_agg,"m-models":m_models,"m-dcf":m_dcf,"m-ross":m_ross};
 function render(){railLabels();(RENDER[active]||(()=>{}))();}
 document.getElementById("foot").innerHTML=`<b>Illustrative data</b>, computed live from the models on this page — not real portfolio figures. In production these views are witnesses over governed facts: PD·LGD·EAD and the loss tail from <code>diligence.risk.pack</code> / internal-model #1293, EP &amp; variance from <code>economic-prophet</code>, surfaced through <code>lattice-studio</code> / <code>dashboard-bff</code>. Truthful, reproducible-from-source — no captured third-party images or branding. Colorblind-safe throughout: blue/orange not red/green, status shown with icon + label.`;
 go("m-el");

--- a/apps/lattice-studio/viz/credit-risk-thesis.html
+++ b/apps/lattice-studio/viz/credit-risk-thesis.html
@@ -1,0 +1,536 @@
+<title>Credit Risk &amp; Economic Capital — a visualization thesis</title>
+<style>
+  :root{
+    --ground:#f6f7f9;--surface:#ffffff;--surface-2:#eef1f5;--surface-3:#e6eaf0;
+    --ink:#161a20;--muted:#5c6570;--faint:#8b93a1;--line:#dfe3e9;--grid:#e9ecf1;
+    --accent:#b8860b;--pos:#0f62fe;--neg:#e8590c;--pos2:#8a3ffc;--neg2:#009d9a;
+    --good:#1a7f37;--bad:#c9372c;--warn:#9a6700;--good-bg:#e6f4ea;--bad-bg:#fbe9e7;
+    --shadow:0 1px 2px rgba(16,22,32,.06),0 6px 20px rgba(16,22,32,.05);--r:12px;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --ground:#0e1116;--surface:#171b22;--surface-2:#1e232c;--surface-3:#252b35;
+    --ink:#e6e9ee;--muted:#98a1ae;--faint:#6b7480;--line:#272d37;--grid:#232833;
+    --accent:#b0821a;--pos:#3b7fe4;--neg:#c95109;--pos2:#a56eff;--neg2:#0aa7a4;
+    --good:#3fb950;--bad:#f85149;--warn:#d29922;--good-bg:#132a1b;--bad-bg:#2c1615;
+    --shadow:0 1px 2px rgba(0,0,0,.3),0 8px 28px rgba(0,0,0,.35);
+  }}
+  :root[data-theme="light"]{--ground:#f6f7f9;--surface:#fff;--surface-2:#eef1f5;--surface-3:#e6eaf0;--ink:#161a20;--muted:#5c6570;--faint:#8b93a1;--line:#dfe3e9;--grid:#e9ecf1;--accent:#b8860b;--pos:#0f62fe;--neg:#e8590c;--pos2:#8a3ffc;--neg2:#009d9a;--good:#1a7f37;--bad:#c9372c;--good-bg:#e6f4ea;--bad-bg:#fbe9e7}
+  :root[data-theme="dark"]{--ground:#0e1116;--surface:#171b22;--surface-2:#1e232c;--surface-3:#252b35;--ink:#e6e9ee;--muted:#98a1ae;--faint:#6b7480;--line:#272d37;--grid:#232833;--accent:#b0821a;--pos:#3b7fe4;--neg:#c95109;--pos2:#a56eff;--neg2:#0aa7a4;--good:#3fb950;--bad:#f85149;--good-bg:#132a1b;--bad-bg:#2c1615}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--ground);color:var(--ink);font-size:14px;line-height:1.45;
+    font-family:ui-sans-serif,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased}
+  .num{font-family:ui-monospace,"SF Mono","Cascadia Code",Menlo,Consolas,monospace;font-variant-numeric:tabular-nums;letter-spacing:-.01em}
+  .app{display:grid;grid-template-columns:238px 1fr;min-height:100vh}
+  aside{border-right:1px solid var(--line);background:var(--surface);padding:20px 14px;position:sticky;top:0;height:100vh;overflow-y:auto}
+  aside .brand{font-weight:650;font-size:14px;letter-spacing:-.01em;padding:0 8px 2px}
+  aside .brand small{display:block;font-weight:500;color:var(--faint);font-size:11px;letter-spacing:.02em}
+  .navgrp{margin-top:18px}
+  .navgrp h4{font-size:10px;text-transform:uppercase;letter-spacing:.12em;color:var(--faint);margin:0 0 6px;padding:0 8px}
+  .navgrp a{display:flex;gap:9px;align-items:center;padding:7px 8px;border-radius:8px;color:var(--muted);text-decoration:none;font-size:13px;font-weight:500;cursor:pointer}
+  .navgrp a .n{font-size:10px;color:var(--faint);width:14px;text-align:right}
+  .navgrp a:hover{background:var(--surface-2);color:var(--ink)}
+  .navgrp a.active{background:var(--accent);color:#fff}
+  .navgrp a.active .n{color:rgba(255,255,255,.7)}
+  main{padding:26px 30px 70px;max-width:1000px}
+  .eyebrow{text-transform:uppercase;letter-spacing:.12em;font-size:11px;color:var(--faint);font-weight:600}
+  h1{font-size:23px;margin:.1em 0 .15em;font-weight:650;letter-spacing:-.015em;text-wrap:balance}
+  h2{font-size:18px;margin:.1em 0 .1em;font-weight:640;letter-spacing:-.01em}
+  .sub{color:var(--muted);font-size:13px;max-width:70ch;margin:.2em 0 0}
+  .rail{display:flex;flex-wrap:wrap;gap:16px 22px;background:var(--surface);border:1px solid var(--line);border-radius:var(--r);
+    padding:14px 18px;margin:18px 0 22px;box-shadow:var(--shadow)}
+  .rail .ctl{min-width:132px;flex:1}
+  .rail .ctl label{font-size:11px;color:var(--muted);font-weight:600;display:flex;justify-content:space-between;gap:8px}
+  .rail .ctl label b{color:var(--ink);font-weight:650}
+  input[type=range]{width:100%;accent-color:var(--accent);margin-top:7px;cursor:pointer}
+  .railhint{width:100%;font-size:11px;color:var(--faint);border-top:1px solid var(--line);padding-top:9px;margin-top:2px}
+  .module{display:none}
+  .module.on{display:block}
+  .tiles{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px;margin:16px 0}
+  .tile{background:var(--surface);border:1px solid var(--line);border-radius:var(--r);padding:13px 15px;box-shadow:var(--shadow)}
+  .tile .k{font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--faint);font-weight:600}
+  .tile .v{font-size:23px;font-weight:600;margin-top:5px}
+  .tile .d{font-size:11.5px;color:var(--muted);margin-top:3px}
+  .panel{background:var(--surface);border:1px solid var(--line);border-radius:var(--r);box-shadow:var(--shadow);margin:14px 0;padding:16px 18px}
+  .panel .ph{font-size:12px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);font-weight:650;margin-bottom:4px;display:flex;justify-content:space-between}
+  .cap{font-size:11.5px;color:var(--faint);margin-top:8px;line-height:1.5}
+  .legend{display:flex;gap:15px;flex-wrap:wrap;font-size:11.5px;color:var(--muted);margin:4px 0 8px}
+  .legend i{width:10px;height:10px;border-radius:2px;display:inline-block;margin-right:5px;vertical-align:-1px}
+  svg,canvas{display:block;width:100%;height:auto;overflow:visible}
+  .gridline{stroke:var(--grid)}.axis{stroke:var(--line)}.tick{fill:var(--faint);font-size:10px}
+  .lbl{fill:var(--muted);font-size:10.5px}.vlab{font-size:10px;font-weight:600}
+  .pill{display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:700;padding:2px 7px;border-radius:999px}
+  .pill.up{background:var(--good-bg);color:var(--good)}.pill.down{background:var(--bad-bg);color:var(--bad)}
+  table{width:100%;border-collapse:collapse;font-size:12.5px}
+  th{font-size:10px;text-transform:uppercase;letter-spacing:.05em;color:var(--faint);font-weight:600;text-align:left;padding:8px 10px;border-bottom:1px solid var(--line)}
+  td{padding:9px 10px;border-bottom:1px solid var(--grid);vertical-align:top}
+  tr.hi td{background:var(--surface-2)}
+  .tooltip{position:fixed;pointer-events:none;z-index:60;background:var(--surface);border:1px solid var(--line);box-shadow:var(--shadow);
+    border-radius:8px;padding:8px 10px;font-size:12px;opacity:0;transition:opacity .1s;max-width:250px}
+  .tooltip .tt-k{color:var(--muted);font-size:10px;text-transform:uppercase;letter-spacing:.05em}
+  .seg{display:inline-flex;background:var(--surface-2);border:1px solid var(--line);border-radius:8px;padding:3px;gap:2px;margin:4px 0}
+  .seg button{font:inherit;font-size:12px;font-weight:600;color:var(--muted);background:none;border:0;padding:5px 11px;border-radius:6px;cursor:pointer}
+  .seg button[aria-pressed=true]{background:var(--surface);color:var(--ink);box-shadow:var(--shadow)}
+  a:focus-visible,button:focus-visible,input:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+  .foot{color:var(--faint);font-size:11.5px;margin-top:26px;border-top:1px solid var(--line);padding-top:14px;line-height:1.6}
+  .foot code{color:var(--muted)}
+  @media(max-width:840px){.app{grid-template-columns:1fr}aside{position:static;height:auto;display:flex;flex-wrap:wrap;gap:4px}
+    .navgrp{margin-top:8px}main{padding:20px 16px 50px}}
+  @media(prefers-reduced-motion:reduce){*{transition:none!important}}
+</style>
+
+<div class="app">
+  <aside>
+    <div class="brand">Credit Risk &amp; Economic Capital<small>a visualization thesis · illustrative</small></div>
+    <nav id="nav"></nav>
+  </aside>
+  <main>
+    <div class="eyebrow" id="crumb">Loss · Expected loss</div>
+    <h1 id="mtitle">Expected loss</h1>
+    <p class="sub" id="mdesc"></p>
+
+    <div class="rail" id="rail">
+      <div class="ctl"><label for="pd">PD — probability of default <b id="pdV"></b></label><input type="range" id="pd" min="0.1" max="12" step="0.1"></div>
+      <div class="ctl"><label for="lgd">LGD — loss given default <b id="lgdV"></b></label><input type="range" id="lgd" min="5" max="90" step="1"></div>
+      <div class="ctl"><label for="ead">EAD — exposure at default <b id="eadV"></b></label><input type="range" id="ead" min="1" max="500" step="1"></div>
+      <div class="ctl"><label for="rho">ρ — asset correlation <b id="rhoV"></b></label><input type="range" id="rho" min="1" max="45" step="1"></div>
+      <div class="ctl"><label for="conf">Confidence (VaR) <b id="confV"></b></label><input type="range" id="conf" min="90" max="99.95" step="0.05"></div>
+      <div class="railhint" id="railhint"></div>
+    </div>
+
+    <section class="module on" id="m-el"></section>
+    <section class="module" id="m-sim"></section>
+    <section class="module" id="m-measures"></section>
+    <section class="module" id="m-capital"></section>
+    <section class="module" id="m-ep"></section>
+    <section class="module" id="m-var"></section>
+    <section class="module" id="m-ftp"></section>
+    <section class="module" id="m-recovery"></section>
+    <section class="module" id="m-ead"></section>
+    <section class="module" id="m-agg"></section>
+    <section class="module" id="m-models"></section>
+    <section class="module" id="m-dcf"></section>
+
+    <p class="foot" id="foot"></p>
+  </main>
+</div>
+<div class="tooltip" id="tt" role="status" aria-live="polite"></div>
+
+<script>
+(function(){"use strict";
+// ============ math ============
+function erf(x){const s=x<0?-1:1;x=Math.abs(x);const t=1/(1+0.3275911*x);
+  const y=1-(((((1.061405429*t-1.453152027)*t)+1.421413741)*t-0.284496736)*t+0.254829592)*t*Math.exp(-x*x);return s*y;}
+const N=x=>0.5*(1+erf(x/Math.SQRT2));
+function Ninv(p){if(p<=0)return -8;if(p>=1)return 8;
+  const a=[-39.6968302866538,220.946098424521,-275.928510446969,138.357751867269,-30.6647980661472,2.50662827745924];
+  const b=[-54.4760987982241,161.585836858041,-155.698979859887,66.8013118877197,-13.2806815528857];
+  const c=[-0.00778489400243029,-0.322396458041136,-2.40075827716184,-2.54973253934373,4.37466414146497,2.93816398269878];
+  const d=[0.00778469570904146,0.32246712907004,2.445134137143,3.75440866190742];const pl=0.02425,ph=1-pl;let q,r;
+  if(p<pl){q=Math.sqrt(-2*Math.log(p));return(((((c[0]*q+c[1])*q+c[2])*q+c[3])*q+c[4])*q+c[5])/((((d[0]*q+d[1])*q+d[2])*q+d[3])*q+1);}
+  if(p<=ph){q=p-0.5;r=q*q;return(((((a[0]*r+a[1])*r+a[2])*r+a[3])*r+a[4])*r+a[5])*q/(((((b[0]*r+b[1])*r+b[2])*r+b[3])*r+b[4])*r+1);}
+  q=Math.sqrt(-2*Math.log(1-p));return -(((((c[0]*q+c[1])*q+c[2])*q+c[3])*q+c[4])*q+c[5])/((((d[0]*q+d[1])*q+d[2])*q+d[3])*q+1);}
+let _s=1234567;const rand=()=>{_s^=_s<<13;_s^=_s>>>17;_s^=_s<<5;return((_s>>>0)/4294967296);};
+const randn=()=>{let u=0,v=0;while(!u)u=rand();while(!v)v=rand();return Math.sqrt(-2*Math.log(u))*Math.cos(2*Math.PI*v);};
+// Vasicek analytic worst-case default rate at confidence q
+const vasicekWCDR=(pd,rho,q)=>N((Ninv(pd)+Math.sqrt(rho)*Ninv(q))/Math.sqrt(1-rho));
+
+// ============ state ============
+const S={pd:2.0,lgd:45,ead:100,rho:15,conf:99.9};
+const P=x=>x/100;
+const fmtPct=(v,d=2)=>(v).toFixed(d)+"%";
+const fmtM=v=>(v<0?"−":"")+"$"+Math.abs(v).toFixed(Math.abs(v)>=100?0:2)+"m";
+const HURDLE=12; // %
+const tt=document.getElementById("tt");
+function tip(html,x,y){tt.innerHTML=html;tt.style.opacity=1;const r=tt.getBoundingClientRect();
+  let nx=x+14,ny=y+14;if(nx+r.width>innerWidth-8)nx=x-r.width-14;if(ny+r.height>innerHeight-8)ny=y-r.height-14;
+  tt.style.left=nx+"px";tt.style.top=ny+"px";}
+const hideTip=()=>tt.style.opacity=0;
+function up(){return '<svg width="11" height="11" viewBox="0 0 12 12"><path d="M6 2 10 8 2 8Z" fill="currentColor"/></svg>';}
+function dn(){return '<svg width="11" height="11" viewBox="0 0 12 12"><path d="M6 10 2 4 10 4Z" fill="currentColor"/></svg>';}
+
+// derived portfolio metrics (per $ of EAD, homogeneous pool)
+function metrics(){
+  const pd=P(S.pd),lgd=P(S.lgd),rho=P(S.rho),q=P(S.conf),ead=S.ead;
+  const el=pd*lgd*ead;                         // expected loss $m
+  const wcdr=vasicekWCDR(pd,rho,q);            // worst-case default rate
+  const varL=wcdr*lgd*ead;                     // credit VaR $m
+  const econCap=varL-el;                       // unexpected loss / economic capital
+  // ES (analytic-ish): average WCDR beyond q
+  let esr=0,cnt=0;for(let a=q;a<0.99999;a+=(1-q)/40){esr+=vasicekWCDR(pd,rho,a);cnt++;}
+  const es=(esr/cnt)*lgd*ead;
+  const spread=0.045*ead;                      // illustrative margin income
+  const rorac=econCap>0?(spread-el)/econCap*100:0;
+  return {pd,lgd,rho,q,ead,el,wcdr,varL,econCap,es,spread,rorac};
+}
+
+// ============ modules registry ============
+const NAVS=[
+  ["LOSS",[["m-el","Expected loss","EL = PD × LGD × EAD"],
+           ["m-sim","Portfolio simulation","Monte-Carlo loss distribution"],
+           ["m-measures","Risk measures","VaR · ES · σ · spectral"],
+           ["m-ead","EAD — race to default","LEQ / CCF, revolving vs term"],
+           ["m-recovery","Recovery &amp; PD↔RR","seniority, default-recovery link"]]],
+  ["CAPITAL",[["m-capital","Capital stack","regulatory vs economic"],
+           ["m-agg","Risk aggregation","summation → copula diversification"],
+           ["m-var","EP variance","price/volume/cost/capital drivers"]]],
+  ["VALUE",[["m-ep","Economic profit","EP waterfall"],
+           ["m-ftp","Funds-transfer pricing","matched-maturity FTP"],
+           ["m-dcf","DCF life-cycle","ROIC−WACC fade"]]],
+  ["REFERENCE",[["m-models","Credit-model taxonomy","PD models × LGD treatment"]]]
+];
+const META={};NAVS.forEach(([g,items])=>items.forEach(([id,t,d])=>META[id]={g,t,d}));
+const RAILON=new Set(["m-el","m-sim","m-measures","m-capital","m-agg","m-var","m-ep"]);
+
+// build nav
+const nav=document.getElementById("nav");
+NAVS.forEach(([g,items])=>{const gd=document.createElement("div");gd.className="navgrp";
+  gd.innerHTML=`<h4>${g}</h4>`;items.forEach(([id,t])=>{const a=document.createElement("a");a.dataset.id=id;
+    a.innerHTML=`<span>${t}</span>`;a.onclick=()=>go(id);gd.appendChild(a);});nav.appendChild(gd);});
+
+let active="m-el";
+function go(id){active=id;
+  document.querySelectorAll(".module").forEach(m=>m.classList.toggle("on",m.id===id));
+  document.querySelectorAll("#nav a").forEach(a=>a.classList.toggle("active",a.dataset.id===id));
+  document.getElementById("crumb").textContent=META[id].g[0]+META[id].g.slice(1).toLowerCase()+" · "+META[id].t.replace(/&amp;/g,"&");
+  document.getElementById("mtitle").innerHTML=META[id].t;
+  document.getElementById("mdesc").innerHTML=DESC[id]||"";
+  document.getElementById("rail").style.display=RAILON.has(id)?"flex":"none";
+  render();
+}
+const DESC={
+ "m-el":"The mortgage-calculator of credit risk. Expected loss is the mean loss a lender prices into every deal — covered by earnings, not capital. Move the three levers and watch it compose.",
+ "m-sim":"The deeper engine. A single-factor (Vasicek) portfolio: every obligor shares a systematic factor with correlation ρ. We Monte-Carlo thousands of economies; the tail — not the mean — is what capital must survive.",
+ "m-measures":"Four ways to name the same tail. Standard deviation, Value-at-Risk, Expected Shortfall and a spectral measure read the identical loss distribution differently — coherence is the property that separates them.",
+ "m-capital":"Two answers to 'how much capital'. The regulator sets a floor from risk-weighted assets and Basel III buffers; the bank's own model sets economic capital from its loss tail. They rarely agree.",
+ "m-agg":"Diversification is a discount. Roll several risk types into one number and the method chosen — naive summation to a full copula simulation — decides how much diversification benefit you are allowed to claim.",
+ "m-var":"Why did economic profit move? Decompose ΔEP into after-tax P&L drivers then balance-sheet drivers adjusted for capital cost.",
+ "m-ep":"Economic profit is what's left after the cost of the capital at risk: Revenue − EL − Expenses − Funding + Credits − Taxes − Capital charge.",
+ "m-ftp":"The treasury prices every asset and liability at a matched-maturity funds-transfer rate, splitting the margin into a client spread and a funding spread so each unit owns only what it controls.",
+ "m-recovery":"Loss given default is one minus recovery, and recovery is neither constant nor independent of default — it falls exactly when defaults rise.",
+ "m-ead":"Exposure at default is the weakest link in the Basel machinery. Revolving lines fill up as a borrower deteriorates (the 'race to default'); term loans amortise away.",
+ "m-dcf":"Value fades. A franchise earns above its cost of capital for a while, then competition erodes the ROIC−WACC spread — and a naive perpetuity assumption mis-prices exactly that fade.",
+ "m-models":"A field guide. Credit-risk models fall into statistical, structural, reduced-form and value-at-risk families, differing above all in how they treat recovery and its link to default."
+};
+
+// ============ shared rail wiring ============
+const ranges=["pd","lgd","ead","rho","conf"];
+ranges.forEach(k=>{const el=document.getElementById(k);el.value=S[k];
+  el.addEventListener("input",()=>{S[k]=+el.value;render();});});
+function railLabels(){document.getElementById("pdV").textContent=fmtPct(S.pd,1);
+  document.getElementById("lgdV").textContent=S.lgd+"%";document.getElementById("eadV").textContent="$"+S.ead+"m";
+  document.getElementById("rhoV").textContent=S.rho+"%";document.getElementById("confV").textContent=S.conf+"%";
+  document.getElementById("railhint").innerHTML="Shared portfolio — one homogeneous pool. These five levers flow through EL, the simulation, risk measures and capital. <b class='num'>Basel-style ρ ≈ 12–24%; VaR at 99.9% is the Basel IRB confidence.</b>";}
+
+// ============ SVG helpers ============
+function svg(w,h){return {w,h,parts:[],add(s){this.parts.push(s);return this;},
+  html(){return `<svg viewBox="0 0 ${this.w} ${this.h}" role="img">${this.parts.join("")}</svg>`;}};}
+
+// ---------- MODULES ----------
+function m_el(){const m=metrics();const box=document.getElementById("m-el");
+  const parts=[{k:"PD",v:fmtPct(S.pd,1),c:"var(--muted)"},{k:"LGD",v:S.lgd+"%",c:"var(--muted)"},{k:"EAD",v:"$"+S.ead+"m",c:"var(--muted)"}];
+  const W=640,H=120,gap=8;const seg=[["PD",P(S.pd),"var(--pos)"],["LGD",P(S.lgd),"var(--neg)"]];
+  // decomposition: bar showing EAD, then EL as PD×LGD slice
+  const s=svg(W,H);
+  const barY=30,barH=34,x0=10,x1=W-10;
+  s.add(`<text class="lbl" x="${x0}" y="18">EAD exposure — $${S.ead}m at risk</text>`);
+  s.add(`<rect x="${x0}" y="${barY}" width="${x1-x0}" height="${barH}" rx="4" fill="var(--surface-3)"/>`);
+  const elW=(x1-x0)*P(S.pd)*P(S.lgd);
+  s.add(`<rect x="${x0}" y="${barY}" width="${Math.max(2,elW)}" height="${barH}" rx="4" fill="var(--accent)"/>`);
+  s.add(`<text class="vlab num" x="${x0+6}" y="${barY+barH+16}" fill="var(--accent)">EL ${fmtM(m.el)}  =  PD ${fmtPct(S.pd,1)} × LGD ${S.lgd}% × EAD $${S.ead}m</text>`);
+  box.innerHTML=`
+   <div class="tiles">
+     <div class="tile"><div class="k">Expected loss</div><div class="v num" style="color:var(--accent)">${fmtM(m.el)}</div><div class="d">priced into the deal</div></div>
+     <div class="tile"><div class="k">Loss rate</div><div class="v num">${fmtPct(S.pd*S.lgd/100,2)}</div><div class="d">of exposure</div></div>
+     <div class="tile"><div class="k">Survives (no default)</div><div class="v num">${fmtPct(100-S.pd,1)}</div><div class="d">of the time</div></div>
+   </div>
+   <div class="panel"><div class="ph">Decomposition</div>${s.html()}
+     <div class="cap">Expected loss is a <b>mean</b> — it is covered by loan pricing and earnings. The capital question is about the losses <em>beyond</em> the mean → open <b>Portfolio simulation</b>.</div>
+   </div>`;
+}
+
+let simCache=null,simKey="";
+function runSim(){
+  const key=[S.pd,S.lgd,S.rho].join();if(key===simKey&&simCache)return simCache;
+  const pd=P(S.pd),lgd=P(S.lgd),rho=P(S.rho),thr=Ninv(pd),M=6000,n=800;
+  const losses=new Float64Array(M);const sa=Math.sqrt(rho),sb=Math.sqrt(1-rho);
+  for(let m=0;m<M;m++){const Z=randn();let d=0;for(let i=0;i<n;i++){if(sa*Z+sb*randn()<thr)d++;}losses[m]=(d/n)*lgd;}
+  const sorted=Float64Array.from(losses).sort();simCache={losses,sorted,M,n};simKey=key;return simCache;
+}
+function quant(sorted,q){const i=Math.min(sorted.length-1,Math.floor(q*sorted.length));return sorted[i];}
+function histify(losses,bins,max){const h=new Array(bins).fill(0);for(const v of losses){let b=Math.floor(v/max*bins);if(b<0)b=0;if(b>=bins)b=bins-1;h[b]++;}return h;}
+
+function m_sim(){const m=metrics();const box=document.getElementById("m-sim");const sim=runSim();const ead=S.ead;
+  const el=sim.losses.reduce((a,b)=>a+b,0)/sim.M;const varq=quant(sim.sorted,P(S.conf));
+  let es=0,c=0;for(const v of sim.sorted)if(v>=varq){es+=v;c++;}es=c?es/c:varq;
+  const maxL=Math.max(quant(sim.sorted,0.9995)*1.15,el*4,0.01);const bins=60;const h=histify(sim.losses,bins,maxL);const hmax=Math.max(...h);
+  const W=660,H=280,padL=8,padR=8,padB=40,padT=10;const iw=W-padL-padR;
+  const X=v=>padL+(v/maxL)*iw;const bw=iw/bins;const Y=c=>H-padB-(c/hmax)*(H-padB-padT);
+  const s=svg(W,H);
+  // economic-capital shaded band EL..VaR
+  s.add(`<rect x="${X(el)}" y="${padT}" width="${Math.max(1,X(varq)-X(el))}" height="${H-padB-padT}" fill="var(--neg)" opacity="0.09"/>`);
+  h.forEach((c,i)=>{const x=padL+i*bw;const beyond=(i*maxL/bins)>=varq;
+    s.add(`<rect x="${x+0.5}" y="${Y(c)}" width="${Math.max(0.5,bw-1)}" height="${H-padB-Y(c)}" fill="${beyond?'var(--neg)':'var(--pos)'}" opacity="${beyond?0.9:0.82}" rx="1"/>`);});
+  s.add(`<line class="axis" x1="${padL}" y1="${H-padB}" x2="${W-padR}" y2="${H-padB}"/>`);
+  // markers
+  const mk=(v,col,lab,dash)=>{s.add(`<line x1="${X(v)}" y1="${padT}" x2="${X(v)}" y2="${H-padB}" stroke="${col}" stroke-width="1.6" ${dash?'stroke-dasharray="4 3"':''}/>`);
+    s.add(`<text class="vlab num" x="${X(v)}" y="${padT+2}" text-anchor="middle" fill="${col}">${lab}</text>`);};
+  mk(el,"var(--pos2)","EL",true);mk(varq,"var(--neg)","VaR "+S.conf+"%",false);
+  s.add(`<text class="lbl" x="${(X(el)+X(varq))/2}" y="${H-padB+16}" text-anchor="middle">economic capital = VaR − EL</text>`);
+  s.add(`<text class="lbl" x="${W-padR}" y="${H-padB+16}" text-anchor="end">portfolio loss →</text>`);
+  const rorac=(m.spread-el*ead)/((varq-el)*ead)*100;
+  box.innerHTML=`
+   <div class="tiles">
+     <div class="tile"><div class="k">Expected loss</div><div class="v num" style="color:var(--pos2)">${fmtM(el*ead)}</div><div class="d">mean of ${sim.M.toLocaleString()} sims</div></div>
+     <div class="tile"><div class="k">Credit VaR ${S.conf}%</div><div class="v num" style="color:var(--neg)">${fmtM(varq*ead)}</div><div class="d">tail quantile</div></div>
+     <div class="tile"><div class="k">Economic capital</div><div class="v num">${fmtM((varq-el)*ead)}</div><div class="d">unexpected loss = VaR−EL</div></div>
+     <div class="tile"><div class="k">Expected shortfall</div><div class="v num">${fmtM(es*ead)}</div><div class="d">mean loss beyond VaR</div></div>
+     <div class="tile"><div class="k">RORAC</div><div class="v num">${rorac.toFixed(1)}%</div><div class="d"><span class="pill ${rorac>=HURDLE?'up':'down'}">${rorac>=HURDLE?up():dn()}${rorac>=HURDLE?'above':'below'} ${HURDLE}% hurdle</span></div></div>
+   </div>
+   <div class="panel"><div class="ph">Simulated portfolio-loss distribution <span class="num" style="color:var(--faint)">ρ=${S.rho}% · ${sim.n} obligors · ${sim.M.toLocaleString()} economies</span></div>
+     <div class="legend"><span><i style="background:var(--pos)"></i>body (expected range)</span><span><i style="background:var(--neg)"></i>tail beyond VaR — capital's job</span></div>
+     ${s.html()}
+     <div class="cap">Raise <b>ρ</b> and the distribution grows a fat right tail — the same average loss, far more dangerous. Economic capital is the width of the shaded band: what the bank holds so the tail doesn't sink it. This is the Vasicek single-factor model behind Basel IRB.</div>
+   </div>`;
+  const svgEl=box.querySelector("svg");svgEl.addEventListener("mousemove",e=>{const r=svgEl.getBoundingClientRect();
+    const vx=((e.clientX-r.left)/r.width*W-padL)/iw*maxL;if(vx<0||vx>maxL)return hideTip();
+    const pct=sim.losses.filter(v=>v<=vx).length/sim.M*100;
+    tip(`<div class="tt-k">loss ≤ ${fmtM(vx*ead)}</div><b>${pct.toFixed(1)}%</b> of simulated economies<br><span class="tt-k">exceedance</span> ${(100-pct).toFixed(2)}%`,e.clientX,e.clientY);});
+  svgEl.addEventListener("mouseleave",hideTip);
+}
+
+function m_measures(){const box=document.getElementById("m-measures");const sim=runSim();const ead=S.ead;
+  const el=sim.losses.reduce((a,b)=>a+b,0)/sim.M;
+  let vs=0;for(const v of sim.losses)vs+=(v-el)*(v-el);const sd=Math.sqrt(vs/sim.M);
+  const q=P(S.conf);const varq=quant(sim.sorted,q);let es=0,c=0;for(const v of sim.sorted)if(v>=varq){es+=v;c++;}es=c?es/c:varq;
+  // spectral: weight tail losses increasingly (illustrative risk-aversion kernel)
+  let spec=0,wsum=0;sim.sorted.forEach((v,i)=>{const u=(i+0.5)/sim.M;const w=Math.exp(4*u);spec+=w*v;wsum+=w;});spec/=wsum;
+  const rows=[["Standard deviation σ",sd,"var(--muted)","symmetric spread; penalises upside too — not coherent (violates monotonicity)"],
+    ["Value-at-Risk (99.9%)",varq,"var(--neg)","a quantile; ignores how bad the tail is beyond it — not sub-additive"],
+    ["Expected Shortfall",es,"var(--neg2)","mean loss beyond VaR — coherent; the Basel FRTB measure"],
+    ["Spectral / distorted",spec,"var(--pos2)","weights the whole tail by risk-aversion — coherent, tunable"]];
+  const maxv=Math.max(...rows.map(r=>r[1]));
+  const W=640,rowH=46,H=rows.length*rowH+10,x0=190,x1=W-70;
+  const s=svg(W,H);rows.forEach((r,i)=>{const y=i*rowH+22;const w=(x1-x0)*(r[1]/maxv);
+    s.add(`<text class="lbl" x="0" y="${y+4}" style="font-weight:600;fill:var(--ink)">${r[0]}</text>`);
+    s.add(`<rect x="${x0}" y="${y-9}" width="${Math.max(2,w)}" height="18" rx="3" fill="${r[2]}" opacity="0.85"/>`);
+    s.add(`<text class="vlab num" x="${x0+w+7}" y="${y+4}" fill="var(--muted)">${fmtM(r[1]*ead)}</text>`);});
+  box.innerHTML=`<div class="panel"><div class="ph">The same tail, measured four ways</div>${s.html()}
+     <div class="cap">All four read the identical simulated distribution. <b>Coherence</b> (Artzner et al.) requires monotonicity, sub-additivity, homogeneity and translation-invariance — VaR and σ each fail one; Expected Shortfall and spectral measures pass. Raise ρ and watch ES/spectral pull away from VaR: they <em>see</em> the fattening tail that VaR cannot.</div></div>
+     <table><thead><tr><th>Measure</th><th>Coherent?</th><th>What it captures</th></tr></thead><tbody>
+       ${rows.map(r=>`<tr><td><b>${r[0]}</b></td><td>${r[0].startsWith('Expected')||r[0].startsWith('Spectral')?'<span class="pill up">'+up()+'yes</span>':'<span class="pill down">'+dn()+'no</span>'}</td><td style="color:var(--muted)">${r[3]}</td></tr>`).join("")}
+     </tbody></table>`;
+}
+
+function m_capital(){const m=metrics();const box=document.getElementById("m-capital");
+  // regulatory stack (Basel III) as % of RWA; economic from sim
+  const reg=[["CET1 minimum",4.5,"var(--pos)"],["Additional Tier 1",1.5,"var(--pos2)"],["Tier 2",2.0,"var(--neg2)"],
+    ["Capital conservation",2.5,"var(--accent)"],["Countercyclical",1.0,"var(--warn)"],["G-SIB surcharge",1.5,"var(--neg)"]];
+  const regTot=reg.reduce((a,r)=>a+r[1],0);
+  const sim=runSim();const el=sim.losses.reduce((a,b)=>a+b,0)/sim.M;const varq=quant(sim.sorted,P(S.conf));
+  const econPct=(varq-el)*100/0.08*8/ (S.ead*0)||0; // display econ capital as % of exposure scaled
+  const econCapPctRWA=Math.max(2,(varq-el)*100* (S.lgd>0?1:1) * (100/ (S.pd*S.lgd/100+8)) *0+ (varq-el)*100*1.2/1);
+  const econ=Math.min(24,Math.max(3,(varq-el)*100*1.35+2)); // illustrative econ capital as % RWA
+  const W=640,H=210,colW=150,gap=90,x0=90;const maxPct=Math.max(regTot,econ)*1.15;
+  const s=svg(W,H);const baseY=H-34;const scale=(baseY-16)/maxPct;
+  function stack(cx,items,label){let y=baseY;items.forEach(([nm,v,col])=>{const hh=v*scale;y-=hh;
+    s.add(`<rect x="${cx}" y="${y}" width="${colW}" height="${Math.max(1,hh-1.5)}" rx="2" fill="${col}" opacity="0.9"><title>${nm}: ${v}% of RWA</title></rect>`);
+    if(hh>15)s.add(`<text class="vlab num" x="${cx+colW/2}" y="${y+hh/2+3}" text-anchor="middle" fill="#fff">${v}%</text>`);});
+    s.add(`<text class="lbl" x="${cx+colW/2}" y="${baseY+16}" text-anchor="middle" style="fill:var(--ink);font-weight:600">${label}</text>`);
+    const tot=items.reduce((a,i)=>a+i[1],0);s.add(`<text class="vlab num" x="${cx+colW/2}" y="${baseY+30}" text-anchor="middle" fill="var(--muted)">${tot.toFixed(1)}% RWA</text>`);}
+  stack(x0,reg,"Regulatory (Basel III)");
+  stack(x0+colW+gap,[["Economic capital (from tail)",econ,"var(--neg)"]],"Economic (own model)");
+  box.innerHTML=`<div class="tiles">
+     <div class="tile"><div class="k">Regulatory minimum</div><div class="v num">${regTot.toFixed(1)}%</div><div class="d">of risk-weighted assets</div></div>
+     <div class="tile"><div class="k">Economic capital</div><div class="v num">${econ.toFixed(1)}%</div><div class="d">from your loss tail</div></div>
+     <div class="tile"><div class="k">Binding constraint</div><div class="v num" style="font-size:19px">${econ>regTot?'Economic':'Regulatory'}</div><div class="d">the higher one bites</div></div>
+   </div>
+   <div class="panel"><div class="ph">Regulatory vs economic capital <span style="color:var(--faint)">% of RWA</span></div>${s.html()}
+     <div class="cap">The regulator builds capital bottom-up from Basel III minimums and buffers (CET1 4.5% → Tier-1 6% → Total 8%, plus conservation, countercyclical and G-SIB). The bank's own model sizes <b>economic capital</b> from the loss tail you're simulating. When ρ or PD rises, economic capital can exceed the regulatory floor — the McKinsey "R-Cap vs E-Cap" divergence.</div></div>`;
+}
+
+function waterfall(id,steps,scope){
+  const W=660,H=280,padL=48,padR=12,padB=62,padT=14;const s=svg(W,H);
+  let cum=steps[0].v,rows=[{label:steps[0].label,type:"total",cum}];
+  for(let i=1;i<steps.length-1;i++){const dv=steps[i].v;rows.push({label:steps[i].label,type:dv>=0?"pos":"neg",from:cum,cum:cum+dv,v:dv});cum+=dv;}
+  rows.push({label:steps[steps.length-1].label,type:"total",cum});
+  const vals=rows.flatMap(r=>[r.cum,r.from||r.cum]);let lo=Math.min(0,...vals),hi=Math.max(...vals);const pad=(hi-lo)*0.15||1;hi+=pad;
+  const bw=(W-padL-padR)/rows.length-9;const X=i=>padL+i*((W-padL-padR)/rows.length)+4;const Y=v=>padT+(1-(v-lo)/(hi-lo))*(H-padT-padB);
+  for(let g=0;g<=4;g++){const gv=lo+(hi-lo)*g/4,gy=Y(gv);s.add(`<line class="gridline" x1="${padL}" y1="${gy}" x2="${W-padR}" y2="${gy}"/><text class="tick" x="${padL-6}" y="${gy+3}" text-anchor="end">${gv.toFixed(0)}</text>`);}
+  if(lo<0)s.add(`<line class="axis" x1="${padL}" y1="${Y(0)}" x2="${W-padR}" y2="${Y(0)}"/>`);
+  rows.forEach((r,i)=>{const x=X(i);let top,bot,fill;
+    if(r.type==="total"){top=Y(Math.max(0,r.cum));bot=Y(Math.min(0,r.cum));fill="var(--accent)";}
+    else{top=Y(Math.max(r.from,r.cum));bot=Y(Math.min(r.from,r.cum));fill=r.type==="pos"?"var(--pos)":"var(--neg)";}
+    s.add(`<rect x="${x}" y="${top}" width="${bw}" height="${Math.max(2,bot-top)}" rx="2" fill="${fill}"><title>${r.label}</title></rect>`);
+    if(i<rows.length-1)s.add(`<line x1="${x}" y1="${Y(r.cum)}" x2="${x+bw+9}" y2="${Y(r.cum)}" stroke="var(--faint)" stroke-dasharray="2 2"/>`);
+    s.add(`<text class="lbl" x="${x+bw/2}" y="${H-padB+14}" text-anchor="middle" transform="rotate(24 ${x+bw/2} ${H-padB+14})">${r.label}</text>`);
+    s.add(`<text class="vlab num" x="${x+bw/2}" y="${(r.type==='neg'?bot+12:top-5)}" text-anchor="middle" fill="var(--muted)">${r.type==='total'?r.cum.toFixed(0):(r.v>=0?'+':'−')+Math.abs(r.v).toFixed(0)}</text>`);});
+  return s.html();
+}
+function m_ep(){const m=metrics();const box=document.getElementById("m-ep");
+  const rev=S.ead*0.075,exp=S.ead*0.02,fund=S.ead*0.028,cred=S.ead*0.012,el=m.el,tax=(rev-el-exp-fund+cred)*0.25,cap=m.econCap*(HURDLE/100);
+  const ep=rev-el-exp-fund+cred-tax-cap;
+  const steps=[{label:"Revenue",v:rev},{label:"− Exp. loss",v:-el},{label:"− Expenses",v:-exp},{label:"− Funding",v:-fund},
+    {label:"+ Credits",v:cred},{label:"− Taxes",v:-tax},{label:"− Capital charge",v:-cap},{label:"= EP",v:0}];
+  box.innerHTML=`<div class="tiles">
+     <div class="tile"><div class="k">Economic profit</div><div class="v num" style="color:${ep>=0?'var(--pos)':'var(--neg)'}">${fmtM(ep)}</div><div class="d">${ep>=0?'value created':'value destroyed'}</div></div>
+     <div class="tile"><div class="k">Capital charge</div><div class="v num">${fmtM(cap)}</div><div class="d">${HURDLE}% × economic capital ${fmtM(m.econCap)}</div></div>
+     <div class="tile"><div class="k">EP margin</div><div class="v num">${(ep/rev*100).toFixed(1)}%</div><div class="d">of revenue</div></div>
+   </div>
+   <div class="panel"><div class="ph">Economic-profit waterfall</div>
+   <div class="legend"><span><i style="background:var(--pos)"></i>adds</span><span><i style="background:var(--neg)"></i>subtracts</span><span><i style="background:var(--accent)"></i>level</span></div>
+   ${waterfall("ep",steps)}
+   <div class="cap">EP charges the business for the capital its risk consumes (${HURDLE}% hurdle × economic capital). A unit can be profitable on paper and still <em>destroy</em> value once the capital charge lands. This is why the capital charge links straight back to the simulation's tail.</div></div>`;
+}
+function m_var(){const box=document.getElementById("m-var");
+  const base=40;const dr=[["EP₀",base],["Price",9],["Volume",14],["Cost",-11],["Productivity",7],["Investment",8],["Lending",12],["Financing",-9],["Op. assets",-7]];
+  let ep1=dr.reduce((a,d)=>a+d[1],0);const steps=dr.map((d,i)=>({label:d[0],v:d[1]})).concat([{label:"EP₁",v:0}]);
+  box.innerHTML=`<div class="panel"><div class="ph">EP variance decomposition</div>
+   <div class="legend"><span><i style="background:var(--pos)"></i>increases EP</span><span><i style="background:var(--neg)"></i>decreases EP</span><span><i style="background:var(--accent)"></i>EP level</span></div>
+   ${waterfall("var",steps)}
+   <div class="cap">The first block is P&L economic profit (price · volume · cost · productivity, after tax); the second is balance-sheet EP — net-working-capital and fixed-asset drivers adjusted for their capital cost. Additive by construction, so it rolls up from transaction to firm. (Illustrative driver set — a fuller drilldown lives in the profit-&-risk dashboard.)</div></div>`;
+}
+
+function m_ftp(){const box=document.getElementById("m-ftp");
+  // loan earns client rate; funded at FTP; deposit pays client rate; credited at FTP
+  const ftp=2.6,loanRate=5.4,depRate=0.8,size=100;
+  const loanSpread=loanRate-ftp,depSpread=ftp-depRate;
+  const W=640,H=200,padL=8,mid=H/2;const s=svg(W,H);
+  const seg=(x,w,y,h,col,lab,val)=>{s.add(`<rect x="${x}" y="${y}" width="${w}" height="${h}" rx="3" fill="${col}" opacity="0.88"/>`);
+    s.add(`<text class="vlab num" x="${x+w/2}" y="${y+h/2+4}" text-anchor="middle" fill="#fff">${lab} ${val}%</text>`);};
+  const scale=560/loanRate;
+  s.add(`<text class="lbl" x="${padL}" y="18">Asset (loan) — client rate ${loanRate}%</text>`);
+  seg(padL,ftp*scale,26,34,"var(--muted)","FTP",ftp);seg(padL+ftp*scale,loanSpread*scale,26,34,"var(--pos)","Client spread",loanSpread);
+  s.add(`<text class="lbl" x="${padL}" y="104">Liability (deposit) — client rate ${depRate}%</text>`);
+  seg(padL,depRate*scale,112,34,"var(--muted)","Client rate",depRate);seg(padL+depRate*scale,depSpread*scale,112,34,"var(--neg2)","Funding credit",depSpread);
+  s.add(`<text class="lbl num" x="${padL}" y="182" style="fill:var(--ink);font-weight:600">Net interest margin ${(loanSpread+depSpread).toFixed(1)}% = client spread ${loanSpread.toFixed(1)}% (lending) + funding credit ${depSpread.toFixed(1)}% (deposits) — split at the FTP line ${ftp}%</text>`);
+  box.innerHTML=`<div class="tiles">
+     <div class="tile"><div class="k">Lending margin</div><div class="v num" style="color:var(--pos)">${loanSpread.toFixed(1)}%</div><div class="d">loan rate − FTP</div></div>
+     <div class="tile"><div class="k">Funding value</div><div class="v num" style="color:var(--neg2)">${depSpread.toFixed(1)}%</div><div class="d">FTP − deposit rate</div></div>
+     <div class="tile"><div class="k">FTP rate</div><div class="v num">${ftp}%</div><div class="d">matched-maturity transfer</div></div>
+   </div>
+   <div class="panel"><div class="ph">Matched-maturity funds-transfer pricing</div>${s.html()}
+   <div class="cap">Treasury buys every asset's cashflows and sells every liability's at one matched-maturity <b>FTP</b> rate. That single line splits the margin so the lending desk owns only its client spread and the deposit desk owns only its funding value — interest-rate risk lands in Treasury, where it's hedged. (Illustrative rates.)</div></div>`;
+}
+
+function m_recovery(){const box=document.getElementById("m-recovery");
+  // recovery by seniority: [p10,p25,med,p75,p90]
+  const sen=[["Bank loans",[36,60,80,88,91]],["Sr. secured",[28,40,55,66,93]],["Sr. unsecured",[15,32,51,73,88]],["Subordinated",[9,18,31,45,65]],["Jr. sub.",[4,10,13,20,32]]];
+  const W=640,H=240,padL=90,padB=28,padT=10,x0=padL,x1=W-16;const s=svg(W,H);const rowH=(H-padB-padT)/sen.length;
+  const X=v=>x0+(v/100)*(x1-x0);
+  for(let g=0;g<=100;g+=25){s.add(`<line class="gridline" x1="${X(g)}" y1="${padT}" x2="${X(g)}" y2="${H-padB}"/><text class="tick" x="${X(g)}" y="${H-padB+14}" text-anchor="middle">${g}%</text>`);}
+  sen.forEach((r,i)=>{const y=padT+i*rowH+rowH/2;const[p10,p25,med,p75,p90]=r[1];
+    s.add(`<text class="lbl" x="0" y="${y+3}" style="font-weight:600;fill:var(--ink)">${r[0]}</text>`);
+    s.add(`<line x1="${X(p10)}" y1="${y}" x2="${X(p90)}" y2="${y}" stroke="var(--faint)" stroke-width="1.4"/>`);
+    s.add(`<rect x="${X(p25)}" y="${y-8}" width="${X(p75)-X(p25)}" height="16" rx="3" fill="var(--pos)" opacity="0.28" stroke="var(--pos)"/>`);
+    s.add(`<circle cx="${X(med)}" cy="${y}" r="4.5" fill="var(--accent)"><title>${r[0]} median recovery ${med}%</title></circle>`);});
+  s.add(`<text class="lbl" x="${x1}" y="${padT-2}" text-anchor="end">recovery rate (100% − LGD) →</text>`);
+  box.innerHTML=`<div class="panel"><div class="ph">Recovery by seniority <span style="color:var(--faint)">10–90th pct · median gold</span></div>${s.html()}
+   <div class="cap">LGD = 1 − recovery, and recovery is <b>ranked by seniority</b>: a senior secured loan recovers far more than a junior bond, but the dispersion is huge. This is why LGD is modelled as a distribution, not a point (Duffie-Singleton).</div></div>
+   <div class="panel"><div class="ph">Default ↔ recovery association</div>${(function(){
+     const W=640,H=210,padL=40,padB=30,padT=10;const s2=svg(W,H);const X=d=>padL+(d/12)*(W-padL-16);const Y=r=>padT+(1-(r-20)/45)*(H-padT-padB);
+     for(let g=0;g<=12;g+=3)s2.add(`<line class="gridline" x1="${X(g)}" y1="${padT}" x2="${X(g)}" y2="${H-padB}"/><text class="tick" x="${X(g)}" y="${H-padB+14}" text-anchor="middle">${g}%</text>`);
+     // Altman-style negative relation: recovery = 50.9 - 2.6*default (illustrative)
+     let path="";for(let d=0.5;d<=11;d+=0.5){const r=Math.max(22,50.9-2.6*d);path+=(path?"L":"M")+X(d)+" "+Y(r)+" ";}
+     // scatter
+     const pts=[[1,55],[1.5,52],[2.5,44],[3.3,38],[4.2,38],[5,28],[5.2,25],[10.2,24],[10.5,30],[1,48]];
+     pts.forEach(p=>s2.add(`<circle cx="${X(p[0])}" cy="${Y(p[1])}" r="3.5" fill="var(--neg)" opacity="0.7"/>`));
+     s2.add(`<path d="${path}" fill="none" stroke="var(--accent)" stroke-width="2"/>`);
+     s2.add(`<text class="lbl" x="${W-16}" y="${padT+2}" text-anchor="end">default rate →</text>`);
+     s2.add(`<text class="lbl" x="${padL-4}" y="${padT+8}" text-anchor="end" transform="rotate(-90 ${padL-4} ${padT+8})"> </text>`);
+     return s2.html();})()}
+   <div class="cap">Recovery falls as defaults rise — they share the macro cycle. Assuming a constant, independent recovery (many first-generation models) understates losses exactly in the downturns that matter (Altman-Resti).</div></div>`;
+}
+
+function m_ead(){const box=document.getElementById("m-ead");
+  const leq=0.55;const W=640,H=240,padL=48,padB=34,padT=12;const s=svg(W,H);
+  const X=t=>padL+t*(W-padL-14);const Y=v=>padT+(1-v/1100)*(H-padT-padB);
+  for(let g=0;g<=1000;g+=250)s.add(`<line class="gridline" x1="${padL}" y1="${Y(g)}" x2="${W-14}" y2="${Y(g)}"/><text class="tick" x="${padL-6}" y="${Y(g)+3}" text-anchor="end">$${g}</text>`);
+  // revolving: commitment flat 1000; drawn rises 500->1000 via LEQ as quality deteriorates
+  let rev="",commit="";for(let t=0;t<=1;t+=0.02){const drawn=500+leq*500*Math.pow(t,1.4);rev+=(rev?"L":"M")+X(t)+" "+Y(drawn)+" ";commit+=(commit?"L":"M")+X(t)+" "+Y(1000)+" ";}
+  // term: amortises 1000->300
+  let term="";for(let t=0;t<=1;t+=0.02){const bal=1000-700*t;term+=(term?"L":"M")+X(t)+" "+Y(bal)+" ";}
+  s.add(`<path d="${commit}" fill="none" stroke="var(--faint)" stroke-width="1.4" stroke-dasharray="4 3"/>`);
+  s.add(`<path d="${rev}" fill="none" stroke="var(--neg)" stroke-width="2.4"/>`);
+  s.add(`<path d="${term}" fill="none" stroke="var(--pos)" stroke-width="2.4"/>`);
+  s.add(`<text class="lbl" x="${X(0)}" y="${H-padB+16}">today</text><text class="lbl" x="${X(1)}" y="${H-padB+16}" text-anchor="end">default (credit quality deteriorates →)</text>`);
+  s.add(`<text class="vlab" x="${X(0.72)}" y="${Y(880)}" fill="var(--neg)">revolving — drawn EAD rises</text>`);
+  s.add(`<text class="vlab" x="${X(0.55)}" y="${Y(560)}" fill="var(--pos)">term — amortises away</text>`);
+  s.add(`<text class="vlab" x="${X(0.05)}" y="${Y(1030)}" fill="var(--faint)">committed line</text>`);
+  box.innerHTML=`<div class="tiles">
+   <div class="tile"><div class="k">LEQ / CCF</div><div class="v num">${(leq*100).toFixed(0)}%</div><div class="d">of undrawn drawn by default</div></div>
+   <div class="tile"><div class="k">Revolving EAD</div><div class="v num">$${(500+leq*500).toFixed(0)}m</div><div class="d">at default</div></div>
+   <div class="tile"><div class="k">Term EAD</div><div class="v num">$300m</div><div class="d">amortised balance</div></div>
+   </div>
+   <div class="panel"><div class="ph">The race to default — exposure paths</div>${s.html()}
+   <div class="cap">EAD is the current balance plus expected further drawdowns. A distressed borrower <b>draws down revolving lines</b> to preserve liquidity (loan-equivalent LEQ / credit-conversion CCF), so exposure climbs precisely as default nears — while a term loan amortises. EAD modelling is, per the OCC, one of the weakest links in Basel. (Illustrative.)</div></div>`;
+}
+
+function m_agg(){const box=document.getElementById("m-agg");
+  const comps=[["Credit",100],["Market",55],["Operational",40],["Business",30]];const sum=comps.reduce((a,c)=>a+c[1],0);
+  const corr=0.3;// inter-risk
+  // var-cov: sqrt(sum_i sum_j c_i c_j rho_ij), rho=1 diag else corr
+  let q=0;for(let i=0;i<comps.length;i++)for(let j=0;j<comps.length;j++)q+=comps[i][1]*comps[j][1]*(i===j?1:corr);
+  const varcov=Math.sqrt(q);const constDiv=sum*0.85;const copula=varcov*0.93;
+  const methods=[["Summation",sum,"var(--neg)","adds components; no diversification"],["Constant diversification",constDiv,"var(--warn)","fixed haircut; insensitive to interactions"],
+    ["Variance-covariance",varcov,"var(--pos)","bilateral correlations; misses non-linearity"],["Copula / full simulation",copula,"var(--pos2)","joint loss distribution; most accurate, hardest"]];
+  const W=640,H=220,x0=200,x1=W-80,rowH=48;const s=svg(W,H);const mx=sum;
+  methods.forEach((m,i)=>{const y=i*rowH+26,w=(x1-x0)*(m[1]/mx);
+    s.add(`<text class="lbl" x="0" y="${y+4}" style="font-weight:600;fill:var(--ink)">${m[0]}</text>`);
+    s.add(`<rect x="${x0}" y="${y-10}" width="${w}" height="20" rx="3" fill="${m[2]}" opacity="0.85"/>`);
+    s.add(`<text class="vlab num" x="${x0+w+7}" y="${y+4}" fill="var(--muted)">$${m[1].toFixed(0)}m</text>`);
+    if(i>0)s.add(`<text class="vlab num" x="${x0+w-4}" y="${y+4}" text-anchor="end" fill="#fff">−${((1-m[1]/sum)*100).toFixed(0)}%</text>`);});
+  box.innerHTML=`<div class="tiles">
+   <div class="tile"><div class="k">Standalone sum</div><div class="v num">$${sum}m</div><div class="d">no diversification</div></div>
+   <div class="tile"><div class="k">Full-simulation capital</div><div class="v num">$${copula.toFixed(0)}m</div><div class="d">diversified</div></div>
+   <div class="tile"><div class="k">Diversification benefit</div><div class="v num" style="color:var(--pos)">${((1-copula/sum)*100).toFixed(0)}%</div><div class="d">capital released</div></div>
+   </div>
+   <div class="panel"><div class="ph">Aggregating risk types → total economic capital</div>${s.html()}
+   <div class="cap">Total economic capital is <em>less</em> than the sum of its parts because risks don't all peak together. The method you're allowed to use decides how much of that diversification you can claim — from conservative summation to a full copula simulation of the joint loss distribution (inter-risk correlation shown at ${(corr*100)|0}%). More accuracy costs enormously more in data and compute.</div></div>`;
+}
+
+function m_models(){const box=document.getElementById("m-models");
+  const rows=[["Statistical (Altman Z, CAMELS)","classification / discriminant","observed (empirical)","implicit in ratios","Bankruptcy prediction from financial ratios"],
+   ["1st-gen structural (Merton)","option-theoretic","endogenous — falls from firm value","inverse (RR↓ as PD↑)","Default = assets < debt at horizon"],
+   ["2nd-gen structural","structural","exogenous, fixed fraction","independent","RR a fixed ratio of debt"],
+   ["Reduced-form (Jarrow-Turnbull)","intensity / hazard","exogenous (const or stochastic)","independent by assumption","Default an unpredictable jump"],
+   ["Credit VaR (CreditMetrics, KMV)","portfolio loss","stochastic (beta) / constant","independent","Portfolio-level default or MtM"],
+   ["Latest PD-RR (Frye, Altman)","macro-conditional","stochastic, common factor","negatively correlated","RR &amp; PD share the cycle"]];
+  box.innerHTML=`<div class="panel"><div class="ph">Credit-model taxonomy — how each treats recovery</div>
+   <table><thead><tr><th>Model family</th><th>Form</th><th>Recovery (RR)</th><th>RR–PD link</th></tr></thead><tbody>
+   ${rows.map((r,i)=>`<tr data-i="${i}"><td><b>${r[0]}</b></td><td style="color:var(--muted)">${r[1]}</td><td style="color:var(--muted)">${r[2]}</td><td>${r[3].includes('negativ')||r[3].includes('inverse')?'<span class="pill down">'+dn()+r[3]+'</span>':'<span style="color:var(--muted)">'+r[3]+'</span>'}</td></tr>`).join("")}
+   </tbody></table>
+   <div class="cap">Click a row for its defining idea. The field's arc runs from treating recovery as a fixed constant to recognising that <b>recovery and default move together</b> — the single assumption that most changes a capital number (BIS WP 113).</div>
+   <div id="modelnote" class="cap" style="margin-top:10px;color:var(--muted);border-top:1px solid var(--line);padding-top:10px"></div></div>`;
+  const notes=rows.map(r=>r[4]);box.querySelectorAll("tr[data-i]").forEach(tr=>{tr.style.cursor="pointer";
+    tr.onclick=()=>{box.querySelectorAll("tr").forEach(x=>x.classList.remove("hi"));tr.classList.add("hi");
+      document.getElementById("modelnote").innerHTML="<b>"+rows[+tr.dataset.i][0]+"</b> — "+notes[+tr.dataset.i];};});
+}
+
+function m_dcf(){const box=document.getElementById("m-dcf");
+  const fade=8;// years explicit
+  const W=640,H=240,padL=44,padB=34,padT=14;const s=svg(W,H);const X=t=>padL+(t/20)*(W-padL-14);const Y=v=>padT+(1-v/10)*(H-padT-padB);
+  s.add(`<line class="axis" x1="${padL}" y1="${Y(0)}" x2="${W-14}" y2="${Y(0)}"/>`);
+  // true life-cycle: spread rises then fades to 0
+  let life="";for(let t=0;t<=20;t+=0.25){const v=9*Math.exp(-Math.pow((t-4)/6,2));life+=(life?"L":"M")+X(t)+" "+Y(v)+" ";}
+  // naive DCF: flat explicit then perpetuity (cliff)
+  let naive="";for(let t=0;t<=fade;t+=0.25){const v=9*Math.exp(-Math.pow((4-4)/6,2))*(t<1?t:1);naive+=(naive?"L":"M")+X(t)+" "+Y(t<1?9*t:9)+" ";}
+  naive+=`L ${X(fade)} ${Y(9)} L ${X(fade)} ${Y(4)} L ${X(20)} ${Y(4)}`;
+  s.add(`<rect x="${padL}" y="${padT}" width="${X(fade)-padL}" height="${H-padT-padB}" fill="var(--pos)" opacity="0.05"/>`);
+  s.add(`<text class="lbl" x="${(padL+X(fade))/2}" y="${padT+12}" text-anchor="middle">explicit forecast</text>`);
+  s.add(`<path d="${life}" fill="none" stroke="var(--pos)" stroke-width="2.4"/>`);
+  s.add(`<path d="${naive}" fill="none" stroke="var(--neg)" stroke-width="2" stroke-dasharray="5 3"/>`);
+  s.add(`<text class="vlab" x="${X(10)}" y="${Y(2.6)}" fill="var(--pos)">true life-cycle fade</text>`);
+  s.add(`<text class="vlab" x="${X(12)}" y="${Y(4.4)}" fill="var(--neg)">naive continuing-value (perpetuity)</text>`);
+  s.add(`<text class="lbl" x="${padL-4}" y="${padT+8}" text-anchor="end" transform="rotate(-90 ${padL-4} ${padT+8})">ROIC − WACC</text>`);
+  s.add(`<text class="lbl" x="${W-14}" y="${H-padB+16}" text-anchor="end">time →</text>`);
+  box.innerHTML=`<div class="panel"><div class="ph">DCF fitted to life-cycle theory</div>${s.html()}
+   <div class="cap">A franchise earns a positive <b>ROIC−WACC</b> spread, but competition fades it toward zero. Freezing the last explicit year into a perpetuity (the red cliff) assumes the fade never happens — over-valuing exactly the mature businesses whose advantage is eroding (Mauboussin). The honest curve returns to zero economic profit.</div></div>`;
+}
+
+const RENDER={"m-el":m_el,"m-sim":m_sim,"m-measures":m_measures,"m-capital":m_capital,"m-ep":m_ep,"m-var":m_var,
+  "m-ftp":m_ftp,"m-recovery":m_recovery,"m-ead":m_ead,"m-agg":m_agg,"m-models":m_models,"m-dcf":m_dcf};
+function render(){railLabels();(RENDER[active]||(()=>{}))();}
+document.getElementById("foot").innerHTML=`<b>Illustrative data</b>, computed live from the models on this page — not real portfolio figures. In production these views are witnesses over governed facts: PD·LGD·EAD and the loss tail from <code>diligence.risk.pack</code> / internal-model #1293, EP &amp; variance from <code>economic-prophet</code>, surfaced through <code>lattice-studio</code> / <code>dashboard-bff</code>. Truthful, reproducible-from-source — no captured third-party images or branding. Colorblind-safe throughout: blue/orange not red/green, status shown with icon + label.`;
+go("m-el");
+})();
+</script>

--- a/apps/lattice-studio/viz/profit-risk-drilldown.html
+++ b/apps/lattice-studio/viz/profit-risk-drilldown.html
@@ -1,0 +1,421 @@
+<title>Economic Profit &amp; Risk — drilldown</title>
+<style>
+  :root{
+    --ground:#f6f7f9; --surface:#ffffff; --surface-2:#eef1f5;
+    --ink:#161a20; --muted:#5c6570; --faint:#8b93a1;
+    --line:#dfe3e9; --grid:#e9ecf1;
+    --accent:#b8860b; --accent-soft:#f3e6c4;
+    --pos:#0f62fe; --neg:#e8590c;           /* CVD-safe blue vs orange */
+    --good:#1a7f37; --bad:#c9372c; --warn:#9a6700;
+    --good-bg:#e6f4ea; --bad-bg:#fbe9e7;
+    --shadow:0 1px 2px rgba(16,22,32,.06),0 6px 20px rgba(16,22,32,.05);
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --ground:#0e1116; --surface:#171b22; --surface-2:#1e232c;
+    --ink:#e6e9ee; --muted:#98a1ae; --faint:#6b7480;
+    --line:#272d37; --grid:#232833;
+    --accent:#b0821a; --accent-soft:#3a3320;
+    --pos:#3b7fe4; --neg:#c95109;
+    --good:#3fb950; --bad:#f85149; --warn:#d29922;
+    --good-bg:#132a1b; --bad-bg:#2c1615;
+    --shadow:0 1px 2px rgba(0,0,0,.3),0 8px 28px rgba(0,0,0,.35);
+  }}
+  :root[data-theme="light"]{
+    --ground:#f6f7f9; --surface:#ffffff; --surface-2:#eef1f5;
+    --ink:#161a20; --muted:#5c6570; --faint:#8b93a1; --line:#dfe3e9; --grid:#e9ecf1;
+    --accent:#b8860b; --accent-soft:#f3e6c4; --pos:#0f62fe; --neg:#e8590c;
+    --good:#1a7f37; --bad:#c9372c; --warn:#9a6700; --good-bg:#e6f4ea; --bad-bg:#fbe9e7;
+  }
+  :root[data-theme="dark"]{
+    --ground:#0e1116; --surface:#171b22; --surface-2:#1e232c;
+    --ink:#e6e9ee; --muted:#98a1ae; --faint:#6b7480; --line:#272d37; --grid:#232833;
+    --accent:#b0821a; --accent-soft:#3a3320; --pos:#3b7fe4; --neg:#c95109;
+    --good:#3fb950; --bad:#f85149; --warn:#d29922; --good-bg:#132a1b; --bad-bg:#2c1615;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--ground);color:var(--ink);
+    font-family:ui-sans-serif,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    font-size:14px;line-height:1.45;-webkit-font-smoothing:antialiased}
+  .num{font-family:ui-monospace,"SF Mono","Cascadia Code","JetBrains Mono",Menlo,Consolas,monospace;
+    font-variant-numeric:tabular-nums;letter-spacing:-.01em}
+  .wrap{max-width:1180px;margin:0 auto;padding:28px 22px 60px}
+  .eyebrow{text-transform:uppercase;letter-spacing:.12em;font-size:11px;color:var(--faint);font-weight:600}
+  h1{font-size:22px;margin:.15em 0 .1em;font-weight:650;letter-spacing:-.01em;text-wrap:balance}
+  .sub{color:var(--muted);font-size:13px;max-width:66ch}
+  .topbar{display:flex;justify-content:space-between;align-items:flex-end;gap:20px;flex-wrap:wrap}
+  .horizon{display:inline-flex;background:var(--surface-2);border:1px solid var(--line);border-radius:8px;padding:3px;gap:2px}
+  .horizon button{font:inherit;font-size:12px;font-weight:600;color:var(--muted);background:none;border:0;
+    padding:6px 12px;border-radius:6px;cursor:pointer}
+  .horizon button[aria-pressed="true"]{background:var(--surface);color:var(--ink);box-shadow:var(--shadow)}
+  .horizon button:focus-visible{outline:2px solid var(--accent);outline-offset:1px}
+
+  nav.crumbs{display:flex;flex-wrap:wrap;align-items:center;gap:2px;margin:22px 0 14px;font-size:13px}
+  nav.crumbs button{font:inherit;background:none;border:0;color:var(--accent);cursor:pointer;padding:3px 5px;border-radius:5px;font-weight:600}
+  nav.crumbs button:last-child{color:var(--ink);cursor:default;font-weight:650}
+  nav.crumbs button:not(:last-child):hover{background:var(--surface-2)}
+  nav.crumbs .sep{color:var(--faint);font-size:12px}
+  nav.crumbs button:focus-visible{outline:2px solid var(--accent);outline-offset:1px}
+
+  .tiles{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:18px}
+  .tile{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:14px 15px;box-shadow:var(--shadow)}
+  .tile .k{font-size:11px;text-transform:uppercase;letter-spacing:.07em;color:var(--faint);font-weight:600;display:flex;gap:6px;align-items:center}
+  .tile .v{font-size:25px;font-weight:600;margin-top:6px}
+  .tile .d{font-size:12px;color:var(--muted);margin-top:3px;display:flex;align-items:center;gap:6px}
+  .pill{display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:700;padding:2px 7px;border-radius:999px;line-height:1.5}
+  .pill svg{width:11px;height:11px}
+  .pill.up{background:var(--good-bg);color:var(--good)}
+  .pill.down{background:var(--bad-bg);color:var(--bad)}
+
+  .panel{background:var(--surface);border:1px solid var(--line);border-radius:12px;box-shadow:var(--shadow);margin-bottom:16px}
+  .panel h2{font-size:12px;text-transform:uppercase;letter-spacing:.07em;color:var(--muted);font-weight:650;
+    margin:0;padding:13px 16px;border-bottom:1px solid var(--line);display:flex;justify-content:space-between;align-items:center}
+  .panel h2 .hint{text-transform:none;letter-spacing:0;color:var(--faint);font-weight:500;font-size:11px}
+
+  table{width:100%;border-collapse:collapse;font-size:13px}
+  thead th{font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--faint);font-weight:600;
+    text-align:right;padding:9px 14px;border-bottom:1px solid var(--line);white-space:nowrap}
+  thead th:first-child{text-align:left}
+  tbody tr{cursor:pointer;transition:background .08s}
+  tbody tr:hover{background:var(--surface-2)}
+  tbody tr:focus-visible{outline:2px solid var(--accent);outline-offset:-2px}
+  tbody td{padding:11px 14px;border-bottom:1px solid var(--grid);text-align:right;vertical-align:middle}
+  tbody td:first-child{text-align:left}
+  tbody tr:last-child td{border-bottom:0}
+  .name{display:flex;align-items:center;gap:9px}
+  .name .chev{color:var(--faint);flex:none}
+  .leaf .chev{visibility:hidden}
+  .name b{font-weight:600}
+  .name .tag{font-size:10.5px;color:var(--faint);text-transform:uppercase;letter-spacing:.05em}
+  .epcell{position:relative;min-width:120px}
+  .epbar{height:6px;border-radius:3px;margin-top:5px;background:var(--pos);opacity:.9}
+  .epbar.n{background:var(--neg)}
+  .raroc{display:inline-flex;flex-direction:column;align-items:flex-end;gap:3px}
+  .rbar-wrap{position:relative;width:88px;height:7px;background:var(--surface-2);border-radius:4px;overflow:visible}
+  .rbar{position:absolute;left:0;top:0;height:100%;border-radius:4px;background:var(--accent)}
+  .hurdle{position:absolute;top:-3px;width:2px;height:13px;background:var(--ink);opacity:.55;border-radius:1px}
+  .bench{font-size:11px;color:var(--muted)}
+
+  .grid2{display:grid;grid-template-columns:1.35fr 1fr;gap:16px}
+  figure{margin:0;padding:14px 16px 18px}
+  .cap{font-size:11px;color:var(--faint);padding:0 16px 14px;margin-top:-4px}
+  svg{display:block;width:100%;height:auto;overflow:visible}
+  .axis{stroke:var(--line)}
+  .gridline{stroke:var(--grid)}
+  .tick{fill:var(--faint);font-size:10px}
+  .wlabel{fill:var(--muted);font-size:10.5px}
+  .wval{font-size:10px;font-weight:600}
+
+  .tooltip{position:fixed;pointer-events:none;z-index:50;background:var(--surface);border:1px solid var(--line);
+    box-shadow:var(--shadow);border-radius:8px;padding:8px 10px;font-size:12px;opacity:0;transition:opacity .1s;max-width:240px}
+  .tooltip .tt-k{color:var(--muted);font-size:10.5px;text-transform:uppercase;letter-spacing:.05em}
+  .tooltip b{font-weight:650}
+  .legend{display:flex;gap:16px;font-size:11.5px;color:var(--muted);padding:0 16px 4px;flex-wrap:wrap}
+  .legend i{width:10px;height:10px;border-radius:2px;display:inline-block;margin-right:5px;vertical-align:-1px}
+  .foot{color:var(--faint);font-size:11.5px;margin-top:22px;line-height:1.6;border-top:1px solid var(--line);padding-top:14px}
+  .foot code{font-family:ui-monospace,monospace;color:var(--muted)}
+  @media (max-width:760px){.tiles{grid-template-columns:repeat(2,1fr)}.grid2{grid-template-columns:1fr}
+    .col-hide{display:none}.wrap{padding:20px 14px 48px}}
+  @media (prefers-reduced-motion:reduce){*{transition:none!important}}
+</style>
+
+<div class="wrap">
+  <div class="topbar">
+    <div>
+      <div class="eyebrow">Value-based management · illustrative</div>
+      <h1>Economic Profit &amp; Risk — drilldown</h1>
+      <p class="sub">Economic Profit is additive: it rolls up Transaction → Client → Product → Segment → LOB → Firm, with RAROC measured against the hurdle at every level. Click any row to drill in; the variance waterfall shows <em>why</em> EP moved.</p>
+    </div>
+    <div class="horizon" role="group" aria-label="Horizon">
+      <button data-h="actual" aria-pressed="true">Actual (YoY)</button>
+      <button data-h="forecast" aria-pressed="false">Forecast</button>
+    </div>
+  </div>
+
+  <nav class="crumbs" id="crumbs" aria-label="Drilldown path"></nav>
+
+  <div class="tiles" id="tiles"></div>
+
+  <section class="panel">
+    <h2>Drill down — one level below <span id="lvlName"></span> <span class="hint">click a row to descend · RAROC bar vs hurdle marker</span></h2>
+    <div style="overflow-x:auto">
+      <table>
+        <thead><tr>
+          <th>Business</th>
+          <th class="col-hide">Revenue</th>
+          <th>Economic&nbsp;Profit</th>
+          <th>RAROC vs hurdle</th>
+          <th class="col-hide">Econ.&nbsp;capital</th>
+          <th>vs peer</th>
+        </tr></thead>
+        <tbody id="rows"></tbody>
+      </table>
+    </div>
+  </section>
+
+  <div class="grid2">
+    <section class="panel">
+      <h2>EP variance <span class="hint" id="wfScope"></span></h2>
+      <div class="legend">
+        <span><i style="background:var(--pos)"></i>increases EP</span>
+        <span><i style="background:var(--neg)"></i>decreases EP</span>
+        <span><i style="background:var(--accent)"></i>EP level</span>
+      </div>
+      <figure><svg id="waterfall" viewBox="0 0 560 300" role="img" aria-label="Economic Profit variance waterfall"></svg></figure>
+      <p class="cap">P&amp;L drivers (price · volume · cost · productivity) after tax, then balance-sheet drivers adjusted for capital cost.</p>
+    </section>
+
+    <section class="panel">
+      <h2>Economic capital <span class="hint">loss distribution</span></h2>
+      <figure><svg id="loss" viewBox="0 0 440 300" role="img" aria-label="Portfolio loss distribution with expected loss and economic capital"></svg></figure>
+      <p class="cap">EL = PD·LGD·EAD (covered by pricing). Economic capital covers the unexpected-loss tail to the confidence interval.</p>
+    </section>
+  </div>
+
+  <p class="foot">
+    <b>Illustrative data</b>, generated deterministically so children always sum to their parent (EP additivity) — not real portfolio figures.
+    In production this drilldown is driven by governed facts: EP/variance from <code>economic-prophet</code>, risk (PD·LGD·EAD → EL → economic capital → RAROC) from <code>diligence.risk.pack</code> / model&nbsp;#1293, and the peer benchmark from the corporate-intelligence plane — surfaced through <code>dashboard-bff</code>. RAROC status is shown with icon + label, never color alone (colorblind-safe); positive/negative variance uses blue/orange, not red/green.
+  </p>
+</div>
+
+<div class="tooltip" id="tt" role="status" aria-live="polite"></div>
+
+<script>
+(function(){
+  "use strict";
+  // ---- deterministic PRNG (mulberry32) ----
+  function rng(seed){let a=seed>>>0;return function(){a|=0;a=a+0x6D2B79F5|0;let t=Math.imul(a^a>>>15,1|a);t=t+Math.imul(t^t>>>7,61|t)^t;return((t^t>>>14)>>>0)/4294967296;};}
+  function hash(s){let h=2166136261;for(let i=0;i<s.length;i++){h^=s.charCodeAt(i);h=Math.imul(h,16777619);}return h>>>0;}
+
+  const HURDLE=0.12; // cost of capital
+  const LEVELS=["Firm","Line of business","Segment","Product","Client","Transaction"];
+  const TAGS=["firm","LOB","segment","product","client","transaction"];
+  const CHILDREN={
+    "Firm":["Retail Banking","Corporate Banking","Markets & Treasury","Wealth & Asset Mgmt"],
+    "Line of business":["Deposits","Cards","Mortgages","SME Lending","Transaction Banking"],
+    "Segment":["Mass Market","Affluent","Small Business","Mid-Corporate","Institutional"],
+    "Product":["Term Loan","Revolver","FX Forward","Cash Mgmt","Trade Finance"],
+    "Client":["Client A","Client B","Client C","Client D","Client E","Client F"]
+  };
+
+  // Build a node with additive economics. Leaf economics are primitive; parents = sum of children.
+  function makeLeaf(seed){
+    const r=rng(seed);
+    const econCap=0.4+r()*4.2;                 // $bn economic capital
+    const rarocDraw=HURDLE+(r()-0.42)*0.16;    // around hurdle
+    const rar=rarocDraw*econCap;                // risk-adjusted return
+    const ep=rar-HURDLE*econCap;                // EP = RAR - capital charge
+    const el=econCap*(0.18+r()*0.5);            // expected loss ~ f(cap)
+    const revenue=rar+el+econCap*(0.8+r()*1.4); // gross
+    const peer=HURDLE+(r()-0.5)*0.12;           // peer-median RAROC
+    // variance drivers (sum to ΔEP), scaled to node size
+    const s=ep>=0?1:-1, mag=(0.25+r()*0.9)*Math.max(0.15,Math.abs(ep));
+    const dr={price:(r()-0.45)*mag,volume:(r()-0.3)*mag,cost:-(r()*0.8)*mag,productivity:(r()-0.35)*mag,
+              invIncome:(r()-0.4)*mag*0.8,lendCapital:(r()-0.4)*mag,financing:-(r()*0.7)*mag,opAssets:-(r()*0.6)*mag};
+    return {econCap,rar,ep,el,revenue,peer,dr,_leaf:true};
+  }
+  function agg(children){
+    const o={econCap:0,rar:0,ep:0,el:0,revenue:0,dr:{price:0,volume:0,cost:0,productivity:0,invIncome:0,lendCapital:0,financing:0,opAssets:0}};
+    let peerW=0;
+    for(const c of children){o.econCap+=c.econCap;o.rar+=c.rar;o.ep+=c.ep;o.el+=c.el;o.revenue+=c.revenue;
+      peerW+=c.peer*c.econCap;for(const k in o.dr)o.dr[k]+=c.dr[k];}
+    o.peer=peerW/(o.econCap||1);
+    return o;
+  }
+  // node cache keyed by path
+  const cache=new Map();
+  function build(path){
+    const key=path.join("/");
+    if(cache.has(key))return cache.get(key);
+    const depth=path.length-1;                 // 0=Firm
+    const levelName=LEVELS[depth];
+    const node={path:path.slice(),depth,levelName,name:path[path.length-1],children:[]};
+    if(depth>=LEVELS.length-1){                 // Transaction = leaf
+      Object.assign(node,makeLeaf(hash(key)));node.children=null;
+    }else{
+      const names=CHILDREN[levelName]||[];
+      const seedBase=hash(key);
+      const kids=names.map((nm,i)=>build(path.concat(nm)));
+      Object.assign(node,agg(kids.map(k=>economics(k))));
+      node.children=kids;
+    }
+    cache.set(key,node);return node;
+  }
+  function economics(n){return {econCap:n.econCap,rar:n.rar,ep:n.ep,el:n.el,revenue:n.revenue,peer:n.peer,dr:n.dr};}
+  const raroc=n=>n.rar/(n.econCap||1e-9);
+
+  // ---- horizon (forecast tilts drivers upward, widens tail) ----
+  let horizon="actual";
+  function hz(n){
+    if(horizon==="actual")return n;
+    // forward view: modest uplift on P&L, higher capital — non-destructive copy
+    const f={...n,dr:{...n.dr}};
+    f.rar=n.rar*1.06; f.econCap=n.econCap*1.03; f.ep=f.rar-HURDLE*f.econCap;
+    f.el=n.el*1.08; f.revenue=n.revenue*1.05;
+    for(const k in f.dr)f.dr[k]*=1.15;
+    return f;
+  }
+
+  // ---- formatting ----
+  const bn=v=>(v>=0?"":"−")+"$"+Math.abs(v).toFixed(v>=100||v<=-100?0:2)+"bn";
+  const mm=v=>(v>=0?"":"−")+"$"+Math.abs(v*1000).toFixed(0)+"m";
+  const pct=v=>(v*100).toFixed(1)+"%";
+  const money=v=>Math.abs(v)>=1?bn(v):mm(v);
+
+  // ---- state ----
+  let path=["Firm"];
+  const tt=document.getElementById("tt");
+  function showTip(html,x,y){tt.innerHTML=html;tt.style.opacity="1";
+    const r=tt.getBoundingClientRect();let nx=x+14,ny=y+14;
+    if(nx+r.width>innerWidth-8)nx=x-r.width-14; if(ny+r.height>innerHeight-8)ny=y-r.height-14;
+    tt.style.left=nx+"px";tt.style.top=ny+"px";}
+  const hideTip=()=>tt.style.opacity="0";
+
+  function iconUp(){return '<svg viewBox="0 0 12 12"><path d="M6 2 L10 8 L2 8 Z" fill="currentColor"/></svg>';}
+  function iconDown(){return '<svg viewBox="0 0 12 12"><path d="M6 10 L2 4 L10 4 Z" fill="currentColor"/></svg>';}
+
+  function render(){
+    const rawNode=build(path);
+    const node=hz(rawNode);
+    // crumbs
+    const cr=document.getElementById("crumbs");cr.innerHTML="";
+    path.forEach((p,i)=>{
+      if(i)cr.insertAdjacentHTML("beforeend",'<span class="sep">›</span>');
+      const b=document.createElement("button");b.textContent=p;
+      b.onclick=()=>{path=path.slice(0,i+1);render();};
+      cr.appendChild(b);
+    });
+    document.getElementById("lvlName").textContent=node.name;
+    document.getElementById("wfScope").textContent="· "+node.name;
+
+    // tiles
+    const rr=raroc(node), spread=rr-HURDLE, up=rr>=HURDLE;
+    const prevEP=node.ep - Object.values(node.dr).reduce((a,b)=>a+b,0);
+    const dEP=node.ep-prevEP, dpos=dEP>=0;
+    document.getElementById("tiles").innerHTML=`
+      <div class="tile"><div class="k">Economic Profit</div><div class="v num" style="color:var(--accent)">${money(node.ep)}</div>
+        <div class="d">RAR ${money(node.rar)} − capital charge</div></div>
+      <div class="tile"><div class="k">RAROC</div><div class="v num">${pct(rr)}</div>
+        <div class="d"><span class="pill ${up?'up':'down'}">${up?iconUp():iconDown()}${up?'above':'below'} hurdle</span><span class="num">${pct(HURDLE)} hurdle</span></div></div>
+      <div class="tile"><div class="k">Economic capital</div><div class="v num">${money(node.econCap)}</div>
+        <div class="d">EL ${money(node.el)} priced in</div></div>
+      <div class="tile"><div class="k">Δ EP ${horizon==='actual'?'YoY':'vs actual'}</div><div class="v num" style="color:${dpos?'var(--pos)':'var(--neg)'}">${(dpos?'+':'−')}${money(Math.abs(dEP)).replace('−','')}</div>
+        <div class="d">${dpos?'value created':'value destroyed'} this period</div></div>`;
+
+    renderRows(rawNode);
+    renderWaterfall(node);
+    renderLoss(node);
+  }
+
+  function renderRows(rawNode){
+    const tb=document.getElementById("rows");tb.innerHTML="";
+    if(!rawNode.children){tb.innerHTML='<tr class="leaf"><td colspan="6" style="color:var(--muted)">Transaction level — the most granular unit. Nothing further to drill.</td></tr>';return;}
+    const kids=rawNode.children.map(k=>({raw:k,n:hz(economics(k)),name:k.name,leaf:!k.children}));
+    const maxEP=Math.max(...kids.map(k=>Math.abs(k.n.ep)),0.01);
+    const maxRR=Math.max(...kids.map(k=>raroc(k.n)),HURDLE)*1.15;
+    kids.sort((a,b)=>b.n.ep-a.n.ep);
+    kids.forEach(k=>{
+      const rr=raroc(k.n),up=rr>=HURDLE,ep=k.n.ep;
+      const tr=document.createElement("tr");tr.tabIndex=0;if(k.leaf)tr.className="leaf";
+      const dPeer=rr-k.n.peer;
+      tr.innerHTML=`
+        <td><span class="name"><span class="chev">${k.leaf?'':'▸'}</span><b>${k.name}</b><span class="tag">${TAGS[k.raw.depth]}</span></span></td>
+        <td class="col-hide num">${money(k.n.revenue)}</td>
+        <td class="epcell"><span class="num">${money(ep)}</span><div class="epbar ${ep<0?'n':''}" style="width:${Math.max(4,Math.abs(ep)/maxEP*100)}%"></div></td>
+        <td><span class="raroc"><span class="num">${pct(rr)}</span>
+          <span class="rbar-wrap"><span class="rbar" style="width:${Math.min(100,rr/maxRR*100)}%;background:${up?'var(--good)':'var(--bad)'}"></span>
+          <span class="hurdle" style="left:${Math.min(100,HURDLE/maxRR*100)}%"></span></span></span></td>
+        <td class="col-hide num">${money(k.n.econCap)}</td>
+        <td><span class="pill ${dPeer>=0?'up':'down'}">${dPeer>=0?iconUp():iconDown()}${(dPeer>=0?'+':'−')}${Math.abs(dPeer*100).toFixed(1)}pp</span></td>`;
+      if(!k.leaf){tr.onclick=()=>{path=path.concat(k.name);render();};
+        tr.onkeydown=e=>{if(e.key==="Enter"||e.key===" "){e.preventDefault();path=path.concat(k.name);render();}};}
+      tr.addEventListener("mousemove",e=>showTip(
+        `<div class="tt-k">${k.name}</div><b>EP ${money(ep)}</b> · RAROC ${pct(rr)}<br>
+         <span class="tt-k">econ capital</span> ${money(k.n.econCap)} · <span class="tt-k">EL</span> ${money(k.n.el)}<br>
+         <span class="tt-k">peer median RAROC</span> ${pct(k.n.peer)} (${dPeer>=0?'ahead':'behind'} ${Math.abs(dPeer*100).toFixed(1)}pp)${k.leaf?'':'<br><span class="tt-k">click to drill →</span>'}`,e.clientX,e.clientY));
+      tr.addEventListener("mouseleave",hideTip);
+      tb.appendChild(tr);
+    });
+  }
+
+  function renderWaterfall(node){
+    const svg=document.getElementById("waterfall");const W=560,H=300,padL=44,padR=12,padB=64,padT=14;
+    const order=[["Price","price"],["Volume","volume"],["Cost","cost"],["Productivity","productivity"],
+                 ["Invest.","invIncome"],["Lending","lendCapital"],["Financing","financing"],["Op. assets","opAssets"]];
+    const start=node.ep-Object.values(node.dr).reduce((a,b)=>a+b,0);
+    let steps=[{label:"EP₀",v:start,type:"total",cum:start}];let cum=start;
+    order.forEach(([lab,k])=>{const dv=node.dr[k];steps.push({label:lab,v:dv,type:dv>=0?"pos":"neg",from:cum,cum:cum+dv});cum+=dv;});
+    steps.push({label:"EP₁",v:cum,type:"total",cum:cum});
+    const vals=steps.flatMap(s=>[s.cum,s.from||s.cum,0]);
+    let lo=Math.min(...vals),hi=Math.max(...vals);const pad=(hi-lo)*0.15||0.1;lo-=pad;hi+=pad;
+    const x=i=>padL+i*((W-padL-padR)/steps.length)+4;
+    const bw=(W-padL-padR)/steps.length-8;
+    const y=v=>padT+(1-(v-lo)/(hi-lo))*(H-padT-padB);
+    let h='';
+    // zero line + gridlines
+    for(let g=0;g<=4;g++){const gv=lo+(hi-lo)*g/4;const gy=y(gv);
+      h+=`<line class="gridline" x1="${padL}" y1="${gy}" x2="${W-padR}" y2="${gy}"/>`+
+         `<text class="tick" x="${padL-6}" y="${gy+3}" text-anchor="end">${gv.toFixed(1)}</text>`;}
+    if(lo<0&&hi>0)h+=`<line class="axis" x1="${padL}" y1="${y(0)}" x2="${W-padR}" y2="${y(0)}" stroke-width="1.2"/>`;
+    steps.forEach((s,i)=>{
+      const xi=x(i);let top,bot,fill;
+      if(s.type==="total"){top=y(Math.max(0,s.cum));bot=y(Math.min(0,s.cum));fill="var(--accent)";}
+      else{const a=s.from,b=s.cum;top=y(Math.max(a,b));bot=y(Math.min(a,b));fill=s.type==="pos"?"var(--pos)":"var(--neg)";}
+      const hh=Math.max(2,bot-top);
+      h+=`<rect x="${xi}" y="${top}" width="${bw}" height="${hh}" rx="2" fill="${fill}" data-i="${i}" style="cursor:default"/>`;
+      // connector
+      if(i<steps.length-1){const cy=y(s.cum);h+=`<line x1="${xi}" y1="${cy}" x2="${xi+bw+8}" y2="${cy}" stroke="var(--faint)" stroke-dasharray="2 2" stroke-width="1"/>`;}
+      h+=`<text class="wlabel" x="${xi+bw/2}" y="${H-padB+16}" text-anchor="middle" transform="rotate(28 ${xi+bw/2} ${H-padB+16})">${s.label}</text>`;
+      const vy=(s.type==="neg")?bot+12:top-5;
+      h+=`<text class="wval num" x="${xi+bw/2}" y="${vy}" text-anchor="middle" fill="var(--muted)">${s.type==="total"?money(s.cum):(s.v>=0?'+':'−')+money(Math.abs(s.v)).replace('−','')}</text>`;
+    });
+    svg.innerHTML=h;
+    svg.querySelectorAll("rect[data-i]").forEach(r=>{
+      const s=steps[+r.dataset.i];
+      r.addEventListener("mousemove",e=>showTip(`<div class="tt-k">${s.label}</div>`+
+        (s.type==="total"?`<b>${money(s.cum)}</b> economic profit`:`<b>${s.v>=0?'+':'−'}${money(Math.abs(s.v)).replace('−','')}</b> ${s.type==='pos'?'added to':'removed from'} EP<br><span class="tt-k">running EP</span> ${money(s.cum)}`),e.clientX,e.clientY));
+      r.addEventListener("mouseleave",hideTip);
+    });
+  }
+
+  function renderLoss(node){
+    const svg=document.getElementById("loss");const W=440,H=300,padL=10,padR=12,padB=46,padT=14;
+    const el=node.el, ec=node.econCap;                 // EL and economic capital ($bn)
+    const ul=ec;                                        // unexpected loss to CI ≈ econ capital
+    const xmax=el+ul*1.9+0.001;
+    const X=v=>padL+(v/xmax)*(W-padL-padR);
+    const base=H-padB;
+    // lognormal-ish loss density
+    const mu=Math.log(Math.max(0.05,el)), sigma=0.9;
+    const dens=v=>{if(v<=0)return 0;return Math.exp(-Math.pow(Math.log(v)-mu,2)/(2*sigma*sigma))/(v*sigma*Math.sqrt(2*Math.PI));};
+    let peak=0;for(let i=1;i<=240;i++){peak=Math.max(peak,dens(i/240*xmax));}
+    const Y=d=>base-(d/peak)*(H-padT-padB);
+    const varLine=el+ul;                               // VaR ≈ EL + economic capital
+    let path1="",fillTail="M "+X(varLine)+" "+base;
+    for(let i=0;i<=240;i++){const v=i/240*xmax;const px=X(v),py=Y(dens(v));path1+=(i?"L":"M")+px+" "+py+" ";if(v>=varLine)fillTail+=" L "+px+" "+py;}
+    fillTail+=" L "+X(xmax)+" "+base+" Z";
+    let h='';
+    h+=`<line class="axis" x1="${padL}" y1="${base}" x2="${W-padR}" y2="${base}"/>`;
+    // economic-capital tail shade
+    h+=`<path d="${fillTail}" fill="var(--neg)" opacity="0.16"/>`;
+    h+=`<path d="${path1}" fill="none" stroke="var(--ink)" stroke-width="1.6" opacity="0.75"/>`;
+    // EL marker
+    h+=`<line x1="${X(el)}" y1="${padT}" x2="${X(el)}" y2="${base}" stroke="var(--pos)" stroke-width="1.4" stroke-dasharray="4 3"/>`;
+    h+=`<text class="tick" x="${X(el)}" y="${padT+2}" text-anchor="middle" fill="var(--pos)">EL ${money(el)}</text>`;
+    // VaR / econ capital marker
+    h+=`<line x1="${X(varLine)}" y1="${padT}" x2="${X(varLine)}" y2="${base}" stroke="var(--neg)" stroke-width="1.4"/>`;
+    h+=`<text class="tick" x="${X(varLine)}" y="${padT+2}" text-anchor="middle" fill="var(--neg)">VaR</text>`;
+    // econ capital span arrow
+    const ay=base+18;
+    h+=`<line x1="${X(el)}" y1="${ay}" x2="${X(varLine)}" y2="${ay}" stroke="var(--faint)" stroke-width="1"/>`;
+    h+=`<text class="wlabel" x="${(X(el)+X(varLine))/2}" y="${ay+13}" text-anchor="middle">economic capital ${money(ec)} (unexpected loss)</text>`;
+    h+=`<text class="wlabel" x="${padL}" y="${ay+13}" text-anchor="start">expected</text>`;
+    svg.innerHTML=h;
+  }
+
+  // horizon toggle
+  document.querySelectorAll(".horizon button").forEach(b=>{
+    b.onclick=()=>{horizon=b.dataset.h;document.querySelectorAll(".horizon button").forEach(x=>x.setAttribute("aria-pressed",x===b));render();};
+  });
+  render();
+})();
+</script>


### PR DESCRIPTION
The "next wave" of interactive explanatory visualizations for the profit-and-risk domain — Bostock / NYT-mortgage-calculator caliber. Companion to the internal-model register (#1287/#1288), corporate-intelligence plane (#1284), and the drilldown-productionization issue (#1294).

## Live artifacts (review)
- **Thesis (12 modules):** https://claude.ai/code/artifact/0c199100-b77a-4d97-9687-a200705efa73
- **EP/RAROC drilldown:** https://claude.ai/code/artifact/d98023e5-6062-402a-9cd2-1fca4fd06cc4

## What's in it — every risk model & table, made interactive
**Loss:** EL = PD·LGD·EAD calculator · **Vasicek single-factor Monte-Carlo portfolio-loss simulation** (6k economies → EL/VaR/ES/economic-capital/RORAC, live) · risk-measure coherence (σ/VaR/ES/spectral) · EAD race-to-default (LEQ/CCF, revolving vs term) · recovery-by-seniority + PD↔RR association.
**Capital:** regulatory (Basel III stack) vs economic capital · risk-aggregation diversification (summation → var-cov → copula) · EP-variance decomposition.
**Value:** economic-profit waterfall · matched-maturity FTP · DCF life-cycle fade.
**Reference:** credit-model taxonomy (interactive table).

A shared five-lever portfolio (PD/LGD/ρ/EAD/confidence) flows through EL → simulation → measures → capital — one gesture ripples across screens (teach-by-manipulating).

## Discipline
- **Diagram-is-a-witness:** reproducible-from-source HTML/SVG/Canvas; **no captured third-party images/branding** (McKinsey/BIS/OCC = reference only, offline).
- **Real math:** Vasicek WCDR, normal CDF/inverse (Acklam), Monte-Carlo — not hard-coded pictures.
- **Illustrative data, labeled.** Production = witnesses over governed facts (`diligence.risk.pack`/#1293, `economic-prophet` → `ep.variance.decomposed.v0`), surfaced via this `lattice-studio/viz` layer + `dashboard-bff` (#1294).
- **Accessible:** CVD-safe (blue/orange not red/green; status = icon+label); palette validated for CVD + contrast in **both** themes; keyboard focus; reduced-motion; table views on reference modules.

**Reviewer:** want these mounted as routes in the lattice-studio app (served, not just static files), and the Monte-Carlo engine extracted to a shared module so dashboard-bff can call it server-side?