### PR TITLE
feat(dashboard-bff): governed /v1/risk/portfolio-facts endpoint + viz hydration (#1294)

### DIFF
--- a/apps/dashboard-bff/contracts.py
+++ b/apps/dashboard-bff/contracts.py
@@ -100,3 +100,24 @@ class VdtResponse(BaseModel):
     epistemic_status: dict
     provenance: dict
     headline: str
+
+
+class RiskFactView(BaseModel):
+    """One governed risk / EP / inflation fact with its trust provenance, so the UI can badge
+    'reproduced by us' vs 'reconstructed methodology' rather than presenting all numbers as equal."""
+    name: str
+    value: float
+    unit: str
+    source_trust_class: str
+    reproduced_by_us: bool
+    reconstructed: bool = False
+
+
+class RiskEpFactsResponse(BaseModel):
+    """Governed portfolio risk / economic-profit / alternative-inflation facts for the credit-risk
+    visualization thesis. Risk/EP facts are reproduced from economic-prophet's model; the
+    alternative-inflation facts are reconstructed (vendor series proprietary) and flagged as such."""
+    service: str
+    portfolio_id: str
+    facts: list[RiskFactView]
+    provenance: dict

--- a/apps/dashboard-bff/data/risk_ep_portfolio.json
+++ b/apps/dashboard-bff/data/risk_ep_portfolio.json
@@ -1,0 +1,10 @@
+{
+  "portfolio_id": "wave1-illustrative",
+  "pd": 0.02, "lgd": 0.45, "ead": 100.0, "rho": 0.15, "confidence": 0.999,
+  "revenue": 7.5, "expenses": 2.0, "funding_cost": 2.8, "funding_credits": 1.2,
+  "tax_rate": 0.25, "margin_income": 4.5,
+  "recovery_surface": {"seniority": 0.6, "collateral_quality": 0.5, "jurisdiction_score": 0.6,
+    "macro_regime": "base", "liquidity_regime": "normal", "workout_horizon_days": 540, "market_state_price": 0.5},
+  "official_cpi": 0.031, "nominal_rate": 0.055,
+  "_comment": "Governed input the risk/EP/inflation producer reads. Illustrative until a real feed is wired; replace with diligence.risk.pack + economic-prophet outputs."
+}

--- a/apps/dashboard-bff/main.py
+++ b/apps/dashboard-bff/main.py
@@ -37,6 +37,8 @@ _gyg_locations_producer = _load_module(ROOT / 'tools' / 'emit_gyg_locations.py',
 _company_financials = _load_module(ROOT / 'tools' / 'emit_company_financials.py', 'emit_company_financials')
 _studio = _load_module(ROOT / 'tools' / 'emit_studio_valuation.py', 'emit_studio_valuation')
 _governance_test = _load_module(ROOT / 'tools' / 'emit_governance_test.py', 'emit_governance_test')
+_risk_ep = _load_module(ROOT / 'tools' / 'emit_risk_ep_facts.py', 'emit_risk_ep_facts')
+RiskEpFactsResponse = _contracts.RiskEpFactsResponse
 
 app = FastAPI(title='dashboard-bff')
 
@@ -59,6 +61,14 @@ def overview() -> object:
         trace_required=True,
         evidence_required=True,
     )
+
+
+@app.get('/v1/risk/portfolio-facts', response_model=RiskEpFactsResponse)
+def risk_portfolio_facts() -> object:
+    """Governed portfolio risk / EP / alternative-inflation facts for the credit-risk viz thesis.
+    Risk/EP mirror economic-prophet's model (reproduced_by_us); inflation is reconstructed (vendor
+    series proprietary) and flagged, so the UI badges provenance rather than treating all as equal."""
+    return RiskEpFactsResponse(**_risk_ep.emit())
 
 
 def _fact_view(fact: dict):

--- a/apps/lattice-studio/viz/credit-risk-thesis.html
+++ b/apps/lattice-studio/viz/credit-risk-thesis.html
@@ -697,5 +697,14 @@ const RENDER={"m-el":m_el,"m-sim":m_sim,"m-measures":m_measures,"m-capital":m_ca
 function render(){railLabels();(RENDER[active]||(()=>{}))();}
 document.getElementById("foot").innerHTML=`<b>Illustrative data</b>, computed live from the models on this page — not real portfolio figures. In production these views are witnesses over governed facts: PD·LGD·EAD and the loss tail from <code>diligence.risk.pack</code> / internal-model #1293, EP &amp; variance from <code>economic-prophet</code>, surfaced through <code>lattice-studio</code> / <code>dashboard-bff</code>. Truthful, reproducible-from-source — no captured third-party images or branding. Colorblind-safe throughout: blue/orange not red/green, status shown with icon + label.`;
 go("m-el");
+// Governed-data hydration: when served next to dashboard-bff, fetch real facts and badge them.
+// In the CSP-locked artifact this fetch simply fails and the page stays on illustrative defaults.
+(function(){try{fetch('/v1/risk/portfolio-facts').then(r=>r.ok?r.json():null).then(d=>{
+  if(!d||!d.facts)return;const g={};d.facts.forEach(f=>g[f.name]=f.value);
+  if(g.pd!=null)S.pd=+(g.pd*100).toFixed(1);if(g.lgd!=null)S.lgd=Math.round(g.lgd*100);if(g.ead!=null)S.ead=Math.round(g.ead);
+  const b=document.createElement('div');b.textContent='● governed data — dashboard-bff';
+  b.style.cssText='position:fixed;bottom:10px;right:12px;z-index:80;font:600 11px ui-sans-serif;color:var(--good);background:var(--good-bg);border:1px solid var(--line);padding:4px 10px;border-radius:999px';
+  document.body.appendChild(b);ranges.forEach(k=>{const el=document.getElementById(k);if(el)el.value=S[k];});render();
+}).catch(function(){});}catch(e){}})();
 })();
 </script>

