### PR TITLE
feat(lattice): project InferenceGateway board into the cloud model catalog

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/inference_gateway_board.py
+++ b/apps/lattice-studio/src/lattice_studio/inference_gateway_board.py
@@ -1,0 +1,68 @@
+"""Register the InferenceGateway intersection board into the cloud model catalog.
+
+The sovereign model plane is defined once at the intersection seam (sourceos-spec
+`inference-gateway-intersection.md`); this projects that board — foundation models AND
+business-target champions (fraud/churn/credit/AML) — into the prophet-platform / lattice
+model catalog as `model-catalog-entry.v0` entries. Sovereignty is carried in
+`privacy_profile` (sovereign-local / sovereign-both / vendor-cloud) so the cloud catalog,
+notebooks, and leaderboards rank on the same sovereignty-aware board the cockpit surfaces do.
+
+Foundation and business models sit in ONE catalog — the differentiator watsonx.ai /
+SageMaker / Seldon split across separate products.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+_CREATED = "2026-08-03T00:00:00Z"
+
+
+def _entry(model_id: str, provider_id: str, privacy: str, *, modalities: List[str],
+           structured: bool, tool_use: bool, vision: bool = False,
+           latency: str = "mid", cost: str = "mid") -> Dict[str, Any]:
+    return {
+        "model_id": model_id,
+        "provider_id": provider_id,
+        "modalities": modalities,
+        "supports_structured_output": structured,
+        "supports_tool_use": tool_use,
+        "supports_vision": vision,
+        "latency_band": latency,
+        "cost_band": cost,
+        "privacy_profile": privacy,
+        "created_at": _CREATED,
+    }
+
+
+def foundation_entries() -> List[Dict[str, Any]]:
+    return [
+        _entry("claude-opus-4-8", "anthropic", "vendor-cloud",
+               modalities=["text", "vision"], structured=True, tool_use=True, vision=True,
+               latency="low", cost="high"),
+        _entry("llama-3.3-70b", "meta-open-weight", "sovereign-both",
+               modalities=["text"], structured=True, tool_use=True, latency="mid", cost="low"),
+        _entry("deepseek-v3", "deepseek-open-weight", "sovereign-both",
+               modalities=["text"], structured=True, tool_use=True, latency="mid", cost="low"),
+        _entry("gemma-2-9b-it", "google-open-weight", "sovereign-local",
+               modalities=["text"], structured=True, tool_use=False, latency="low", cost="minimal"),
+    ]
+
+
+def business_champion_entries() -> List[Dict[str, Any]]:
+    # Each business target's production champion, as a catalog entry. Champion/challenger
+    # promotion lineage lives in the model-zoo promotion layer; this is the catalog face.
+    return [
+        _entry("gbm-fraud-v4", "socioprophet-fraud", "sovereign-local",
+               modalities=["tabular"], structured=True, tool_use=False, latency="low", cost="low"),
+        _entry("xgb-churn-v7", "socioprophet-churn", "sovereign-local",
+               modalities=["tabular"], structured=True, tool_use=False, latency="low", cost="low"),
+        _entry("scorecard-v12", "socioprophet-credit", "sovereign-local",
+               modalities=["tabular"], structured=True, tool_use=False, latency="low", cost="low"),
+        _entry("rules-gbm-aml-v3", "socioprophet-aml", "sovereign-local",
+               modalities=["tabular", "graph"], structured=True, tool_use=False, latency="low", cost="low"),
+    ]
+
+
+def board_catalog_entries() -> List[Dict[str, Any]]:
+    """The full intersection board projected as cloud catalog entries."""
+    return foundation_entries() + business_champion_entries()

--- a/apps/lattice-studio/tests/test_inference_gateway_board.py
+++ b/apps/lattice-studio/tests/test_inference_gateway_board.py
@@ -1,0 +1,63 @@
+"""The InferenceGateway board projects into the cloud catalog, schema-conformant.
+
+Validates against the real contracts/crystal-atlas/schemas/model-catalog-entry.v0.schema.json
+(no external dep — the schema is strict: additionalProperties=false), and asserts the
+sovereignty encoding that makes the board rank sovereignty-aware.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lattice_studio.inference_gateway_board import (
+    board_catalog_entries, foundation_entries, business_champion_entries,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCHEMA = json.loads((REPO_ROOT / "contracts" / "crystal-atlas" / "schemas"
+                     / "model-catalog-entry.v0.schema.json").read_text())
+
+_TYPES = {"string": str, "boolean": bool, "array": list, "number": (int, float), "object": dict}
+
+
+def _validate(entry: dict) -> list[str]:
+    errs = []
+    for k in SCHEMA.get("required", []):
+        if k not in entry:
+            errs.append(f"missing required {k}")
+    if SCHEMA.get("additionalProperties") is False:
+        for k in entry:
+            if k not in SCHEMA["properties"]:
+                errs.append(f"additional property {k}")
+    for k, v in entry.items():
+        spec = SCHEMA["properties"].get(k)
+        if spec and spec.get("type") in _TYPES and not isinstance(v, _TYPES[spec["type"]]):
+            errs.append(f"{k} wrong type")
+    return errs
+
+
+def test_every_board_entry_conforms_to_model_catalog_entry_v0():
+    for e in board_catalog_entries():
+        assert _validate(e) == [], f"{e['model_id']}: {_validate(e)}"
+
+
+def test_board_unites_foundation_and_business_models():
+    ids = {e["model_id"] for e in board_catalog_entries()}
+    assert "claude-opus-4-8" in ids           # foundation (vendor)
+    assert "llama-3.3-70b" in ids             # foundation (open-weight, intersection)
+    assert "gbm-fraud-v4" in ids              # business champion
+    assert len(board_catalog_entries()) == len(foundation_entries()) + len(business_champion_entries())
+
+
+def test_sovereignty_is_encoded_and_honest():
+    by = {e["model_id"]: e["privacy_profile"] for e in board_catalog_entries()}
+    assert by["claude-opus-4-8"] == "vendor-cloud"        # not client-owned — honest
+    assert by["gemma-2-9b-it"] == "sovereign-local"       # fully local
+    assert by["llama-3.3-70b"] == "sovereign-both"        # the client-owned intersection
+    # every business model is client-owned/sovereign
+    for e in business_champion_entries():
+        assert e["privacy_profile"].startswith("sovereign")
+
+
+def test_no_business_champion_claims_vendor_lock():
+    assert all(e["privacy_profile"] != "vendor-cloud" for e in business_champion_entries())


### PR DESCRIPTION
The **cloud fan-out** of the model-plane intersection (sourceos-spec `inference-gateway-intersection.md`). Projects the board into the prophet-platform / lattice model catalog so the cloud catalog, notebooks, and leaderboards read the same board as the cockpit surfaces.

- `apps/lattice-studio/src/lattice_studio/inference_gateway_board.py` — foundation models **and** business-target champions (fraud/churn/credit/AML) as `model-catalog-entry.v0` entries; sovereignty carried in `privacy_profile` (`sovereign-local` / `sovereign-both` / `vendor-cloud`). **One catalog for foundation + business models** — the differentiator watsonx.ai / SageMaker / Seldon split across separate products.
- 4 tests: strict schema conformance (`additionalProperties:false`) + honest sovereignty (Claude=vendor-cloud, open-weight & business models=sovereign; no business champion claims vendor-lock).

Verified: 4 pytest pass against the real `contracts/crystal-atlas/schemas/model-catalog-entry.v0.schema.json`.