### PR TITLE
feat(eval): public leaderboard round surface + OAIS preservation vault (#1272)

### DIFF
--- a/.github/workflows/eval-surfaces-gate.yml
+++ b/.github/workflows/eval-surfaces-gate.yml
@@ -1,0 +1,55 @@
+# The two beyond-slice eval surfaces, fired as real controls (#1272):
+#   * the public ranked/tiered LEADERBOARD ROUND surface — a round PUBLISHES only
+#     when every entry's submission passes validate_submission (#1271); a round
+#     with a failed-gate entry is REJECTED. OPEN rounds are flagged non-comparable.
+#   * the OAIS PRESERVATION/CURATION VAULT check — an accepted submission produces
+#     a citable AIP (SHA-256 fixity + preservation metadata + OAI-PMH record); an
+#     AIP missing fixity/metadata, a non-SHA-256 algorithm, tampered content, or a
+#     DIP that doesn't match its AIP is REJECTED.
+# Teeth are proven BOTH ways in the pytest suites. Path-scoped so the gate runs
+# when the surfaces, their schemas, examples, or tests move — a control that never
+# fires is worse than none. SHA-256 here is the FIPS 180-4 algorithm via stdlib
+# hashlib, NOT a FIPS 140-validated module.
+name: eval-surfaces-gate
+
+on:
+  pull_request:
+    paths:
+      - 'tools/publish_leaderboard_round.py'
+      - 'tools/oais_deposition.py'
+      - 'tools/validate_submission.py'
+      - 'schemas/eval/**'
+      - 'tests/platform_stubs/test_publish_leaderboard_round.py'
+      - 'tests/platform_stubs/test_oais_deposition.py'
+      - '.github/workflows/eval-surfaces-gate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'tools/publish_leaderboard_round.py'
+      - 'tools/oais_deposition.py'
+      - 'tools/validate_submission.py'
+      - 'schemas/eval/**'
+      - 'tests/platform_stubs/test_publish_leaderboard_round.py'
+      - 'tests/platform_stubs/test_oais_deposition.py'
+      - '.github/workflows/eval-surfaces-gate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  eval-surfaces:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: python -m pip install --upgrade pip jsonschema rfc3339-validator pytest
+      - name: Leaderboard round — example PUBLISHES
+        run: python tools/publish_leaderboard_round.py schemas/eval/examples/leaderboard-round.closed.example.json
+      - name: OAIS deposition — example ACCEPTED
+        run: python tools/oais_deposition.py verify schemas/eval/examples/oais-deposition.example.json
+      - name: Teeth — surfaces PUBLISH/ACCEPT on valid input and REJECT on a broken gate/fixity
+        run: pytest -q tests/platform_stubs/test_publish_leaderboard_round.py tests/platform_stubs/test_oais_deposition.py

--- a/Makefile
+++ b/Makefile
@@ -655,6 +655,30 @@ validate-recipe-proof:
 			--register tests/platform_stubs/fixtures/crystal-atlas-register.fixture.json && \
 		pytest -q tests/platform_stubs/test_recipe_proof.py
 
+.PHONY: validate-leaderboard-round validate-oais-deposition validate-eval-surfaces
+# The public ranked/tiered leaderboard round surface (#1263 feature 4, #1272): a
+# round is PUBLISHABLE iff every entry's submission passes validate_submission
+# (#1271); a round with a failed-gate entry is REJECTED. Proven both ways.
+# Mirrors .github/workflows/eval-surfaces-gate.yml.
+validate-leaderboard-round:
+	test -d .venv-tools || python3 -m venv .venv-tools
+	. .venv-tools/bin/activate && python -m pip install --upgrade pip jsonschema rfc3339-validator pytest >/dev/null && \
+		python tools/publish_leaderboard_round.py schemas/eval/examples/leaderboard-round.closed.example.json && \
+		pytest -q tests/platform_stubs/test_publish_leaderboard_round.py
+
+# The OAIS preservation/curation vault check (#1263 feature 9, #1272): an accepted
+# submission produces a citable AIP (SHA-256 fixity + preservation metadata +
+# OAI-PMH record); an AIP missing fixity/metadata, a non-SHA-256 algorithm, a
+# tampered content digest, or a DIP that does not match its AIP is REJECTED.
+# SHA-256 is the FIPS 180-4 algorithm via stdlib hashlib, NOT a FIPS 140 module.
+validate-oais-deposition:
+	test -d .venv-tools || python3 -m venv .venv-tools
+	. .venv-tools/bin/activate && python -m pip install --upgrade pip jsonschema rfc3339-validator pytest >/dev/null && \
+		python tools/oais_deposition.py verify schemas/eval/examples/oais-deposition.example.json && \
+		pytest -q tests/platform_stubs/test_oais_deposition.py
+
+validate-eval-surfaces: validate-leaderboard-round validate-oais-deposition
+
 .PHONY: canary-slo-gate-check
 # Fail-closed Argo Rollouts SLO gates: an empty Prometheus series must ABORT a
 # canary, not promote it ("no data" != "healthy"). tools/check_canary_slo_gate.py

--- a/schemas/eval/README.md
+++ b/schemas/eval/README.md
@@ -19,3 +19,11 @@ These schemas are intentionally narrow starter anchors. They let the platform re
 - `judge-descriptor.schema.json` — `JudgeDescriptor`: descriptor for the judge (model, human, or hybrid) used in an eval run
 
 Example payloads for each governance/provenance schema are in the `examples/` subdirectory.
+
+## Submission validity and public surfaces (MLPerf / Zenodo parity)
+
+- `submission.schema.json` + `division-rules.json` — the submission descriptor and the OPEN/CLOSED division rules (#1271). `tools/validate_submission.py` composes the estate gates into ONE pass/fail verdict per division.
+- `leaderboard-round.schema.json` — `LeaderboardRound`: a versioned, ranked-or-tiered public round FOR ONE division (#1272). `tools/publish_leaderboard_round.py` publishes a round only when EVERY entry's submission passes `validate_submission`; OPEN rounds are flagged non-comparable. An entry may reference a `RecipeProof` (#1296) and a DOI (#1267).
+- `oais-deposition.schema.json` — `OaisDeposition`: the OAIS preservation/curation vault package chain SIP→AIP→DIP (#1272). `tools/oais_deposition.py` verifies SHA-256 fixity (FIPS 180-4 algorithm), PREMIS-shaped preservation metadata, an OAI-PMH (`oai_dc`) record, and that the DIP fixity matches the AIP. An accepted submission produces a citable, DOI-ready AIP (#1267).
+
+Examples: `examples/leaderboard-round.closed.example.json`, `examples/oais-deposition.example.json` (+ `examples/oais-content/`). Gate: `make validate-eval-surfaces` / `.github/workflows/eval-surfaces-gate.yml`.

--- a/schemas/eval/examples/leaderboard-round.closed.example.json
+++ b/schemas/eval/examples/leaderboard-round.closed.example.json
@@ -1,0 +1,68 @@
+{
+  "round_id": "sherlock-stage2-2026Q3",
+  "version": "v1",
+  "division": "CLOSED",
+  "comparable": true,
+  "published_at": "2026-08-03T00:00:00Z",
+  "ranking_rule": {
+    "metric_id": "md.isota.tournament_composite",
+    "direction": "higher_is_better",
+    "mode": "ranked"
+  },
+  "entries": [
+    {
+      "entry_id": "e-alpha",
+      "candidate_id": "cand.internal-runner-alpha",
+      "rank": 1,
+      "headline": {"metric_id": "md.isota.tournament_composite", "value": 0.842},
+      "recipe_proof_ref": {"recipe_proof_id": "rp-alpha-r1"},
+      "doi_ref": {"concept_doi": "10.71234/round.sherlock-stage2", "version_doi": "10.71234/round.sherlock-stage2.v1.alpha"},
+      "submission": {
+        "submission_id": "sub-alpha",
+        "division": "CLOSED",
+        "candidate_id": "cand.internal-runner-alpha",
+        "benchmark_contract_id": "bc.sherlock.stage2",
+        "governance": {"api": true, "rate": true, "auth": true, "cost": true, "observability": true},
+        "provider_neutrality": {"scored_by": "internal_runner", "provider_terms_in_scoring": false},
+        "metric_facts": [
+          {"metric_definition_id": "md.isota.tournament_composite", "reproduced_by_us": true,
+           "source_trust_class": "internal_reproduced", "is_headline": true, "trial_count": 30}
+        ],
+        "clean_eval_certificate": {"certificate_id": "ce-alpha", "status": "clean",
+                                    "corpus_ref": "corpus://sherlock", "checked_at": "2026-08-03T00:00:00Z"},
+        "repro_ledger_entry": {"repro_ledger_entry_id": "rl-alpha", "run_id": "run-alpha",
+                                "environment_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                                "methodology_snapshot_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                                "seed_policy": "fixed:1729", "replay_artifact_id": "replay-alpha"},
+        "task_manifest": {"unchanged": true, "declared_deviations": []},
+        "minimum_trial_count": 30
+      }
+    },
+    {
+      "entry_id": "e-beta",
+      "candidate_id": "cand.internal-runner-beta",
+      "rank": 2,
+      "headline": {"metric_id": "md.isota.tournament_composite", "value": 0.791},
+      "submission": {
+        "submission_id": "sub-beta",
+        "division": "CLOSED",
+        "candidate_id": "cand.internal-runner-beta",
+        "benchmark_contract_id": "bc.sherlock.stage2",
+        "governance": {"api": true, "rate": true, "auth": true, "cost": true, "observability": true},
+        "provider_neutrality": {"scored_by": "independent_harness", "provider_terms_in_scoring": false},
+        "metric_facts": [
+          {"metric_definition_id": "md.isota.tournament_composite", "reproduced_by_us": true,
+           "source_trust_class": "internal_reproduced", "is_headline": true, "trial_count": 32}
+        ],
+        "clean_eval_certificate": {"certificate_id": "ce-beta", "status": "clean",
+                                    "corpus_ref": "corpus://sherlock", "checked_at": "2026-08-03T00:00:00Z"},
+        "repro_ledger_entry": {"repro_ledger_entry_id": "rl-beta", "run_id": "run-beta",
+                                "environment_hash": "sha256:ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                                "methodology_snapshot_hash": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+                                "seed_policy": "fixed:1729", "replay_artifact_id": "replay-beta"},
+        "task_manifest": {"unchanged": true, "declared_deviations": []},
+        "minimum_trial_count": 30
+      }
+    }
+  ]
+}

--- a/schemas/eval/examples/oais-content/sherlock-stage2-r1.txt
+++ b/schemas/eval/examples/oais-content/sherlock-stage2-r1.txt
@@ -1,0 +1,2 @@
+SocioProphet benchmark AIP payload — sherlock-stage2 round v1 archival object.
+This file stands in for the immutable, content-addressed bytes preserved in the OAIS AIP.

--- a/schemas/eval/examples/oais-deposition.example.json
+++ b/schemas/eval/examples/oais-deposition.example.json
@@ -1,0 +1,48 @@
+{
+  "deposition_id": "dep-sherlock-stage2-r1",
+  "submission_id": "sub-001",
+  "sip": {
+    "content_locator": "schemas/eval/examples/oais-content/sherlock-stage2-r1.txt",
+    "media_type": "text/plain",
+    "size_bytes": 171,
+    "submitted_at": "2026-08-03T00:00:00Z"
+  },
+  "aip": {
+    "aip_id": "aip-sherlock-stage2-r1",
+    "storage": "zot",
+    "fixity": {
+      "algorithm": "SHA-256",
+      "digest": "0eff070f2cff743f26f5ed856357d2171b272e047101ed1f81b9ee1f5e54d82e"
+    },
+    "preservation_metadata": {
+      "preservation_level": "full",
+      "retention_tier": "permanent",
+      "fixity_check_schedule": "P30D",
+      "format": "text/plain",
+      "created_at": "2026-08-03T00:00:00Z",
+      "provenance": "accepted submission sub-001 (validate_submission VALID, CLOSED); ingested by tools/oais_deposition.py"
+    },
+    "oai_pmh_record": {
+      "identifier": "oai:commons.socioprophet.ai:aip-sherlock-stage2-r1",
+      "datestamp": "2026-08-03T00:00:00Z",
+      "metadata_prefix": "oai_dc",
+      "dc": {
+        "title": "Sherlock Stage-2 CLOSED round v1 — archival object",
+        "creator": ["SocioProphet Knowledge Commons"],
+        "date": "2026-08-03",
+        "identifier": "sha256:0eff070f2cff743f26f5ed856357d2171b272e047101ed1f81b9ee1f5e54d82e",
+        "format": "text/plain",
+        "rights": "internal-commons"
+      }
+    }
+  },
+  "dip": {
+    "dip_id": "dip-sherlock-stage2-r1",
+    "fixity": {
+      "algorithm": "SHA-256",
+      "digest": "0eff070f2cff743f26f5ed856357d2171b272e047101ed1f81b9ee1f5e54d82e"
+    },
+    "access_url": "https://commons.socioprophet.ai/oai?verb=GetRecord&identifier=oai:commons.socioprophet.ai:aip-sherlock-stage2-r1&metadataPrefix=oai_dc",
+    "disseminated_at": "2026-08-03T00:00:00Z"
+  }
+}

--- a/schemas/eval/leaderboard-round.schema.json
+++ b/schemas/eval/leaderboard-round.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schema://eval/leaderboard-round.schema.json",
+  "title": "LeaderboardRound",
+  "description": "A public, versioned, ranked-or-tiered leaderboard round for ONE division (MLPerf-parity versioned rounds; #1263 feature 4, follow-up #1272). A round names its division (OPEN or CLOSED, from schemas/eval/division-rules.json / #1271), a ranking rule, and an ordered set of entries. Each entry embeds the submission descriptor consumed by tools/validate_submission.py (#1271) and its headline metric; a round is PUBLISHABLE iff EVERY entry's submission passes the division's required gates. OPEN rounds are flagged non-comparable. An entry MAY reference a RecipeProof (schema://eval/recipe-proof.schema.json, PR #1296 OPEN — soft reference) and a citable DOI (DataCite concept/version, #1267). This contract does NOT re-implement any gate: publishing runs validate_submission over each entry.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["round_id", "version", "division", "ranking_rule", "entries"],
+  "properties": {
+    "round_id": {"type": "string", "minLength": 1, "description": "Stable round identity (e.g. sherlock-stage2-2026Q3)."},
+    "version": {"type": "string", "minLength": 1, "description": "Round schema/methodology version, e.g. v1. Versioned rounds are the MLPerf-parity requirement."},
+    "division": {"enum": ["OPEN", "CLOSED"], "description": "The single division this round ranks. CLOSED = strict apples-to-apples comparability; OPEN = novel methods, NOT directly comparable (flagged)."},
+    "comparable": {"type": "boolean", "description": "OPTIONAL declared comparability. If present it MUST equal the division's `comparable` flag in division-rules.json (CLOSED=true, OPEN=false); the publisher enforces this."},
+    "published_at": {"type": "string", "description": "RFC3339 publish timestamp. Documentary."},
+    "ranking_rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metric_id", "direction"],
+      "description": "How entries are ordered. The headline metric of every entry MUST be `metric_id`; entries are ranked by `direction` over that value.",
+      "properties": {
+        "metric_id": {"type": "string", "minLength": 1, "description": "The headline metric every entry is ranked on."},
+        "direction": {"enum": ["higher_is_better", "lower_is_better"]},
+        "mode": {"enum": ["ranked", "tiered"], "default": "ranked", "description": "ranked = strict order (rank 1..N); tiered = grouped bands. Both are surfaced per division."}
+      }
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["entry_id", "candidate_id", "headline", "submission"],
+        "properties": {
+          "entry_id": {"type": "string", "minLength": 1},
+          "candidate_id": {"type": "string", "minLength": 1, "description": "The model/system candidate this entry ranks."},
+          "rank": {"type": "integer", "minimum": 1, "description": "OPTIONAL declared rank. When present the publisher verifies it matches the rank it computes from ranking_rule (a declared rank that lies is REJECTED)."},
+          "tier": {"type": "string", "description": "OPTIONAL tier label when ranking_rule.mode is tiered."},
+          "headline": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["metric_id", "value"],
+            "description": "The headline metric this entry is ranked on. metric_id MUST equal ranking_rule.metric_id.",
+            "properties": {
+              "metric_id": {"type": "string", "minLength": 1},
+              "value": {"type": "number"}
+            }
+          },
+          "submission": {
+            "type": "object",
+            "description": "The submission descriptor consumed by tools/validate_submission.py (schema://eval/submission.schema.json). The publisher runs the division gates over THIS descriptor; an entry whose submission fails ANY required gate for the round's division makes the whole round non-publishable.",
+            "required": ["division"],
+            "additionalProperties": true
+          },
+          "recipe_proof_ref": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "OPTIONAL soft reference to a RecipeProof (schema://eval/recipe-proof.schema.json, PR #1296 OPEN). Binds this entry to a portable/reproducible/citable proof; format-checked here, resolution deferred until #1296 lands.",
+            "required": ["recipe_proof_id"],
+            "properties": {
+              "recipe_proof_id": {"type": "string", "minLength": 1},
+              "receipt_ref": {"type": "string", "pattern": "^[0-9a-f]{64}$", "description": "OPTIONAL SHA-256 entry_digest of the repro-ledger receipt the proof binds (FIPS 180-4 algorithm)."}
+            }
+          },
+          "doi_ref": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "OPTIONAL citable identity (DataCite concept/version, #1267). Referenced, not minted here.",
+            "properties": {
+              "concept_doi": {"type": "string", "minLength": 1},
+              "version_doi": {"type": "string", "minLength": 1}
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/eval/oais-deposition.schema.json
+++ b/schemas/eval/oais-deposition.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schema://eval/oais-deposition.schema.json",
+  "title": "OaisDeposition",
+  "description": "An OAIS-model preservation deposition for an accepted benchmark submission (#1263 feature 9, follow-up #1272). Models the OAIS information-package chain: SIP (Submission Information Package, what the depositor hands in) -> AIP (Archival Information Package, what is preserved: fixity + preservation metadata + a harvestable OAI-PMH record) -> DIP (Dissemination Information Package, what is served out). Fixity is SHA-256 (FIPS 180-4 algorithm via stdlib hashlib; NOT a claim of a FIPS 140-validated module). An AIP without fixity or preservation metadata is not archival; a DIP whose fixity does not match its AIP is not a faithful dissemination. tools/oais_deposition.py enforces both. The AIP is DOI-ready: its fixity digest is the content address a DataCite version DOI binds to (#1267).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["deposition_id", "sip", "aip"],
+  "properties": {
+    "deposition_id": {"type": "string", "minLength": 1},
+    "submission_id": {"type": "string", "description": "The accepted submission this deposition preserves (validate_submission verdict was VALID)."},
+    "sip": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["content_locator", "media_type"],
+      "description": "Submission Information Package — the depositor's handoff.",
+      "properties": {
+        "content_locator": {"type": "string", "minLength": 1, "description": "Repo-relative path or storage URI of the deposited bytes (e.g. zot OCI ref or s3://). Fixity is computed over these bytes."},
+        "media_type": {"type": "string", "minLength": 1},
+        "size_bytes": {"type": "integer", "minimum": 0},
+        "submitted_at": {"type": "string", "description": "RFC3339."}
+      }
+    },
+    "aip": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["aip_id", "fixity", "preservation_metadata", "oai_pmh_record"],
+      "description": "Archival Information Package — what is preserved. MUST carry fixity + preservation metadata + a harvestable OAI-PMH record.",
+      "properties": {
+        "aip_id": {"type": "string", "minLength": 1},
+        "storage": {"enum": ["zot", "workspace-minio"], "description": "Content-addressed immutable backing store."},
+        "fixity": {"$ref": "#/$defs/fixity"},
+        "preservation_metadata": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["preservation_level", "retention_tier", "fixity_check_schedule", "format", "created_at"],
+          "description": "PREMIS-shaped preservation metadata. Missing any required key makes the AIP non-archival (REJECTED).",
+          "properties": {
+            "preservation_level": {"enum": ["bit-level", "logical", "full"], "description": "OAIS preservation level."},
+            "retention_tier": {"enum": ["hot", "warm", "cold", "permanent"], "description": "Retention tier driving GC/lifecycle policy."},
+            "fixity_check_schedule": {"type": "string", "minLength": 1, "description": "Cadence of periodic fixity re-verification, e.g. 'P30D' (ISO-8601 duration)."},
+            "format": {"type": "string", "minLength": 1, "description": "Preserved object format / media type."},
+            "created_at": {"type": "string", "minLength": 1, "description": "RFC3339 AIP creation time."},
+            "provenance": {"type": "string", "description": "Preservation provenance note (agent, ingest process)."}
+          }
+        },
+        "oai_pmh_record": {"$ref": "#/$defs/oaiPmhRecord"}
+      }
+    },
+    "dip": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["dip_id", "fixity"],
+      "description": "Dissemination Information Package — what is served. Its fixity MUST match the AIP fixity (algorithm AND digest); otherwise the dissemination is not faithful to the archived object (REJECTED).",
+      "properties": {
+        "dip_id": {"type": "string", "minLength": 1},
+        "fixity": {"$ref": "#/$defs/fixity"},
+        "access_url": {"type": "string", "description": "Where the DIP is served (e.g. the OAI-PMH GetRecord landing / resolver)."},
+        "disseminated_at": {"type": "string"}
+      }
+    },
+    "doi_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "OPTIONAL citable identity minted from the AIP fixity digest (DataCite concept/version, #1267). Referenced, not minted here.",
+      "properties": {
+        "concept_doi": {"type": "string", "minLength": 1},
+        "version_doi": {"type": "string", "minLength": 1}
+      }
+    }
+  },
+  "$defs": {
+    "fixity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "digest"],
+      "description": "A content-integrity check. algorithm is fixed to SHA-256 (FIPS 180-4 algorithm); digest is 64 lowercase hex.",
+      "properties": {
+        "algorithm": {"const": "SHA-256"},
+        "digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+      }
+    },
+    "oaiPmhRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["identifier", "datestamp", "metadata_prefix", "dc"],
+      "description": "An OAI-PMH-shaped record (Open Archives Initiative Protocol for Metadata Harvesting) so the deposition is harvestable. Carries a Dublin Core (oai_dc) payload.",
+      "properties": {
+        "identifier": {"type": "string", "minLength": 1, "description": "OAI identifier, e.g. oai:commons.socioprophet.ai:<aip_id>."},
+        "datestamp": {"type": "string", "minLength": 1, "description": "RFC3339 / UTCdatetime record datestamp."},
+        "metadata_prefix": {"const": "oai_dc", "description": "Dublin Core metadata format."},
+        "dc": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["title", "identifier"],
+          "description": "Dublin Core elements.",
+          "properties": {
+            "title": {"type": "string", "minLength": 1},
+            "creator": {"type": "array", "items": {"type": "string"}},
+            "date": {"type": "string"},
+            "identifier": {"type": "string", "minLength": 1, "description": "Preferably the AIP fixity content address or the DOI once minted."},
+            "format": {"type": "string"},
+            "rights": {"type": "string"}
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/platform_stubs/test_oais_deposition.py
+++ b/tests/platform_stubs/test_oais_deposition.py
@@ -1,0 +1,117 @@
+"""Teeth for oais-deposition — the OAIS preservation/curation vault check (#1272).
+
+Proven BOTH ways (controls that fire):
+  1. a well-formed deposition is ACCEPTED, and its AIP fixity matches the SHA-256
+     of the real committed content bytes (fixity is verified, not asserted);
+  2. an AIP with NO fixity is REJECTED;
+  3. an AIP missing preservation metadata is REJECTED;
+  4. a DIP whose fixity does not match the AIP fixity is REJECTED;
+  5. a non-SHA-256 fixity algorithm is REJECTED;
+  6. content that no longer hashes to the declared digest (tamper) is REJECTED;
+  7. ingest_sip produces a self-consistent, schema-valid, ACCEPTED AIP;
+  8. the committed example validates against the schema.
+"""
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_DIR = ROOT / "schemas" / "eval"
+EXAMPLE = SCHEMA_DIR / "examples" / "oais-deposition.example.json"
+CONTENT = SCHEMA_DIR / "examples" / "oais-content" / "sherlock-stage2-r1.txt"
+
+
+def _mod():
+    path = ROOT / "tools" / "oais_deposition.py"
+    spec = importlib.util.spec_from_file_location("oais_deposition", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _dep() -> dict:
+    return json.loads(EXAMPLE.read_text())
+
+
+# ── TEETH 1: well-formed deposition ACCEPTED, fixity matches real bytes ──
+def test_example_accepted_and_fixity_matches_content():
+    mod = _mod()
+    v = mod.verify_deposition(_dep(), root=ROOT)
+    assert v.accepted is True, v.reasons
+    real = hashlib.sha256(CONTENT.read_bytes()).hexdigest()
+    assert _dep()["aip"]["fixity"]["digest"] == real
+
+
+# ── TEETH 2: AIP with no fixity is REJECTED ──
+def test_missing_aip_fixity_is_rejected():
+    mod = _mod()
+    dep = _dep()
+    del dep["aip"]["fixity"]
+    v = mod.verify_deposition(dep, root=ROOT)
+    assert v.accepted is False and any("fixity" in r for r in v.reasons)
+
+
+# ── TEETH 3: AIP missing preservation metadata is REJECTED ──
+def test_missing_preservation_metadata_is_rejected():
+    mod = _mod()
+    dep = _dep()
+    dep["aip"]["preservation_metadata"].pop("retention_tier")
+    v = mod.verify_deposition(dep, root=ROOT)
+    assert v.accepted is False and any("preservation_metadata" in r for r in v.reasons)
+
+
+# ── TEETH 4: DIP fixity that does not match the AIP fixity is REJECTED ──
+def test_dip_fixity_mismatch_is_rejected():
+    mod = _mod()
+    dep = _dep()
+    dep["dip"]["fixity"]["digest"] = "f" * 64  # valid shape, wrong value
+    v = mod.verify_deposition(dep, root=ROOT)
+    assert v.accepted is False and any("does not match the AIP fixity" in r for r in v.reasons)
+
+
+# ── TEETH 5: non-SHA-256 algorithm is REJECTED ──
+def test_non_sha256_algorithm_is_rejected():
+    mod = _mod()
+    dep = _dep()
+    dep["aip"]["fixity"]["algorithm"] = "MD5"
+    v = mod.verify_deposition(dep, root=ROOT)
+    assert v.accepted is False and any("algorithm" in r for r in v.reasons)
+
+
+# ── TEETH 6: content that no longer hashes to the declared digest is REJECTED ──
+def test_tampered_content_is_rejected():
+    mod = _mod()
+    dep = _dep()
+    # keep a valid-shaped digest that simply does not match the real bytes
+    dep["aip"]["fixity"]["digest"] = "0" * 64
+    dep["dip"]["fixity"]["digest"] = "0" * 64  # keep DIP==AIP so only the content check fires
+    v = mod.verify_deposition(dep, root=ROOT)
+    assert v.accepted is False and any("does not match SIP content bytes" in r for r in v.reasons)
+
+
+# ── TEETH 7: ingest_sip -> self-consistent, ACCEPTED, schema-valid AIP ──
+def test_ingest_roundtrips_and_is_accepted():
+    mod = _mod()
+    content = b"hello preservation vault"
+    dep = mod.ingest_sip(content, aip_id="aip-x", title="unit AIP", media_type="text/plain")
+    assert dep["aip"]["fixity"]["digest"] == hashlib.sha256(content).hexdigest()
+    # inline SIP has no resolvable path, so the byte-check is skipped; structure still ACCEPTED
+    v = mod.verify_deposition(dep, root=ROOT)
+    assert v.accepted is True, v.reasons
+    schema = json.loads((SCHEMA_DIR / "oais-deposition.schema.json").read_text())
+    jsonschema.validate(dep, schema)
+
+
+# ── TEETH 8: committed example validates against the schema ──
+def test_example_validates_against_schema():
+    schema = json.loads((SCHEMA_DIR / "oais-deposition.schema.json").read_text())
+    jsonschema.validate(_dep(), schema)

--- a/tests/platform_stubs/test_oais_deposition.py
+++ b/tests/platform_stubs/test_oais_deposition.py
@@ -98,6 +98,18 @@ def test_tampered_content_is_rejected():
     assert v.accepted is False and any("does not match SIP content bytes" in r for r in v.reasons)
 
 
+# ── TEETH 6b: a content_locator that does not resolve is REJECTED ──
+# Fail-closed: content_locator is contract-required and points in-tree, so a
+# deposition pointing at bytes which are not there leaves the fixity unverifiable
+# and must not silently pass ("no bytes" != "faithful fixity").
+def test_unresolvable_content_locator_is_rejected():
+    mod = _mod()
+    dep = _dep()
+    dep["sip"]["content_locator"] = "schemas/eval/examples/oais-content/does-not-exist.txt"
+    v = mod.verify_deposition(dep, root=ROOT)
+    assert v.accepted is False and any("does not resolve to a file" in r for r in v.reasons)
+
+
 # ── TEETH 7: ingest_sip -> self-consistent, ACCEPTED, schema-valid AIP ──
 def test_ingest_roundtrips_and_is_accepted():
     mod = _mod()

--- a/tests/platform_stubs/test_publish_leaderboard_round.py
+++ b/tests/platform_stubs/test_publish_leaderboard_round.py
@@ -1,0 +1,124 @@
+"""Teeth for publish-leaderboard-round — the public ranked/tiered round surface (#1272).
+
+Proven BOTH ways (controls that fire):
+  1. a round whose every entry passes validate_submission (#1271) PUBLISHES;
+  2. a round containing an entry that FAILS a division gate is REJECTED;
+  3. an OPEN round is flagged NON-comparable, and a declared comparable=true on
+     an OPEN round is REJECTED (the division split is honoured);
+  4. a declared `rank` that lies (disagrees with the ranking rule) is REJECTED;
+  5. an entry whose headline is not the ranking metric is REJECTED;
+  6. an entry whose submission is in the wrong division is REJECTED;
+  7. the round contract + committed example validate against the schema.
+"""
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_DIR = ROOT / "schemas" / "eval"
+EXAMPLE = SCHEMA_DIR / "examples" / "leaderboard-round.closed.example.json"
+
+
+def _mod():
+    path = ROOT / "tools" / "publish_leaderboard_round.py"
+    spec = importlib.util.spec_from_file_location("publish_leaderboard_round", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _round() -> dict:
+    return json.loads(EXAMPLE.read_text())
+
+
+# ── TEETH 1: all-valid round PUBLISHES ──
+def test_all_valid_round_publishes():
+    mod = _mod()
+    v = mod.publish_round(_round())
+    assert v.publishable is True, v.to_dict()
+    assert v.comparable is True  # CLOSED
+    ranked = v.to_dict()["ranked_entries"]
+    assert [e["entry_id"] for e in ranked] == ["e-alpha", "e-beta"]
+    assert [e["rank"] for e in ranked] == [1, 2]
+
+
+# ── TEETH 2: an entry that fails a division gate makes the round NON-publishable ──
+def test_round_with_failed_gate_entry_is_rejected():
+    mod = _mod()
+    rnd = _round()
+    # break the second entry's clean-eval certificate -> fails a CLOSED (and OPEN) gate
+    rnd["entries"][1]["submission"]["clean_eval_certificate"] = None
+    v = mod.publish_round(rnd)
+    assert v.publishable is False
+    bad = [e for e in v.entries if e.entry_id == "e-beta"][0]
+    assert not bad.valid and any("required gates" in r for r in bad.reasons)
+
+
+# ── TEETH 3: OPEN is non-comparable; a lying comparable flag is rejected ──
+def test_open_round_flagged_non_comparable():
+    mod = _mod()
+    rnd = _round()
+    rnd["division"] = "OPEN"
+    for e in rnd["entries"]:
+        e["submission"]["division"] = "OPEN"
+    del rnd["comparable"]
+    v = mod.publish_round(rnd)
+    assert v.publishable is True, v.to_dict()
+    assert v.comparable is False  # OPEN is flagged non-comparable
+
+
+def test_open_round_declaring_comparable_true_is_rejected():
+    mod = _mod()
+    rnd = _round()
+    rnd["division"] = "OPEN"
+    for e in rnd["entries"]:
+        e["submission"]["division"] = "OPEN"
+    rnd["comparable"] = True  # lies: OPEN is never comparable
+    v = mod.publish_round(rnd)
+    assert v.publishable is False
+    assert any("contradicts division" in r for r in v.reasons)
+
+
+# ── TEETH 4: a declared rank that lies is rejected ──
+def test_lying_declared_rank_is_rejected():
+    mod = _mod()
+    rnd = _round()
+    rnd["entries"][0]["rank"] = 2  # alpha has the higher score -> computed rank 1
+    rnd["entries"][1]["rank"] = 1
+    v = mod.publish_round(rnd)
+    assert v.publishable is False
+    assert any("computed rank" in r for e in v.entries for r in e.reasons)
+
+
+# ── TEETH 5: headline metric must be the ranking metric ──
+def test_headline_metric_mismatch_is_rejected():
+    mod = _mod()
+    rnd = _round()
+    rnd["entries"][0]["headline"]["metric_id"] = "md.some.other"
+    v = mod.publish_round(rnd)
+    assert v.publishable is False
+    assert any("ranking metric" in r for e in v.entries for r in e.reasons)
+
+
+# ── TEETH 6: entry submission must be in the round's division ──
+def test_entry_wrong_division_is_rejected():
+    mod = _mod()
+    rnd = _round()
+    rnd["entries"][1]["submission"]["division"] = "OPEN"  # round is CLOSED
+    v = mod.publish_round(rnd)
+    assert v.publishable is False
+    assert any("division" in r for e in v.entries for r in e.reasons)
+
+
+# ── TEETH 7: contract + example validate against the schema ──
+def test_round_validates_against_schema():
+    schema = json.loads((SCHEMA_DIR / "leaderboard-round.schema.json").read_text())
+    jsonschema.validate(_round(), schema)

--- a/tools/oais_deposition.py
+++ b/tools/oais_deposition.py
@@ -12,9 +12,11 @@ content address a DataCite version DOI binds to (#1267).
 
 TEETH — a deposition is ACCEPTED iff:
   1. the AIP fixity is SHA-256 with a 64-hex digest (missing/other -> REJECTED);
-  2. when SIP content bytes are resolvable, the AIP fixity digest MATCHES the
-     SHA-256 of those bytes (tampered content -> REJECTED — fixity is verified,
-     not merely present);
+  2. a PATH-shaped SIP content_locator MUST resolve and the AIP fixity digest
+     MATCHES the SHA-256 of those bytes (tampered content -> REJECTED, and a path
+     locator that does not resolve -> REJECTED — fixity is verified, not merely
+     present; an opaque "(inline:…)" SIP has no in-tree bytes to re-hash and is
+     trusted on its ingest-time fixity);
   3. the AIP carries the required preservation-metadata keys (missing -> REJECTED);
   4. the AIP carries an OAI-PMH-shaped record (missing/wrong prefix -> REJECTED);
   5. if a DIP is present, its fixity MATCHES the AIP fixity exactly
@@ -85,10 +87,15 @@ def verify_deposition(dep: dict, root: Path | None = None) -> DepositionVerdict:
     # 1. AIP fixity shape
     aip_fixity_ok = _check_fixity_shape(aip_fixity, "AIP", reasons)
 
-    # 2. fixity actually verifies the SIP bytes when they are resolvable
+    # 2. fixity actually verifies the SIP bytes. A PATH-shaped content_locator is an
+    #    in-tree object reference and MUST resolve: an asserted-but-absent object
+    #    leaves the fixity unverifiable and fails closed ("no bytes" != "faithful
+    #    fixity"). An opaque/inline SIP (the "(inline:Nb)" sentinel from ingest_sip,
+    #    or any parenthesized handle) carries no in-tree path to re-hash — its fixity
+    #    was computed from the bytes at ingest — so the byte re-check is skipped.
     sip = dep.get("sip") or {}
     locator = sip.get("content_locator")
-    if aip_fixity_ok and locator:
+    if aip_fixity_ok and locator and not locator.startswith("("):
         candidate = (root / locator) if not Path(locator).is_absolute() else Path(locator)
         if candidate.is_file():
             actual = sha256_hex(candidate.read_bytes())
@@ -96,6 +103,10 @@ def verify_deposition(dep: dict, root: Path | None = None) -> DepositionVerdict:
                 reasons.append(
                     f"AIP: fixity digest does not match SIP content bytes "
                     f"(declared {aip_fixity['digest'][:12]}..., actual {actual[:12]}...) — content tampered or wrong")
+        else:
+            reasons.append(
+                f"AIP: SIP content_locator {locator!r} does not resolve to a file "
+                "— fixity is unverifiable (fail-closed)")
 
     # 3. preservation metadata
     pm = aip.get("preservation_metadata") or {}

--- a/tools/oais_deposition.py
+++ b/tools/oais_deposition.py
@@ -1,0 +1,224 @@
+"""oais-deposition — the OAIS preservation/curation vault contract check.
+
+Enforces the OAIS information-package chain for an accepted benchmark
+submission (#1263 feature 9, follow-up #1272):
+
+    SIP (submitted bytes) -> AIP (preserved: fixity + preservation metadata
+    + harvestable OAI-PMH record) -> DIP (disseminated: fixity == AIP fixity).
+
+Fixity is SHA-256 (FIPS 180-4 algorithm via stdlib ``hashlib``; NOT a claim of
+a FIPS 140-validated module). The AIP is DOI-ready: its fixity digest is the
+content address a DataCite version DOI binds to (#1267).
+
+TEETH — a deposition is ACCEPTED iff:
+  1. the AIP fixity is SHA-256 with a 64-hex digest (missing/other -> REJECTED);
+  2. when SIP content bytes are resolvable, the AIP fixity digest MATCHES the
+     SHA-256 of those bytes (tampered content -> REJECTED — fixity is verified,
+     not merely present);
+  3. the AIP carries the required preservation-metadata keys (missing -> REJECTED);
+  4. the AIP carries an OAI-PMH-shaped record (missing/wrong prefix -> REJECTED);
+  5. if a DIP is present, its fixity MATCHES the AIP fixity exactly
+     (mismatch -> REJECTED — an unfaithful dissemination is not archival).
+
+Usage:
+    python tools/oais_deposition.py verify <deposition.json> [--root DIR]
+    python tools/oais_deposition.py ingest <content-file> --aip-id ID [--out FILE]
+    # verify: exit 0 = ACCEPTED, 1 = REJECTED, 2 = malformed
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+
+FIXITY_ALGORITHM = "SHA-256"  # FIPS 180-4 algorithm (hashlib.sha256); NOT a FIPS 140 module.
+REQUIRED_PRESERVATION_KEYS = (
+    "preservation_level", "retention_tier", "fixity_check_schedule", "format", "created_at",
+)
+
+
+def sha256_hex(data: bytes) -> str:
+    """SHA-256 content address (FIPS 180-4 algorithm via stdlib hashlib)."""
+    return hashlib.sha256(data).hexdigest()
+
+
+@dataclass
+class DepositionVerdict:
+    deposition_id: str
+    accepted: bool
+    reasons: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"deposition_id": self.deposition_id, "accepted": self.accepted, "reasons": self.reasons}
+
+
+def _check_fixity_shape(fixity: dict | None, where: str, reasons: list[str]) -> bool:
+    if not fixity:
+        reasons.append(f"{where}: no fixity (an unfixed package is not archival)")
+        return False
+    if fixity.get("algorithm") != FIXITY_ALGORITHM:
+        reasons.append(f"{where}: fixity algorithm {fixity.get('algorithm')!r} != {FIXITY_ALGORITHM!r}")
+        return False
+    digest = fixity.get("digest") or ""
+    if len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest):
+        reasons.append(f"{where}: fixity digest is not 64-hex SHA-256")
+        return False
+    return True
+
+
+def verify_deposition(dep: dict, root: Path | None = None) -> DepositionVerdict:
+    """Verify the OAIS chain. See module docstring for the accept conditions."""
+    root = root or ROOT
+    reasons: list[str] = []
+    v = DepositionVerdict(deposition_id=dep.get("deposition_id", "?"), accepted=False)
+
+    aip = dep.get("aip") or {}
+    aip_fixity = aip.get("fixity")
+
+    # 1. AIP fixity shape
+    aip_fixity_ok = _check_fixity_shape(aip_fixity, "AIP", reasons)
+
+    # 2. fixity actually verifies the SIP bytes when they are resolvable
+    sip = dep.get("sip") or {}
+    locator = sip.get("content_locator")
+    if aip_fixity_ok and locator:
+        candidate = (root / locator) if not Path(locator).is_absolute() else Path(locator)
+        if candidate.is_file():
+            actual = sha256_hex(candidate.read_bytes())
+            if actual != aip_fixity["digest"]:
+                reasons.append(
+                    f"AIP: fixity digest does not match SIP content bytes "
+                    f"(declared {aip_fixity['digest'][:12]}..., actual {actual[:12]}...) — content tampered or wrong")
+
+    # 3. preservation metadata
+    pm = aip.get("preservation_metadata") or {}
+    missing_pm = [k for k in REQUIRED_PRESERVATION_KEYS if not pm.get(k)]
+    if missing_pm:
+        reasons.append(f"AIP: preservation_metadata missing required keys {missing_pm}")
+
+    # 4. OAI-PMH record shape
+    rec = aip.get("oai_pmh_record") or {}
+    if not rec:
+        reasons.append("AIP: no oai_pmh_record (not harvestable)")
+    else:
+        if rec.get("metadata_prefix") != "oai_dc":
+            reasons.append(f"AIP: oai_pmh_record.metadata_prefix {rec.get('metadata_prefix')!r} != 'oai_dc'")
+        for k in ("identifier", "datestamp"):
+            if not rec.get(k):
+                reasons.append(f"AIP: oai_pmh_record missing {k}")
+        dc = rec.get("dc") or {}
+        for k in ("title", "identifier"):
+            if not dc.get(k):
+                reasons.append(f"AIP: oai_pmh_record.dc missing {k}")
+
+    # 5. DIP fixity must match AIP fixity exactly
+    dip = dep.get("dip")
+    if dip:
+        dip_fixity = dip.get("fixity")
+        if _check_fixity_shape(dip_fixity, "DIP", reasons) and aip_fixity_ok:
+            if dip_fixity["algorithm"] != aip_fixity["algorithm"] or dip_fixity["digest"] != aip_fixity["digest"]:
+                reasons.append("DIP: fixity does not match the AIP fixity (unfaithful dissemination)")
+
+    v.reasons = reasons
+    v.accepted = not reasons
+    return v
+
+
+def ingest_sip(content: bytes, *, aip_id: str, title: str, media_type: str = "application/octet-stream",
+               storage: str = "zot", retention_tier: str = "permanent",
+               preservation_level: str = "full", fixity_check_schedule: str = "P30D",
+               creators: list[str] | None = None, content_locator: str = "") -> dict:
+    """Ingest raw SIP bytes -> a schema-valid, self-consistent AIP deposition.
+
+    The AIP fixity is COMPUTED from the actual bytes, and both AIP and (mirror)
+    DIP carry that digest — so an accepted submission produces a citable AIP
+    (the fixity digest is the DataCite content address, #1267).
+    """
+    digest = sha256_hex(content)
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    fixity = {"algorithm": FIXITY_ALGORITHM, "digest": digest}
+    return {
+        "deposition_id": f"dep-{aip_id}",
+        "sip": {
+            "content_locator": content_locator or f"(inline:{len(content)}b)",
+            "media_type": media_type, "size_bytes": len(content), "submitted_at": now,
+        },
+        "aip": {
+            "aip_id": aip_id, "storage": storage, "fixity": fixity,
+            "preservation_metadata": {
+                "preservation_level": preservation_level, "retention_tier": retention_tier,
+                "fixity_check_schedule": fixity_check_schedule, "format": media_type,
+                "created_at": now, "provenance": "tools/oais_deposition.py ingest",
+            },
+            "oai_pmh_record": {
+                "identifier": f"oai:commons.socioprophet.ai:{aip_id}",
+                "datestamp": now, "metadata_prefix": "oai_dc",
+                "dc": {
+                    "title": title, "creator": creators or ["SocioProphet Knowledge Commons"],
+                    "date": now, "identifier": f"sha256:{digest}", "format": media_type,
+                },
+            },
+        },
+        "dip": {
+            "dip_id": f"dip-{aip_id}", "fixity": fixity,
+            "access_url": f"https://commons.socioprophet.ai/oai?verb=GetRecord&identifier=oai:commons.socioprophet.ai:{aip_id}",
+            "disseminated_at": now,
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="OAIS preservation deposition — verify / ingest")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    pv = sub.add_parser("verify", help="verify an OAIS deposition (fixity + preservation + OAI-PMH + DIP match)")
+    pv.add_argument("deposition", type=Path)
+    pv.add_argument("--root", type=Path, default=ROOT, help="root for resolving relative content_locator")
+
+    pi = sub.add_parser("ingest", help="ingest content bytes into a schema-valid AIP deposition")
+    pi.add_argument("content", type=Path)
+    pi.add_argument("--aip-id", required=True)
+    pi.add_argument("--title", default="benchmark deposition")
+    pi.add_argument("--media-type", default="application/octet-stream")
+    pi.add_argument("--out", type=Path, default=None)
+
+    args = ap.parse_args(argv)
+
+    if args.cmd == "ingest":
+        try:
+            content = args.content.read_bytes()
+        except OSError as exc:
+            print(f"cannot read content: {exc}", file=sys.stderr)
+            return 2
+        dep = ingest_sip(content, aip_id=args.aip_id, title=args.title, media_type=args.media_type,
+                         content_locator=str(args.content))
+        out = json.dumps(dep, indent=2)
+        if args.out:
+            args.out.write_text(out)
+        else:
+            print(out)
+        return 0
+
+    # verify
+    try:
+        dep = json.loads(args.deposition.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"malformed deposition: {exc}", file=sys.stderr)
+        return 2
+    verdict = verify_deposition(dep, root=args.root)
+    print(json.dumps(verdict.to_dict(), indent=2))
+    status = "ACCEPTED" if verdict.accepted else "REJECTED"
+    tail = "" if verdict.accepted else " — " + "; ".join(verdict.reasons)
+    print(f"\n{status}: {verdict.deposition_id}{tail}", file=sys.stderr)
+    return 0 if verdict.accepted else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/publish_leaderboard_round.py
+++ b/tools/publish_leaderboard_round.py
@@ -1,0 +1,209 @@
+"""publish-leaderboard-round — the public ranked/tiered leaderboard round surface.
+
+Turns a set of validated submissions into a versioned, ranked-or-tiered
+leaderboard round FOR ONE DIVISION (MLPerf-parity versioned rounds; #1263
+feature 4, follow-up #1272), driven by:
+
+  * schemas/eval/leaderboard-round.schema.json — the round contract;
+  * tools/validate_submission.py + schemas/eval/division-rules.json (#1271) —
+    the SINGLE division-validity verdict. This module does NOT re-implement any
+    gate; it runs validate_submission over every entry's embedded submission.
+
+TEETH — a round is PUBLISHABLE iff, for its division:
+  1. every entry's submission is in the round's division;
+  2. every entry's submission passes validate_submission (all required gates);
+  3. every entry's headline metric IS the ranking_rule metric;
+  4. any declared `rank` matches the rank computed from ranking_rule
+     (a declared rank that lies is REJECTED).
+An OPEN round is published but flagged non-comparable; a declared `comparable`
+that disagrees with the division is REJECTED.
+
+Usage:
+    python tools/publish_leaderboard_round.py <round.json>
+    # exit 0 = PUBLISHED (prints the ranked round), 1 = REJECTED, 2 = malformed
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = ROOT / "schemas" / "eval"
+
+
+def _load_validator():
+    """Load tools/validate_submission.py as a module — the single division verdict (#1271)."""
+    path = ROOT / "tools" / "validate_submission.py"
+    spec = importlib.util.spec_from_file_location("validate_submission", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@dataclass
+class EntryVerdict:
+    entry_id: str
+    candidate_id: str
+    value: float
+    computed_rank: int | None
+    valid: bool
+    reasons: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "entry_id": self.entry_id,
+            "candidate_id": self.candidate_id,
+            "headline_value": self.value,
+            "rank": self.computed_rank,
+            "valid": self.valid,
+            "reasons": self.reasons,
+        }
+
+
+@dataclass
+class RoundVerdict:
+    round_id: str
+    version: str
+    division: str
+    comparable: bool
+    publishable: bool
+    ranking_rule: dict[str, Any]
+    entries: list[EntryVerdict] = field(default_factory=list)
+    reasons: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "round_id": self.round_id,
+            "version": self.version,
+            "division": self.division,
+            "comparable": self.comparable,
+            "publishable": self.publishable,
+            "ranking_rule": self.ranking_rule,
+            "ranked_entries": [e.to_dict() for e in sorted(
+                self.entries, key=lambda e: (e.computed_rank is None, e.computed_rank or 0))],
+            "reasons": self.reasons,
+        }
+
+
+def _rank_entries(entries: list[dict], direction: str) -> dict[str, int]:
+    """Assign 1..N ranks over headline value per direction (ties share the higher rank)."""
+    reverse = direction == "higher_is_better"
+    ordered = sorted(entries, key=lambda e: e["headline"]["value"], reverse=reverse)
+    ranks: dict[str, int] = {}
+    last_value = None
+    last_rank = 0
+    for i, e in enumerate(ordered, start=1):
+        v = e["headline"]["value"]
+        if last_value is not None and v == last_value:
+            ranks[e["entry_id"]] = last_rank  # tie -> same rank
+        else:
+            ranks[e["entry_id"]] = i
+            last_rank = i
+            last_value = v
+    return ranks
+
+
+def publish_round(rnd: dict, rules: dict | None = None, validator=None) -> RoundVerdict:
+    """Compute the round verdict. PUBLISHABLE iff every entry is valid for the division."""
+    validator = validator or _load_validator()
+    rules = rules or validator.load_division_rules()
+
+    division = rnd.get("division")
+    div_spec = (rules.get("divisions") or {}).get(division)
+    if div_spec is None:
+        raise ValueError(f"unknown division {division!r} (expected one of {list((rules.get('divisions') or {}))})")
+    div_comparable = bool(div_spec.get("comparable", False))
+
+    ranking_rule = rnd.get("ranking_rule") or {}
+    metric_id = ranking_rule.get("metric_id")
+    direction = ranking_rule.get("direction")
+
+    verdict = RoundVerdict(
+        round_id=rnd.get("round_id", "?"), version=rnd.get("version", "?"),
+        division=division, comparable=div_comparable, publishable=False,
+        ranking_rule=ranking_rule,
+    )
+
+    # round-level: a declared comparability must match the division's truth
+    if "comparable" in rnd and bool(rnd["comparable"]) != div_comparable:
+        verdict.reasons.append(
+            f"declared comparable={rnd['comparable']} contradicts division {division} (comparable={div_comparable})")
+    if not metric_id or direction not in ("higher_is_better", "lower_is_better"):
+        verdict.reasons.append("ranking_rule requires a metric_id and a valid direction")
+
+    entries = rnd.get("entries") or []
+    if not entries:
+        verdict.reasons.append("a round must have at least one entry")
+
+    computed = _rank_entries(entries, direction) if (entries and direction and metric_id) else {}
+
+    for e in entries:
+        eid = e.get("entry_id", "?")
+        reasons: list[str] = []
+        headline = e.get("headline") or {}
+        value = headline.get("value")
+
+        # entry must be in the round's division
+        sub = e.get("submission") or {}
+        if sub.get("division") != division:
+            reasons.append(f"entry submission division {sub.get('division')!r} != round division {division!r}")
+
+        # headline metric must be the ranking metric
+        if metric_id and headline.get("metric_id") != metric_id:
+            reasons.append(f"headline metric {headline.get('metric_id')!r} != ranking metric {metric_id!r}")
+
+        # the single division verdict (#1271) — no gate re-implemented here
+        try:
+            sub_verdict = validator.validate_submission(sub, rules=rules)
+            if not sub_verdict.valid:
+                reasons.append(f"submission failed required gates: {sub_verdict.failed_gates()}")
+        except ValueError as exc:
+            reasons.append(f"submission invalid: {exc}")
+
+        # a declared rank that lies is rejected
+        crank = computed.get(eid)
+        if "rank" in e and crank is not None and e["rank"] != crank:
+            reasons.append(f"declared rank {e['rank']} != computed rank {crank}")
+
+        verdict.entries.append(EntryVerdict(
+            entry_id=eid, candidate_id=e.get("candidate_id", "?"),
+            value=value if isinstance(value, (int, float)) else float("nan"),
+            computed_rank=crank, valid=not reasons, reasons=reasons,
+        ))
+
+    verdict.publishable = not verdict.reasons and all(en.valid for en in verdict.entries)
+    return verdict
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="publish a ranked/tiered leaderboard round for a division")
+    ap.add_argument("round", type=Path, help="path to a leaderboard-round JSON")
+    args = ap.parse_args(argv)
+    try:
+        rnd = json.loads(args.round.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"malformed round: {exc}", file=sys.stderr)
+        return 2
+    try:
+        verdict = publish_round(rnd)
+    except ValueError as exc:
+        print(f"invalid round: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(verdict.to_dict(), indent=2))
+    status = "PUBLISHED" if verdict.publishable else "REJECTED"
+    tail = "" if verdict.publishable else (
+        " — " + "; ".join(verdict.reasons + [f"{e.entry_id}: {e.reasons}" for e in verdict.entries if not e.valid]))
+    comp = "comparable" if verdict.comparable else "NON-COMPARABLE (OPEN)"
+    print(f"\n{status}: {verdict.round_id}@{verdict.version} [{verdict.division}, {comp}]{tail}", file=sys.stderr)
+    return 0 if verdict.publishable else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes the **buildable slice of #1272** — the two beyond-slice CK/MLCommons-parity gaps left after the #1263 scorecard and PRs #1267 (Lever A, MERGED) / #1271 (Lever B, MERGED). Both are **consume-not-fork**: they WIRE the gates that already exist (the single division verdict from #1271) rather than re-implementing them. Cross-ref: #1263, #1271, #1267, #1296 (RecipeProof — coordinated as a soft ref), #76.

## 1. Public ranked/tiered leaderboard round surface (#1263 feature 4)
- `schemas/eval/leaderboard-round.schema.json` — **LeaderboardRound**: `round_id` + `version`, ONE division (OPEN/CLOSED, from `schemas/eval/division-rules.json`), a ranking rule (`metric_id` + direction, ranked|tiered), and ranked entries. Each entry embeds the submission descriptor consumed by `tools/validate_submission.py`, a headline metric, and OPTIONAL soft refs to a **RecipeProof** (`schema://eval/recipe-proof.schema.json`, #1296 OPEN) and a **DOI** (DataCite concept/version, #1267).
- `tools/publish_leaderboard_round.py` — a round is **PUBLISHABLE iff every entry's submission passes `validate_submission`** for the round's division. No gate is re-implemented. OPEN rounds are flagged **non-comparable**.

## 2. OAIS preservation/curation vault (#1263 feature 9)
- `schemas/eval/oais-deposition.schema.json` — **OaisDeposition**: the OAIS package chain **SIP → AIP → DIP** with **SHA-256 fixity**, **PREMIS-shaped preservation metadata** (preservation level, retention tier, fixity-check schedule), and a harvestable **OAI-PMH (`oai_dc`) record**. The AIP fixity digest is the **DOI-ready content address** (#1267).
- `tools/oais_deposition.py` — `verify` (fail-closed) + `ingest` (content bytes → a citable AIP with computed fixity).

> SHA-256 is the **FIPS 180-4 algorithm** via stdlib `hashlib`, **NOT** a FIPS 140-validated module.

## Teeth (both ways, verified locally — 16 passed)
**Leaderboard:** all-valid round PUBLISHES; a round with an entry that **failed a division gate is REJECTED**; a lying declared `rank`, a headline that isn't the ranking metric, and a wrong-division entry are REJECTED; an OPEN round declaring `comparable=true` is REJECTED.
**OAIS:** deposition ACCEPTED with fixity matching the **real committed content bytes**; an AIP **missing fixity**, **missing preservation metadata**, a **non-SHA-256 algorithm**, **tampered content** (digest≠bytes), or a **DIP not matching its AIP fixity** are all REJECTED.

CI: `.github/workflows/eval-surfaces-gate.yml` (path-scoped); local mirror: `make validate-eval-surfaces`. Self-contained examples committed for both surfaces.

## Filed as follow-ups (deploy/live surfaces, out of this contract slice)
- Live leaderboard round UI (Vue) per division + versioned rounds.
- Deployed OAIS preservation vault: zot/MinIO backing + scheduled fixity job + a real OAI-PMH endpoint; promote `prophet-domain-gaia-curation-vault` from stub.

**prophet-platform requires review to merge** — not auto-merging. @mdheller