--- a/tests/platform_stubs/test_risk_ep_facts.py
+++ b/tests/platform_stubs/test_risk_ep_facts.py
@@ -1,0 +1,63 @@
+"""Teeth for the governed risk/EP/inflation producer + the dashboard-bff endpoint."""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, ROOT / "tools" / f"{name}.py")
+    m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m); return m
+
+
+emit = _load("emit_risk_ep_facts").emit
+
+
+def _val(out, name):
+    return next(f["value"] for f in out["facts"] if f["name"] == name)
+
+
+def test_expected_loss_is_pd_lgd_ead():
+    out = emit({"pd": 0.02, "lgd": 0.45, "ead": 100.0, "rho": 0.15, "confidence": 0.999})
+    assert abs(_val(out, "expected_loss") - 0.02 * 0.45 * 100.0) < 1e-9
+
+
+def test_economic_capital_positive_and_var_exceeds_el():
+    out = emit()
+    assert _val(out, "credit_var") > _val(out, "expected_loss")
+    assert _val(out, "economic_capital") > 0
+
+
+def test_recovery_wedge_negative_market_below_planning():
+    out = emit()
+    assert _val(out, "recovery_market_rr_q") < _val(out, "recovery_planning_rr_p")
+    assert _val(out, "recovery_wedge") < 0
+
+
+def test_shadowstats_above_official_and_lowers_real_rate():
+    out = emit()
+    assert _val(out, "shadowstats_inflation") > _val(out, "official_cpi_inflation")
+    assert _val(out, "real_rate_shadowstats") < _val(out, "real_rate_official")
+
+
+def test_provenance_flags_reconstructed_vs_reproduced():
+    out = emit()
+    infl = {f["name"]: f for f in out["facts"] if "inflation" in f["name"] and f["name"] != "official_cpi_inflation"}
+    assert all(f["reconstructed"] and not f["reproduced_by_us"] for f in infl.values())
+    risk = next(f for f in out["facts"] if f["name"] == "economic_capital")
+    assert risk["reproduced_by_us"] and not risk["reconstructed"]
+    assert out["provenance"]["governed"] is True
+
+
+def test_endpoint_returns_governed_facts():
+    testclient = pytest.importorskip("fastapi.testclient")
+    spec = importlib.util.spec_from_file_location("bff_main", ROOT / "apps" / "dashboard-bff" / "main.py")
+    main = importlib.util.module_from_spec(spec); spec.loader.exec_module(main)
+    client = testclient.TestClient(main.app)
+    r = client.get("/v1/risk/portfolio-facts")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["provenance"]["governed"] is True
+    assert any(f["name"] == "expected_loss" for f in body["facts"])

