### PR TITLE
feat(lattice): sovereignty-aware leaderboard + notebook over the model board

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/inference_gateway_board.py
+++ b/apps/lattice-studio/src/lattice_studio/inference_gateway_board.py
@@ -1,0 +1,68 @@
+"""Register the InferenceGateway intersection board into the cloud model catalog.
+
+The sovereign model plane is defined once at the intersection seam (sourceos-spec
+`inference-gateway-intersection.md`); this projects that board — foundation models AND
+business-target champions (fraud/churn/credit/AML) — into the prophet-platform / lattice
+model catalog as `model-catalog-entry.v0` entries. Sovereignty is carried in
+`privacy_profile` (sovereign-local / sovereign-both / vendor-cloud) so the cloud catalog,
+notebooks, and leaderboards rank on the same sovereignty-aware board the cockpit surfaces do.
+
+Foundation and business models sit in ONE catalog — the differentiator watsonx.ai /
+SageMaker / Seldon split across separate products.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+_CREATED = "2026-08-03T00:00:00Z"
+
+
+def _entry(model_id: str, provider_id: str, privacy: str, *, modalities: List[str],
+           structured: bool, tool_use: bool, vision: bool = False,
+           latency: str = "mid", cost: str = "mid") -> Dict[str, Any]:
+    return {
+        "model_id": model_id,
+        "provider_id": provider_id,
+        "modalities": modalities,
+        "supports_structured_output": structured,
+        "supports_tool_use": tool_use,
+        "supports_vision": vision,
+        "latency_band": latency,
+        "cost_band": cost,
+        "privacy_profile": privacy,
+        "created_at": _CREATED,
+    }
+
+
+def foundation_entries() -> List[Dict[str, Any]]:
+    return [
+        _entry("claude-opus-4-8", "anthropic", "vendor-cloud",
+               modalities=["text", "vision"], structured=True, tool_use=True, vision=True,
+               latency="low", cost="high"),
+        _entry("llama-3.3-70b", "meta-open-weight", "sovereign-both",
+               modalities=["text"], structured=True, tool_use=True, latency="mid", cost="low"),
+        _entry("deepseek-v3", "deepseek-open-weight", "sovereign-both",
+               modalities=["text"], structured=True, tool_use=True, latency="mid", cost="low"),
+        _entry("gemma-2-9b-it", "google-open-weight", "sovereign-local",
+               modalities=["text"], structured=True, tool_use=False, latency="low", cost="minimal"),
+    ]
+
+
+def business_champion_entries() -> List[Dict[str, Any]]:
+    # Each business target's production champion, as a catalog entry. Champion/challenger
+    # promotion lineage lives in the model-zoo promotion layer; this is the catalog face.
+    return [
+        _entry("gbm-fraud-v4", "socioprophet-fraud", "sovereign-local",
+               modalities=["tabular"], structured=True, tool_use=False, latency="low", cost="low"),
+        _entry("xgb-churn-v7", "socioprophet-churn", "sovereign-local",
+               modalities=["tabular"], structured=True, tool_use=False, latency="low", cost="low"),
+        _entry("scorecard-v12", "socioprophet-credit", "sovereign-local",
+               modalities=["tabular"], structured=True, tool_use=False, latency="low", cost="low"),
+        _entry("rules-gbm-aml-v3", "socioprophet-aml", "sovereign-local",
+               modalities=["tabular", "graph"], structured=True, tool_use=False, latency="low", cost="low"),
+    ]
+
+
+def board_catalog_entries() -> List[Dict[str, Any]]:
+    """The full intersection board projected as cloud catalog entries."""
+    return foundation_entries() + business_champion_entries()

--- a/apps/lattice-studio/src/lattice_studio/inference_gateway_leaderboard.py
+++ b/apps/lattice-studio/src/lattice_studio/inference_gateway_leaderboard.py
@@ -1,0 +1,51 @@
+"""Sovereignty-aware leaderboard + notebook fixture over the InferenceGateway board.
+
+Ranks the cloud catalog entries the same way the cockpit surface does — not on raw
+capability but on **sovereignty and locality** (privacy_profile) plus the latency/cost
+bands the catalog entry already carries. This is the cloud lattice face of the board:
+one leaderboard across foundation + business models, cloud ∩ local, ranked by the thesis.
+No new fields are invented — scoring reads only `model-catalog-entry.v0` properties.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from lattice_studio.inference_gateway_board import board_catalog_entries
+
+_SOV = {"sovereign-local": 3.0, "sovereign-both": 3.0, "vendor-cloud": 1.0}
+_LAT = {"low": 1.0, "mid": 0.5, "high": 0.0}
+_COST = {"minimal": 1.0, "low": 0.5, "mid": 0.0, "high": -0.5}
+
+
+def score(entry: Dict[str, Any]) -> float:
+    return round(
+        _SOV.get(entry.get("privacy_profile"), 0.0)
+        + _LAT.get(entry.get("latency_band"), 0.0)
+        + _COST.get(entry.get("cost_band"), 0.0),
+        2,
+    )
+
+
+def leaderboard() -> List[Dict[str, Any]]:
+    ranked = sorted(board_catalog_entries(), key=score, reverse=True)
+    return [
+        {"rank": i + 1, "model_id": e["model_id"], "provider_id": e["provider_id"],
+         "privacy_profile": e["privacy_profile"], "score": score(e)}
+        for i, e in enumerate(ranked)
+    ]
+
+
+def notebook_fixture() -> Dict[str, Any]:
+    """A lattice notebook artifact rendering the board — kind-tagged like the model-zoo fixtures."""
+    entries = board_catalog_entries()
+    mix: Dict[str, int] = {}
+    for e in entries:
+        mix[e["privacy_profile"]] = mix.get(e["privacy_profile"], 0) + 1
+    return {
+        "kind": "ModelBoardNotebook",
+        "generatedBy": "lattice_studio.inference_gateway_leaderboard",
+        "entryCount": len(entries),
+        "sovereigntyMix": mix,
+        "leaderboard": leaderboard(),
+        "note": "One board across foundation + business models, cloud ∩ local, ranked by sovereignty × locality. Reads the shared InferenceGateway catalog + GatewayCallAudit stream.",
+    }

