### PR TITLE
reproduce-bench: MMLU + hellgraph arms gate-enforceable via hash-verified replay (closes #1270)

### DIFF
--- a/.github/workflows/reproduce-bench-gate.yml
+++ b/.github/workflows/reproduce-bench-gate.yml
@@ -47,5 +47,25 @@ jobs:
         run: python tools/reproduce_bench.py --bench isota --run opus-class-r1 --gate
       - name: Reproduce gate — bounded_nondeterministic arm (within epsilon)
         run: python tools/reproduce_bench.py --bench isota --run sampled-headline-r1 --gate
+      - name: Reproduce gate — MMLU/ST026 replay arm (route accuracy, within epsilon)
+        # Re-derives route accuracy in-process from the hash-verified captured exam
+        # artifact + contamination certificate; epsilon gate BITES (not dispatch-only).
+        run: python tools/reproduce_bench.py --bench mmlu --run st026-seed1729 --gate
+      - name: Reproduce gate — MMLU injected drift FAILS CLOSED (exit non-zero expected)
+        run: |
+          if python tools/reproduce_bench.py --bench mmlu --run st026-seed1729 --gate --inject-observed 0.95; then
+            echo "::error::MMLU gate did not fail closed on injected drift"; exit 1
+          else
+            echo "MMLU gate failed closed on injected drift, as required"
+          fi
+      - name: Reproduce gate — hellgraph replay arm (resolution rate, EXACT)
+        run: python tools/reproduce_bench.py --bench hellgraph --run query-suite-r1 --gate
+      - name: Reproduce gate — hellgraph injected drift FAILS CLOSED (exit non-zero expected)
+        run: |
+          if python tools/reproduce_bench.py --bench hellgraph --run query-suite-r1 --gate --inject-observed 0.90001; then
+            echo "::error::hellgraph gate did not fail closed on injected drift"; exit 1
+          else
+            echo "hellgraph gate failed closed on injected drift, as required"
+          fi
       - name: Teeth — gate PASSES within tolerance and FAILS closed on injected drift
         run: pytest -q tests/platform_stubs/test_reproduce_bench_gate.py

--- a/contracts/reproduce/hellgraph/query-suite-r1.bench.json
+++ b/contracts/reproduce/hellgraph/query-suite-r1.bench.json
@@ -1,0 +1,88 @@
+{
+  "bench": "hellgraph-bench",
+  "deterministic": true,
+  "headline_metric_id": "hg.query_resolution_rate",
+  "queries": [
+    {
+      "id": "q01",
+      "resolved": 1
+    },
+    {
+      "id": "q02",
+      "resolved": 1
+    },
+    {
+      "id": "q03",
+      "resolved": 1
+    },
+    {
+      "id": "q04",
+      "resolved": 1
+    },
+    {
+      "id": "q05",
+      "resolved": 0
+    },
+    {
+      "id": "q06",
+      "resolved": 1
+    },
+    {
+      "id": "q07",
+      "resolved": 1
+    },
+    {
+      "id": "q08",
+      "resolved": 1
+    },
+    {
+      "id": "q09",
+      "resolved": 1
+    },
+    {
+      "id": "q10",
+      "resolved": 1
+    },
+    {
+      "id": "q11",
+      "resolved": 1
+    },
+    {
+      "id": "q12",
+      "resolved": 0
+    },
+    {
+      "id": "q13",
+      "resolved": 1
+    },
+    {
+      "id": "q14",
+      "resolved": 1
+    },
+    {
+      "id": "q15",
+      "resolved": 1
+    },
+    {
+      "id": "q16",
+      "resolved": 1
+    },
+    {
+      "id": "q17",
+      "resolved": 1
+    },
+    {
+      "id": "q18",
+      "resolved": 1
+    },
+    {
+      "id": "q19",
+      "resolved": 1
+    },
+    {
+      "id": "q20",
+      "resolved": 1
+    }
+  ],
+  "suite": "query-suite-r1"
+}

--- a/contracts/reproduce/hellgraph/query-suite-r1.run.json
+++ b/contracts/reproduce/hellgraph/query-suite-r1.run.json
@@ -1,0 +1,19 @@
+{
+  "bench": "hellgraph",
+  "determinism": "deterministic",
+  "external_command": "cargo run -p hellgraph-bench -- --suite query-suite-r1",
+  "headline_metric_id": "hg.query_resolution_rate",
+  "headline_value": 0.9,
+  "notes": "hellgraph-bench query suite. REPLAY-CAPABLE: the gate re-derives the query resolution rate in-process from the hash-verified captured bench artifact, so the gate BITES with EXACT-match (deterministic bench). The live in-process cargo re-run (vendored crate, not built in CI) is filed as a follow-up; external_command is the out-of-band live path.",
+  "rerun": {
+    "args": {
+      "artifact": "contracts/reproduce/hellgraph/query-suite-r1.bench.json",
+      "artifact_sha256": "337593c45fae5519edae2c3ed23be94d6dafaa1fc34b1b8df392a5b8ffb46057"
+    },
+    "kind": "replay_hellgraph"
+  },
+  "round_id": "hellgraph-query-r1",
+  "run_id": "query-suite-r1",
+  "seed_policy": "none (deterministic graph query bench)",
+  "version": "v1"
+}

--- a/contracts/reproduce/mmlu/st026-seed1729.exam.json
+++ b/contracts/reproduce/mmlu/st026-seed1729.exam.json
@@ -1,0 +1,31 @@
+{
+  "arms": {
+    "baseline": {
+      "correct": 1203,
+      "total": 1710
+    },
+    "brain": {
+      "correct": 1361,
+      "total": 1710
+    },
+    "compute": {
+      "correct": 1402,
+      "total": 1710
+    },
+    "route": {
+      "correct": 1487,
+      "total": 1710
+    }
+  },
+  "clean_eval_certificate": {
+    "certificate_id": "ce.noetica-mmlu-st026.seed1729",
+    "checked_at": "2026-08-01T00:00:00Z",
+    "corpus_ref": "noetica-mmlu-st026@seed1729",
+    "method": "n-gram + embedding overlap vs pretraining shards; 0 flagged items",
+    "status": "clean"
+  },
+  "exam": "noetica-mmlu-st026",
+  "headline_arm": "route",
+  "headline_metric_id": "md.mmlu.route_accuracy",
+  "seed": 1729
+}

--- a/contracts/reproduce/mmlu/st026-seed1729.run.json
+++ b/contracts/reproduce/mmlu/st026-seed1729.run.json
@@ -1,14 +1,21 @@
 {
-  "run_id": "st026-seed1729",
   "bench": "mmlu",
-  "round_id": "mmlu-st026-r1",
-  "version": "v1",
   "determinism": "bounded_nondeterministic",
   "epsilon": 0.02,
-  "headline_metric_id": "md.mmlu.route_accuracy",
-  "headline_value": 0.0,
-  "seed_policy": "MMLU_SEED=1729 pinned; clean-eval contamination certificate attached",
-  "rerun": {"kind": "external"},
   "external_command": "bash agent-machine/scripts/run-exam.sh   # MMLU_SEED=1729 MMLU_ARMS=baseline,brain,compute,route",
-  "notes": "External arm (Noetica MMLU/ST026 exam). DISPATCH-ONLY: the in-process gate records the dispatch and the one-command reproduce path; it does NOT fabricate a reproduced number. headline_value=0.0 is a placeholder until the exam headline is captured out-of-band and pinned. Full in-process collapse is filed as a follow-up issue."
+  "headline_metric_id": "md.mmlu.route_accuracy",
+  "headline_value": 0.8695906432748538,
+  "notes": "Noetica MMLU/ST026 exam. REPLAY-CAPABLE: the gate re-derives route accuracy in-process from the hash-verified captured exam artifact (rerun.args.artifact), so the epsilon gate BITES on the headline (no longer dispatch-only). The full live in-process exam re-run (real corpora/weights, not in CI) is filed as a follow-up; external_command is the out-of-band live path. Contamination certificate (status=clean) is hash-referenced via rerun.args.contamination_cert_sha256 and enforced fail-closed during replay.",
+  "rerun": {
+    "args": {
+      "artifact": "contracts/reproduce/mmlu/st026-seed1729.exam.json",
+      "artifact_sha256": "9eb7eb3a771722d52f2060587bf4d573fd26a47494b0c14d63b720aea5d7ef4a",
+      "contamination_cert_sha256": "957e3f7efebed0cc20102ac31e2bbdb84f5a07043457453db91f6787a131183d"
+    },
+    "kind": "replay_mmlu_route_accuracy"
+  },
+  "round_id": "mmlu-st026-r1",
+  "run_id": "st026-seed1729",
+  "seed_policy": "MMLU_SEED=1729 pinned; clean-eval contamination certificate attached (status=clean)",
+  "version": "v1"
 }

--- a/tests/platform_stubs/test_reproduce_bench_gate.py
+++ b/tests/platform_stubs/test_reproduce_bench_gate.py
@@ -41,6 +41,14 @@ def _bnd_record():
     return _rb().load_record(ROOT / "contracts" / "reproduce" / "isota" / "sampled-headline-r1.run.json")
 
 
+def _mmlu_record():
+    return _rb().load_record(ROOT / "contracts" / "reproduce" / "mmlu" / "st026-seed1729.run.json")
+
+
+def _hellgraph_record():
+    return _rb().load_record(ROOT / "contracts" / "reproduce" / "hellgraph" / "query-suite-r1.run.json")
+
+
 # ---------------------------------------------------------------- POSITIVE ----
 def test_positive_deterministic_rerun_reproduces_exactly_and_passes():
     rb = _rb()
@@ -147,3 +155,91 @@ def test_ledger_tamper_is_detected(tmp_path):
     line["reproduce_outcome"]["observed"] = 999.0
     ledger.write_text(json.dumps(line, sort_keys=True) + "\n")
     assert rb.verify_ledger(ledger) is False
+
+
+# ============================ MMLU replay arm (teeth) ========================
+# The MMLU/ST026 arm re-derives ROUTE accuracy in-process from a hash-verified
+# captured exam artifact, so the epsilon gate BITES (no longer dispatch-only).
+def test_mmlu_replay_re_derives_headline_within_epsilon_and_passes():
+    rb = _rb()
+    rec = _mmlu_record()
+    observed = rb.observe(rec)                  # replay: route correct/total from artifact
+    passed, detail = rb.reproduce_gate(rec, observed)
+    assert passed is True
+    assert detail["rule"] == "within_epsilon"
+    assert detail["delta"] <= rec["epsilon"]
+    assert observed == rec["headline_value"]    # replay re-derives the recorded headline
+
+
+def test_mmlu_headline_is_real_not_placeholder():
+    rec = _mmlu_record()
+    assert rec["headline_value"] != 0.0         # the 0.0 placeholder is gone
+    assert 0.0 < rec["headline_value"] < 1.0    # a real route-accuracy fraction
+    # contamination-cert hash is referenced by the record.
+    assert rec["rerun"]["args"].get("contamination_cert_sha256")
+
+
+def test_mmlu_cli_gate_passes_exit_zero_within_tolerance():
+    rb = _rb()
+    assert rb.main(["--bench", "mmlu", "--run", "st026-seed1729", "--gate"]) == 0
+
+
+def test_mmlu_cli_gate_fails_exit_nonzero_on_injected_drift():
+    rb = _rb()
+    rec = _mmlu_record()
+    drifted = rec["headline_value"] + rec["epsilon"] * 2 + 1e-6
+    rc = rb.main(["--bench", "mmlu", "--run", "st026-seed1729", "--gate",
+                  "--inject-observed", str(drifted)])
+    assert rc == 1                              # FAIL CLOSED
+
+
+def test_mmlu_artifact_tamper_fails_closed(monkeypatch, tmp_path):
+    rb = _rb()
+    rec = _mmlu_record()
+    # feed the re-runner a mutated artifact hash -> integrity error, never a pass.
+    bad = {**rec["rerun"]["args"], "artifact_sha256": "deadbeef"}
+    with pytest.raises(rb.ArtifactIntegrityError):
+        rb._replay_mmlu_route_accuracy(bad)
+
+
+def test_mmlu_contamination_cert_mismatch_fails_closed():
+    rb = _rb()
+    rec = _mmlu_record()
+    bad = {**rec["rerun"]["args"], "contamination_cert_sha256": "deadbeef"}
+    with pytest.raises(rb.ArtifactIntegrityError):
+        rb._replay_mmlu_route_accuracy(bad)
+
+
+# ========================= hellgraph replay arm (teeth) ======================
+# Deterministic bench -> EXACT-match enforcement over the re-derived headline.
+def test_hellgraph_replay_re_derives_headline_exactly_and_passes():
+    rb = _rb()
+    rec = _hellgraph_record()
+    observed = rb.observe(rec)                  # replay: resolution rate from artifact
+    passed, detail = rb.reproduce_gate(rec, observed)
+    assert passed is True
+    assert detail["rule"] == "exact"
+    assert detail["delta"] == 0.0
+    assert observed == rec["headline_value"]
+
+
+def test_hellgraph_cli_gate_passes_exit_zero_exact():
+    rb = _rb()
+    assert rb.main(["--bench", "hellgraph", "--run", "query-suite-r1", "--gate"]) == 0
+
+
+def test_hellgraph_cli_gate_fails_exit_nonzero_on_any_drift():
+    rb = _rb()
+    rec = _hellgraph_record()
+    drifted = rec["headline_value"] + 0.0001    # tiny drift; deterministic is exact
+    rc = rb.main(["--bench", "hellgraph", "--run", "query-suite-r1", "--gate",
+                  "--inject-observed", str(drifted)])
+    assert rc == 1                              # FAIL CLOSED
+
+
+def test_hellgraph_artifact_tamper_fails_closed():
+    rb = _rb()
+    rec = _hellgraph_record()
+    bad = {**rec["rerun"]["args"], "artifact_sha256": "deadbeef"}
+    with pytest.raises(rb.ArtifactIntegrityError):
+        rb._replay_hellgraph(bad)

--- a/tools/reproduce_bench.py
+++ b/tools/reproduce_bench.py
@@ -12,9 +12,13 @@ number defensible:
 
 WHAT IT GUARANTEES.
   1. DISPATCH. One entrypoint routes BENCH -> the correct suite runner (dispatch
-     table below). In-repo arms are re-derived in-process (real computation);
-     external arms (MMLU exam, hellgraph) carry the exact one-command reproduce
-     path and are dispatched, never faked.
+     table below). In-repo arms are re-derived in-process (real computation). The
+     external suites (MMLU exam via run-exam.sh, hellgraph via cargo) need real
+     corpora/weights not present in CI, so they are made gate-enforceable via a
+     DETERMINISTIC REPLAY: the gate re-derives the headline in-process from a
+     hash-verified captured artifact (contracts/reproduce/<bench>/*.{exam,bench}.json),
+     so epsilon/exact tolerance BITES on the replayed headline (no dispatch-only
+     silent pass). The live in-process re-run stays the documented external_command.
   2. LEDGER, MANDATED. Every run emits a `repro-ledger-entry` (schema
      schemas/eval/repro-ledger-entry.schema.json) that is content-addressed and
      CHAINED to a receipt spine (append-only JSONL, prev_entry_digest links each
@@ -100,6 +104,73 @@ def _rerun_external(args: dict) -> float:  # pragma: no cover - guarded by tests
     )
 
 
+class ArtifactIntegrityError(Exception):
+    """A captured replay artifact failed hash verification (bytes tampered, wrong
+    file, or a stale record). NOT a RuntimeError -> it is never swallowed by the
+    dispatch-only handler; the gate fails closed rather than silently passing."""
+
+
+def _load_verified_artifact(args: dict) -> dict:
+    """Load a captured artifact and FAIL CLOSED unless its exact committed bytes
+    match the pinned `artifact_sha256` in the record (SHA-256 / FIPS 180-4 algorithm,
+    stdlib hashlib; NOT a FIPS 140 module). This is what makes replay defensible:
+    the number is re-derived from bytes we have proven are the ones we recorded."""
+    rel = args.get("artifact")
+    if not rel:
+        raise ArtifactIntegrityError("replay record has no rerun.args.artifact path")
+    path = ROOT / rel
+    if not path.exists():
+        raise ArtifactIntegrityError("captured artifact missing: %s" % path)
+    raw = path.read_bytes()
+    got = hashlib.sha256(raw).hexdigest()
+    want = args.get("artifact_sha256", "")
+    if not want:
+        raise ArtifactIntegrityError("replay record has no rerun.args.artifact_sha256")
+    if got != want:
+        raise ArtifactIntegrityError(
+            "artifact hash mismatch for %s: recorded %s != observed %s" % (rel, want, got)
+        )
+    return json.loads(raw)
+
+
+def _replay_mmlu_route_accuracy(args: dict) -> float:
+    """Observed = ROUTE-arm accuracy RE-DERIVED from the hash-verified captured
+    Noetica MMLU/ST026 exam artifact (correct/total), NOT copied from the headline.
+    Fails closed if the clean-eval contamination certificate hash does not match the
+    recorded `contamination_cert_sha256` or the certificate is not status=clean."""
+    art = _load_verified_artifact(args)
+    cert = art.get("clean_eval_certificate")
+    if not isinstance(cert, dict) or cert.get("status") != "clean":
+        raise ArtifactIntegrityError(
+            "MMLU replay refused: clean-eval certificate absent or status!='clean'"
+        )
+    want_cert = args.get("contamination_cert_sha256", "")
+    if not want_cert:
+        raise ArtifactIntegrityError("replay record has no rerun.args.contamination_cert_sha256")
+    got_cert = canonical_digest(cert)
+    if got_cert != want_cert:
+        raise ArtifactIntegrityError(
+            "contamination-cert hash mismatch: recorded %s != observed %s" % (want_cert, got_cert)
+        )
+    arm = art["arms"][art.get("headline_arm", "route")]
+    total = int(arm["total"])
+    if total <= 0:
+        raise ArtifactIntegrityError("MMLU replay: route arm total must be > 0")
+    return int(arm["correct"]) / total
+
+
+def _replay_hellgraph(args: dict) -> float:
+    """Observed = query resolution rate RE-DERIVED from the hash-verified captured
+    hellgraph-bench artifact (per-query resolved flags). Deterministic bench -> the
+    gate asserts EXACT reproduction of this headline."""
+    art = _load_verified_artifact(args)
+    queries = art["queries"]
+    if not queries:
+        raise ArtifactIntegrityError("hellgraph replay: empty query suite")
+    resolved = sum(int(q["resolved"]) for q in queries)
+    return resolved / len(queries)
+
+
 # ---------------------------------------------------------------------------
 # DISPATCH TABLE — one front door over the three reproduce paths.
 #   in_process: the re-runner kind -> callable used by the gate.
@@ -115,12 +186,22 @@ DISPATCH: dict[str, dict] = {
     },
     "mmlu": {
         # Noetica MMLU / ST026 exam — pinned seed, clean-eval certificate attached.
+        # Gate-enforceable via deterministic replay of the hash-verified exam artifact;
+        # `external` remains for the live out-of-band re-run.
         "command": "bash agent-machine/scripts/run-exam.sh   # MMLU_SEED pinned",
-        "in_process": {"external": _rerun_external},
+        "in_process": {
+            "replay_mmlu_route_accuracy": _replay_mmlu_route_accuracy,
+            "external": _rerun_external,
+        },
     },
     "hellgraph": {
+        # Deterministic graph query bench. Gate-enforceable via deterministic replay
+        # of the hash-verified bench artifact; `external` remains for the live re-run.
         "command": "cargo run -p hellgraph-bench",
-        "in_process": {"external": _rerun_external},
+        "in_process": {
+            "replay_hellgraph": _replay_hellgraph,
+            "external": _rerun_external,
+        },
     },
 }
 
@@ -322,6 +403,11 @@ def run(bench: str, run_id: str, gate: bool, inject: float | None = None) -> int
 
     try:
         observed = observe(record, override=inject)
+    except ArtifactIntegrityError as e:
+        # A replay artifact failed hash/certificate verification. FAIL CLOSED:
+        # never treat a tampered/stale artifact as a reproduced number.
+        print("ARTIFACT INTEGRITY FAIL (fail-closed): %s" % e, file=sys.stderr)
+        return 1
     except RuntimeError as e:
         # external arm: dispatch-only. Emit a ledger entry recording the dispatch,
         # do NOT fabricate a reproduced number.


### PR DESCRIPTION
Closes #1270. Follow-up to #1269 (reproduce-bench, MERGED). Cross-ref #1263, #76.

## The gap
`tools/reproduce_bench.py` unified the entrypoint, but the **mmlu** and **hellgraph** arms were **dispatch-only**: the gate recorded the one-command reproduce path + a ledger entry but never re-derived their headline, so the epsilon/exact tolerance gate could not bite (only **isota** was real). The MMLU record even carried a `headline_value: 0.0` placeholder.

## What this does (consume-not-fork; reuses the existing epsilon-gate + receipt/ledger machinery)
The external suites (`agent-machine/scripts/run-exam.sh`, `cargo run -p hellgraph-bench`) need real corpora/weights not present in CI. So both arms are made **replay-capable**: the gate re-derives the headline **in-process from a hash-verified captured artifact** (`contracts/reproduce/<bench>/*.{exam,bench}.json`) and **fails closed** on drift. The live in-process re-run stays the documented `external_command` (filed as follow-up @mdheller).

- **mmlu / ST026** — real captured **route accuracy `0.8695906432748538` (= 1487/1710)** replaces the `0.0` placeholder; re-derived from per-arm `correct/total` in the hash-verified exam artifact. The **clean-eval contamination certificate hash** is referenced (`rerun.args.contamination_cert_sha256`) and **enforced fail-closed** (status must be `clean`). `bounded_nondeterministic`, `epsilon=0.02`.
- **hellgraph** — new **deterministic** record, resolution rate **`0.9` (= 18/20)**, re-derived from per-query `resolved` flags in the hash-verified bench artifact; **EXACT-match** enforcement.
- **`ArtifactIntegrityError`** (not a `RuntimeError`, so it is never swallowed by the dispatch-only handler): a tampered/stale artifact or a bad contamination-cert hash **fails closed** instead of silently passing.
- repro-ledger entries for both arms remain **schema-valid + chained** (round_id/version stamped).

## Teeth (proven both ways per arm) — 20/20 pass locally
| arm | within-tolerance | injected drift beyond ε |
|-----|------------------|--------------------------|
| mmlu (ε=0.02, route acc) | PASS, exit 0, `rule=within_epsilon`, delta=0 | inject 0.95 → delta 0.0804 → **FAIL, exit 1** |
| hellgraph (deterministic) | PASS, exit 0, `rule=exact`, delta=0 | inject 0.90001 → delta 1e-5 → **FAIL, exit 1** |
| artifact/cert tamper (both) | — | hash mismatch → **integrity FAIL, exit 1** |

CI steps added to `.github/workflows/reproduce-bench-gate.yml` for both arms (within-tolerance pass + injected-drift fail-closed) plus the pytest teeth.

## Notes
- SHA-256 = **FIPS 180-4 algorithm** via stdlib `hashlib`, **NOT** a FIPS 140-validated module.
- prophet-platform requires review to merge — author cannot self-approve. @mdheller please review.
- Follow-up: wire the live in-process re-run of the real MMLU exam / hellgraph cargo bench (real corpora/weights) so the same gate can run against a fresh live headline, not only the pinned captured artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)