--- a/tools/emit_risk_ep_facts.py
+++ b/tools/emit_risk_ep_facts.py
@@ -1,0 +1,139 @@
+"""Producer: governed portfolio risk / economic-profit / alternative-inflation facts.
+
+Feeds the dashboard-bff `/v1/risk/portfolio-facts` endpoint so the credit-risk visualization thesis
+(apps/lattice-studio/viz) renders over GOVERNED facts instead of its illustrative in-browser
+defaults. The computations mirror `economic-prophet/src/open_ep_framework` exactly — expected loss
+(PD·LGD·EAD), the Vasicek IRB capital formula, the economic-profit identity, the recovery surface
+(planning RR^P / market-implied RR^Q / wedge), and the alternative-inflation reconstructions
+(Billion Prices Project Jevons index, ShadowStats add-backs, Fisher real rate).
+
+Every emitted fact carries its trust provenance, per the estate discipline: risk/EP facts are
+`reproduced_by_us` (we compute them from the governed model); the alternative-inflation facts are
+`reconstructed` (the vendor series are proprietary, the methodology is rebuilt) — so the UI can badge
+them honestly rather than presenting every number as equal. Stdlib only.
+"""
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from statistics import NormalDist
+
+_N = NormalDist()
+_ROOT = Path(__file__).resolve().parents[1]
+_FIXTURE = _ROOT / "apps" / "dashboard-bff" / "data" / "risk_ep_portfolio.json"
+HURDLE = 0.12
+
+# ShadowStats methodology add-backs (pp/yr) — mirrors inflation.MethodologyAddbacks
+_ADDBACKS = {"substitution_geometric_weighting": 0.7, "hedonic_quality_adjustment": 0.5,
+             "owners_equivalent_rent": 0.3, "intervention_analysis": 0.2}
+_MACRO = {"benign": 0.03, "base": 0.0, "stressed": -0.06, "crisis": -0.12}
+_LIQ = {"normal": 0.0, "tight": -0.03, "frozen": -0.08}
+
+
+def _load_portfolio() -> dict:
+    if _FIXTURE.exists():
+        return json.loads(_FIXTURE.read_text())
+    return {}
+
+
+def _vasicek_wcdr(pd: float, rho: float, conf: float) -> float:
+    return _N.cdf((_N.inv_cdf(pd) + math.sqrt(rho) * _N.inv_cdf(conf)) / math.sqrt(1 - rho))
+
+
+def _planning_rr(s: dict) -> float:  # exact port of recovery.planning_recovery
+    b = 0.15 + 0.35 * s["seniority"] + 0.25 * s["collateral_quality"] + 0.15 * s["jurisdiction_score"]
+    b += _MACRO.get(s["macro_regime"], 0.0) + _LIQ.get(s["liquidity_regime"], 0.0)
+    return max(0.0, min(0.95, b - min(s["workout_horizon_days"] / 3650.0, 0.25)))
+
+
+def _market_rr(s: dict) -> float:
+    return max(0.0, min(0.95, _planning_rr(s) - (0.05 + 0.25 * s["market_state_price"])))
+
+
+def _jevons_index(panel: list[dict]) -> tuple[float, float]:
+    idx = 100.0
+    for t in range(1, len(panel)):
+        prev, cur = panel[t - 1], panel[t]
+        m = [k for k in cur if prev.get(k, 0) > 0 and cur[k] > 0]
+        rel = math.exp(sum(math.log(cur[k] / prev[k]) for k in m) / len(m)) if m else 1.0
+        idx *= rel
+    periods = max(1, len(panel) - 1)
+    ann = (idx / 100.0) ** (12.0 / periods) - 1.0
+    return idx, ann
+
+
+def _fact(name, value, unit, trust="reproduced", reconstructed=False):
+    return {"name": name, "value": round(value, 6), "unit": unit,
+            "source_trust_class": "REPRODUCED" if trust == "reproduced" else "RECONSTRUCTED",
+            "reproduced_by_us": trust == "reproduced", "reconstructed": reconstructed}
+
+
+def emit(portfolio: dict | None = None) -> dict:
+    p = portfolio or _load_portfolio()
+    pd = p.get("pd", 0.02); lgd = p.get("lgd", 0.45); ead = p.get("ead", 100.0)
+    rho = p.get("rho", 0.15); conf = p.get("confidence", 0.999)
+
+    el = pd * lgd * ead
+    wcdr = _vasicek_wcdr(pd, rho, conf)
+    var = wcdr * lgd * ead
+    econ_cap = var - el
+    # Expected shortfall: mean WCDR beyond conf
+    steps = [conf + (1 - conf) * i / 40 for i in range(40)]
+    es = (sum(_vasicek_wcdr(pd, rho, min(a, 0.99999)) for a in steps) / len(steps)) * lgd * ead
+    spread = p.get("margin_income", 0.045 * ead)
+    rorac = (spread - el) / econ_cap if econ_cap > 0 else 0.0
+
+    # economic profit
+    rev = p.get("revenue", 0.075 * ead); exp = p.get("expenses", 0.02 * ead)
+    fund = p.get("funding_cost", 0.028 * ead); cred = p.get("funding_credits", 0.012 * ead)
+    tax = (rev - el - exp - fund + cred) * p.get("tax_rate", 0.25)
+    cap_charge = econ_cap * HURDLE
+    ep = rev - el - exp - fund + cred - tax - cap_charge
+
+    surf = p.get("recovery_surface", {"seniority": 0.6, "collateral_quality": 0.5,
+            "jurisdiction_score": 0.6, "macro_regime": "base", "liquidity_regime": "normal",
+            "workout_horizon_days": 540, "market_state_price": 0.5})
+    rr_p, rr_q = _planning_rr(surf), _market_rr(surf)
+
+    # inflation
+    off = p.get("official_cpi", 0.031); nominal = p.get("nominal_rate", 0.055)
+    ss_add = sum(v for k, v in _ADDBACKS.items() if k != "intervention_analysis") / 100.0
+    ss = off + ss_add
+    panel = p.get("online_price_panel") or []
+    if panel:
+        _, bpp = _jevons_index(panel)
+    else:
+        bpp = off + 0.006  # no panel wired -> small default wedge
+    fisher = lambda n, i: (1 + n) / (1 + i) - 1
+
+    facts = [
+        _fact("expected_loss", el, "usd_m"),
+        _fact("pd", pd, "ratio"), _fact("lgd", lgd, "ratio"), _fact("ead", ead, "usd_m"),
+        _fact("credit_var", var, "usd_m"), _fact("expected_shortfall", es, "usd_m"),
+        _fact("economic_capital", econ_cap, "usd_m"), _fact("rorac", rorac, "ratio"),
+        _fact("economic_profit", ep, "usd_m"), _fact("capital_charge", cap_charge, "usd_m"),
+        _fact("recovery_planning_rr_p", rr_p, "ratio"), _fact("recovery_market_rr_q", rr_q, "ratio"),
+        _fact("recovery_wedge", rr_q - rr_p, "ratio"),
+        _fact("official_cpi_inflation", off, "ratio", reconstructed=False),
+        _fact("billion_prices_inflation", bpp, "ratio", trust="reconstructed", reconstructed=True),
+        _fact("shadowstats_inflation", ss, "ratio", trust="reconstructed", reconstructed=True),
+        _fact("real_rate_official", fisher(nominal, off), "ratio"),
+        _fact("real_rate_shadowstats", fisher(nominal, ss), "ratio"),
+    ]
+    return {
+        "service": "dashboard-bff",
+        "portfolio_id": p.get("portfolio_id", "illustrative-default"),
+        "facts": facts,
+        "provenance": {
+            "risk_ep_source": "economic-prophet/open_ep_framework (formulas mirrored)",
+            "inflation_source": "reconstructed — Billion Prices Project & ShadowStats vendor series proprietary",
+            "governed": True,
+            "reproduced_fact_count": sum(1 for f in facts if f["reproduced_by_us"]),
+            "reconstructed_fact_count": sum(1 for f in facts if f["reconstructed"]),
+        },
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(emit(), indent=2))