--- a/apps/lattice-studio/tests/test_inference_gateway_board.py
+++ b/apps/lattice-studio/tests/test_inference_gateway_board.py
@@ -1,0 +1,63 @@
+"""The InferenceGateway board projects into the cloud catalog, schema-conformant.
+
+Validates against the real contracts/crystal-atlas/schemas/model-catalog-entry.v0.schema.json
+(no external dep — the schema is strict: additionalProperties=false), and asserts the
+sovereignty encoding that makes the board rank sovereignty-aware.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from lattice_studio.inference_gateway_board import (
+    board_catalog_entries, foundation_entries, business_champion_entries,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCHEMA = json.loads((REPO_ROOT / "contracts" / "crystal-atlas" / "schemas"
+                     / "model-catalog-entry.v0.schema.json").read_text())
+
+_TYPES = {"string": str, "boolean": bool, "array": list, "number": (int, float), "object": dict}
+
+
+def _validate(entry: dict) -> list[str]:
+    errs = []
+    for k in SCHEMA.get("required", []):
+        if k not in entry:
+            errs.append(f"missing required {k}")
+    if SCHEMA.get("additionalProperties") is False:
+        for k in entry:
+            if k not in SCHEMA["properties"]:
+                errs.append(f"additional property {k}")
+    for k, v in entry.items():
+        spec = SCHEMA["properties"].get(k)
+        if spec and spec.get("type") in _TYPES and not isinstance(v, _TYPES[spec["type"]]):
+            errs.append(f"{k} wrong type")
+    return errs
+
+
+def test_every_board_entry_conforms_to_model_catalog_entry_v0():
+    for e in board_catalog_entries():
+        assert _validate(e) == [], f"{e['model_id']}: {_validate(e)}"
+
+
+def test_board_unites_foundation_and_business_models():
+    ids = {e["model_id"] for e in board_catalog_entries()}
+    assert "claude-opus-4-8" in ids           # foundation (vendor)
+    assert "llama-3.3-70b" in ids             # foundation (open-weight, intersection)
+    assert "gbm-fraud-v4" in ids              # business champion
+    assert len(board_catalog_entries()) == len(foundation_entries()) + len(business_champion_entries())
+
+
+def test_sovereignty_is_encoded_and_honest():
+    by = {e["model_id"]: e["privacy_profile"] for e in board_catalog_entries()}
+    assert by["claude-opus-4-8"] == "vendor-cloud"        # not client-owned — honest
+    assert by["gemma-2-9b-it"] == "sovereign-local"       # fully local
+    assert by["llama-3.3-70b"] == "sovereign-both"        # the client-owned intersection
+    # every business model is client-owned/sovereign
+    for e in business_champion_entries():
+        assert e["privacy_profile"].startswith("sovereign")
+
+
+def test_no_business_champion_claims_vendor_lock():
+    assert all(e["privacy_profile"] != "vendor-cloud" for e in business_champion_entries())

--- a/apps/lattice-studio/tests/test_inference_gateway_leaderboard.py
+++ b/apps/lattice-studio/tests/test_inference_gateway_leaderboard.py
@@ -1,0 +1,31 @@
+from lattice_studio.inference_gateway_leaderboard import score, leaderboard, notebook_fixture
+from lattice_studio.inference_gateway_board import board_catalog_entries
+
+
+def test_every_entry_is_scored_and_ranked():
+    lb = leaderboard()
+    assert len(lb) == len(board_catalog_entries())
+    assert [r["rank"] for r in lb] == list(range(1, len(lb) + 1))
+    # ranks are non-increasing by score
+    scores = [r["score"] for r in lb]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_sovereign_outranks_vendor():
+    lb = {r["model_id"]: r for r in leaderboard()}
+    assert lb["gemma-2-9b-it"]["score"] > lb["claude-opus-4-8"]["score"]
+    # the vendor-cloud model is not #1 — the thesis, encoded
+    assert lb["claude-opus-4-8"]["rank"] != 1
+
+
+def test_notebook_fixture_shape():
+    nb = notebook_fixture()
+    assert nb["kind"] == "ModelBoardNotebook"
+    assert nb["entryCount"] == len(board_catalog_entries())
+    assert sum(nb["sovereigntyMix"].values()) == nb["entryCount"]
+    assert nb["leaderboard"][0]["rank"] == 1
+
+
+def test_scoring_reads_only_catalog_fields():
+    # a minimal valid-ish entry still scores without error
+    assert isinstance(score({"privacy_profile": "vendor-cloud", "latency_band": "low", "cost_band": "high"}), float)


### PR DESCRIPTION
Stacked on #1298. The cloud **leaderboard + notebook** face of the intersection board.

- `inference_gateway_leaderboard.py` — `leaderboard()` ranks catalog entries by **sovereignty × locality** (reads only `model-catalog-entry.v0` fields). `notebook_fixture()` renders a kind-tagged `ModelBoardNotebook` — the prophet-lattice notebook screen.
- One leaderboard across foundation **+** business models, cloud ∩ local. **sovereign-local ranks top; Claude (vendor-cloud) last** — the thesis, tested (8 tests).

Stacked on #1298; once that merges this shows only the leaderboard commit.