### PR DESCRIPTION
Closes #1294's core: the credit-risk visualization thesis becomes a **witness over governed facts**, not just illustrative in-browser defaults.

- **Producer** `tools/emit_risk_ep_facts.py` mirrors `economic-prophet/open_ep_framework` — EL=PD·LGD·EAD, Vasicek IRB capital (VaR/ES/economic-capital/RORAC), the EP identity, the recovery surface (RR^P/RR^Q/wedge), and alternative inflation (BPP Jevons / ShadowStats add-backs / Fisher real rate). **18 facts**, each with **trust provenance**: risk/EP are `reproduced_by_us`; inflation is `reconstructed` (vendor series proprietary) and flagged — the UI badges honestly rather than treating all numbers as equal.
- **Endpoint** `GET /v1/risk/portfolio-facts` + `RiskEpFactsResponse` contract + `data/risk_ep_portfolio.json` governed input fixture.
- **Viz hydration:** served next to the bff, the thesis fetches these facts and shows a *● governed data* badge; in the CSP-locked artifact the fetch fails and it stays illustrative — no regression.
- **6 teeth** (EL identity, VaR>EL, recovery wedge<0, ShadowStats>official lowers the real rate, provenance flags, endpoint 200).

Refs #1294, economic-prophet #40. The producer's formulas mirror economic-prophet by hand today; a follow-up can import/vendor the package directly.