### PR TITLE
chore(vendor): refresh open_ep_framework to 4c761fa (lint fixes; byte-faithful)

### DIFF
--- a/third_party/open_ep_framework/VENDOR.md
+++ b/third_party/open_ep_framework/VENDOR.md
@@ -5,7 +5,7 @@ Vendored copy of the estate's economic-profit / risk framework so prophet-platfo
 own dogfood.
 
 - **Upstream:** SocioProphet/economic-prophet — package `open-ep-framework` (`src/open_ep_framework/`)
-- **Commit:** `32281bcb1402946e00d3ff267579141b79e09817`
+- **Commit:** `4c761fa35b3aaf25ad9d8a9a51f7b4f057af776b`
 - **License:** Apache-2.0 — the upstream `LICENSE` is vendored verbatim alongside the source
   (`third_party/open_ep_framework/LICENSE`), as Apache-2.0 §4 requires for redistribution. Estate
   policy is MIT/Apache only; this satisfies it.

--- a/third_party/open_ep_framework/__init__.py
+++ b/third_party/open_ep_framework/__init__.py
@@ -4,7 +4,6 @@ __all__ = [
     "expected_loss",
     "recovery",
     "capital",
-    "pricing",
     "attribution",
     "audit",
     "heller_mesh",

--- a/third_party/open_ep_framework/aggregation_method.py
+++ b/third_party/open_ep_framework/aggregation_method.py
@@ -1,0 +1,311 @@
+"""Aggregation-methodology taxonomy with the tail-dependence guard (AGG-1).
+
+Rolling three risk-type economic capitals (credit / market / operational) into ONE
+number is a MODELLING CHOICE, and the choice determines how much diversification you
+are allowed to claim. This contract makes the choice EXPLICIT, receipted and governed,
+with its stated trade-off and its limitation, and it guards the one failure that
+matters: assuming diversification that evaporates in the tail (the 2008 lesson).
+
+The taxonomy (trade-off / limitation)
+-------------------------------------
+  * summation             -- Sigma EC_i. Conservative super-additive UPPER BOUND;
+                             ignores diversification entirely.
+  * constant_diversification -- Sigma EC_i x (1 - d). Simple; the flat haircut d is
+                             not risk-sensitive and is essentially arbitrary.
+  * variance_covariance   -- sqrt(EC' R EC). Bilateral (linear) correlation; MISSES
+                             non-linearity and tail dependence.
+  * copula                -- joins the marginals with a dependence structure that has
+                             UPPER-TAIL DEPENDENCE; captures the tail, but is hard to
+                             validate (model risk).
+  * full_simulation       -- the full joint loss distribution; flexible, but carries
+                             false-precision risk.
+
+Summation is the conservative bound every other method is measured against.
+
+Consume, do NOT reinvent
+------------------------
+  * ``regulatory_capital.economic_vs_regulatory`` (economic-prophet #42) applies a
+    flat cross-risk diversification benefit -- this contract is the taxonomy that
+    names WHICH aggregation produced that benefit and whether it survives the tail.
+  * ``settlement`` (IC-1, #39) -- the FIPS SHA-256 ``sha256:`` receipt spine.
+  * ``sociosphere:gbrg/governance/omnirisk_allocation.py`` (OMNI-1) -- soft ref; the
+    aggregate EC is the cross-cut total the walker reconciles to per-node contributions.
+
+Deterministic: the copula / full-simulation paths are SEEDED Monte-Carlo (stdlib
+``random``), so CI is reproducible.
+
+Teeth (verdicts)
+----------------
+  * VERIFIED -- the chosen method declares its assumption, records its limitation, and
+        its aggregate is <= summation.
+  * FLAGGED  -- a variance_covariance choice whose aggregate is BELOW a tail-dependent
+        copula / simulation aggregate (it claims diversification that vanishes in the
+        tail -- the 2008 lesson).
+  * REJECTED (raises) --
+        a method whose aggregate EXCEEDS summation (super-additive -- impossible for a
+            legitimate diversification claim);
+        a diversifying method (constant_diversification / variance_covariance / copula /
+            full_simulation) with NO declared correlation / copula / diversification
+            assumption (no silent diversification).
+
+Measurement, simulation and audit only.
+"""
+from __future__ import annotations
+
+import json
+import math
+import random
+from pathlib import Path
+
+from .settlement import _canonical, _sha256
+from .validation import validate_json_file
+
+_SCHEMA = "schemas/aggregation_method.schema.json"
+_TOL = 1e-6
+
+OMNIRISK_WALKER_REF = "sociosphere:gbrg/governance/omnirisk_allocation.py (OMNI-1)"
+REGCAP_REF = "economic-prophet:src/open_ep_framework/regulatory_capital.py#economic_vs_regulatory"
+
+RISK_TYPES = ("credit", "market", "operational")
+DIVERSIFYING_METHODS = frozenset(
+    {"constant_diversification", "variance_covariance", "copula", "full_simulation"}
+)
+_TAIL_DEPENDENT = frozenset({"copula"})
+
+TRADE_OFFS = {
+    "summation": {
+        "trade_off": "conservative super-additive upper bound",
+        "limitation": "ignores diversification entirely",
+    },
+    "constant_diversification": {
+        "trade_off": "single flat diversification haircut",
+        "limitation": "not risk-sensitive; the haircut is arbitrary",
+    },
+    "variance_covariance": {
+        "trade_off": "bilateral (linear) correlation",
+        "limitation": "misses non-linearity and tail dependence",
+    },
+    "copula": {
+        "trade_off": "captures tail dependence",
+        "limitation": "hard to validate (model risk)",
+    },
+    "full_simulation": {
+        "trade_off": "full joint loss distribution",
+        "limitation": "false-precision risk",
+    },
+}
+
+
+class AggregationMethodError(ValueError):
+    """Raised when the aggregation choice violates the taxonomy teeth (REJECTED)."""
+
+
+# --------------------------------------------------------------------------- #
+# analytic methods
+# --------------------------------------------------------------------------- #
+def _correlation_matrix(corr: dict) -> list[list[float]]:
+    cm = float(corr.get("credit_market", 0.0))
+    co = float(corr.get("credit_operational", 0.0))
+    mo = float(corr.get("market_operational", 0.0))
+    return [[1.0, cm, co], [cm, 1.0, mo], [co, mo, 1.0]]
+
+
+def _summation(ec: list[float]) -> float:
+    return sum(ec)
+
+
+def _constant_diversification(ec: list[float], d: float) -> float:
+    return sum(ec) * (1.0 - d)
+
+
+def _variance_covariance(ec: list[float], R: list[list[float]]) -> float:
+    total = 0.0
+    for i in range(len(ec)):
+        for j in range(len(ec)):
+            total += R[i][j] * ec[i] * ec[j]
+    return math.sqrt(max(0.0, total))
+
+
+# --------------------------------------------------------------------------- #
+# simulated methods (seeded, deterministic)
+# --------------------------------------------------------------------------- #
+def _cholesky(R: list[list[float]]) -> list[list[float]]:
+    n = len(R)
+    L = [[0.0] * n for _ in range(n)]
+    for i in range(n):
+        for j in range(i + 1):
+            s = sum(L[i][k] * L[j][k] for k in range(j))
+            if i == j:
+                L[i][j] = math.sqrt(max(1e-12, R[i][i] - s))
+            else:
+                L[i][j] = (R[i][j] - s) / L[j][j]
+    return L
+
+
+def _simulate_aggregate(
+    ec: list[float], R: list[list[float]], confidence: float,
+    *, seed: int, sims: int,
+) -> float:
+    """full_simulation: the `confidence` quantile of the summed joint loss under a
+    Gaussian copula, by seeded Monte-Carlo.
+
+    Lognormal marginals are each calibrated (from a seeded calibration batch) so their own
+    `confidence` quantile equals the standalone ``EC_i``; positions are joined by a
+    Gaussian copula (correlation ``R``). Because the marginals are skewed but light-tailed
+    and the copula has no tail dependence, the simulated aggregate tracks the
+    variance-covariance number -- which is exactly the point: full simulation buys
+    precision, not a different diversification story (false-precision risk). Seeded, so CI
+    is reproducible.
+    """
+    L = _cholesky(R)
+    n = len(ec)
+    sigma = 0.35  # marginal log-volatility (skew without heavy tails)
+
+    def _draw(rng):
+        z = [rng.gauss(0.0, 1.0) for _ in range(n)]
+        corr = [sum(L[i][k] * z[k] for k in range(n)) for i in range(n)]
+        return [math.exp(sigma * c) for c in corr]
+
+    # Per-marginal calibration quantile q_i of exp(sigma * Z_i).
+    cal_rng = random.Random(seed ^ 0x5DEECE66D)
+    cal_cols = [[] for _ in range(n)]
+    for _ in range(sims):
+        d = _draw(cal_rng)
+        for i in range(n):
+            cal_cols[i].append(d[i])
+    q = []
+    for i in range(n):
+        cal_cols[i].sort()
+        q.append(cal_cols[i][min(sims - 1, int(round(confidence * sims)))])
+
+    rng = random.Random(seed)
+    agg = []
+    for _ in range(sims):
+        d = _draw(rng)
+        agg.append(sum(ec[i] * d[i] / q[i] for i in range(n)))
+    agg.sort()
+    return agg[min(len(agg) - 1, int(round(confidence * len(agg))))]
+
+
+# --------------------------------------------------------------------------- #
+# comparison table over all computable methods
+# --------------------------------------------------------------------------- #
+def _compute_methods(ec: list[float], assumption: dict, confidence: float) -> dict:
+    R = _correlation_matrix(assumption["correlation"]) if assumption.get("correlation") else None
+    seed = int(assumption.get("seed", 7))
+    sims = int(assumption.get("sims", 20000))
+
+    methods: dict[str, float] = {"summation": _summation(ec)}
+    if assumption.get("diversification_factor") is not None:
+        methods["constant_diversification"] = _constant_diversification(
+            ec, float(assumption["diversification_factor"])
+        )
+    if R is not None:
+        vc = _variance_covariance(ec, R)
+        methods["variance_covariance"] = vc
+        # full_simulation = seeded Gaussian-copula Monte-Carlo (tracks the sqrt formula).
+        methods["full_simulation"] = _simulate_aggregate(
+            ec, R, confidence, seed=seed, sims=sims
+        )
+        # copula = tail-dependent aggregation: the declared upper-tail dependence lambda
+        # pulls the aggregate from the correlation-diversified number (lambda=0) toward the
+        # comonotone summation bound (lambda=1). Diversification vanishes in the tail.
+        if assumption.get("tail_dependence") is not None or assumption.get("copula_family"):
+            lam = float(assumption.get("tail_dependence", 0.0))
+            lam = min(1.0, max(0.0, lam))
+            methods["copula"] = vc + lam * (methods["summation"] - vc)
+    return methods
+
+
+# --------------------------------------------------------------------------- #
+# contract
+# --------------------------------------------------------------------------- #
+def evaluate_contract(spec: dict) -> dict:
+    contract_id = spec.get("contract_id", "agg")
+    as_of = spec.get("as_of", "")
+    method = spec["chosen_method"]
+    confidence = float(spec.get("confidence", 0.999))
+    assumption = spec.get("assumption") or {}
+    ec = [float(spec["risk_inputs"][t]) for t in RISK_TYPES]
+
+    # Teeth: a diversifying method must declare its assumption (no silent diversification).
+    if method in DIVERSIFYING_METHODS:
+        has_assumption = (
+            (method == "constant_diversification" and assumption.get("diversification_factor") is not None)
+            or (method in ("variance_covariance", "full_simulation") and assumption.get("correlation"))
+            or (method == "copula" and assumption.get("correlation") and (
+                assumption.get("copula_family") or assumption.get("tail_dependence") is not None))
+        )
+        if not has_assumption:
+            raise AggregationMethodError(
+                f"REJECTED: method {method!r} claims diversification but declares no "
+                "correlation / copula / diversification assumption (no silent diversification)"
+            )
+
+    methods = _compute_methods(ec, assumption, confidence)
+    summation = methods["summation"]
+    if method not in methods:
+        raise AggregationMethodError(
+            f"REJECTED: chosen method {method!r} could not be computed from the declared "
+            "assumption (missing correlation/copula parameters)"
+        )
+    chosen_aggregate = methods[method]
+
+    warnings: list[str] = []
+
+    # Teeth: no method may exceed the summation upper bound (super-additive).
+    for name, value in methods.items():
+        if value > summation + _TOL:
+            raise AggregationMethodError(
+                f"REJECTED: method {name!r} aggregate {value} exceeds the summation upper "
+                f"bound {summation}; summation is the conservative super-additive ceiling"
+            )
+
+    # Teeth: variance_covariance understating a tail-dependent method is FLAGGED.
+    flagged = False
+    if method == "variance_covariance":
+        for td in _TAIL_DEPENDENT:
+            if td in methods and chosen_aggregate < methods[td] - _TOL:
+                flagged = True
+                warnings.append(
+                    f"tail-dependence-blind: variance_covariance aggregate {chosen_aggregate:.2f} "
+                    f"is below the {td} aggregate {methods[td]:.2f}; the claimed diversification "
+                    "vanishes in the tail (the 2008 lesson)"
+                )
+
+    diversification_benefit = summation - chosen_aggregate
+    verdict = "flagged" if flagged else "verified"
+
+    body = {
+        "contract_id": contract_id,
+        "as_of": as_of,
+        "chosen_method": method,
+        "confidence": confidence,
+        "risk_inputs": {t: ec[i] for i, t in enumerate(RISK_TYPES)},
+        "chosen_aggregate": chosen_aggregate,
+        "summation_upper_bound": summation,
+        "diversification_benefit": diversification_benefit,
+        "diversification_benefit_pct": (diversification_benefit / summation * 100) if summation else 0.0,
+        "method_comparison": methods,
+        "trade_off": TRADE_OFFS[method]["trade_off"],
+        "stated_limitation": spec.get("limitation", TRADE_OFFS[method]["limitation"]),
+        "assumption": assumption,
+        "verdict": verdict,
+        "soft_references": {
+            "economic_vs_regulatory": REGCAP_REF,
+            "omnirisk_walker": OMNIRISK_WALKER_REF,
+        },
+        "warnings": warnings,
+    }
+    receipt = dict(body)
+    receipt["input_hash"] = _sha256(_canonical(spec))
+    receipt["output_hash"] = _sha256(_canonical(body))
+    receipt["receipt_hash"] = _sha256(_canonical(receipt))
+    return receipt
+
+
+def run_aggregation_method(path: str) -> dict:
+    """Load, schema-validate and evaluate an AggregationMethod contract fixture."""
+    validate_json_file(path, _SCHEMA)
+    spec = json.loads(Path(path).read_text())
+    return evaluate_contract(spec)

--- a/third_party/open_ep_framework/asset_ladder/__init__.py
+++ b/third_party/open_ep_framework/asset_ladder/__init__.py
@@ -1,0 +1,31 @@
+"""Jacob's Ladder of Assets (ALC-1): the governed asset-class ontology.
+
+A total, ordered ladder of value-transformation (natural capital -> extraction /
+harvest -> processed goods -> commodity/labor/mercantile markets -> pure service
+-> digital asset -> digital service) that replaces the thin
+``{credit, equity, market, crypto}`` asset_class enum and binds each rung to a
+valuation_model and an RM-1 ``risk_F_family``.
+"""
+from .ladder import (
+    AssetLadderError,
+    LADDER_ORDER,
+    RENEWABILITY_REGIME,
+    check_ladder,
+    classify,
+    canonical_rung,
+    load_ladder,
+    run_check,
+)
+
+__all__ = [
+    "AssetLadderError",
+    "LADDER_ORDER",
+    "RENEWABILITY_REGIME",
+    "check_ladder",
+    "classify",
+    "canonical_rung",
+    "load_ladder",
+    "run_check",
+]
+
+CONTRACT = "ALC-1"

--- a/third_party/open_ep_framework/asset_ladder/__main__.py
+++ b/third_party/open_ep_framework/asset_ladder/__main__.py
@@ -1,0 +1,3 @@
+from .ladder import main
+
+raise SystemExit(main())

--- a/third_party/open_ep_framework/asset_ladder/ladder.py
+++ b/third_party/open_ep_framework/asset_ladder/ladder.py
@@ -1,0 +1,382 @@
+"""Jacob's Ladder of Assets -- the governed asset-class ontology (ALC-1).
+
+A contract-with-teeth for the estate omnirisk ``asset_class`` axis. It grounds
+asset classes in the real economy as a TOTAL, ORDERED ladder of value-
+transformation, from tangible extraction (rung 0) up to pure digital services
+(rung 8), and it REPLACES the thin ``{credit, equity, market, crypto}`` enum.
+
+Why a ladder and not a flat enum
+--------------------------------
+``credit``/``equity``/``market``/``crypto`` are all *financial claims* -- they
+name what a balance sheet holds after value already exists. They cannot say
+where Revenue comes from. The ladder does: extraction (rungs 1 / 1') and
+labor-mixing (rung 2) are the value-GENESIS the economic-prophet kernel needs
+before anything becomes a financial claim (rungs 3+). Each rung binds:
+
+  * a ``valuation_model`` -- how value is measured at that rung
+    (real-option / Hotelling / sustainable-yield / Lockean labor-value-add /
+    spot-futures-vol / human-capital-wage / spatiotemporal-arbitrage / DCF /
+    network-memetic / Economia-Mentium); and
+  * a ``risk_F_family`` -- the RM-1 risk kernel that scores that rung's loss
+    distribution F (sharpe / sortino / kappa / var / expected_shortfall /
+    spectral / stddev).
+
+The renewability axis is bound to a stochastic-process regime (TC-1 crosswalk):
+
+    depleting_stock   <-> monotone_absorbing   (drift to an absorbing barrier
+                                                 at zero reserves; Hotelling)
+    regenerating_flow <-> mean_reverting_ou     (OU reversion to a sustainable
+                                                 yield; TC-1 persistence)
+    non_physical      <-> non_physical          (a claim / service / digital
+                                                 asset; no physical stock)
+
+Teeth (both directions)
+-----------------------
+VERIFIES  the ladder is total + ordered; every rung carries every axis; farming
+          classifies ``regenerating_flow``; mining classifies
+          ``depleting_stock``; a digital_service classifies ``non_rival``.
+REJECTS   a renewable_harvest tagged ``depleting_stock`` (or mining as
+          ``regenerating_flow``); a digital_asset priced by SCARCITY as if rival
+          (non-rival economics: value is network / attention, not scarcity);
+          a non-renewable with NO depletion / Hotelling model; a rung missing
+          any required axis; a value_stage ordering that is not monotone
+          tangible -> digital.
+
+Deterministic and stdlib-only. Measurement, simulation and audit only.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ..risk_measures import KNOWN_KERNELS
+from ..validation import validate_json_file
+
+_SCHEMA = "schemas/asset_class_ladder.schema.json"
+
+# --------------------------------------------------------------------------- #
+# controlled vocabularies (the checker is the authority; the schema documents)
+# --------------------------------------------------------------------------- #
+REQUIRED_AXES = (
+    "value_stage",
+    "key",
+    "label",
+    "tangibility",
+    "rivalry",
+    "renewability",
+    "labor_content",
+    "process_regime",
+    "valuation_model",
+    "risk_F_family",
+)
+
+TANGIBILITY_ORDER = {"tangible": 3, "semi_tangible": 2, "intangible": 1}
+RIVALRY = {"rival", "non_rival"}
+RENEWABILITY = {"depleting_stock", "regenerating_flow", "non_physical"}
+PROCESS_REGIME = {"monotone_absorbing", "mean_reverting_ou", "non_physical"}
+LABOR_CONTENT = {"none", "low", "moderate", "high"}
+VALUATION_MODELS = {
+    "real_option",
+    "hotelling_rent",
+    "sustainable_yield",
+    "labor_value_add",
+    "spot_futures_vol",
+    "human_capital_wage",
+    "spatiotemporal_arbitrage",
+    "dcf",
+    "network_memetic",
+    "economia_mentium",
+}
+
+# renewability <-> process-regime crosswalk (total function on RENEWABILITY).
+RENEWABILITY_REGIME = {
+    "depleting_stock": "monotone_absorbing",
+    "regenerating_flow": "mean_reverting_ou",
+    "non_physical": "non_physical",
+}
+
+# Class-defining axes. renewability and rivalry are DEFINITIONAL for an asset
+# class (mining is by definition a depleting stock; a digital asset is by
+# definition non-rival), so the ladder must bind them exactly. valuation_model,
+# risk_F_family and labor_content may vary within these constraints.
+CANONICAL_RENEWABILITY = {
+    "natural_capital": "depleting_stock",
+    "extractive_nonrenewable": "depleting_stock",
+    "renewable_harvest": "regenerating_flow",
+    "processed_goods": "regenerating_flow",
+    "commodity_market": "non_physical",
+    "labor_market": "non_physical",
+    "mercantile_trade": "non_physical",
+    "pure_service": "non_physical",
+    "digital_asset": "non_physical",
+    "digital_service": "non_physical",
+}
+CANONICAL_RIVALRY = {
+    "natural_capital": "rival",
+    "extractive_nonrenewable": "rival",
+    "renewable_harvest": "rival",
+    "processed_goods": "rival",
+    "commodity_market": "rival",
+    "labor_market": "rival",
+    "mercantile_trade": "rival",
+    "pure_service": "rival",
+    "digital_asset": "non_rival",
+    "digital_service": "non_rival",
+}
+
+# The canonical ordered rung keys (0 .. 8, with 1' as the renewable sibling).
+LADDER_ORDER = (
+    "natural_capital",
+    "extractive_nonrenewable",
+    "renewable_harvest",
+    "processed_goods",
+    "commodity_market",
+    "labor_market",
+    "mercantile_trade",
+    "pure_service",
+    "digital_asset",
+    "digital_service",
+)
+
+# Depletion-aware valuation models: any depleting_stock rung MUST use one of
+# these (a non-renewable priced without a Hotelling / depletion model is silent
+# infinite-reserve pricing and is REJECTED).
+DEPLETION_MODELS = {"real_option", "hotelling_rent"}
+
+# Scarcity / cash-flow models: asserting one of these on a NON-RIVAL digital
+# asset is the wrong model (copying is free -> no scarcity rent, no cash flow to
+# discount). Value there is network / memetic.
+SCARCITY_OR_CASHFLOW_MODELS = {"real_option", "hotelling_rent", "dcf"}
+NONRIVAL_VALUATION_MODELS = {"network_memetic", "economia_mentium"}
+
+
+class AssetLadderError(ValueError):
+    """Raised when the ladder or a descriptor violates the contract (REJECTED)."""
+
+
+# --------------------------------------------------------------------------- #
+# loading
+# --------------------------------------------------------------------------- #
+def load_ladder(path: str) -> dict:
+    return json.loads(Path(path).read_text())
+
+
+# --------------------------------------------------------------------------- #
+# per-rung teeth
+# --------------------------------------------------------------------------- #
+def _check_rung_axes(rung: dict, where: str) -> None:
+    for axis in REQUIRED_AXES:
+        if axis not in rung or rung[axis] in (None, ""):
+            raise AssetLadderError(f"{where}: missing required axis {axis!r}")
+
+    if rung["tangibility"] not in TANGIBILITY_ORDER:
+        raise AssetLadderError(f"{where}: unknown tangibility {rung['tangibility']!r}")
+    if rung["rivalry"] not in RIVALRY:
+        raise AssetLadderError(f"{where}: unknown rivalry {rung['rivalry']!r}")
+    if rung["renewability"] not in RENEWABILITY:
+        raise AssetLadderError(f"{where}: unknown renewability {rung['renewability']!r}")
+    if rung["process_regime"] not in PROCESS_REGIME:
+        raise AssetLadderError(f"{where}: unknown process_regime {rung['process_regime']!r}")
+    if rung["labor_content"] not in LABOR_CONTENT:
+        raise AssetLadderError(f"{where}: unknown labor_content {rung['labor_content']!r}")
+    if rung["valuation_model"] not in VALUATION_MODELS:
+        raise AssetLadderError(f"{where}: unknown valuation_model {rung['valuation_model']!r}")
+    if rung["risk_F_family"] not in KNOWN_KERNELS:
+        raise AssetLadderError(
+            f"{where}: risk_F_family {rung['risk_F_family']!r} is not a known RM-1 kernel "
+            f"({sorted(KNOWN_KERNELS)})"
+        )
+
+
+def _check_renewability_regime(rung: dict, where: str) -> None:
+    expected = RENEWABILITY_REGIME[rung["renewability"]]
+    if rung["process_regime"] != expected:
+        raise AssetLadderError(
+            f"{where}: renewability {rung['renewability']!r} requires process_regime "
+            f"{expected!r}, got {rung['process_regime']!r} "
+            f"(depleting_stock<->monotone_absorbing, "
+            f"regenerating_flow<->mean_reverting_ou, non_physical<->non_physical)"
+        )
+
+
+def _check_class_invariants(rung: dict, where: str) -> None:
+    key = rung["key"]
+    want_ren = CANONICAL_RENEWABILITY.get(key)
+    if want_ren is not None and rung["renewability"] != want_ren:
+        raise AssetLadderError(
+            f"{where}: asset class {key!r} is defined as renewability={want_ren!r}, "
+            f"got {rung['renewability']!r} "
+            f"(e.g. mining is a depleting_stock; farming is a regenerating_flow)"
+        )
+    want_riv = CANONICAL_RIVALRY.get(key)
+    if want_riv is not None and rung["rivalry"] != want_riv:
+        raise AssetLadderError(
+            f"{where}: asset class {key!r} is defined as rivalry={want_riv!r}, "
+            f"got {rung['rivalry']!r} "
+            f"(digital assets/services are NON-RIVAL: copying is free)"
+        )
+
+
+def _check_valuation_binding(rung: dict, where: str) -> None:
+    # A depleting (non-renewable) stock must be priced with a depletion-aware
+    # model (Hotelling / real option) -- never as an infinite reserve.
+    if rung["renewability"] == "depleting_stock" and rung["valuation_model"] not in DEPLETION_MODELS:
+        raise AssetLadderError(
+            f"{where}: depleting_stock rung must use a depletion/Hotelling model "
+            f"{sorted(DEPLETION_MODELS)}, got {rung['valuation_model']!r}"
+        )
+    # The extractive non-renewable rung is specifically the Hotelling rung.
+    if rung["key"] == "extractive_nonrenewable" and rung["valuation_model"] != "hotelling_rent":
+        raise AssetLadderError(
+            f"{where}: extractive_nonrenewable must be priced by hotelling_rent, "
+            f"got {rung['valuation_model']!r}"
+        )
+    # A renewable flow must be priced by sustainable yield.
+    if rung["key"] == "renewable_harvest" and rung["valuation_model"] != "sustainable_yield":
+        raise AssetLadderError(
+            f"{where}: renewable_harvest must be priced by sustainable_yield, "
+            f"got {rung['valuation_model']!r}"
+        )
+    # Non-rival digital assets are NOT priced by scarcity or cash flow.
+    if rung["rivalry"] == "non_rival" and rung["valuation_model"] in SCARCITY_OR_CASHFLOW_MODELS:
+        raise AssetLadderError(
+            f"{where}: non_rival asset priced by scarcity/cash-flow model "
+            f"{rung['valuation_model']!r}; non-rival value is network/attention "
+            f"(one of {sorted(NONRIVAL_VALUATION_MODELS)}), not scarcity"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# ladder-level teeth: totality + ordering
+# --------------------------------------------------------------------------- #
+def _check_totality_and_order(rungs: list) -> None:
+    keys = [r.get("key") for r in rungs]
+    if keys != list(LADDER_ORDER):
+        raise AssetLadderError(
+            f"ladder is not total/ordered: expected keys {list(LADDER_ORDER)}, got {keys}"
+        )
+
+    prev_stage = None
+    prev_tang = None
+    for idx, rung in enumerate(rungs):
+        where = f"rung[{idx}] {rung.get('key')!r}"
+        stage = rung["value_stage"]
+        if prev_stage is not None and stage <= prev_stage:
+            raise AssetLadderError(
+                f"{where}: value_stage {stage} is not strictly increasing "
+                f"(previous {prev_stage}); the ladder must be monotone tangible->digital"
+            )
+        tang = TANGIBILITY_ORDER[rung["tangibility"]]
+        if prev_tang is not None and tang > prev_tang:
+            raise AssetLadderError(
+                f"{where}: tangibility {rung['tangibility']!r} is more tangible than the "
+                f"rung below it; tangibility must be monotone non-increasing tangible->digital"
+            )
+        prev_stage = stage
+        prev_tang = tang
+
+    # The top of the ladder must be non-rival digital (value beyond scarcity).
+    if rungs[-1]["rivalry"] != "non_rival":
+        raise AssetLadderError("top rung (digital_service) must be non_rival")
+
+
+def check_ladder(ladder: dict) -> dict:
+    """Validate the whole ladder against every tooth. Raise on violation.
+
+    Returns a deterministic receipt describing the verified ladder.
+    """
+    if "rungs" not in ladder or not isinstance(ladder["rungs"], list) or not ladder["rungs"]:
+        raise AssetLadderError("ladder has no rungs")
+
+    rungs = ladder["rungs"]
+    for idx, rung in enumerate(rungs):
+        where = f"rung[{idx}] {rung.get('key')!r}"
+        _check_rung_axes(rung, where)
+        _check_class_invariants(rung, where)
+        _check_renewability_regime(rung, where)
+        _check_valuation_binding(rung, where)
+
+    _check_totality_and_order(rungs)
+
+    return {
+        "contract": "ALC-1",
+        "ladder_id": ladder.get("ladder_id"),
+        "rung_count": len(rungs),
+        "total": True,
+        "ordered": True,
+        "replaces_enum": ladder.get("replaces_enum", []),
+        "rungs": [
+            {
+                "value_stage": r["value_stage"],
+                "key": r["key"],
+                "tangibility": r["tangibility"],
+                "rivalry": r["rivalry"],
+                "renewability": r["renewability"],
+                "process_regime": r["process_regime"],
+                "valuation_model": r["valuation_model"],
+                "risk_F_family": r["risk_F_family"],
+            }
+            for r in rungs
+        ],
+    }
+
+
+def run_check(ladder_path: str, schema_path: str = _SCHEMA) -> dict:
+    """Schema-validate then apply the teeth. Returns the receipt."""
+    validate_json_file(ladder_path, schema_path)
+    return check_ladder(load_ladder(ladder_path))
+
+
+# --------------------------------------------------------------------------- #
+# classification: bind a real-world asset descriptor to its rung
+# --------------------------------------------------------------------------- #
+def canonical_rung(key: str, ladder: dict) -> dict:
+    for rung in ladder["rungs"]:
+        if rung.get("key") == key:
+            return rung
+    raise AssetLadderError(f"unknown asset-class key {key!r}")
+
+
+def classify(descriptor: dict, ladder: dict) -> dict:
+    """Classify an asset descriptor onto the ladder.
+
+    ``descriptor`` must carry a ``key``; any axes it also asserts
+    (renewability, rivalry, ...) are checked against the canonical rung. A
+    contradiction (e.g. farming asserted as ``depleting_stock``) is REJECTED.
+    Returns the canonical rung.
+    """
+    key = descriptor.get("key")
+    if not key:
+        raise AssetLadderError("descriptor has no asset-class key")
+    rung = canonical_rung(key, ladder)
+    for axis in ("tangibility", "rivalry", "renewability", "process_regime", "valuation_model"):
+        if axis in descriptor and descriptor[axis] != rung[axis]:
+            raise AssetLadderError(
+                f"{key!r} classified {axis}={descriptor[axis]!r} but the ladder binds "
+                f"{axis}={rung[axis]!r}"
+            )
+    return rung
+
+
+# --------------------------------------------------------------------------- #
+# CLI: emit a deterministic receipt for CI
+# --------------------------------------------------------------------------- #
+def main(argv=None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Check the Jacob's Ladder of Assets contract (ALC-1).")
+    parser.add_argument("--ladder", default="examples/asset_class_ladder.json")
+    parser.add_argument("--schema", default=_SCHEMA)
+    parser.add_argument("--receipt", default=None, help="Optional path to write the receipt JSON.")
+    args = parser.parse_args(argv)
+
+    receipt = run_check(args.ladder, args.schema)
+    text = json.dumps(receipt, indent=2, sort_keys=True)
+    if args.receipt:
+        Path(args.receipt).write_text(text + "\n")
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/third_party/open_ep_framework/capital_floor.py
+++ b/third_party/open_ep_framework/capital_floor.py
@@ -1,0 +1,250 @@
+"""R-Cap vs E-Cap with the Basel regulatory floor (RFL-1).
+
+Two capital numbers must be stated for every node in the estate omnirisk/EP spine:
+the regulator's (**R-Cap**, Basel ``8% x RWA``) and the bank's own diversified
+economic capital (**E-Cap**, the coherent-tail Euler contribution the kernel already
+produces). This contract carries them as PARALLEL per-node measures, forms the
+**E-Cap/R-Cap ratio**, and enforces the **regulatory floor**::
+
+    allocated_capital = max(economic_capital_contribution, regulatory_floor)
+
+with the divergence flagged. The teeth make the McKinsey Working Papers on Risk #38
+footnote enforceable: *diversification can lower a node's economic capital, but it
+can never lower it below the regulatory minimum silently.*
+
+Consume, do NOT reinvent
+------------------------
+  * ``regulatory_capital`` (economic-prophet #42) -- the genuine Basel IRB-Advanced
+    corporate risk-weight function. R-Cap here is ``target_capital_ratio x RWA`` with
+    RWA from ``irb_regulatory_capital``; the standardized path takes RWA directly.
+  * ``risk_measures`` (RM-1, #43/#44) -- ``euler_allocation`` supplies the diversified
+    E-Cap contribution per node (coherent ES/spectral, so contributions conserve). It
+    is given to this layer as a labelled node input, exactly as the GBRG walker takes
+    its node inputs (see ``KERNEL_*`` / ``OMNIRISK_WALKER_REF`` soft references).
+  * ``settlement`` (IC-1, #39) -- the FIPS SHA-256 ``sha256:`` receipt spine.
+
+Teeth (verdicts)
+----------------
+  * VERIFIED -- E-Cap contribution >= R-Cap floor (economic binds); ratio reconciles.
+  * FLAGGED  -- the regulatory floor binds (E-Cap < R-Cap): allocated at the floor,
+        divergence recorded. The floor did its job; the node is over-diversified.
+  * REJECTED (raises) --
+        a node whose diversified E-Cap is below its regulatory minimum but whose
+            ``declared_allocated_capital`` is that sub-floor E-Cap figure (silent
+            sub-floor diversification -- the #38 footnote);
+        the E-Cap/R-Cap ratio does not reconcile to its inputs;
+        the 8% target-ratio assumption is absent, non-positive, or inconsistent with
+            R-Cap = target_ratio x RWA;
+        a non-positive regulatory floor (no denominator for the ratio).
+
+Measurement, simulation and audit only. Deterministic + stdlib.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .regulatory_capital import irb_regulatory_capital
+from .settlement import _canonical, _sha256
+from .validation import validate_json_file
+
+_SCHEMA = "schemas/capital_floor.schema.json"
+
+# Basel minimum total-capital ratio. Asserted, never assumed silently.
+BASEL_CAPITAL_RATIO = 0.08
+_TOL = 1e-6
+
+# Soft references (consumed by reference, not re-implemented).
+KERNEL_REGCAP_REF = "economic-prophet:src/open_ep_framework/regulatory_capital.py"
+KERNEL_EULER_REF = "economic-prophet:src/open_ep_framework/risk_measures.py#euler_allocation"
+OMNIRISK_WALKER_REF = "sociosphere:gbrg/governance/omnirisk_allocation.py (OMNI-1)"
+
+
+class CapitalFloorError(ValueError):
+    """Raised when a node cannot be allocated under the regulatory floor (REJECTED)."""
+
+
+# --------------------------------------------------------------------------- #
+# regulatory capital (R-Cap) per node
+# --------------------------------------------------------------------------- #
+def _regulatory_capital(reg: dict, target_ratio: float) -> tuple[float, float, dict]:
+    """Return (r_cap, rwa, readout). R-Cap = target_ratio x RWA.
+
+    Standardized: RWA is given directly. IRB: RWA comes from the Basel corporate
+    risk-weight function (``irb_regulatory_capital``); we then apply the DECLARED
+    target ratio so the 8% assumption is used, not buried inside the kernel call.
+    """
+    if "rwa" in reg and reg["rwa"] is not None:
+        rwa = float(reg["rwa"])
+        readout = {"approach": "standardized", "rwa": round(rwa, 4)}
+    elif {"pd", "lgd", "ead"} <= set(reg):
+        irb = irb_regulatory_capital(
+            float(reg["pd"]), float(reg["lgd"]), float(reg["ead"]),
+            float(reg.get("maturity", 2.5)),
+        )
+        rwa = float(irb["rwa"])
+        readout = {"approach": irb["approach"], "rwa": irb["rwa"],
+                   "capital_requirement_K": irb["capital_requirement_K"],
+                   "expected_loss": irb["expected_loss"]}
+    else:
+        raise CapitalFloorError(
+            "REJECTED: node.regulatory needs either 'rwa' (standardized) or "
+            "'pd'/'lgd'/'ead' (IRB) to form a regulatory floor"
+        )
+    r_cap = target_ratio * rwa
+    return r_cap, rwa, readout
+
+
+# --------------------------------------------------------------------------- #
+# single node: E-Cap vs R-Cap, the floor, and the ratio
+# --------------------------------------------------------------------------- #
+def evaluate_node(node: dict, target_ratio: float) -> dict:
+    node_id = node["node_id"]
+    e_cap = float(node["economic_capital_contribution"])
+    r_cap, rwa, reg_readout = _regulatory_capital(node["regulatory"], target_ratio)
+
+    if r_cap <= 0.0:
+        # No denominator for the ratio, no floor to enforce.
+        raise CapitalFloorError(
+            f"REJECTED: node {node_id!r} has a non-positive regulatory floor "
+            f"(RWA={rwa}); cannot form an E-Cap/R-Cap ratio"
+        )
+
+    # The 8% assumption must be self-consistent: R-Cap == target_ratio x RWA.
+    if abs(r_cap - target_ratio * rwa) > _TOL:
+        raise CapitalFloorError(
+            f"REJECTED: node {node_id!r} regulatory capital {r_cap} != "
+            f"target_ratio {target_ratio} x RWA {rwa} (the 8% assumption is inconsistent)"
+        )
+
+    ratio = e_cap / r_cap  # E-Cap / R-Cap
+    # Teeth: the ratio must reconcile to its inputs.
+    if abs(ratio * r_cap - e_cap) > _TOL:
+        raise CapitalFloorError(
+            f"REJECTED: node {node_id!r} E-Cap/R-Cap ratio {ratio} does not "
+            f"reconcile (ratio x R-Cap {ratio * r_cap} != E-Cap {e_cap})"
+        )
+
+    allocated = max(e_cap, r_cap)          # the regulatory floor
+    binding = "economic" if e_cap >= r_cap else "regulatory"
+    divergence = e_cap - r_cap
+    floor_binds = binding == "regulatory"
+
+    warnings: list[str] = []
+    if floor_binds:
+        warnings.append(
+            f"divergence flagged: diversified E-Cap {e_cap} is below the regulatory "
+            f"floor {r_cap}; allocated at the floor (E-Cap/R-Cap={ratio:.4f} < 1)"
+        )
+
+    # Teeth: a declared allocation BELOW the floor is silent sub-floor diversification.
+    declared = node.get("declared_allocated_capital")
+    if declared is not None:
+        declared = float(declared)
+        if declared < r_cap - _TOL:
+            raise CapitalFloorError(
+                f"REJECTED: node {node_id!r} declares allocated capital {declared} "
+                f"below its regulatory floor {r_cap}. You cannot diversify under the "
+                f"regulatory minimum silently (McKinsey WP #38). "
+                f"allocated_capital must be max(E-Cap {e_cap}, R-Cap {r_cap}) = {allocated}"
+            )
+        if abs(declared - allocated) > _TOL:
+            warnings.append(
+                f"declared allocated capital {declared} != floored allocation {allocated}; "
+                "using the floored allocation"
+            )
+
+    verdict = "flagged" if floor_binds else "verified"
+    return {
+        "node_id": node_id,
+        "economic_capital": e_cap,
+        "regulatory_capital": r_cap,
+        "regulatory_detail": reg_readout,
+        "ecap_rcap_ratio": ratio,
+        "allocated_capital": allocated,
+        "binding_constraint": binding,
+        "divergence_economic_minus_regulatory": divergence,
+        "floor_binds": floor_binds,
+        "verdict": verdict,
+        "warnings": warnings,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# portfolio: roll up the floored allocations
+# --------------------------------------------------------------------------- #
+def evaluate_contract(spec: dict) -> dict:
+    contract_id = spec.get("contract_id", "rfl")
+    as_of = spec.get("as_of", "")
+    approach = spec.get("approach", "IRB-Advanced")
+
+    assumptions = spec.get("assumptions") or {}
+    if "target_capital_ratio" not in assumptions:
+        raise CapitalFloorError(
+            "REJECTED: assumptions.target_capital_ratio is required "
+            "(the 8% Basel ratio must be asserted, not assumed silently)"
+        )
+    target_ratio = float(assumptions["target_capital_ratio"])
+    if target_ratio <= 0.0:
+        raise CapitalFloorError("REJECTED: target_capital_ratio must be positive")
+
+    nodes = [evaluate_node(n, target_ratio) for n in spec["nodes"]]
+
+    sum_ecap = sum(n["economic_capital"] for n in nodes)
+    sum_rcap = sum(n["regulatory_capital"] for n in nodes)
+    sum_allocated = sum(n["allocated_capital"] for n in nodes)
+    portfolio_ratio = sum_ecap / sum_rcap if sum_rcap > 0 else None
+
+    warnings: list[str] = []
+    # The floor is applied per node, so the portfolio allocation can never fall below
+    # either the summed economic OR the summed regulatory capital -- the floor cannot
+    # be diversified away at the portfolio level either.
+    if sum_allocated < sum_rcap - _TOL or sum_allocated < sum_ecap - _TOL:
+        raise CapitalFloorError(
+            "REJECTED: floored portfolio allocation fell below a summed capital total "
+            "(floor conservation violated)"
+        )
+    if abs((portfolio_ratio or 0.0) * sum_rcap - sum_ecap) > _TOL and sum_rcap > 0:
+        raise CapitalFloorError(
+            "REJECTED: portfolio E-Cap/R-Cap ratio does not reconcile to summed inputs"
+        )
+
+    flagged = [n["node_id"] for n in nodes if n["verdict"] == "flagged"]
+    if flagged:
+        warnings.append(f"regulatory floor binds on nodes: {flagged}")
+
+    body = {
+        "contract_id": contract_id,
+        "as_of": as_of,
+        "approach": approach,
+        "assumptions": {"target_capital_ratio": target_ratio,
+                        "basel_minimum": BASEL_CAPITAL_RATIO,
+                        "asserted": abs(target_ratio - BASEL_CAPITAL_RATIO) <= _TOL},
+        "nodes": nodes,
+        "portfolio": {
+            "sum_economic_capital": sum_ecap,
+            "sum_regulatory_capital": sum_rcap,
+            "sum_allocated_capital": sum_allocated,
+            "ecap_rcap_ratio": portfolio_ratio,
+            "binding_constraint": "economic" if sum_ecap >= sum_rcap else "regulatory",
+            "floor_uplift": sum_allocated - sum_ecap,
+        },
+        "soft_references": {
+            "regulatory_capital_kernel": KERNEL_REGCAP_REF,
+            "euler_allocation_kernel": KERNEL_EULER_REF,
+            "omnirisk_walker": OMNIRISK_WALKER_REF,
+        },
+        "warnings": warnings,
+    }
+    receipt = dict(body)
+    receipt["input_hash"] = _sha256(_canonical(spec))
+    receipt["output_hash"] = _sha256(_canonical(body))
+    receipt["receipt_hash"] = _sha256(_canonical(receipt))
+    return receipt
+
+
+def run_capital_floor(path: str) -> dict:
+    """Load, schema-validate and evaluate a RegulatoryCapitalFloor contract fixture."""
+    validate_json_file(path, _SCHEMA)
+    spec = json.loads(Path(path).read_text())
+    return evaluate_contract(spec)

--- a/third_party/open_ep_framework/causal_graph.py
+++ b/third_party/open_ep_framework/causal_graph.py
@@ -233,7 +233,6 @@ def propagate(
 
     # Only well-formed edges participate; the abstention log names the rest.
     adj: dict[str, list[Edge]] = {}
-    endpoint_ids = {e.from_ref for e in edge_list} | {e.to_ref for e in edge_list}
     for e in edge_list:
         # Filter edges the invariant pass would have complained about.
         if e.from_ref == e.to_ref:

--- a/third_party/open_ep_framework/causal_intervention.py
+++ b/third_party/open_ep_framework/causal_intervention.py
@@ -40,18 +40,14 @@ from typing import Any, Iterable
 
 from .causal_graph import (
     Edge,
-    GraphInvariantError,
     Hypothesis,
-    PathContribution,
     Propagation,
-    enforce_invariants,
     propagate,
 )
 
 try:  # abduction is a sibling; counterfactual step 1 uses it when available.
-    from .causal_abduction import Abduction, abduce
+    from .causal_abduction import abduce
 except Exception:  # pragma: no cover - abduction is expected present in-tree
-    Abduction = None  # type: ignore
     abduce = None  # type: ignore
 
 

--- a/third_party/open_ep_framework/cli.py
+++ b/third_party/open_ep_framework/cli.py
@@ -2,10 +2,13 @@ import argparse
 import json
 from pathlib import Path
 
+from .aggregation_method import run_aggregation_method
 from .associated_surplus import run_associated_surplus
 from .audit import write_audit_pack
 from .breakeven import economic_profit_for_rate, solve_break_even_rate
 from .capital import capital_charge
+from .capital_floor import run_capital_floor
+from .concern_ladder import run_concern_ladder
 from .causal_identification import scenario_from_document
 from .domain import CapitalStack, ExpectedLossInputs, FTPStack, PricingContext, RecoverySurfaceInputs
 from .expected_loss import expected_loss_amount
@@ -15,9 +18,11 @@ from .impact_vdt import run_impact_vdt
 from .object_graph import ObjectGraph, lineage_aware_output
 from .policy_simulation import run_policy_simulation_profile
 from .policy_simulation_uvmc import run_policy_simulation_measured_entity
+from .ftp_curve import run_ftp_separation
 from .product_objects import build_instrument_context
 from .recovery import market_implied_recovery, planning_recovery, recovery_wedge
 from .relationship import RelationshipEffects, relationship_required_rate
+from .risk_adjusted_profit import run_risk_adjusted_profit
 from .settlement import run_settlement
 from .validation import validate_json_file
 from .vdt import run_vdt
@@ -141,8 +146,8 @@ def _derive_audit_identity(inputs: dict, args) -> tuple[str, str]:
         receipt = inputs.get("calculation_receipt", {})
         context = inputs.get("measurement_context", {})
         return receipt.get("run_id", args.object_id), context.get("scenario_ref", "base")
-    run_id = inputs.get("run_id") or inputs.get("relationship_id") or args.object_id
-    scenario = inputs.get("scenario", "base")
+    run_id = inputs.get("run_id") or inputs.get("relationship_id") or inputs.get("contract_id") or inputs.get("book_id") or args.object_id
+    scenario = inputs.get("scenario") or inputs.get("scoring_mode") or "base"
     return run_id, scenario
 
 
@@ -165,6 +170,11 @@ def main():
             "vdt-impact",
             "causal-scenario",
             "settlement",
+            "risk-adjusted-profit",
+            "ftp-separation",
+            "capital-floor",
+            "concern-ladder",
+            "aggregation-method",
         ],
         default="instrument",
     )
@@ -239,6 +249,48 @@ def main():
         if example == "examples/synthetic_run.json":
             example = "examples/conservation_settlement_balanced.json"
         outputs = run_settlement(example)
+        inputs = json.loads(Path(example).read_text())
+    elif args.mode == "risk-adjusted-profit":
+        # RAROC / economic-profit contract (RAP-1): EP + RAROC with a pluggable
+        # risk measure, IC-1 conservation reconciliation across org cuts, and dual
+        # economic/epistemic scoring. Rejects non-conserving cuts and no-capital arms.
+        example = args.example
+        if example == "examples/synthetic_run.json":
+            example = "examples/risk_adjusted_profit_economic.json"
+        outputs = run_risk_adjusted_profit(example)
+        inputs = json.loads(Path(example).read_text())
+    elif args.mode == "ftp-separation":
+        # Matched-maturity FTP separation-theorem decomposition (FTP-1): unit spreads
+        # + Treasury residual reconciled to NIM under IC-1. Rejects hidden cross-subsidy.
+        example = args.example
+        if example == "examples/synthetic_run.json":
+            example = "examples/ftp_separation_book.json"
+        outputs = run_ftp_separation(example)
+        inputs = json.loads(Path(example).read_text())
+    elif args.mode == "capital-floor":
+        # R-Cap vs E-Cap regulatory floor (RFL-1): allocated = max(E-Cap, Basel 8% x RWA).
+        # Rejects a node allocated at a diversified E-Cap below its regulatory minimum.
+        example = args.example
+        if example == "examples/synthetic_run.json":
+            example = "examples/capital_floor_book.json"
+        outputs = run_capital_floor(example)
+        inputs = json.loads(Path(example).read_text())
+    elif args.mode == "concern-ladder":
+        # Going/gone-concern confidence ladder == capital waterfall (CLD-1). Rejects a
+        # non-monotone ladder, out-of-subordination booking, or gone->going-soft mapping.
+        example = args.example
+        if example == "examples/synthetic_run.json":
+            example = "examples/concern_ladder_book.json"
+        outputs = run_concern_ladder(example)
+        inputs = json.loads(Path(example).read_text())
+    elif args.mode == "aggregation-method":
+        # Aggregation-methodology taxonomy + tail-dependence guard (AGG-1). Summation is
+        # the conservative upper bound; a super-additive method or a tail-blind var-covar is
+        # rejected/flagged.
+        example = args.example
+        if example == "examples/synthetic_run.json":
+            example = "examples/aggregation_method_copula.json"
+        outputs = run_aggregation_method(example)
         inputs = json.loads(Path(example).read_text())
     elif args.mode == "causal-scenario":
         # The global --example default is an instrument doc, not a causal scenario;

--- a/third_party/open_ep_framework/concern_ladder.py
+++ b/third_party/open_ep_framework/concern_ladder.py
@@ -1,0 +1,287 @@
+"""Going-concern / gone-concern confidence ladder == capital waterfall (CLD-1).
+
+A bank's survival is a *ladder of confidence levels*, and each rung is absorbed by a
+*layer of the capital waterfall* in subordination order:
+
+  * Early-Warning   alpha 0.80  (30/250d)  <- hidden reserves        (going-concern)
+  * Severe-Stress   alpha 0.95  (250d)     <- retained earnings/Tier1 (going-concern)
+  * Liquidation     alpha 0.9998/1.00      <- Tier2/subordinated/debt  (gone-concern)
+
+Going-concern (the firm SURVIVES) vs gone-concern (LIQUIDATION / creditor
+protection) is exactly the alpha range: below the going->gone boundary the firm is a
+going concern; at/above it, it is being resolved. **CoCos convert at that boundary.**
+
+Loss absorbs in subordination order -- equity/first-loss -> ... -> senior debt -- and
+this contract reuses the kernel's securitization waterfall to prove it, rather than
+re-deriving one:
+
+Consume, do NOT reinvent
+------------------------
+  * ``risk_measures.structural_transform`` (RM-1, economic-prophet #43/#44) -- the
+    seniority/tranche waterfall: a [attach, detach] layer absorbs
+    ``clip(pool_loss - attach, 0, detach - attach)``. A contiguous partition of the
+    loss sums back to the pool loss (conservation), which is precisely "loss hits
+    equity, then the next layer, ... in order". The capital stack here IS such a
+    partition; each layer's absorbed loss is computed by ``structural_transform``.
+  * ``risk_measures.expected_loss`` / ``LossDistribution`` -- the pool F.
+  * ``settlement`` (IC-1, #39) -- the FIPS SHA-256 ``sha256:`` receipt spine.
+  * ``sociosphere:gbrg/governance/omnirisk_allocation.py`` (OMNI-1) -- soft ref; the
+    ladder's per-layer absorbed capital is a node input the cross-cut walker consumes.
+
+Teeth (verdicts)
+----------------
+  * VERIFIED -- alphas strictly increase; every scenario is booked to the marginal
+        layer its loss actually reaches (subordination-correct); coverage holds; the
+        concern label matches the alpha range; CoCos convert at the boundary.
+  * FLAGGED  -- a scenario whose absorbing capital is LESS than its loss at alpha
+        (under-capitalized -- loss punches through the booked layer); a concern label
+        inconsistent with the boundary; CoCo conversion off the boundary.
+  * REJECTED (raises) --
+        alphas not strictly increasing down the ladder (non-monotone);
+        a loss booked against a SENIOR layer while junior layers are unpierced
+            (out of subordination order);
+        a gone-concern scenario mapped to a going-concern soft layer (e.g. hidden
+            reserves cannot absorb a liquidation loss).
+
+Measurement, simulation and audit only. Deterministic + stdlib.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .risk_measures import LossDistribution, expected_loss, structural_transform
+from .settlement import _canonical, _sha256
+from .validation import validate_json_file
+
+_SCHEMA = "schemas/concern_ladder.schema.json"
+_TOL = 1e-6
+
+# Soft references (consumed by reference).
+KERNEL_WATERFALL_REF = "economic-prophet:src/open_ep_framework/risk_measures.py#structural_transform"
+OMNIRISK_WALKER_REF = "sociosphere:gbrg/governance/omnirisk_allocation.py (OMNI-1)"
+
+GOING = "going"
+GONE = "gone"
+
+
+class ConcernLadderError(ValueError):
+    """Raised when the ladder violates monotonicity or subordination (REJECTED)."""
+
+
+# --------------------------------------------------------------------------- #
+# capital stack -> cumulative attach/detach partition of the loss axis
+# --------------------------------------------------------------------------- #
+def _layers_with_bounds(stack: list[dict]) -> list[dict]:
+    """Turn the ordered stack into a contiguous [attach, detach] partition.
+
+    Layer 0 (most junior) is the first-loss piece [0, amount_0]; each subsequent
+    layer attaches where the previous detaches. This is exactly the partition
+    ``structural_transform`` treats as a securitization waterfall.
+    """
+    layers = []
+    cursor = 0.0
+    for spec in stack:
+        amount = float(spec["amount"])
+        attach = cursor
+        detach = cursor + amount
+        layers.append({
+            "layer": spec["layer"],
+            "concern": spec["concern"],
+            "kind": spec.get("kind", ""),
+            "amount": amount,
+            "attach": attach,
+            "detach": detach,
+        })
+        cursor = detach
+    return layers
+
+
+def _find_layer(layers: list[dict], name: str) -> dict:
+    for layer in layers:
+        if layer["layer"] == name:
+            return layer
+    raise ConcernLadderError(
+        f"REJECTED: absorbing_capital_layer {name!r} is not in the capital stack"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# waterfall demonstration via the kernel's structural_transform
+# --------------------------------------------------------------------------- #
+def _waterfall_absorption(layers: list[dict], samples: list[float]) -> list[dict]:
+    """Per-layer EXPECTED absorbed loss over the pool F, via structural_transform.
+
+    Proves loss hits the layers in order and that the partition conserves: the sum of
+    layer expected-absorbed losses equals the pool expected loss capped at the stack.
+    """
+    F = LossDistribution.from_samples(samples)
+    out = []
+    for layer in layers:
+        tranche = structural_transform(F, layer["attach"], layer["detach"])
+        out.append({
+            "layer": layer["layer"],
+            "attach": layer["attach"],
+            "detach": layer["detach"],
+            "expected_absorbed_loss": expected_loss(tranche),
+        })
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# evaluate one scenario against the waterfall
+# --------------------------------------------------------------------------- #
+def _evaluate_scenario(scn: dict, layers: list[dict], boundary: float | None) -> dict:
+    name = scn["name"]
+    alpha = float(scn["confidence_alpha"])
+    loss = float(scn["loss_at_alpha"])
+    declared_name = scn["absorbing_capital_layer"]
+    concern = scn["concern"]
+    layer = _find_layer(layers, declared_name)
+    attach, detach = layer["attach"], layer["detach"]
+
+    warnings: list[str] = []
+
+    # Teeth: gone-concern loss cannot be absorbed by a going-concern soft layer.
+    if concern == GONE and layer["concern"] == GOING:
+        raise ConcernLadderError(
+            f"REJECTED: scenario {name!r} is gone-concern but is mapped to going-concern "
+            f"soft layer {declared_name!r}; a going-concern buffer cannot absorb a "
+            f"liquidation loss (gone-concern must land on Tier2/subordinated/senior debt)"
+        )
+
+    # Teeth: loss booked against a SENIOR layer while junior layers are unpierced.
+    if attach >= loss + _TOL:
+        raise ConcernLadderError(
+            f"REJECTED: scenario {name!r} loss {loss} is booked against layer "
+            f"{declared_name!r} (attach={attach}) but the loss does not even reach it; "
+            f"a more junior layer absorbs it first (out of subordination order)"
+        )
+
+    # Coverage: capital up to and including the booked layer must cover the loss.
+    covered = detach + _TOL >= loss
+    if not covered:
+        warnings.append(
+            f"under-capitalized: loss {loss} punches through layer {declared_name!r} "
+            f"(capital up to it = {detach}); it is not fully absorbed"
+        )
+
+    # Concern label vs the going->gone boundary.
+    if boundary is not None:
+        implied = GOING if alpha < boundary - _TOL else GONE
+        if implied != concern:
+            warnings.append(
+                f"concern label {concern!r} inconsistent with alpha {alpha} vs "
+                f"going->gone boundary {boundary} (implies {implied!r})"
+            )
+
+    return {
+        "name": name,
+        "confidence_alpha": alpha,
+        "horizon_days": scn.get("horizon_days"),
+        "trigger": scn.get("trigger"),
+        "concern": concern,
+        "loss_at_alpha": loss,
+        "absorbing_capital_layer": declared_name,
+        "layer_attach": attach,
+        "layer_detach": detach,
+        "capital_up_to_layer": detach,
+        "covered": covered,
+        "verdict": "verified" if (covered and not warnings) else "flagged",
+        "warnings": warnings,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# contract
+# --------------------------------------------------------------------------- #
+def evaluate_contract(spec: dict) -> dict:
+    contract_id = spec.get("contract_id", "cld")
+    as_of = spec.get("as_of", "")
+    boundary = spec.get("going_gone_boundary_alpha")
+    boundary = float(boundary) if boundary is not None else None
+
+    layers = _layers_with_bounds(spec["capital_stack"])
+
+    # Teeth: alphas must strictly increase down the ladder.
+    scenarios_in = spec["scenarios"]
+    alphas = [float(s["confidence_alpha"]) for s in scenarios_in]
+    for i in range(len(alphas) - 1):
+        if not (alphas[i + 1] > alphas[i] + _TOL):
+            raise ConcernLadderError(
+                f"REJECTED: ladder alphas are not strictly increasing at rung {i}: "
+                f"{alphas[i]} -> {alphas[i + 1]} (going->gone confidence must climb)"
+            )
+
+    scenarios = [_evaluate_scenario(s, layers, boundary) for s in scenarios_in]
+
+    warnings: list[str] = []
+    # CoCos convert at the going->gone boundary.
+    coco = spec.get("coco_conversion")
+    if coco:
+        _find_layer(layers, coco["layer"])  # must exist (else REJECT)
+        if boundary is not None and abs(float(coco.get("alpha", -1)) - boundary) > _TOL:
+            warnings.append(
+                f"CoCo conversion alpha {coco.get('alpha')} is not at the going->gone "
+                f"boundary {boundary}; convertible capital should trigger at the boundary"
+            )
+
+    # Waterfall proof via the kernel's structural_transform (if a pool is supplied).
+    waterfall = None
+    pool = spec.get("loss_pool_samples")
+    if pool:
+        losses = [abs(float(x)) for x in pool]
+        # LossDistribution stores returns (negative == loss); pass -loss so .losses == loss.
+        layer_absorption = _waterfall_absorption(layers, [-x for x in losses])
+        total_cap = layers[-1]["detach"]
+        el = sum(losses) / len(losses)
+        capped_el = sum(min(x, total_cap) for x in losses) / len(losses)
+        absorbed_sum = sum(w["expected_absorbed_loss"] for w in layer_absorption)
+        conserved = abs(absorbed_sum - capped_el) <= 1e-4
+        if not conserved:
+            raise ConcernLadderError(
+                "REJECTED: waterfall layers do not conserve the pool loss "
+                f"(sum absorbed {absorbed_sum} != capped EL {capped_el})"
+            )
+        waterfall = {
+            "layers": layer_absorption,
+            "pool_expected_loss": el,
+            "capped_expected_loss": capped_el,
+            "sum_absorbed": absorbed_sum,
+            "conserved": conserved,
+        }
+
+    flagged = [s["name"] for s in scenarios if s["verdict"] == "flagged"]
+
+    body = {
+        "contract_id": contract_id,
+        "as_of": as_of,
+        "going_gone_boundary_alpha": boundary,
+        "coco_conversion": coco,
+        "capital_stack": [
+            {k: layer[k] for k in ("layer", "concern", "kind", "amount", "attach", "detach")}
+            for layer in layers
+        ],
+        "total_capital": layers[-1]["detach"],
+        "scenarios": scenarios,
+        "waterfall": waterfall,
+        "flagged_scenarios": flagged,
+        "monotone_alphas": True,
+        "soft_references": {
+            "structural_transform_kernel": KERNEL_WATERFALL_REF,
+            "omnirisk_walker": OMNIRISK_WALKER_REF,
+        },
+        "warnings": warnings,
+    }
+    receipt = dict(body)
+    receipt["input_hash"] = _sha256(_canonical(spec))
+    receipt["output_hash"] = _sha256(_canonical(body))
+    receipt["receipt_hash"] = _sha256(_canonical(receipt))
+    return receipt
+
+
+def run_concern_ladder(path: str) -> dict:
+    """Load, schema-validate and evaluate a ConcernLadder contract fixture."""
+    validate_json_file(path, _SCHEMA)
+    spec = json.loads(Path(path).read_text())
+    return evaluate_contract(spec)

--- a/third_party/open_ep_framework/crypto/__init__.py
+++ b/third_party/open_ep_framework/crypto/__init__.py
@@ -1,0 +1,55 @@
+"""Crypto as a distinct asset class for Economic Prophet (CAV-1 / BR-1 / MS-1).
+
+Crypto is NOT credit and NOT equity: most tokens have no cash flows, exhibit
+extreme reflexivity, and derive value from network, narrative and psychology. The
+credit/equity DCF machinery therefore does NOT apply. This package supplies crypto
+its own valuation criteria (network / fee / memetic) and its own reflexive loss
+distribution F, while REUSING the estate's risk kernel and receipt spine by
+reference rather than forking them.
+
+Three contracts, one asset class:
+
+  * ``valuation``          -- CAV-1 CryptoAssetValuation. Tokenomics + on-chain +
+                              Metcalfe/NVT network value + a modified economic profit
+                              (fee_revenue - security_cost - emission_dilution -
+                              risk_capital) + an evidence-bound memetic/information
+                              value. Guards against the wrong (DCF) model.
+  * ``behavioral_regime``  -- BR-1 BehavioralRegime. A 2-state greed/fear Markov
+                              regime-switching overlay (Hamilton filter) plus a
+                              prospect-theory value/probability distortion.
+  * ``manipulation``       -- MS-1 ManipulationSignal. Adverse selection
+                              (Glosten-Milgrom / Kyle) extended with concentration
+                              (whale/Gini), wash-trade and MEV indicators, emitted in
+                              a GBRG-governance-plane shape.
+
+Consume-by-reference hooks (do NOT fork):
+  * risk kernel      -- ``open_ep_framework.risk_measures`` (RM-1): the reflexive
+                        fat-tailed F is shaped for the kernel's LPM / Expected
+                        Shortfall, which supplies ``risk_capital``.
+  * memory-regime    -- the BR-1 regime carries the memory-mesh characterizer's
+                        arrival-regime taxonomy label (reflexive/self-exciting ==
+                        the Hawkes / long-memory arrival regime).
+  * GBRG plane       -- MS-1 emits a governed-blast-radius-graph-shaped signal for
+                        the governance/containment plane.
+  * microstructure   -- the MS-1 adverse-selection block is shaped to consume the
+                        in-flight order-flow contract (feat/microstructure-order-flow).
+
+Deterministic and stdlib-only (analytic where possible, seeded PRNG otherwise), so
+CI is reproducible. Measurement, simulation and audit only: no live on-chain feeds,
+token issuance, custody, or trading.
+"""
+from .behavioral_regime import BehavioralRegimeError, evaluate_behavioral_regime, run_behavioral_regime
+from .manipulation import ManipulationError, evaluate_manipulation, run_manipulation
+from .valuation import CryptoValuationError, evaluate_valuation, run_valuation
+
+__all__ = [
+    "CryptoValuationError",
+    "evaluate_valuation",
+    "run_valuation",
+    "BehavioralRegimeError",
+    "evaluate_behavioral_regime",
+    "run_behavioral_regime",
+    "ManipulationError",
+    "evaluate_manipulation",
+    "run_manipulation",
+]

--- a/third_party/open_ep_framework/crypto/behavioral_regime.py
+++ b/third_party/open_ep_framework/crypto/behavioral_regime.py
@@ -1,0 +1,269 @@
+"""BehavioralRegime contract (BR-1) -- greed/fear regimes + prospect theory.
+
+Crypto returns are psychology-driven and regime-switching: a "greed" (euphoria)
+regime with a high mean AND high volatility, and a "fear" (capitulation) regime with
+a low/negative mean and lower volatility. This contract fits a 2-state Hamilton-style
+Markov regime-switching model and overlays a prospect-theory value distortion.
+
+Markov regime switching (Hamilton)
+----------------------------------
+A 2x2 transition matrix ``P`` (rows == P(next | current), each row summing to 1) and
+per-regime Gaussian return distributions. Given a return series, a forward Hamilton
+filter produces the posterior P(greed) at each step; a point is labelled greed when
+that posterior exceeds 0.5. Teeth: a transition matrix whose rows do not sum to 1 is
+REJECTED; and on a seeded greed-heavy series the greed-labelled points must exhibit a
+HIGHER mean AND a HIGHER volatility than the fear-labelled points.
+
+Prospect theory (Kahneman-Tversky)
+----------------------------------
+Value function ``v(x) = x^alpha`` for gains and ``v(x) = -lambda*(-x)^beta`` for
+losses (loss aversion ``lambda > 1``), and probability weighting
+``w(p) = p^gamma / (p^gamma + (1-p)^gamma)^(1/gamma)``. Teeth: ``lambda <= 1`` is
+REJECTED (there must be loss aversion), and a probability weighting that is not
+monotone increasing over [0,1] is REJECTED.
+
+Memory-regime binding (consume by reference)
+--------------------------------------------
+Each regime carries an ``arrival_regime`` label drawn from the memory-mesh regime
+characterizer's taxonomy: the reflexive / self-exciting phase is the
+``hawkes_self_exciting`` (or ``long_memory``) arrival regime -- the SAME taxonomy the
+memory mesh uses -- rather than a private label. The reflexive fat-tailed F consumed
+by CAV-1 corresponds to this self-exciting arrival regime.
+
+Deterministic and stdlib-only (seeded). Measurement, simulation and audit only.
+"""
+from __future__ import annotations
+
+import json
+import math
+import random
+from pathlib import Path
+
+from ..settlement import _canonical, _sha256
+from ..validation import validate_json_file
+
+_SCHEMA = "schemas/behavioral_regime.schema.json"
+
+# The memory-mesh regime characterizer taxonomy (consumed by reference).
+ARRIVAL_REGIMES = {"poisson_memoryless", "hawkes_self_exciting", "long_memory"}
+
+_ROW_SUM_TOL = 1e-9
+
+
+class BehavioralRegimeError(ValueError):
+    """Raised when a regime spec is inadmissible (REJECTED)."""
+
+
+# --------------------------------------------------------------------------- #
+# transition matrix
+# --------------------------------------------------------------------------- #
+def _validate_transition_matrix(P: list) -> list:
+    """A 2x2 stochastic matrix; each row must sum to 1 (teeth)."""
+    if len(P) != 2 or any(len(row) != 2 for row in P):
+        raise BehavioralRegimeError("transition_matrix must be 2x2 (greed, fear)")
+    rows = [[float(x) for x in row] for row in P]
+    for i, row in enumerate(rows):
+        if any(x < 0 for x in row):
+            raise BehavioralRegimeError(f"transition_matrix row {i} has a negative probability")
+        if not math.isclose(sum(row), 1.0, abs_tol=_ROW_SUM_TOL):
+            raise BehavioralRegimeError(
+                f"REJECTED: transition_matrix row {i} sums to {sum(row)}, not 1.0; "
+                "a regime-switching transition matrix must be row-stochastic"
+            )
+    return rows
+
+
+# --------------------------------------------------------------------------- #
+# prospect theory
+# --------------------------------------------------------------------------- #
+def prospect_value(x: float, alpha: float, beta: float, lam: float) -> float:
+    """KT value function: gains x^alpha; losses -lambda*(-x)^beta (lambda>1)."""
+    if x >= 0:
+        return x ** alpha
+    return -lam * ((-x) ** beta)
+
+
+def probability_weight(p: float, gamma: float) -> float:
+    """Tversky-Kahneman probability weighting w(p)."""
+    if p <= 0:
+        return 0.0
+    if p >= 1:
+        return 1.0
+    num = p ** gamma
+    den = (p ** gamma + (1.0 - p) ** gamma) ** (1.0 / gamma)
+    return num / den
+
+
+def _validate_prospect(params: dict) -> dict:
+    """Teeth: loss aversion lambda>1, and monotone-increasing probability weighting."""
+    alpha = float(params.get("alpha", 0.88))
+    beta = float(params.get("beta", 0.88))
+    lam = float(params.get("lambda", 2.25))
+    gamma = float(params.get("gamma", 0.61))
+
+    if lam <= 1.0:
+        raise BehavioralRegimeError(
+            f"REJECTED: prospect-theory loss aversion lambda={lam} <= 1; "
+            "loss aversion requires lambda > 1"
+        )
+    # Numerically verify probability weighting is monotone non-decreasing on [0,1].
+    grid = [i / 200.0 for i in range(201)]
+    w = [probability_weight(p, gamma) for p in grid]
+    for i in range(len(w) - 1):
+        if w[i + 1] < w[i] - 1e-9:
+            raise BehavioralRegimeError(
+                f"REJECTED: probability weighting is non-monotone at p~{grid[i]:.3f} "
+                f"(gamma={gamma}); a weighting function must be monotone increasing"
+            )
+    # A representative distortion: loss aversion ratio at unit stake.
+    loss_aversion_ratio = -prospect_value(-1.0, alpha, beta, lam) / prospect_value(1.0, alpha, beta, lam)
+    return {
+        "alpha": alpha,
+        "beta": beta,
+        "lambda": lam,
+        "gamma": gamma,
+        "loss_aversion_ratio": loss_aversion_ratio,
+        "w_at_0_1": probability_weight(0.1, gamma),
+        "w_at_0_9": probability_weight(0.9, gamma),
+        "monotone_weighting": True,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# simulation + Hamilton filter
+# --------------------------------------------------------------------------- #
+_GREED, _FEAR = 0, 1
+
+
+def _gauss_pdf(x: float, mu: float, sigma: float) -> float:
+    if sigma <= 0:
+        return 0.0
+    z = (x - mu) / sigma
+    return math.exp(-0.5 * z * z) / (sigma * math.sqrt(2.0 * math.pi))
+
+
+def _simulate_series(P: list, regimes: dict, n: int, seed: int) -> list:
+    """Simulate a return series from the regime-switching model (seeded)."""
+    rng = random.Random(seed)
+    mu = [regimes["greed"]["mu"], regimes["fear"]["mu"]]
+    sigma = [regimes["greed"]["sigma"], regimes["fear"]["sigma"]]
+    state = _GREED if rng.random() < 0.5 else _FEAR
+    out = []
+    for _ in range(n):
+        r = rng.gauss(mu[state], sigma[state])
+        out.append(r)
+        state = _GREED if rng.random() < P[state][_GREED] else _FEAR
+    return out
+
+
+def hamilton_filter(series: list, P: list, regimes: dict) -> list:
+    """Forward Hamilton filter -> posterior P(greed) at each step."""
+    mu = [regimes["greed"]["mu"], regimes["fear"]["mu"]]
+    sigma = [regimes["greed"]["sigma"], regimes["fear"]["sigma"]]
+    xi = [0.5, 0.5]  # prior over (greed, fear)
+    posterior = []
+    for r in series:
+        # predict: propagate through P (columns are next-state)
+        pred = [
+            xi[_GREED] * P[_GREED][j] + xi[_FEAR] * P[_FEAR][j] for j in (_GREED, _FEAR)
+        ]
+        # update with Gaussian emission density
+        dens = [_gauss_pdf(r, mu[j], sigma[j]) for j in (_GREED, _FEAR)]
+        unnorm = [pred[j] * dens[j] for j in (_GREED, _FEAR)]
+        total = sum(unnorm)
+        if total <= 0:
+            xi = [0.5, 0.5]
+        else:
+            xi = [u / total for u in unnorm]
+        posterior.append(xi[_GREED])
+    return posterior
+
+
+def _classify_and_stat(series: list, posterior: list) -> dict:
+    greed = [r for r, pg in zip(series, posterior) if pg > 0.5]
+    fear = [r for r, pg in zip(series, posterior) if pg <= 0.5]
+
+    def _mean(xs):
+        return sum(xs) / len(xs) if xs else float("nan")
+
+    def _vol(xs):
+        if len(xs) < 2:
+            return float("nan")
+        m = _mean(xs)
+        return math.sqrt(sum((x - m) ** 2 for x in xs) / (len(xs) - 1))
+
+    greed_mean, fear_mean = _mean(greed), _mean(fear)
+    greed_vol, fear_vol = _vol(greed), _vol(fear)
+    return {
+        "n_total": len(series),
+        "n_greed": len(greed),
+        "n_fear": len(fear),
+        "greed_mean": greed_mean,
+        "fear_mean": fear_mean,
+        "greed_vol": greed_vol,
+        "fear_vol": fear_vol,
+        "greed_has_higher_mean": bool(greed_mean > fear_mean),
+        "greed_has_higher_vol": bool(greed_vol > fear_vol),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# contract
+# --------------------------------------------------------------------------- #
+def evaluate_behavioral_regime(spec: dict) -> dict:
+    """Evaluate BR-1: validate matrix + prospect params, classify a series, receipt."""
+    P = _validate_transition_matrix(spec["transition_matrix"])
+    regimes = spec["regimes"]
+    for name in ("greed", "fear"):
+        if name not in regimes:
+            raise BehavioralRegimeError(f"regimes must define '{name}'")
+
+    arrival_regime = spec.get("arrival_regime", "hawkes_self_exciting")
+    if arrival_regime not in ARRIVAL_REGIMES:
+        raise BehavioralRegimeError(
+            f"unknown arrival_regime {arrival_regime!r}; the memory-mesh characterizer "
+            f"taxonomy is {sorted(ARRIVAL_REGIMES)}"
+        )
+
+    prospect = _validate_prospect(spec.get("prospect_theory", {}))
+
+    # Series: either provided directly or simulated (seeded) from the model.
+    if "series" in spec:
+        series = [float(x) for x in spec["series"]]
+        source = "provided"
+    else:
+        sim = spec.get("simulate", {})
+        series = _simulate_series(
+            P, regimes, n=int(sim.get("n", 400)), seed=int(sim.get("seed", 0))
+        )
+        source = f"simulated(seed={int(sim.get('seed', 0))})"
+    posterior = hamilton_filter(series, P, regimes)
+    stats = _classify_and_stat(series, posterior)
+
+    body = {
+        "contract_id": spec.get("contract_id", "behavioral-regime"),
+        "as_of": spec.get("as_of", ""),
+        "arrival_regime": arrival_regime,
+        "memory_regime_ref": spec.get(
+            "memory_regime_ref",
+            "memory-mesh:characterizer/arrival-regime",
+        ),
+        "transition_matrix": P,
+        "regime_stats": stats,
+        "prospect_theory": prospect,
+        "series_source": source,
+        "verdict": "verified"
+        if (stats["greed_has_higher_mean"] and stats["greed_has_higher_vol"])
+        else "regime_separation_weak",
+    }
+    receipt = dict(body)
+    receipt["output_hash"] = _sha256(_canonical(body))
+    receipt["receipt_hash"] = _sha256(_canonical(receipt))
+    return receipt
+
+
+def run_behavioral_regime(path: str) -> dict:
+    """Load, schema-validate and evaluate a BehavioralRegime fixture."""
+    validate_json_file(path, _SCHEMA)
+    spec = json.loads(Path(path).read_text())
+    return evaluate_behavioral_regime(spec)

--- a/third_party/open_ep_framework/crypto/manipulation.py
+++ b/third_party/open_ep_framework/crypto/manipulation.py
@@ -1,0 +1,242 @@
+"""ManipulationSignal contract (MS-1) -- predatory-cartel / information asymmetry.
+
+The honesty/governance layer for the crypto asset class. It extends the classic
+adverse-selection microstructure models with crypto-native manipulation indicators
+and emits a governed signal shaped for the GBRG (governed-blast-radius-graph)
+governance plane.
+
+Adverse selection (consume the microstructure order-flow contract by reference)
+-------------------------------------------------------------------------------
+  * Glosten-Milgrom -- the adverse-selection spread an honest market maker must quote
+    given a probability of informed trading (PIN):
+        gm_spread = 2 * pin * (value_high - value_low).
+  * Kyle -- price impact / inverse depth of a market with an informed trader:
+        kyle_lambda = sigma_v / (2 * sigma_u)
+    (higher lambda == thinner, more exploitable market). These blocks are shaped to
+    consume the in-flight order-flow contract (feat/microstructure-order-flow).
+
+Crypto-native manipulation indicators
+--------------------------------------
+  * Concentration -- whale risk via the Gini coefficient of holdings and the top-1
+    holder share (a cartel can move price at will).
+  * Wash trading -- self-trade share of reported volume and a volume-inflation ratio
+    (reported vs on-chain-settled volume).
+  * MEV -- maximal extractable value intensity = MEV extracted / volume (sandwiching,
+    front-running: predation on ordinary flow).
+
+Teeth (both directions)
+-----------------------
+  * VERIFIES -- a high-concentration + wash-trade fixture raises a ManipulationSignal
+    with a non-empty evidence list and a non-clean verdict.
+  * REJECTS  -- an ``attested_clean`` claim on a fixture whose concentration is above
+    threshold is a contradiction and is REJECTED (an attestation cannot override the
+    on-chain evidence).
+
+Deterministic and stdlib-only. Measurement, simulation and audit only.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ..settlement import _canonical, _sha256
+from ..validation import validate_json_file
+
+_SCHEMA = "schemas/manipulation_signal.schema.json"
+
+# Detection thresholds (documented, tunable). Above threshold == an indicator fires.
+GINI_THRESHOLD = 0.90
+TOP_HOLDER_SHARE_THRESHOLD = 0.50
+WASH_SELF_TRADE_THRESHOLD = 0.30
+VOLUME_INFLATION_THRESHOLD = 3.0
+MEV_INTENSITY_THRESHOLD = 0.02
+
+
+class ManipulationError(ValueError):
+    """Raised when a manipulation claim is inadmissible / contradicted (REJECTED)."""
+
+
+# --------------------------------------------------------------------------- #
+# concentration
+# --------------------------------------------------------------------------- #
+def gini(balances: list) -> float:
+    """Gini coefficient of a holdings distribution (0 == equal, ->1 == one whale)."""
+    xs = sorted(float(b) for b in balances if float(b) >= 0)
+    n = len(xs)
+    total = sum(xs)
+    if n == 0 or total <= 0:
+        return 0.0
+    cum = 0.0
+    for i, x in enumerate(xs, start=1):
+        cum += i * x
+    return (2.0 * cum) / (n * total) - (n + 1.0) / n
+
+
+def _concentration(spec: dict) -> dict:
+    holders = spec.get("holders")
+    if holders:
+        g = gini(holders)
+        total = sum(float(b) for b in holders)
+        top = max(float(b) for b in holders) / total if total > 0 else 0.0
+    else:
+        g = float(spec.get("gini", 0.0))
+        top = float(spec.get("top_holder_share", 0.0))
+    return {
+        "gini": g,
+        "top_holder_share": top,
+        "flag": bool(g > GINI_THRESHOLD or top > TOP_HOLDER_SHARE_THRESHOLD),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# wash trading + MEV
+# --------------------------------------------------------------------------- #
+def _wash(spec: dict) -> dict:
+    reported = float(spec.get("reported_volume", 0.0))
+    settled = float(spec.get("onchain_settled_volume", reported))
+    self_trade = float(spec.get("self_trade_volume", 0.0))
+    self_share = self_trade / reported if reported > 0 else 0.0
+    inflation = reported / settled if settled > 0 else float("inf")
+    return {
+        "self_trade_share": self_share,
+        "volume_inflation": inflation,
+        "flag": bool(
+            self_share > WASH_SELF_TRADE_THRESHOLD or inflation > VOLUME_INFLATION_THRESHOLD
+        ),
+    }
+
+
+def _mev(spec: dict) -> dict:
+    extracted = float(spec.get("mev_extracted", 0.0))
+    volume = float(spec.get("block_volume", spec.get("reported_volume", 0.0)))
+    intensity = extracted / volume if volume > 0 else 0.0
+    return {
+        "mev_extracted": extracted,
+        "mev_intensity": intensity,
+        "flag": bool(intensity > MEV_INTENSITY_THRESHOLD),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# adverse selection (Glosten-Milgrom / Kyle)
+# --------------------------------------------------------------------------- #
+def _adverse_selection(spec: dict) -> dict:
+    pin = float(spec.get("pin", 0.0))  # probability of informed trading
+    value_high = float(spec.get("value_high", 0.0))
+    value_low = float(spec.get("value_low", 0.0))
+    gm_spread = 2.0 * pin * (value_high - value_low)
+
+    sigma_v = float(spec.get("sigma_v", 0.0))  # fundamental value volatility
+    sigma_u = float(spec.get("sigma_u", 0.0))  # noise (uninformed) order flow
+    kyle_lambda = sigma_v / (2.0 * sigma_u) if sigma_u > 0 else float("inf")
+    return {
+        "pin": pin,
+        "glosten_milgrom_spread": gm_spread,
+        "kyle_lambda": kyle_lambda,
+        # Shaped to consume the in-flight microstructure order-flow contract.
+        "consumes": "feat/microstructure-order-flow-contract",
+        "flag": bool(pin > 0.4 or (sigma_u > 0 and kyle_lambda > 1.0)),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# signal
+# --------------------------------------------------------------------------- #
+_WEIGHTS = {"concentration": 0.35, "wash": 0.30, "mev": 0.20, "adverse_selection": 0.15}
+
+
+def evaluate_manipulation(spec: dict) -> dict:
+    """Evaluate MS-1: build indicators, assemble evidence, emit a GBRG signal."""
+    subject = spec.get("subject", "crypto-asset")
+    concentration = _concentration(spec.get("concentration", {}))
+    wash = _wash(spec.get("volume", {}))
+    mev = _mev(spec.get("mev", {}))
+    adverse = _adverse_selection(spec.get("adverse_selection", {}))
+
+    indicators = {
+        "concentration": concentration,
+        "wash": wash,
+        "mev": mev,
+        "adverse_selection": adverse,
+    }
+
+    evidence = []
+    if concentration["flag"]:
+        evidence.append({
+            "indicator": "concentration",
+            "gini": concentration["gini"],
+            "top_holder_share": concentration["top_holder_share"],
+            "thresholds": {"gini": GINI_THRESHOLD, "top_holder_share": TOP_HOLDER_SHARE_THRESHOLD},
+        })
+    if wash["flag"]:
+        evidence.append({
+            "indicator": "wash_trade",
+            "self_trade_share": wash["self_trade_share"],
+            "volume_inflation": wash["volume_inflation"],
+            "thresholds": {"self_trade_share": WASH_SELF_TRADE_THRESHOLD, "volume_inflation": VOLUME_INFLATION_THRESHOLD},
+        })
+    if mev["flag"]:
+        evidence.append({
+            "indicator": "mev",
+            "mev_intensity": mev["mev_intensity"],
+            "threshold": MEV_INTENSITY_THRESHOLD,
+        })
+    if adverse["flag"]:
+        evidence.append({
+            "indicator": "adverse_selection",
+            "glosten_milgrom_spread": adverse["glosten_milgrom_spread"],
+            "kyle_lambda": adverse["kyle_lambda"],
+            "pin": adverse["pin"],
+        })
+
+    severity = sum(_WEIGHTS[k] for k, ind in indicators.items() if ind["flag"])
+    flagged = bool(evidence)
+
+    # Teeth: an attestation of cleanliness cannot override on-chain evidence.
+    if bool(spec.get("attested_clean", False)) and concentration["flag"]:
+        raise ManipulationError(
+            "REJECTED: attested_clean contradicts on-chain evidence -- concentration is "
+            f"above threshold (gini={concentration['gini']:.4f}, "
+            f"top_holder_share={concentration['top_holder_share']:.4f}); a manipulation-free "
+            "claim on a whale-concentrated asset must be flagged, not attested away"
+        )
+
+    if not flagged:
+        verdict = "clean"
+    elif severity >= 0.5:
+        verdict = "manipulated"
+    else:
+        verdict = "flagged"
+
+    body = {
+        "signal_id": spec.get("signal_id", f"ms1:{subject}"),
+        "as_of": spec.get("as_of", ""),
+        "subject": subject,
+        "indicators": indicators,
+        "severity": severity,
+        "verdict": verdict,
+        "evidence": evidence,
+        # GBRG governance-plane shape (consumed by reference).
+        "gbrg": {
+            "signal_id": spec.get("signal_id", f"ms1:{subject}"),
+            "subject": subject,
+            "severity": severity,
+            "verdict": verdict,
+            "evidence_count": len(evidence),
+            "blast_radius": spec.get("blast_radius", ["price_discovery", "counterparties", "index_inclusion"]),
+            "containment": "quarantine_pending_review" if verdict == "manipulated" else (
+                "monitor" if flagged else "none"
+            ),
+        },
+    }
+    receipt = dict(body)
+    receipt["output_hash"] = _sha256(_canonical(body))
+    receipt["receipt_hash"] = _sha256(_canonical(receipt))
+    return receipt
+
+
+def run_manipulation(path: str) -> dict:
+    """Load, schema-validate and evaluate a ManipulationSignal fixture."""
+    validate_json_file(path, _SCHEMA)
+    spec = json.loads(Path(path).read_text())
+    return evaluate_manipulation(spec)

--- a/third_party/open_ep_framework/crypto/valuation.py
+++ b/third_party/open_ep_framework/crypto/valuation.py
@@ -1,0 +1,341 @@
+"""CryptoAssetValuation contract (CAV-1) -- value criteria that are NOT DCF.
+
+Why crypto needs its own F and its own value criteria
+-----------------------------------------------------
+A token mostly has no cash flows, so a discounted-cash-flow (DCF) valuation is the
+WRONG model: there is nothing to discount. Value instead comes from the protocol
+(supply/emission/burn/security budget), on-chain usage (active addresses, TVL, fee
+revenue), the network itself (Metcalfe value proportional to n^2; NVT ratio == the
+network-value-to-transactions "crypto P/E"), and -- uniquely -- from attention and
+narrative (a memetic / information-theoretic value). This contract makes each of
+those a transparent, testable scalar, and it REJECTS a cash-flow model asserted on a
+no-cash-flow token.
+
+Modified economic profit (the crypto EP identity)
+-------------------------------------------------
+    modified_ep = fee_revenue - security_cost - emission_dilution - risk_capital
+
+  * ``fee_revenue``       -- annualized protocol fee revenue (the real, earned leg).
+  * ``security_cost``     -- the security budget (issuance+fees paid to miners/
+                             validators) that pays for the hashrate/stake defending
+                             the chain; a cost of doing business, not value to holders.
+  * ``emission_dilution`` -- net new issuance charged at price:
+                             (circulating_supply*emission_rate - burn_tokens) * price.
+                             Deflationary (burn > emission) makes this NEGATIVE, i.e.
+                             accretive. A modified-EP that ignores this term is silent
+                             inflation and is REJECTED.
+  * ``risk_capital``      -- a COHERENT tail-risk charge (Expected Shortfall) over a
+                             REFLEXIVE, FAT-TAILED loss distribution F, consumed from
+                             the estate risk kernel (RM-1). Reflexivity amplifies vol;
+                             a small Student-t df supplies the fat left tail.
+
+Memetic / information-theoretic value (Economia Mentium)
+--------------------------------------------------------
+Value as attention/narrative, framed as an information-asset: value == epistemic
+delta, liquidity == attention/volume. From an attention series it computes a virality
+(replication) factor and an information-theoretic epistemic delta (KL of the attention
+distribution from its uniform prior, in bits). Learn-don't-match: a memetic value
+asserted with NO evidence (empty attention series / no evidence list) is REJECTED --
+no bare narrative scores.
+
+Deterministic and stdlib-only. Measurement, simulation and audit only.
+"""
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+from ..risk_measures import LossDistribution, lpm, risk
+from ..settlement import _canonical, _sha256
+from ..validation import validate_json_file
+
+_SCHEMA = "schemas/crypto_asset_valuation.schema.json"
+
+# Value criteria that are legitimate for a (mostly) no-cash-flow token. DCF is
+# deliberately absent: it is the wrong model for an asset with no cash flows.
+NETWORK_METHODS = {"network_metcalfe", "nvt", "fee_modified_ep", "memetic"}
+CASH_FLOW_METHODS = {"dcf", "ddm", "cash_flow"}
+
+
+class CryptoValuationError(ValueError):
+    """Raised when a token cannot be valued under the contract (REJECTED)."""
+
+
+# --------------------------------------------------------------------------- #
+# reflexive, fat-tailed F -> risk_capital (consume the estate risk kernel RM-1)
+# --------------------------------------------------------------------------- #
+def _reflexive_loss_distribution(spec: dict) -> LossDistribution:
+    """Build a reflexive, fat-tailed RETURN distribution F for the risk kernel.
+
+    Reflexivity (Soros): price and fundamentals feed back on each other, fattening
+    and widening the return distribution during self-exciting phases. We model it as
+    a volatility amplifier ``sigma_eff = sigma * (1 + reflexivity)`` on a Student-t
+    body whose (small) degrees of freedom ``df`` supply the fat left tail. The result
+    is a ``LossDistribution`` the RM-1 kernel reads directly for ES / LPM -- we do not
+    reinvent the tail math, we shape F for it.
+    """
+    mu = float(spec.get("mu", 0.0))
+    sigma = float(spec.get("sigma", 0.05))
+    if sigma <= 0:
+        raise CryptoValuationError("reflexive F requires sigma > 0")
+    reflexivity = float(spec.get("reflexivity", 0.0))
+    if reflexivity < 0:
+        raise CryptoValuationError("reflexivity must be >= 0")
+    df = float(spec.get("df", 3.0))  # small df == fat tails
+    sigma_eff = sigma * (1.0 + reflexivity)
+    return LossDistribution.simulate_equity(
+        mu=mu,
+        sigma=sigma_eff,
+        df=df,
+        horizon_days=int(spec.get("horizon_days", 1)),
+        n_scenarios=int(spec.get("n_scenarios", 2000)),
+        seed=int(spec.get("seed", 0)),
+    )
+
+
+def _risk_capital(spec: dict) -> dict:
+    """Coherent tail risk capital = ES_fraction(F) * risk_notional (RM-1).
+
+    ``risk_notional`` is the value exposed (e.g. market cap or a position mark).
+    Expected Shortfall is coherent (unlike VaR), so this is a defensible capital
+    magnitude. LPM_2 (downside deviation squared) is reported alongside so the
+    reflexive downside is auditable via the same kernel.
+    """
+    notional = float(spec.get("risk_notional", 0.0))
+    if notional < 0:
+        raise CryptoValuationError("risk_notional must be >= 0")
+    alpha = float(spec.get("alpha", 0.975))
+    F = _reflexive_loss_distribution(spec)
+    es = risk(F, "expected_shortfall", alpha=alpha)
+    es_fraction = es.value  # per-unit loss fraction from the return F
+    lpm2 = lpm(F.samples, tau=float(spec.get("mar", 0.0)), order=2)
+    return {
+        "risk_capital": es_fraction * notional,
+        "es_fraction": es_fraction,
+        "alpha": alpha,
+        "lpm2_downside": lpm2,
+        "reflexivity": float(spec.get("reflexivity", 0.0)),
+        "df": float(spec.get("df", 3.0)),
+        "coherent": es.coherent,
+        "provisional": es.provisional,
+        "distribution_id": es.distribution_id,
+        "risk_notional": notional,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# network value: Metcalfe (proportional to n^2) and NVT (crypto P/E)
+# --------------------------------------------------------------------------- #
+def _network_value(tokenomics: dict, onchain: dict, network: dict) -> dict:
+    """Metcalfe value (proportional to n^2) and NVT ratio, reconciled to inputs."""
+    n = float(onchain["active_addresses"])
+    if n < 0:
+        raise CryptoValuationError("active_addresses must be >= 0")
+    k = float(network.get("metcalfe_coefficient", 1.0))
+    metcalfe_value = k * n * n  # Metcalfe's law: network value proportional to n^2
+
+    supply = float(tokenomics["circulating_supply"])
+    price = float(tokenomics["price"])
+    market_cap = supply * price
+
+    tx_volume = float(onchain.get("annual_tx_volume", 0.0))
+    if tx_volume <= 0:
+        raise CryptoValuationError(
+            "NVT requires a positive annual_tx_volume (network throughput)"
+        )
+    nvt = market_cap / tx_volume  # network-value-to-transactions == crypto P/E
+
+    metcalfe_implied_price = metcalfe_value / supply if supply > 0 else math.inf
+    # >1 == market price rich vs Metcalfe-fair; <1 == cheap.
+    price_to_metcalfe = price / metcalfe_implied_price if metcalfe_implied_price > 0 else math.inf
+    return {
+        "active_addresses": n,
+        "metcalfe_coefficient": k,
+        "metcalfe_value": metcalfe_value,
+        "metcalfe_implied_price": metcalfe_implied_price,
+        "market_cap": market_cap,
+        "annual_tx_volume": tx_volume,
+        "nvt_ratio": nvt,
+        "price_to_metcalfe": price_to_metcalfe,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# modified economic profit
+# --------------------------------------------------------------------------- #
+def _emission_dilution(tokenomics: dict) -> float:
+    """Net-issuance dilution charged at price = (emission - burn) tokens * price.
+
+    Deflationary tokens (burn > emission) yield a NEGATIVE dilution (accretive).
+    A positive net emission with no price is silent inflation and is REJECTED by the
+    caller, which requires a price whenever emission is present.
+    """
+    supply = float(tokenomics["circulating_supply"])
+    emission_rate = float(tokenomics.get("emission_rate", 0.0))
+    burn_tokens = float(tokenomics.get("burn_tokens_annual", 0.0))
+    price = float(tokenomics["price"])
+    net_new_tokens = supply * emission_rate - burn_tokens
+    return net_new_tokens * price
+
+
+def _modified_ep(spec: dict) -> dict:
+    """modified_ep = fee_revenue - security_cost - emission_dilution - risk_capital."""
+    tokenomics = spec["tokenomics"]
+    onchain = spec["onchain"]
+
+    fee_revenue = float(onchain.get("fee_revenue", 0.0))
+    security_cost = float(spec.get("security", {}).get("security_cost", 0.0))
+    if security_cost < 0:
+        raise CryptoValuationError("security_cost must be >= 0")
+
+    # Teeth: emission dilution may not be silently dropped. A token with net positive
+    # emission MUST carry a price so its dilution is charged.
+    emission_rate = float(tokenomics.get("emission_rate", 0.0))
+    burn_tokens = float(tokenomics.get("burn_tokens_annual", 0.0))
+    supply = float(tokenomics["circulating_supply"])
+    net_new_tokens = supply * emission_rate - burn_tokens
+    if net_new_tokens > 0 and "price" not in tokenomics:
+        raise CryptoValuationError(
+            "REJECTED: net positive emission with no price is unpriced dilution "
+            "(silent inflation); modified-EP must charge emission dilution"
+        )
+    emission_dilution = _emission_dilution(tokenomics)
+
+    rc = _risk_capital(spec.get("risk", {}))
+    risk_capital = rc["risk_capital"]
+
+    modified_ep = fee_revenue - security_cost - emission_dilution - risk_capital
+    return {
+        "modified_ep": modified_ep,
+        "fee_revenue": fee_revenue,
+        "security_cost": security_cost,
+        "emission_dilution": emission_dilution,
+        "net_new_tokens": net_new_tokens,
+        "risk_capital": risk_capital,
+        "risk": rc,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# memetic / information-theoretic value (Economia Mentium)
+# --------------------------------------------------------------------------- #
+def _memetic_value(memetic: dict) -> dict:
+    """Evidence-bound memetic / information value: virality * epistemic delta.
+
+    ``attention_series`` is a time series of an attention/volume proxy (social
+    volume, search interest, mentions). We compute:
+      * virality      -- replication factor = latest / mean(prior window). >1 == the
+                         narrative is spreading faster than its own recent history.
+      * epistemic_delta (bits) -- KL(p || uniform) = log2(T) - H(p), where p is the
+                         attention distribution over the window: how far the narrative
+                         has moved from a flat prior (== information gained).
+      * information_value -- virality * epistemic_delta (both evidence-derived).
+
+    Learn-don't-match: an empty attention_series or empty evidence list is REJECTED.
+    No bare narrative scores.
+    """
+    series = [float(x) for x in memetic.get("attention_series", [])]
+    evidence = memetic.get("evidence", [])
+    if len(series) < 2 or not evidence:
+        raise CryptoValuationError(
+            "REJECTED: memetic/attention value requires an attention series (>=2 points) "
+            "and evidence; a bare narrative score is not admissible"
+        )
+    if any(x < 0 for x in series):
+        raise CryptoValuationError("attention_series values must be >= 0")
+    total = sum(series)
+    if total <= 0:
+        raise CryptoValuationError("attention_series must have positive total attention")
+
+    latest = series[-1]
+    prior = series[:-1]
+    prior_mean = sum(prior) / len(prior)
+    virality = latest / prior_mean if prior_mean > 0 else math.inf
+
+    p = [x / total for x in series]
+    entropy_bits = -sum(pi * math.log2(pi) for pi in p if pi > 0)
+    max_entropy = math.log2(len(series))
+    epistemic_delta = max_entropy - entropy_bits  # KL(p || uniform) in bits, >= 0
+    surprise_latest = -math.log2(p[-1]) if p[-1] > 0 else math.inf
+
+    information_value = virality * epistemic_delta
+    return {
+        "virality": virality,
+        "entropy_bits": entropy_bits,
+        "epistemic_delta_bits": epistemic_delta,
+        "surprise_latest_bits": surprise_latest,
+        "information_value": information_value,
+        "attention_liquidity": total,
+        "evidence_count": len(evidence),
+        "evidence": list(evidence),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# contract
+# --------------------------------------------------------------------------- #
+def _guard_model(spec: dict) -> None:
+    """Wrong-model guard: a cash-flow (DCF) model on a no-cash-flow token is REJECTED."""
+    method = spec.get("valuation_method")
+    cash_flow_bearing = bool(spec.get("tokenomics", {}).get("cash_flow_bearing", False))
+    if method in CASH_FLOW_METHODS and not cash_flow_bearing:
+        raise CryptoValuationError(
+            f"REJECTED: valuation_method '{method}' discounts cash flows, but this token "
+            "has no cash flows (cash_flow_bearing=false). Use network/fee/memetic criteria "
+            f"({sorted(NETWORK_METHODS)}) -- the credit/equity DCF machinery does not apply."
+        )
+    if method is not None and method not in NETWORK_METHODS and method not in CASH_FLOW_METHODS:
+        raise CryptoValuationError(f"unknown valuation_method {method!r}")
+
+
+def _guard_emission_priced(tokenomics: dict) -> None:
+    """Teeth: net positive emission with no price is unpriced dilution (silent inflation)."""
+    supply = float(tokenomics["circulating_supply"])
+    emission_rate = float(tokenomics.get("emission_rate", 0.0))
+    burn_tokens = float(tokenomics.get("burn_tokens_annual", 0.0))
+    net_new_tokens = supply * emission_rate - burn_tokens
+    if net_new_tokens > 0 and "price" not in tokenomics:
+        raise CryptoValuationError(
+            "REJECTED: net positive emission with no price is unpriced dilution "
+            "(silent inflation); modified-EP must charge emission dilution"
+        )
+
+
+def evaluate_valuation(spec: dict) -> dict:
+    """Value a crypto asset under CAV-1: network + fee modified-EP + memetic value."""
+    _guard_model(spec)
+    _guard_emission_priced(spec["tokenomics"])
+
+    network = _network_value(spec["tokenomics"], spec["onchain"], spec.get("network", {}))
+    ep = _modified_ep(spec)
+
+    body = {
+        "asset_id": spec.get("asset_id", "crypto-asset"),
+        "as_of": spec.get("as_of", ""),
+        "valuation_method": spec.get("valuation_method", "fee_modified_ep"),
+        "network_value": network,
+        "modified_economic_profit": ep,
+    }
+
+    memetic_spec = spec.get("memetic")
+    if memetic_spec is not None:
+        body["memetic_value"] = _memetic_value(memetic_spec)
+
+    # Verdict: a fee-bearing chain with a finite modified-EP is scored; a positive
+    # modified-EP is value-accretive after security + dilution + reflexive tail risk.
+    if not math.isfinite(ep["modified_ep"]):
+        raise CryptoValuationError("modified_ep is not finite")
+    body["verdict"] = "accretive" if ep["modified_ep"] > 0 else "value_destroying"
+
+    receipt = dict(body)
+    receipt["output_hash"] = _sha256(_canonical(body))
+    receipt["receipt_hash"] = _sha256(_canonical(receipt))
+    return receipt
+
+
+def run_valuation(path: str) -> dict:
+    """Load, schema-validate and evaluate a CryptoAssetValuation fixture."""
+    validate_json_file(path, _SCHEMA)
+    spec = json.loads(Path(path).read_text())
+    return evaluate_valuation(spec)

--- a/third_party/open_ep_framework/flow_regime/__init__.py
+++ b/third_party/open_ep_framework/flow_regime/__init__.py
@@ -1,0 +1,27 @@
+"""Flow-regime module: the ternary-option <-> low-dimensional-turbulence synthesis.
+
+Two contracts-with-teeth, one thesis -- a market process and a fluid flow are read by
+the SAME regime lens (the memory-mesh characterizer's taxonomy), and each regime picks
+a different pricing / stability mechanism:
+
+  * ``trinomial`` (FRT-1) -- a regime-aware Boyle trinomial option pricer whose MIDDLE
+    ("stay") branch projects to the regime's stable point (memoryless -> Black-Scholes;
+    mean-reverting -> the OU reversion target ``mu``; trending -> drift-dominated;
+    chaotic -> attractor centroid). Consumes ``market_instruments`` (Black-76) and the
+    memory-mesh OU fit / crosswalk by reference.
+  * ``lorenz`` (FRL-1) -- a Lorenz-style 3-variable Navier-Stokes reduction; Jacobian
+    fixed-point stability + the largest Lyapunov exponent classify laminar vs turbulent,
+    and the market vol-cascade is mapped to the turbulent energy cascade (Kolmogorov /
+    multifractal; Ghashghaie 1996; rough-vol H~=0.1). Analogue only -- an explicit
+    no-overclaim guard rejects any claim to solve/prove Navier-Stokes existence/smoothness.
+
+Metaphor -> mechanism, NOT numerology: the ternary form and the turbulence lens are
+earned by the mechanism (a middle branch that lands on a regime-specific stable point;
+a Lyapunov sign that must agree with the characterizer), and every claim carries a
+falsifying tooth.
+
+Deterministic and stdlib-only.
+"""
+from . import lorenz, trinomial  # noqa: F401
+
+__all__ = ["trinomial", "lorenz"]

--- a/third_party/open_ep_framework/flow_regime/lorenz.py
+++ b/third_party/open_ep_framework/flow_regime/lorenz.py
@@ -1,0 +1,315 @@
+"""Low-dimensional flow-regime lens: Lorenz / turbulence <-> Navier-Stokes (FRL-1).
+
+The Lorenz (1963) system is the canonical THREE-variable reduction of Rayleigh-Benard
+convection -- a Navier-Stokes (incompressible, buoyancy-driven) flow truncated to its
+first Fourier modes:
+
+    dx/dt = sigma (y - x)
+    dy/dt = x (rho - z) - y
+    dz/dt = x y - beta z
+
+``x`` ~ convective overturning rate, ``y`` / ``z`` ~ horizontal / vertical temperature
+structure; ``rho`` is the reduced Rayleigh number (drive), ``sigma`` the Prandtl number,
+``beta`` the geometry. This module reads the flow REGIME the way the memory-mesh
+characterizer reads a market series' memory regime, and MAPS the two:
+
+  * fixed-point stability from the Jacobian eigenvalues, and
+  * the largest Lyapunov exponent (positive => sensitive dependence => chaos),
+
+classify **laminar** (a stable fixed point; all eigenvalue real parts negative;
+Lyapunov <= 0) vs **turbulent** (a strange attractor; a positive Lyapunov exponent).
+
+Consume-by-reference (do NOT fork):
+  * memory-mesh regime characterizer -- the Lyapunov ESTIMATOR and the regime TAXONOMY
+    are the memory-mesh property. We expose an INJECTION SEAM ``lyapunov_fn`` (exactly
+    the pattern ``term_calculus`` uses for the Hurst characterizer): when a series-based
+    estimator (memory-mesh ``lyapunov_rosenstein``) is injected it is used; otherwise a
+    local, deterministic Benettin exponent (variational, using the analytic Jacobian --
+    the correct method for a KNOWN vector field, not a re-fit of the series estimator) is
+    the hermetic-CI fallback. The taxonomy map is fixed by reference:
+        chaotic            <-> turbulent
+        memoryless/stable  <-> laminar
+    and the sign-agreement tooth asserts the two never disagree.
+
+Market vol-cascade <-> turbulent energy cascade (documented, ANALOGUE only):
+  Kolmogorov's turbulent energy cascade (energy injected at large scales, dissipated at
+  small scales, with intermittency / multifractal scaling) is the physical twin of the
+  market VOLATILITY cascade. Ghashghaie et al. (Nature, 1996) showed FX returns share
+  the multifractal, cascade-like statistics of hydrodynamic turbulence; rough-volatility
+  (Gatheral-Jaisson-Rosenbaum) finds volatility is itself a fractional process with
+  H~=0.1 -- the ANTI-PERSISTENT / intermittent end of the memory-mesh Hurst axis. The
+  vol cascade maps to the turbulent cascade through that Hurst / multifractal axis. This
+  is a characterization LENS, not an identity.
+
+NO-OVERCLAIM GUARD (Deliverable 2 honesty tooth): this module is an ANALOGUE /
+characterization lens. It does NOT solve, prove, or bear on the Navier-Stokes existence
+and smoothness (Clay Millennium) problem. Any record claiming to do so is REJECTED
+(``reject_navier_stokes_overclaim``); the schema pins ``scope`` to
+``analogue_characterization_only``.
+
+Deterministic and stdlib-only (fixed-seed-free RK4 + analytic Jacobian).
+"""
+from __future__ import annotations
+
+import cmath
+import math
+from dataclasses import dataclass
+
+# The classic chaotic Lorenz parameter set (sigma, rho, beta).
+LORENZ_CLASSIC = (10.0, 28.0, 8.0 / 3.0)
+
+# Chaos threshold on the largest Lyapunov exponent. Consumed BY REFERENCE from the
+# memory-mesh characterizer (memory_regime_estimators.CHAOS_LAMBDA == 0.30): a lambda
+# above this is chaotic/turbulent. Kept identical so the two lenses agree by construction.
+CHAOS_LAMBDA = 0.30
+
+# The fixed memory-mesh-taxonomy <-> flow-regime map (consume-by-reference).
+TAXONOMY_TO_FLOW = {
+    "chaotic": "turbulent",
+    "memoryless": "laminar",
+    "short_decaying": "laminar",
+    "long_memory": "laminar",  # persistent but not (necessarily) sensitive-dependent
+}
+
+# Phrases that make a record an illegitimate Navier-Stokes existence/smoothness claim.
+_NS_ACTS = ("solve", "solved", "solves", "prove", "proved", "proves", "proof",
+            "resolve", "resolves", "settle", "settles", "establish", "establishes")
+_NS_SUBJECTS = ("navier-stokes", "navier stokes", "navierstokes")
+_NS_TARGETS = ("existence", "smoothness", "regularity", "millennium", "global solution",
+               "blow-up", "blowup", "well-posed", "well posed")
+
+
+class FlowRegimeError(ValueError):
+    """Raised for an inadmissible flow record (bad params, an overclaim) -- REJECTED."""
+
+
+LorenzParams = tuple  # (sigma, rho, beta)
+
+
+# --------------------------------------------------------------------------- #
+# vector field, fixed points, Jacobian
+# --------------------------------------------------------------------------- #
+def lorenz_deriv(state, params: LorenzParams):
+    x, y, z = state
+    sigma, rho, beta = params
+    return (sigma * (y - x), x * (rho - z) - y, x * y - beta * z)
+
+
+def fixed_points(params: LorenzParams) -> list:
+    """Fixed points of the Lorenz flow.
+
+    The origin always; for rho>1 the convective pair C+/- =
+    (+-sqrt(beta(rho-1)), +-sqrt(beta(rho-1)), rho-1)."""
+    sigma, rho, beta = params
+    pts = [("origin", (0.0, 0.0, 0.0))]
+    if rho > 1.0:
+        r = math.sqrt(beta * (rho - 1.0))
+        pts.append(("C+", (r, r, rho - 1.0)))
+        pts.append(("C-", (-r, -r, rho - 1.0)))
+    return pts
+
+
+def jacobian(state, params: LorenzParams):
+    x, y, z = state
+    sigma, rho, beta = params
+    return [
+        [-sigma, sigma, 0.0],
+        [rho - z, -1.0, -x],
+        [y, x, -beta],
+    ]
+
+
+def _cubic_roots(a: float, b: float, c: float, d: float):
+    """All three (complex) roots of a x^3 + b x^2 + c x + d = 0 (a != 0)."""
+    b, c, d = b / a, c / a, d / a
+    # depressed cubic t^3 + p t + q with x = t - b/3
+    p = c - b * b / 3.0
+    q = 2.0 * b ** 3 / 27.0 - b * c / 3.0 + d
+    shift = -b / 3.0
+    disc = (q / 2.0) ** 2 + (p / 3.0) ** 3
+    roots = []
+    if abs(p) < 1e-14 and abs(q) < 1e-14:
+        return [complex(shift)] * 3
+    sqrt_disc = cmath.sqrt(disc)
+    u = (-q / 2.0 + sqrt_disc)
+    u = u ** (1.0 / 3.0) if u == 0 else cmath.exp(cmath.log(u) / 3.0)
+    for k in range(3):
+        w = cmath.exp(2j * cmath.pi * k / 3.0) * u
+        if abs(w) < 1e-14:
+            continue
+        v = -p / (3.0 * w)
+        roots.append(w + v + shift)
+    # pad if degenerate
+    while len(roots) < 3:
+        roots.append(complex(shift))
+    return roots[:3]
+
+
+def eigenvalues(state, params: LorenzParams):
+    """Eigenvalues of the Jacobian at ``state`` (via the characteristic cubic
+    lambda^3 - tr lambda^2 + (sum principal 2x2 minors) lambda - det = 0)."""
+    J = jacobian(state, params)
+    tr = J[0][0] + J[1][1] + J[2][2]
+    m11 = J[1][1] * J[2][2] - J[1][2] * J[2][1]
+    m22 = J[0][0] * J[2][2] - J[0][2] * J[2][0]
+    m33 = J[0][0] * J[1][1] - J[0][1] * J[1][0]
+    minors = m11 + m22 + m33
+    det = (
+        J[0][0] * (J[1][1] * J[2][2] - J[1][2] * J[2][1])
+        - J[0][1] * (J[1][0] * J[2][2] - J[1][2] * J[2][0])
+        + J[0][2] * (J[1][0] * J[2][1] - J[1][1] * J[2][0])
+    )
+    return _cubic_roots(1.0, -tr, minors, -det)
+
+
+def is_stable_fixed_point(state, params: LorenzParams) -> bool:
+    """A fixed point is (linearly) stable iff every eigenvalue has negative real part."""
+    return all(ev.real < -1e-9 for ev in eigenvalues(state, params))
+
+
+def any_stable_fixed_point(params: LorenzParams) -> bool:
+    return any(is_stable_fixed_point(s, params) for _, s in fixed_points(params))
+
+
+# --------------------------------------------------------------------------- #
+# RK4 integrator + Benettin largest Lyapunov exponent (local fallback estimator)
+# --------------------------------------------------------------------------- #
+def _rk4_step(state, params, dt):
+    def add(s, k, h):
+        return (s[0] + h * k[0], s[1] + h * k[1], s[2] + h * k[2])
+    k1 = lorenz_deriv(state, params)
+    k2 = lorenz_deriv(add(state, k1, dt / 2), params)
+    k3 = lorenz_deriv(add(state, k2, dt / 2), params)
+    k4 = lorenz_deriv(add(state, k3, dt), params)
+    return (
+        state[0] + dt / 6 * (k1[0] + 2 * k2[0] + 2 * k3[0] + k4[0]),
+        state[1] + dt / 6 * (k1[1] + 2 * k2[1] + 2 * k3[1] + k4[1]),
+        state[2] + dt / 6 * (k1[2] + 2 * k2[2] + 2 * k3[2] + k4[2]),
+    )
+
+
+def trajectory(params: LorenzParams, state0=(1.0, 1.0, 1.0), dt: float = 0.01,
+               n: int = 4000, transient: int = 1000):
+    """Deterministic RK4 trajectory (after discarding a transient) as a list of states."""
+    s = state0
+    for _ in range(transient):
+        s = _rk4_step(s, params, dt)
+    out = []
+    for _ in range(n):
+        s = _rk4_step(s, params, dt)
+        out.append(s)
+    return out
+
+
+def benettin_lyapunov(params: LorenzParams, state0=(1.0, 1.0, 1.0), dt: float = 0.01,
+                      n: int = 6000, transient: int = 2000, d0: float = 1e-8) -> float:
+    """Largest Lyapunov exponent by the Benettin (1980) variational method.
+
+    Two nearby trajectories are advanced by the SAME RK4 flow; their separation is
+    renormalized to ``d0`` each step and the mean log-growth is accumulated. This uses
+    the analytic flow of a KNOWN vector field -- it is NOT a re-fit of the memory-mesh
+    series estimator, which is consumed through the ``lyapunov_fn`` seam instead.
+    """
+    s = state0
+    for _ in range(transient):
+        s = _rk4_step(s, params, dt)
+    # perturbed companion
+    sp = (s[0] + d0, s[1], s[2])
+    total = 0.0
+    for _ in range(n):
+        s = _rk4_step(s, params, dt)
+        sp = _rk4_step(sp, params, dt)
+        dx = (sp[0] - s[0], sp[1] - s[1], sp[2] - s[2])
+        dist = math.sqrt(dx[0] ** 2 + dx[1] ** 2 + dx[2] ** 2)
+        if dist <= 0:
+            continue
+        total += math.log(dist / d0)
+        scale = d0 / dist
+        sp = (s[0] + dx[0] * scale, s[1] + dx[1] * scale, s[2] + dx[2] * scale)
+    return total / (n * dt)
+
+
+# --------------------------------------------------------------------------- #
+# classifier
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class FlowClassification:
+    params: LorenzParams
+    lambda_max: float
+    regime: str                 # "laminar" | "turbulent"
+    stable_fixed_point: bool
+    fixed_point_report: tuple    # ((label, max_real_eigenvalue, stable), ...)
+    lyapunov_source: str        # "benettin" | injected estimator name
+
+    @property
+    def is_turbulent(self) -> bool:
+        return self.regime == "turbulent"
+
+
+def classify_flow(params: LorenzParams, lyapunov_fn=None,
+                  state0=(1.0, 1.0, 1.0)) -> FlowClassification:
+    """Classify a Lorenz parameter set as laminar or turbulent.
+
+    ``lyapunov_fn`` is the consume-by-reference injection seam: if given, it is called
+    as ``lyapunov_fn(series)`` on a trajectory coordinate (the memory-mesh
+    ``lyapunov_rosenstein`` fits this signature); otherwise the local Benettin exponent
+    is used. Turbulent iff lambda_max > CHAOS_LAMBDA (the memory-mesh threshold)."""
+    sigma, rho, beta = params
+    if sigma <= 0 or beta <= 0 or rho < 0:
+        raise FlowRegimeError(f"REJECTED: non-physical Lorenz params {params}")
+    if lyapunov_fn is not None:
+        series = [s[0] for s in trajectory(params, state0=state0)]
+        lam = float(lyapunov_fn(series))
+        source = getattr(lyapunov_fn, "__name__", "injected")
+    else:
+        lam = benettin_lyapunov(params, state0=state0)
+        source = "benettin"
+    report = tuple(
+        (label, max(ev.real for ev in eigenvalues(s, params)),
+         is_stable_fixed_point(s, params))
+        for label, s in fixed_points(params)
+    )
+    stable = any(rep[2] for rep in report)
+    regime = "turbulent" if lam > CHAOS_LAMBDA else "laminar"
+    return FlowClassification(params, round(lam, 4), regime, stable, report, source)
+
+
+# --------------------------------------------------------------------------- #
+# taxonomy agreement + no-overclaim guard (the teeth)
+# --------------------------------------------------------------------------- #
+def flow_regime_for_taxonomy(memory_regime: str) -> str:
+    """Map a memory-mesh taxonomy label to the expected flow regime (by reference)."""
+    if memory_regime not in TAXONOMY_TO_FLOW:
+        raise FlowRegimeError(f"unknown memory-mesh regime label {memory_regime!r}")
+    return TAXONOMY_TO_FLOW[memory_regime]
+
+
+def lyapunov_sign_agrees(classification: FlowClassification, memory_regime: str) -> bool:
+    """The Lyapunov-sign flow regime must match the characterizer's taxonomy regime.
+
+    chaotic (lambda>0) <-> turbulent; a stable/non-chaotic taxonomy label <-> laminar."""
+    return classification.regime == flow_regime_for_taxonomy(memory_regime)
+
+
+def reject_navier_stokes_overclaim(text) -> None:
+    """REJECT any claim to solve/prove Navier-Stokes existence/smoothness.
+
+    The lens is an analogue only; a record asserting it settles the Clay Millennium
+    problem (or global existence / smoothness / regularity / blow-up) is inadmissible.
+    """
+    if text is None:
+        return
+    if isinstance(text, (list, tuple)):
+        for t in text:
+            reject_navier_stokes_overclaim(t)
+        return
+    low = str(text).lower()
+    if not any(subj in low for subj in _NS_SUBJECTS):
+        return
+    has_act = any(act in low for act in _NS_ACTS)
+    has_target = any(t in low for t in _NS_TARGETS)
+    if has_act and has_target:
+        raise FlowRegimeError(
+            "REJECTED: Navier-Stokes existence/smoothness over-claim -- this lens is an "
+            "ANALOGUE/characterization only and does not solve or prove the Clay problem"
+        )

--- a/third_party/open_ep_framework/flow_regime/trinomial.py
+++ b/third_party/open_ep_framework/flow_regime/trinomial.py
@@ -1,0 +1,316 @@
+"""Regime-aware TRINOMIAL (ternary) option pricer (FRT-1).
+
+A CRR *binomial* tree is a two-state (up/down) lattice; in the memoryless limit it
+is Black-Scholes and it is *regime-blind* -- there is no branch that can encode where
+the process wants to sit. This module builds a **trinomial** (Boyle 1986) lattice with
+THREE branches -- up / **stay** / down -- and makes the MIDDLE ("stay") branch carry
+the regime's stable point:
+
+  * ``memoryless``   -- an efficient/GBM regime (memory-mesh taxonomy: ``memoryless`` /
+                       ``brownian_gbm``). No reversion; the middle branch is the plain
+                       martingale "stay". A moment-matched Boyle/Kamrad-Ritchken tree
+                       that CONVERGES TO BLACK-SCHOLES as the step count grows.
+  * ``mean_reverting`` -- an Ornstein-Uhlenbeck / ``short_decaying`` regime (memory-mesh
+                       ``ornstein_uhlenbeck``; option-model anchors Vasicek / Hull-White /
+                       CIR / Heston). The middle branch PROJECTS TO THE REVERSION TARGET
+                       ``mu``: a Hull-White trinomial whose recombining lattice is centred
+                       on ``x = ln(mu)`` and whose reversion speed ``theta`` pulls the
+                       drift to zero exactly at ``mu``. ``theta`` / ``mu`` / half-life are
+                       CONSUMED FROM the memory-mesh process characterizer's OU fit
+                       (``estimate_ou`` -> theta, mu, half_life = ln2/theta), not re-fit here.
+  * ``trending``     -- a long-memory / persistent regime (memory-mesh
+                       ``fractional_brownian_motion`` / rough-vol anchor). Drift dominates:
+                       the middle ("stay") branch is weak because the process keeps moving
+                       in one direction. Represented as a momentum drift overlay
+                       (characterization / real-world measure, not risk-neutral).
+  * ``chaotic``      -- a chaotic regime. The "stable point" is a strange ATTRACTOR, not a
+                       fixed point: ``mu`` is the attractor centroid the middle branch
+                       leans toward, but the local Lyapunov instability is flagged so the
+                       caller does not read it as a true fixed point. See ``flow_regime.lorenz``.
+
+Fuller's Synergetics grammar (microstructure #46): three branches is the tetrahedral /
+tetra-3 fundamental cycle -- the minimum-closure ternary the estate's TrendSignal wave
+grammar already uses. This is a structural note, NOT numerology: the mechanism (a middle
+branch that projects onto a regime-specific stable point) is what earns the ternary form.
+
+Consume-by-reference (do NOT fork):
+  * ``open_ep_framework.market_instruments`` (MKT-1) -- Black-76 ``bs_call`` / ``bs_put``
+    supply the Black-Scholes reference the memoryless tree must converge to and the OU
+    tree must DIFFER from.
+  * memory-mesh process characterizer -- OU (theta, mu, half_life) and the
+    process->regime->option crosswalk taxonomy label are consumed as inputs
+    (``RegimeSpec.source_regime``), the same way ``term_calculus`` consumes the Hurst
+    characterizer through an injection seam rather than re-fitting it.
+
+Teeth (both directions), each a dedicated mutation test in ``tests/``:
+  * BS-LIMIT (VERIFIES): a memoryless-regime European price converges to Black-Scholes
+    within tolerance as the step count grows.
+  * OU-DIFFERS (VERIFIES): a mean-reverting-regime price DIFFERS from Black-Scholes by
+    more than tolerance -- mean reversion is priced.
+  * PROBS-IN-[0,1] (REJECTS): every node's (pu, pm, pd) lies in [0,1] and sums to 1; a
+    triple with a negative middle branch or a non-normalized sum is REJECTED.
+  * REGIME-REALLY-CONSUMED (REJECTS): a "regime-aware" record whose mean-reverting price
+    equals Black-Scholes across ALL regimes is REJECTED -- identical prices prove the
+    regime was never consumed (the no-numerology / no-overclaim guard for Deliverable 1).
+
+Deterministic and stdlib-only (analytic lattice, no PRNG), so CI is reproducible.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+from ..market_instruments import bs_call, bs_put
+
+# The memory-mesh process->regime->option crosswalk labels this module consumes by
+# reference (do NOT fork). Each maps to a middle-branch semantics below.
+REGIME_KINDS = ("memoryless", "mean_reverting", "trending", "chaotic")
+
+# The crosswalk's canonical (memory-mesh taxonomy label -> pricer regime kind) map,
+# consumed by reference from docs/architecture/process-regime-crosswalk.md.
+CROSSWALK = {
+    "brownian_gbm": "memoryless",
+    "markov_regime_switching": "memoryless",
+    "ornstein_uhlenbeck": "mean_reverting",
+    "fractional_brownian_motion": "trending",
+    "hawkes": "mean_reverting",
+    "jump_levy": "memoryless",
+    "chaotic": "chaotic",
+}
+
+_PROB_TOL = 1e-9
+
+
+class TrinomialError(ValueError):
+    """Raised for an inadmissible tree (a branch probability outside [0,1], a
+    non-normalized (pu, pm, pd), or an unusable regime spec) -- REJECTED."""
+
+
+# --------------------------------------------------------------------------- #
+# option + regime specs
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class EuropeanOption:
+    spot: float
+    strike: float
+    vol: float          # per-year volatility of log-price
+    maturity: float     # years
+    rate: float = 0.0   # continuously-compounded risk-free rate
+    call: bool = True
+
+    def payoff(self, s: float) -> float:
+        return max(s - self.strike, 0.0) if self.call else max(self.strike - s, 0.0)
+
+
+@dataclass(frozen=True)
+class RegimeSpec:
+    """Which stable point the middle branch projects to.
+
+    ``theta`` / ``mu`` are CONSUMED from the memory-mesh characterizer's OU fit for a
+    ``mean_reverting`` regime; ``source_regime`` records the memory-mesh taxonomy label
+    for provenance / audit.
+    """
+
+    kind: str = "memoryless"
+    theta: float = 0.0            # OU mean-reversion speed (mean_reverting / chaotic)
+    mu: float = 0.0              # reversion target / attractor centroid (level, > 0)
+    momentum_drift: float = 0.0  # excess drift for a trending regime (per year)
+    source_regime: str = ""       # memory-mesh taxonomy label (provenance)
+
+    def __post_init__(self) -> None:
+        if self.kind not in REGIME_KINDS:
+            raise TrinomialError(f"unknown regime kind {self.kind!r}")
+        if self.kind in ("mean_reverting", "chaotic"):
+            if self.theta <= 0:
+                raise TrinomialError(
+                    f"{self.kind} regime requires theta>0 (a finite reversion timescale)"
+                )
+            if self.mu <= 0:
+                raise TrinomialError(f"{self.kind} regime requires a positive level mu")
+
+    @property
+    def half_life(self) -> float:
+        """OU half-life = ln2/theta (the memory-mesh characterizer's reported statistic)."""
+        if self.theta <= 0:
+            return float("inf")
+        return math.log(2.0) / self.theta
+
+    @classmethod
+    def from_ou_characterization(cls, theta: float, mu: float,
+                                 source_regime: str = "ornstein_uhlenbeck") -> "RegimeSpec":
+        """Build a mean-reverting spec straight from the memory-mesh OU fit
+        (``estimate_ou`` -> theta, mu). Consume-by-reference, do not re-fit."""
+        return cls(kind="mean_reverting", theta=theta, mu=mu, source_regime=source_regime)
+
+
+@dataclass(frozen=True)
+class NodeProbs:
+    """A single node's ternary branch probabilities and its branch targets (level
+    offsets applied to the successor lattice)."""
+
+    pu: float
+    pm: float
+    pd: float
+    up: int
+    mid: int
+    down: int
+
+    def validate(self) -> "NodeProbs":
+        for name, p in (("pu", self.pu), ("pm", self.pm), ("pd", self.pd)):
+            if p < -_PROB_TOL or p > 1.0 + _PROB_TOL:
+                raise TrinomialError(
+                    f"REJECTED: branch probability {name}={p:.6f} outside [0,1]"
+                )
+        s = self.pu + self.pm + self.pd
+        if abs(s - 1.0) > 1e-6:
+            raise TrinomialError(f"REJECTED: branch probabilities sum to {s:.6f} != 1")
+        return self
+
+
+# --------------------------------------------------------------------------- #
+# Black-Scholes reference (consumed from market_instruments, MKT-1)
+# --------------------------------------------------------------------------- #
+def black_scholes_reference(opt: EuropeanOption) -> float:
+    """Black-Scholes price via the estate's Black-76 kernel (forward = spot*e^{rT})."""
+    fwd = opt.spot * math.exp(opt.rate * opt.maturity)
+    df = math.exp(-opt.rate * opt.maturity)
+    fn = bs_call if opt.call else bs_put
+    return fn(fwd, opt.strike, opt.vol, opt.maturity, df)
+
+
+# --------------------------------------------------------------------------- #
+# the regime-aware trinomial pricer
+# --------------------------------------------------------------------------- #
+@dataclass
+class RegimeAwareTrinomial:
+    option: EuropeanOption
+    regime: RegimeSpec
+    steps: int = 200
+    lam: float = math.sqrt(3.0)   # Boyle/Kamrad-Ritchken stretch (dx = lam*sigma*sqrt(dt))
+
+    _last_probs: list = field(default_factory=list, repr=False)
+
+    # ---- memoryless (Boyle/Kamrad-Ritchken) -> converges to Black-Scholes ---- #
+    def _price_memoryless(self) -> float:
+        opt = self.option
+        n = self.steps
+        dt = opt.maturity / n
+        sig = opt.vol
+        dx = self.lam * sig * math.sqrt(dt)
+        drift = (opt.rate - 0.5 * sig * sig) * dt  # risk-neutral log-drift
+        var = sig * sig * dt
+        # moment-matched constant probabilities (mean=drift, var=sig^2 dt)
+        q = (var + drift * drift) / (dx * dx)
+        pu = 0.5 * (q + drift / dx)
+        pm = 1.0 - q
+        pd = 0.5 * (q - drift / dx)
+        NodeProbs(pu, pm, pd, +1, 0, -1).validate()
+        self._last_probs = [(pu, pm, pd)]
+        disc = math.exp(-opt.rate * dt)
+        x0 = math.log(opt.spot)
+        # terminal layer j in [-n, n]
+        vals = [opt.payoff(math.exp(x0 + j * dx)) for j in range(-n, n + 1)]
+        for _ in range(n):
+            nxt = [0.0] * (len(vals) - 2)
+            for k in range(len(nxt)):
+                # node k maps to lattice level; successors are k, k+1, k+2 in vals
+                nxt[k] = disc * (pd * vals[k] + pm * vals[k + 1] + pu * vals[k + 2])
+            vals = nxt
+        return vals[0]
+
+    # ---- mean_reverting (Hull-White trinomial) -> middle branch projects to mu ---- #
+    def _hw_node_probs(self, j: int, jmax: int, a: float, dt: float) -> NodeProbs:
+        """Hull-White stage-1 ternary probabilities for level j (reversion to j=0 == mu).
+
+        Interior nodes branch to (j+1, j, j-1); the top node j=jmax branches DOWN to
+        (j, j-1, j-2) and the bottom node j=-jmax branches UP to (j+2, j+1, j), so the
+        recombining lattice is bounded and every probability stays in [0,1]."""
+        aj = a * j * dt
+        a2j2 = (a * j * dt) ** 2
+        if j == jmax:  # downward branching at the top
+            pu = 7.0 / 6.0 + 0.5 * (a2j2 - 3.0 * aj)
+            pm = -1.0 / 3.0 - a2j2 + 2.0 * aj
+            pd = 1.0 / 6.0 + 0.5 * (a2j2 - aj)
+            return NodeProbs(pu, pm, pd, 0, -1, -2).validate()
+        if j == -jmax:  # upward branching at the bottom
+            pu = 1.0 / 6.0 + 0.5 * (a2j2 + aj)
+            pm = -1.0 / 3.0 - a2j2 - 2.0 * aj
+            pd = 7.0 / 6.0 + 0.5 * (a2j2 + 3.0 * aj)
+            return NodeProbs(pu, pm, pd, +2, +1, 0).validate()
+        pu = 1.0 / 6.0 + 0.5 * (a2j2 - aj)
+        pm = 2.0 / 3.0 - a2j2
+        pd = 1.0 / 6.0 + 0.5 * (a2j2 + aj)
+        return NodeProbs(pu, pm, pd, +1, 0, -1).validate()
+
+    def _price_mean_reverting(self) -> float:
+        opt = self.option
+        reg = self.regime
+        n = self.steps
+        dt = opt.maturity / n
+        a = reg.theta
+        sig = opt.vol
+        dx = sig * math.sqrt(3.0 * dt)  # Hull's spacing
+        jmax = max(2, math.ceil(0.184 / (a * dt)))
+        xbar = math.log(reg.mu)             # lattice centre == the stable point mu
+        levels = list(range(-jmax, jmax + 1))
+        idx = {j: k for k, j in enumerate(levels)}
+        probs = {j: self._hw_node_probs(j, jmax, a, dt) for j in levels}
+        self._last_probs = [(p.pu, p.pm, p.pd) for p in probs.values()]
+        disc = math.exp(-opt.rate * dt)
+        # terminal payoff on the lattice
+        vals = [opt.payoff(math.exp(xbar + j * dx)) for j in levels]
+        for _ in range(n):
+            nxt = [0.0] * len(levels)
+            for j in levels:
+                p = probs[j]
+                nxt[idx[j]] = disc * (
+                    p.pu * vals[idx[j + p.up]]
+                    + p.pm * vals[idx[j + p.mid]]
+                    + p.pd * vals[idx[j + p.down]]
+                )
+            vals = nxt
+        # the option is written on the underlying starting at spot -> nearest lattice node
+        j0 = round((math.log(opt.spot) - xbar) / dx)
+        j0 = max(-jmax, min(jmax, j0))
+        return vals[idx[j0]]
+
+    # ---- trending (momentum-drift overlay; middle branch weak) ---- #
+    def _price_trending(self) -> float:
+        opt = self.option
+        n = self.steps
+        dt = opt.maturity / n
+        sig = opt.vol
+        dx = self.lam * sig * math.sqrt(dt)
+        drift = (opt.rate - 0.5 * sig * sig + self.regime.momentum_drift) * dt
+        var = sig * sig * dt
+        q = (var + drift * drift) / (dx * dx)
+        pu = 0.5 * (q + drift / dx)
+        pm = 1.0 - q
+        pd = 0.5 * (q - drift / dx)
+        NodeProbs(pu, pm, pd, +1, 0, -1).validate()
+        self._last_probs = [(pu, pm, pd)]
+        disc = math.exp(-opt.rate * dt)
+        x0 = math.log(opt.spot)
+        vals = [opt.payoff(math.exp(x0 + j * dx)) for j in range(-n, n + 1)]
+        for _ in range(n):
+            nxt = [0.0] * (len(vals) - 2)
+            for k in range(len(nxt)):
+                nxt[k] = disc * (pd * vals[k] + pm * vals[k + 1] + pu * vals[k + 2])
+            vals = nxt
+        return vals[0]
+
+    def price(self) -> float:
+        kind = self.regime.kind
+        if kind in ("mean_reverting", "chaotic"):
+            # a chaotic regime prices around its attractor centroid mu like an OU pull,
+            # but flags the local instability (see flow_regime.lorenz) to the caller.
+            return self._price_mean_reverting()
+        if kind == "trending":
+            return self._price_trending()
+        return self._price_memoryless()
+
+    def node_probabilities(self) -> list:
+        """The (pu, pm, pd) triples actually used (validated in [0,1], summing to 1)."""
+        if not self._last_probs:
+            self.price()
+        return list(self._last_probs)

--- a/third_party/open_ep_framework/ftp_curve.py
+++ b/third_party/open_ep_framework/ftp_curve.py
@@ -1,0 +1,233 @@
+"""Matched-maturity Fund Transfer Pricing + separation-theorem decomposition (FTP-1).
+
+This layer builds on the term-structure calculus (``term_calculus``) and the IC-1
+conservation law (``settlement``); it does not reinvent either.
+
+Matched-maturity FTP
+--------------------
+An ``FTPCurve`` is the reference funding curve (SOFR/OIS/swap points by tenor). It
+lives on the SAME tenor axis as ``term_calculus`` cash-flow schedules. ``assign_ftp``
+prices every cash flow at the curve point matching its repricing/maturity tenor -- a
+5y cash flow is transfer-priced at the 5y point, NOT overnight -- and returns the
+balance/PV-weighted transfer rate. Funding cost and funding credit that feed the EP
+identity are ``transfer_rate * balance``.
+
+Separation theorem
+------------------
+A unit's net interest margin is separated from the funding book: each unit keeps only
+its spread to the matched-maturity curve, and the Treasury book owns the residual
+(structural rate mismatch + liquidity + basis). By construction
+
+    NIM = sum(unit spreads) + Treasury residual
+
+which is an IC-1 conservation identity (reused, not reinvented): the decomposition is
+settled AS a conservation ledger. Two teeth:
+
+  * A unit funded at an off-market FTP rate (booked != matched-maturity) without the
+    difference being booked to Treasury is a hidden cross-subsidy -> REJECTED.
+  * The Treasury residual's declared components (structural / liquidity / basis) must
+    reconcile to the computed residual -> otherwise REJECTED.
+
+Measurement/simulation/audit only. Deterministic, stdlib only.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from .settlement import _canonical, _sha256, check_conservation
+from .term_calculus import Cashflow
+from .validation import validate_json_file
+
+_SCHEMA = "schemas/ftp_separation.schema.json"
+
+
+class FTPError(ValueError):
+    """Raised when an FTP curve or separation decomposition is invalid (REJECTED)."""
+
+
+# --------------------------------------------------------------------------- #
+# reference curve on the term-structure axis
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class FTPCurve:
+    """Reference funding curve: (tenor_years, rate) points, tenor-ascending."""
+
+    points: tuple[tuple[float, float], ...]
+
+    def __post_init__(self) -> None:
+        if len(self.points) < 1:
+            raise FTPError("FTP curve requires at least one point")
+        tenors = [t for t, _ in self.points]
+        if tenors != sorted(tenors):
+            raise FTPError("FTP curve points must be sorted by ascending tenor")
+        if any(t <= 0 for t in tenors):
+            raise FTPError("FTP curve tenors must be positive")
+
+    @classmethod
+    def from_points(cls, points) -> "FTPCurve":
+        return cls(tuple((float(p["tenor"]), float(p["rate"])) for p in points))
+
+
+def curve_rate(curve: FTPCurve, tenor: float) -> float:
+    """The matched-maturity rate at ``tenor`` (linear interpolation, flat extrapolation)."""
+    pts = curve.points
+    if tenor <= pts[0][0]:
+        return pts[0][1]
+    if tenor >= pts[-1][0]:
+        return pts[-1][1]
+    for (t0, r0), (t1, r1) in zip(pts, pts[1:]):
+        if t0 <= tenor <= t1:
+            frac = (tenor - t0) / (t1 - t0)
+            return r0 + frac * (r1 - r0)
+    return pts[-1][1]
+
+
+def _flows(schedule) -> list[Cashflow]:
+    return [c if isinstance(c, Cashflow) else Cashflow(float(c["tenor"]), float(c["amount"]))
+            for c in schedule]
+
+
+def assign_ftp(cashflow_schedule, curve: FTPCurve) -> dict:
+    """Assign a matched-maturity transfer rate to a cash-flow schedule.
+
+    Each flow is priced at the curve point matching its tenor; the schedule transfer
+    rate is the PV-weighted blend. A single bullet at tenor T returns exactly the
+    curve rate at T (matched-maturity, asserted by tests).
+    """
+    flows = _flows(cashflow_schedule)
+    if not flows:
+        raise FTPError("cash-flow schedule must be non-empty")
+    per_flow = []
+    num = 0.0
+    den = 0.0
+    for f in flows:
+        matched = curve_rate(curve, f.tenor)
+        df = 1.0 / (1.0 + matched) ** f.tenor
+        weight = abs(f.amount) * df
+        per_flow.append({"tenor": f.tenor, "amount": f.amount, "matched_ftp_rate": matched})
+        num += matched * weight
+        den += weight
+    transfer_rate = num / den if den else 0.0
+    return {"transfer_rate": transfer_rate, "per_flow": per_flow}
+
+
+def funding_cost(balance: float, transfer_rate: float) -> float:
+    """FundingCost fed to the EP identity: transfer_rate * balance (asset funding)."""
+    return transfer_rate * balance
+
+
+def funding_credit(balance: float, transfer_rate: float) -> float:
+    """FundingCredit fed to the EP identity: transfer_rate * balance (deposit funding)."""
+    return transfer_rate * balance
+
+
+# --------------------------------------------------------------------------- #
+# separation-theorem decomposition (reconciled under IC-1)
+# --------------------------------------------------------------------------- #
+def separation_decomposition(book: dict) -> dict:
+    """Decompose net interest margin into unit spreads + Treasury residual.
+
+    Rejects a hidden cross-subsidy and a Treasury residual whose declared components
+    do not reconcile to the computed residual. Emits a conservation receipt.
+    """
+    curve = FTPCurve.from_points(book["curve"]["points"])
+    tolerance = float(book.get("tolerance", 1e-6))
+    assets = book.get("assets", [])
+    liabilities = book.get("liabilities", [])
+
+    unit_spreads: list[dict] = []
+    nim = 0.0
+    treasury_ftp = 0.0  # sum(booked_a * bal_a) - sum(booked_l * bal_l)
+
+    def _resolve_ftp(item, matched, side):
+        booked = float(item.get("booked_ftp_rate", matched))
+        if abs(booked - matched) > 1e-12 and not bool(item.get("treasury_absorbs_cross_subsidy", False)):
+            raise FTPError(
+                f"REJECTED: cross-subsidy on {side} unit {item.get('unit')!r}: booked FTP "
+                f"{booked} != matched-maturity rate {matched} (tenor {item.get('tenor')}) "
+                "without booking the difference to Treasury"
+            )
+        return booked
+
+    for a in assets:
+        bal = float(a["balance"])
+        matched = curve_rate(curve, float(a["tenor"]))
+        booked = _resolve_ftp(a, matched, "asset")
+        spread = (float(a["customer_rate"]) - booked) * bal
+        unit_spreads.append({"unit": a["unit"], "side": "asset", "spread": spread,
+                             "matched_ftp_rate": matched, "booked_ftp_rate": booked})
+        nim += float(a["customer_rate"]) * bal
+        treasury_ftp += booked * bal
+
+    for l in liabilities:
+        bal = float(l["balance"])
+        matched = curve_rate(curve, float(l["tenor"]))
+        booked = _resolve_ftp(l, matched, "liability")
+        spread = (booked - float(l["customer_rate"])) * bal
+        unit_spreads.append({"unit": l["unit"], "side": "liability", "spread": spread,
+                             "matched_ftp_rate": matched, "booked_ftp_rate": booked})
+        nim -= float(l["customer_rate"]) * bal
+        treasury_ftp -= booked * bal
+
+    treasury = book.get("treasury", {})
+    structural = float(treasury.get("structural", 0.0))
+    liquidity = float(treasury.get("liquidity", 0.0))
+    basis = float(treasury.get("basis", 0.0))
+    declared_residual = structural + liquidity + basis
+
+    # Treasury residual components must reconcile to the computed FTP residual.
+    if abs(declared_residual - treasury_ftp) > tolerance:
+        raise FTPError(
+            f"REJECTED: Treasury residual components (structural+liquidity+basis="
+            f"{declared_residual}) do not reconcile to computed residual {treasury_ftp}"
+        )
+
+    total_spreads = sum(u["spread"] for u in unit_spreads)
+
+    # NIM conservation via IC-1: inflow NIM, outflows = unit spreads + Treasury residual.
+    settlement = {
+        "settlement_id": f"{book.get('book_id', 'ftp')}:nim",
+        "as_of": book.get("as_of", ""),
+        "conserved_quantity": "net_interest_margin",
+        "tolerance": tolerance,
+        "inflows": [{"leg_id": "nim", "party": "book", "amount": nim}],
+        "outflows": (
+            [{"leg_id": f"unit:{u['unit']}:{u['side']}", "party": u["unit"], "amount": u["spread"]}
+             for u in unit_spreads]
+            + [{"leg_id": "treasury_residual", "party": "treasury", "amount": treasury_ftp}]
+        ),
+    }
+    ledger = check_conservation(settlement)
+    if not ledger["conserved"]:
+        raise FTPError(
+            f"REJECTED: separation decomposition does not reconcile to NIM "
+            f"(residual {ledger['residual']} exceeds tolerance {tolerance})"
+        )
+
+    body = {
+        "book_id": book.get("book_id", "ftp"),
+        "as_of": book.get("as_of", ""),
+        "net_interest_margin": nim,
+        "unit_spreads": unit_spreads,
+        "total_unit_spreads": total_spreads,
+        "treasury_residual": {
+            "computed": treasury_ftp,
+            "structural": structural,
+            "liquidity": liquidity,
+            "basis": basis,
+        },
+        "conservation": ledger,
+    }
+    receipt = dict(body)
+    receipt["input_hash"] = _sha256(_canonical(book))
+    receipt["output_hash"] = _sha256(_canonical(body))
+    receipt["receipt_hash"] = _sha256(_canonical(receipt))
+    return receipt
+
+
+def run_ftp_separation(path: str) -> dict:
+    """Load, schema-validate and run a separation decomposition fixture."""
+    validate_json_file(path, _SCHEMA)
+    return separation_decomposition(json.loads(Path(path).read_text()))

--- a/third_party/open_ep_framework/hedging.py
+++ b/third_party/open_ep_framework/hedging.py
@@ -1,0 +1,108 @@
+"""Swaps / futures as zeroing derivatives -- hedge ratios from the calculus (HDG-1).
+
+A hedge zeroes a derivative of value w.r.t. a factor. The hedge ratio is read from
+``term_calculus``: the first derivative (DV01 / duration) sets a DV01-neutral hedge;
+the second derivative (convexity) is what a linear hedge (swap / futures) cannot
+neutralize, so a convexity mismatch leaves 2nd-order P&L. Nothing here reinvents the
+calculus -- it consumes ``term_calculus``.
+
+Teeth:
+  * a DV01-neutral hedge drives the net first derivative to ~0 under a curve bump
+    (finite-difference reprice);
+  * a convexity-mismatched linear hedge still shows 2nd-order P&L (asserted residual).
+
+Futures are a margined linear rate/commodity hedge marked-to-market daily; a basic
+variation-margin representation is included. Deterministic, stdlib only.
+"""
+from __future__ import annotations
+
+from .term_calculus import (
+    Cashflow,
+    effective_convexity,
+    finite_difference,
+    modified_duration,
+    price,
+    second_difference,
+)
+
+
+class HedgeError(ValueError):
+    pass
+
+
+def _flows(schedule) -> list[Cashflow]:
+    return [c if isinstance(c, Cashflow) else Cashflow(float(c["tenor"]), float(c["amount"]))
+            for c in schedule]
+
+
+def dv01(schedule, y: float) -> float:
+    """Dollar value of 1bp: modified_duration * price * 1e-4 (a first derivative)."""
+    flows = _flows(schedule)
+    return modified_duration(flows, y) * price(flows, y) * 1e-4
+
+
+def hedge_notional(book, y_book: float, instrument, y_instrument: float) -> dict:
+    """Signed instrument notional (per unit-notional instrument) to zero book DV01.
+
+    ``notional = -DV01_book / DV01_instrument_per_unit``: the hedge's first derivative
+    exactly offsets the book's. Convexity is reported so a mismatch is visible.
+    """
+    book_flows = _flows(book)
+    inst_flows = _flows(instrument)
+    dv01_inst = dv01(inst_flows, y_instrument)
+    if dv01_inst == 0:
+        raise HedgeError("hedge instrument has zero DV01; cannot form a hedge ratio")
+    dv01_book = dv01(book_flows, y_book)
+    notional = -dv01_book / dv01_inst
+    return {
+        "notional": notional,
+        "dv01_book": dv01_book,
+        "dv01_instrument_per_unit": dv01_inst,
+        "book_convexity": effective_convexity(lambda yy: price(book_flows, yy), y_book),
+        "instrument_convexity": effective_convexity(lambda yy: price(inst_flows, yy), y_instrument),
+    }
+
+
+def net_first_derivative(book, instrument, notional: float, y: float, bump: float = 1e-4) -> float:
+    """dP/dy of the hedged portfolio (book + notional*instrument) by bump-and-reprice."""
+    book_flows = _flows(book)
+    inst_flows = _flows(instrument)
+    reprice = lambda yy: price(book_flows, yy) + notional * price(inst_flows, yy)
+    return finite_difference(reprice, y, bump)
+
+
+def net_second_derivative(book, instrument, notional: float, y: float, bump: float = 1e-3) -> float:
+    """d2P/dy2 of the hedged portfolio (residual convexity a linear hedge leaves)."""
+    book_flows = _flows(book)
+    inst_flows = _flows(instrument)
+    reprice = lambda yy: price(book_flows, yy) + notional * price(inst_flows, yy)
+    return second_difference(reprice, y, bump)
+
+
+def hedged_pnl(book, instrument, notional: float, y: float, dy: float) -> float:
+    """Actual reprice P&L of the hedged portfolio under a finite curve bump ``dy``."""
+    book_flows = _flows(book)
+    inst_flows = _flows(instrument)
+
+    def reprice(yy):
+        return price(book_flows, yy) + notional * price(inst_flows, yy)
+
+    return reprice(y + dy) - reprice(y)
+
+
+def futures_variation_margin(entry_price: float, price_path, contract_size: float,
+                             position: float) -> dict:
+    """Daily mark-to-market of a margined linear futures hedge.
+
+    ``position`` is signed (long > 0, short < 0). Returns per-day variation margin and
+    the cumulative total; the cumulative equals the linear payoff to the terminal price.
+    """
+    path = [float(p) for p in price_path]
+    daily = []
+    prev = entry_price
+    for p in path:
+        daily.append(position * contract_size * (p - prev))
+        prev = p
+    total = sum(daily)
+    linear_payoff = position * contract_size * (path[-1] - entry_price) if path else 0.0
+    return {"daily_variation_margin": daily, "total": total, "linear_payoff": linear_payoff}

--- a/third_party/open_ep_framework/inflation.py
+++ b/third_party/open_ep_framework/inflation.py
@@ -20,7 +20,7 @@ A real rate then follows from whichever inflation measure you trust: `real_rate(
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from math import log, exp
 from typing import Sequence
 

--- a/third_party/open_ep_framework/market_instruments.py
+++ b/third_party/open_ep_framework/market_instruments.py
@@ -1,0 +1,282 @@
+"""Options, volatility surface, Merton bridge and the Ross recovery seam (MKT-1).
+
+This layer turns option prices into a risk-neutral implied distribution ``F_Q`` that
+the risk kernel (``risk_measures``) can score, bridges structural credit to equity
+options (Merton), and exposes a documented risk-neutral -> physical transform (Ross /
+Arrow-Debreu). It consumes ``risk_measures`` (F objects), ``term_calculus`` (the
+second-derivative operator for Breeden-Litzenberger) and ``expected_loss`` (EL identity).
+
+Chain: VolSurface -> (Breeden-Litzenberger) F_Q -> (Ross/Radon-Nikodym) physical F ->
+LPM / Sortino / ES downside measures.
+
+Teeth:
+  * a put-skew surface implies a fatter downside than a flat-vol lognormal;
+  * a surface with negative implied variance or a static-arbitrage violation
+    (calendar / butterfly) is REJECTED;
+  * Merton: equity = call on assets, risky debt = risk-free - put (put-call parity),
+    and PD & recovery move inversely with leverage; EL reconciles via PD*LGD*EAD;
+  * the Ross transform with an identity kernel returns F_Q unchanged.
+
+Deterministic, stdlib only (Black-76 via math.erf).
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from .expected_loss import expected_loss_amount
+from .domain import ExpectedLossInputs
+from .risk_measures import LossDistribution
+from .term_calculus import second_difference
+
+
+class MarketInstrumentError(ValueError):
+    """Raised for an arbitrageable surface or an invalid instrument (REJECTED)."""
+
+
+def _norm_cdf(x: float) -> float:
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+# --------------------------------------------------------------------------- #
+# Black-76 forward option pricing
+# --------------------------------------------------------------------------- #
+def bs_call(forward: float, strike: float, vol: float, t: float, df: float = 1.0) -> float:
+    """Black-76 forward call price."""
+    if vol <= 0 or t <= 0:
+        return df * max(forward - strike, 0.0)
+    v = vol * math.sqrt(t)
+    d1 = (math.log(forward / strike) + 0.5 * vol * vol * t) / v
+    d2 = d1 - v
+    return df * (forward * _norm_cdf(d1) - strike * _norm_cdf(d2))
+
+
+def bs_put(forward: float, strike: float, vol: float, t: float, df: float = 1.0) -> float:
+    """Black-76 forward put price (put-call parity)."""
+    return bs_call(forward, strike, vol, t, df) - df * (forward - strike)
+
+
+# --------------------------------------------------------------------------- #
+# volatility surface
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class VolSurface:
+    """Implied vol by (tenor, strike). ``nodes`` = tuple of (tenor, strike, vol)."""
+
+    nodes: tuple[tuple[float, float, float], ...]
+
+    @classmethod
+    def from_nodes(cls, nodes) -> "VolSurface":
+        return cls(tuple((float(n["tenor"]), float(n["strike"]), float(n["vol"])) for n in nodes))
+
+    def tenors(self) -> list[float]:
+        return sorted({t for t, _, _ in self.nodes})
+
+    def strikes(self, tenor: float) -> list[float]:
+        return sorted(s for t, s, _ in self.nodes if abs(t - tenor) < 1e-12)
+
+    def implied_vol(self, tenor: float, strike: float) -> float:
+        """Implied vol at (tenor, strike): linear in strike within the tenor slice."""
+        slice_ = sorted((s, v) for t, s, v in self.nodes if abs(t - tenor) < 1e-12)
+        if not slice_:
+            raise MarketInstrumentError(f"no surface slice at tenor {tenor}")
+        if strike <= slice_[0][0]:
+            return slice_[0][1]
+        if strike >= slice_[-1][0]:
+            return slice_[-1][1]
+        for (s0, v0), (s1, v1) in zip(slice_, slice_[1:]):
+            if s0 <= strike <= s1:
+                return v0 + (strike - s0) / (s1 - s0) * (v1 - v0)
+        return slice_[-1][1]
+
+    def validate(self, forward: float = 1.0) -> bool:
+        """Reject negative implied variance and static-arbitrage violations.
+
+        * negative/zero vol -> negative or zero implied variance -> REJECTED;
+        * calendar arbitrage: total variance vol^2 * T must be non-decreasing in T
+          for the same strike -> REJECTED if it falls;
+        * butterfly arbitrage: call price must be convex in strike (density >= 0) ->
+          REJECTED if a negative butterfly (concavity) appears.
+        """
+        for t, s, v in self.nodes:
+            if v <= 0 or v * v * t <= 0:
+                raise MarketInstrumentError(
+                    f"REJECTED: non-positive implied variance at (tenor={t}, strike={s})"
+                )
+        # calendar
+        strikes_by = {}
+        for t, s, v in self.nodes:
+            strikes_by.setdefault(s, []).append((t, v))
+        for s, tv in strikes_by.items():
+            tv.sort()
+            for (t0, v0), (t1, v1) in zip(tv, tv[1:]):
+                if v1 * v1 * t1 + 1e-12 < v0 * v0 * t0:
+                    raise MarketInstrumentError(
+                        f"REJECTED: calendar arbitrage at strike {s}: total variance falls "
+                        f"from tenor {t0} to {t1}"
+                    )
+        # butterfly (convexity of call in strike on each tenor slice)
+        for t in self.tenors():
+            ks = self.strikes(t)
+            if len(ks) >= 3:
+                calls = [bs_call(forward, k, self.implied_vol(t, k), t) for k in ks]
+                for i in range(1, len(ks) - 1):
+                    left = (calls[i] - calls[i - 1]) / (ks[i] - ks[i - 1])
+                    right = (calls[i + 1] - calls[i]) / (ks[i + 1] - ks[i])
+                    # C(K) must be convex (density = C'' >= 0), i.e. slope non-decreasing.
+                    if left - right > 1e-9:
+                        raise MarketInstrumentError(
+                            f"REJECTED: butterfly arbitrage at tenor {t} near strike {ks[i]}"
+                        )
+        return True
+
+
+def implied_distribution(surface: VolSurface, tenor: float, forward: float,
+                         n_samples: int = 500, width: float = 0.8) -> LossDistribution:
+    """Breeden-Litzenberger risk-neutral implied distribution F_Q from the surface.
+
+    The risk-neutral density is q(K) = d2C/dK2; F_Q is returned as return samples
+    (K/forward - 1) drawn by inverse-transform from that density. Feeds the downside
+    measures in ``risk_measures``.
+    """
+    surface.validate(forward)
+    lo = forward * (1.0 - width)
+    hi = forward * (1.0 + width)
+    grid_n = 200
+    step = (hi - lo) / grid_n
+    strikes = [lo + i * step for i in range(1, grid_n)]
+
+    def call_fn(k: float) -> float:
+        return bs_call(forward, k, surface.implied_vol(tenor, k), tenor)
+
+    densities = []
+    for k in strikes:
+        q = second_difference(call_fn, k, step)
+        densities.append(max(q, 0.0))
+    mass = sum(densities)
+    if mass <= 0:
+        raise MarketInstrumentError("implied density has non-positive mass")
+    probs = [d / mass for d in densities]
+
+    # inverse-transform sample deterministically on the quantile grid
+    cdf = []
+    acc = 0.0
+    for p in probs:
+        acc += p
+        cdf.append(acc)
+    samples = []
+    for i in range(n_samples):
+        u = (i + 0.5) / n_samples
+        j = 0
+        while j < len(cdf) - 1 and cdf[j] < u:
+            j += 1
+        samples.append(strikes[j] / forward - 1.0)
+    return LossDistribution.from_samples(samples)
+
+
+# --------------------------------------------------------------------------- #
+# Merton structural bridge
+# --------------------------------------------------------------------------- #
+def equity_as_call(asset_value: float, debt: float, asset_vol: float, t: float,
+                   r: float = 0.0, ead: float | None = None) -> dict:
+    """Merton bridge: equity = call on assets (strike = debt); risky debt = rf - put.
+
+    Returns equity, put, risky/riskfree debt, PD = N(-d2), recovery (endogenous) and
+    LGD = 1 - recovery. PD and recovery move inversely with leverage. EL reconciles via
+    the estate expected-loss identity PD*LGD*EAD (default EAD = discounted debt).
+    """
+    if asset_vol <= 0 or t <= 0:
+        raise MarketInstrumentError("asset_vol and t must be positive")
+    v = asset_vol * math.sqrt(t)
+    d1 = (math.log(asset_value / debt) + (r + 0.5 * asset_vol * asset_vol) * t) / v
+    d2 = d1 - v
+    rf_debt = debt * math.exp(-r * t)
+    equity = asset_value * _norm_cdf(d1) - rf_debt * _norm_cdf(d2)
+    put = rf_debt * _norm_cdf(-d2) - asset_value * _norm_cdf(-d1)
+    risky_debt = asset_value - equity  # == rf_debt - put
+    pd = _norm_cdf(-d2)
+    denom = rf_debt * _norm_cdf(-d2)
+    recovery = min(1.0, (asset_value * _norm_cdf(-d1)) / denom) if denom > 0 else 0.0
+    lgd = 1.0 - recovery
+    ead_used = ead if ead is not None else rf_debt
+    el = expected_loss_amount(ExpectedLossInputs(pd=pd, lgd=lgd, ead=ead_used))
+    return {
+        "equity": equity,
+        "put": put,
+        "risky_debt": risky_debt,
+        "riskfree_debt": rf_debt,
+        "pd": pd,
+        "recovery": recovery,
+        "lgd": lgd,
+        "ead": ead_used,
+        "expected_loss": el,
+        "d1": d1,
+        "d2": d2,
+    }
+
+
+def pd_from_structural(asset_value: float, debt: float, asset_vol: float, t: float,
+                       r: float = 0.0) -> float:
+    """Merton PD = N(-d2)."""
+    return equity_as_call(asset_value, debt, asset_vol, t, r)["pd"]
+
+
+# --------------------------------------------------------------------------- #
+# Ross recovery / Arrow-Debreu seam: risk-neutral -> physical
+# --------------------------------------------------------------------------- #
+def physical_from_riskneutral(f_q: LossDistribution, kernel_fn=None,
+                              n_samples: int | None = None) -> LossDistribution:
+    """Map a risk-neutral F_Q to a physical F via a pricing-kernel (Ross seam).
+
+    ``kernel_fn(return)`` is the pricing kernel m(state); the Radon-Nikodym derivative
+    dP/dQ is proportional to 1/m. With ``kernel_fn=None`` the transform is the identity
+    and returns F_Q UNCHANGED (the documented tooth). A risk-averse kernel (larger m in
+    bad states) up-weights good states under P, so the physical mean exceeds the
+    risk-neutral mean (the equity premium). This is the transparent, testable seam where
+    a full Ross recovery (transition-independent kernel) would be plugged in.
+    """
+    if kernel_fn is None:
+        return f_q
+    samples = list(f_q.samples)
+    weights = []
+    for r in samples:
+        m = kernel_fn(r)
+        if m <= 0:
+            raise MarketInstrumentError("pricing kernel must be positive")
+        weights.append(1.0 / m)
+    total = sum(weights)
+    probs = [w / total for w in weights]
+    order = sorted(range(len(samples)), key=lambda i: samples[i])
+    sorted_samples = [samples[i] for i in order]
+    sorted_probs = [probs[i] for i in order]
+    cdf = []
+    acc = 0.0
+    for p in sorted_probs:
+        acc += p
+        cdf.append(acc)
+    n = n_samples or len(samples)
+    out = []
+    for i in range(n):
+        u = (i + 0.5) / n
+        j = 0
+        while j < len(cdf) - 1 and cdf[j] < u:
+            j += 1
+        out.append(sorted_samples[j])
+    return LossDistribution.from_samples(out)
+
+
+# --------------------------------------------------------------------------- #
+# liquidity premium: volume / regime feeds both curve and surface (light)
+# --------------------------------------------------------------------------- #
+def liquidity_premium(volume: float, regime_hurst: float = 0.5, base_bps: float = 10.0) -> float:
+    """Liquidity premium (bps) as a function of volume and memory regime.
+
+    Falls with traded volume, rises with a persistent (illiquid / trending) regime.
+    ``regime_hurst`` is intended to be supplied by the estate memory-regime
+    characterizer (injection, not a fork). Feeds both the FTP curve (add to the rate)
+    and the vol surface (add to vol). Light reference implementation.
+    """
+    if volume < 0:
+        raise MarketInstrumentError("volume must be non-negative")
+    regime_factor = 1.0 + 2.0 * max(0.0, regime_hurst - 0.5)
+    return base_bps / (1.0 + volume) * regime_factor

--- a/third_party/open_ep_framework/policy_simulation_uvmc.py
+++ b/third_party/open_ep_framework/policy_simulation_uvmc.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from .policy_simulation import load_policy_simulation_profile, summarize_policy_simulation_profile
-from .validation import validate_json_file
 
 
 class PolicySimulationMeasuredEntityError(ValueError):

--- a/third_party/open_ep_framework/risk_adjusted_profit.py
+++ b/third_party/open_ep_framework/risk_adjusted_profit.py
@@ -1,0 +1,351 @@
+"""Risk-adjusted profit / RAROC contract (RAP-1), grounded on Economic Prophet.
+
+This contract computes economic profit (EP) and RAROC on top of the estate's
+residual-value / conservation engine, and it does so for BOTH economic profit and
+epistemic profit with the same machinery (the Economia Mentium binding).
+
+What it reuses (consume, do not reinvent)
+-----------------------------------------
+  * ``uvmc.reconcile_ep_components`` -- the canonical EP identity
+        EP = revenue - expected_loss - expense - funding_costs
+             + funding_credits - taxes - capital_charge.
+  * ``settlement`` (IC-1, economic-prophet#39) -- the conservation law and its
+        receipt spine (FIPS SHA-256, ``sha256:`` prefix). Org/entity decomposition
+        reconciliation is expressed AS a conservation settlement: the parent EP is
+        the single inflow, each child EP an outflow; a cut whose children do not
+        sum to the parent fails ``settle`` and is REJECTED. We do not reinvent the
+        invariant -- we denominate a new quantity ("economic_profit") in it.
+  * ``risk_measures`` (RM-1) -- the unified risk-measure family. EconomicCapital
+        for RAROC defaults to a coherent measure (ES / spectral) over a fitted or
+        simulated loss distribution F.
+
+Model
+-----
+  EconomicCapital = credit + market + operating + business + other risk capital
+        (optionally a coherent risk measure over F supplies / augments a component).
+  CapitalCharge   = HurdleRate * EconomicCapital.
+  RiskAdjustedReturn = revenue - expected_loss - expense - funding_costs
+                       + funding_credits - taxes         (== NOPAT here).
+  EP    = RiskAdjustedReturn - CapitalCharge             (via reconcile_ep_components).
+  RAROC = RiskAdjustedReturn / EconomicCapital ; compared to HurdleRate (RORAC).
+
+Dual scoring (Economia Mentium)
+-------------------------------
+The identical computation runs in ``scoring_mode: "epistemic"``, where the return
+legs carry an epistemic-value delta, EconomicCapital is GKN standing (epistemic
+capital deployed), and the risk / expected-loss leg is counter-test uncertainty.
+Epistemic profit is therefore measured, conserved and receipted with exactly the
+same conservation-law RAROC contract as economic profit.
+
+Teeth (verdicts)
+----------------
+  * VERIFIED -- EP has a real CapitalCharge and RAROC >= HurdleRate.
+  * FLAGGED  -- value-destroying arm: RAROC < HurdleRate (returned, not raised).
+  * REJECTED (raises) --
+        no risk measure supplied;
+        no / non-positive economic capital;
+        a non-coherent measure used as RAROC capital without an explicit override
+            (also emits a coherence warning);
+        an org-cut whose child EPs do not reconcile to the parent (IC-1).
+
+Measurement, simulation and audit only -- mirrors the estate boundary: no live
+money movement, token issuance, redemption, settlement rails or trading.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .risk_measures import (
+    LossDistribution,
+    NONCOHERENT_KERNELS,
+    RiskMeasure,
+    risk,
+)
+from .settlement import SettlementError, _canonical, _sha256, check_conservation
+from .uvmc import reconcile_ep_components
+from .validation import validate_json_file
+
+_SCHEMA = "schemas/risk_adjusted_profit.schema.json"
+
+DECOMPOSITION_CUTS = {
+    "business_unit",
+    "product",
+    "client_segment",
+    "geography",
+    "obligor",
+    "subportfolio",
+    "transaction",
+}
+
+_EC_COMPONENTS = ("credit", "market", "operating", "business", "other")
+
+
+class RiskAdjustedProfitError(ValueError):
+    """Raised when an arm cannot be scored under the contract (REJECTED)."""
+
+
+# --------------------------------------------------------------------------- #
+# distribution + risk measure
+# --------------------------------------------------------------------------- #
+def _build_distribution(spec: dict) -> LossDistribution:
+    if "samples" in spec:
+        return LossDistribution.from_samples(
+            spec["samples"], horizon_days=int(spec.get("horizon_days", 1))
+        )
+    if "credit" in spec:
+        c = spec["credit"]
+        return LossDistribution.simulate_credit(
+            pd_long=float(c["pd_long"]),
+            lgd=float(c["lgd"]),
+            ead=float(c["ead"]),
+            w_systematic=float(c["w_systematic"]),
+            w_idiosyncratic=float(c["w_idiosyncratic"]),
+            horizon_days=int(c.get("horizon_days", 1)),
+            n_scenarios=int(c.get("n_scenarios", 1000)),
+            seed=int(c.get("seed", 0)),
+        )
+    raise RiskAdjustedProfitError(
+        "risk_measure.distribution must provide 'samples' or 'credit' inputs"
+    )
+
+
+def _measure_arm(arm: dict) -> RiskMeasure:
+    rm_spec = arm.get("risk_measure")
+    if not rm_spec or not rm_spec.get("kernel"):
+        # Teeth: a RAROC with no risk measure is not a RAROC.
+        raise RiskAdjustedProfitError(
+            "REJECTED: no risk measure supplied; RAROC requires a risk measure over a loss distribution"
+        )
+    distribution = _build_distribution(rm_spec.get("distribution", {}))
+    return risk(
+        distribution,
+        rm_spec["kernel"],
+        reference=float(rm_spec.get("reference", 0.0)),
+        horizon=float(rm_spec.get("horizon", 1.0)),
+        alpha=float(rm_spec.get("alpha", 0.95)),
+        order=int(rm_spec.get("order", 2)),
+        phi=rm_spec.get("phi"),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# economic capital
+# --------------------------------------------------------------------------- #
+def _economic_capital(arm: dict, measure: RiskMeasure) -> tuple[float, dict, list[str]]:
+    rm_spec = arm.get("risk_measure", {})
+    ec_spec = arm.get("economic_capital", {})
+    components = {name: float(ec_spec.get("components", {}).get(name, 0.0)) for name in _EC_COMPONENTS}
+    warnings: list[str] = []
+
+    capital_from_measure = bool(rm_spec.get("capital_from_measure", False))
+    if capital_from_measure:
+        if measure.family != "tail":
+            raise RiskAdjustedProfitError(
+                "REJECTED: capital_from_measure requires a tail measure (var/expected_shortfall/spectral)"
+            )
+        # The measure supplies the credit risk-capital component.
+        components["credit"] = measure.value
+        if measure.kernel in NONCOHERENT_KERNELS:
+            warnings.append(
+                f"coherence warning: '{measure.kernel}' is not a coherent risk measure; "
+                "economic capital for RAROC should use ES or spectral"
+            )
+            if not bool(rm_spec.get("allow_noncoherent_capital", False)):
+                raise RiskAdjustedProfitError(
+                    "REJECTED: non-coherent risk measure used as RAROC economic capital "
+                    "without allow_noncoherent_capital override"
+                )
+
+    total = sum(components.values())
+    if total <= 0.0:
+        # Teeth: a RAROC with no economic capital is not a RAROC.
+        raise RiskAdjustedProfitError(
+            "REJECTED: no (positive) economic capital; RAROC requires an economic-capital denominator"
+        )
+    breakdown = dict(components)
+    breakdown["total"] = total
+    return total, breakdown, warnings
+
+
+# --------------------------------------------------------------------------- #
+# single arm
+# --------------------------------------------------------------------------- #
+_MODE_LABELS = {
+    "economic": {
+        "return": "risk_adjusted_return",
+        "capital": "economic_capital",
+        "risk": "loss_distribution",
+    },
+    "epistemic": {
+        "return": "epistemic_value_delta",
+        "capital": "gkn_standing_capital",
+        "risk": "counter_test_uncertainty",
+    },
+}
+
+
+def evaluate_arm(arm: dict, mode: str, arm_id: str) -> dict:
+    """Score a single arm: EP, RAROC and a verdict, with a signed receipt."""
+    if mode not in _MODE_LABELS:
+        raise RiskAdjustedProfitError(f"unknown scoring_mode {mode!r}")
+
+    hurdle = float(arm["hurdle_rate"])
+    legs = arm["return_components"]
+    revenue = float(legs["revenue"])
+    expected_loss = float(legs["expected_loss"])
+    expense = float(legs.get("expense", 0.0))
+    funding_costs = float(legs.get("funding_costs", 0.0))
+    funding_credits = float(legs.get("funding_credits", 0.0))
+    taxes = float(legs.get("taxes", 0.0))
+
+    measure = _measure_arm(arm)
+    ec_total, ec_breakdown, warnings = _economic_capital(arm, measure)
+
+    if measure.provisional:
+        warnings.append(
+            f"provisional: loss distribution has n={measure.n_samples} < 30 samples"
+        )
+
+    capital_charge = hurdle * ec_total  # CapitalCharge = HurdleRate * EconomicCapital
+    ep = reconcile_ep_components(
+        {
+            "revenue": revenue,
+            "expected_loss": expected_loss,
+            "expense": expense,
+            "funding_costs": funding_costs,
+            "funding_credits": funding_credits,
+            "taxes": taxes,
+            "capital_charge": capital_charge,
+        }
+    )
+    risk_adjusted_return = ep + capital_charge  # == NOPAT
+    raroc = risk_adjusted_return / ec_total
+    above_hurdle = raroc >= hurdle
+    verdict = "verified" if above_hurdle else "flagged"
+    if not above_hurdle:
+        warnings.append(
+            f"flagged value-destroying: RAROC {raroc:.6f} < hurdle {hurdle:.6f}"
+        )
+
+    labels = _MODE_LABELS[mode]
+    body = {
+        "arm_id": arm_id,
+        "scoring_mode": mode,
+        "interpretation": labels,
+        "hurdle_rate": hurdle,
+        "economic_capital": ec_breakdown,
+        "capital_charge": capital_charge,
+        "economic_profit": ep,
+        "nopat": risk_adjusted_return,
+        "risk_adjusted_return": risk_adjusted_return,
+        "raroc": raroc,
+        "raroc_above_hurdle": above_hurdle,
+        "verdict": verdict,
+        "risk_measure": measure.summary(),
+        "warnings": warnings,
+    }
+    # Reuse the estate receipt spine (settlement's canonical-JSON + SHA-256).
+    input_hash = _sha256(_canonical(arm))
+    receipt = dict(body)
+    receipt["input_hash"] = input_hash
+    receipt["output_hash"] = _sha256(_canonical(body))
+    receipt["receipt_hash"] = _sha256(_canonical(receipt))
+    return receipt
+
+
+# --------------------------------------------------------------------------- #
+# decomposition + conservation reconciliation (reuses IC-1)
+# --------------------------------------------------------------------------- #
+def _reconcile_decomposition(parent: dict, children: list[dict], cut: str, tolerance: float,
+                             contract_id: str, as_of: str) -> dict:
+    """Reconcile child EPs to the parent EP via the IC-1 conservation law.
+
+    Expressed as a settlement: parent EP is the sole inflow, each child EP an
+    outflow. ``settle`` REJECTS a non-conserving ledger, so a cut whose children
+    do not sum to the parent cannot produce a receipt.
+    """
+    settlement = {
+        "settlement_id": f"{contract_id}:decomp:{cut}",
+        "as_of": as_of,
+        "conserved_quantity": "economic_profit",
+        "tolerance": tolerance,
+        "inflows": [
+            {"leg_id": "parent", "party": parent["arm_id"], "amount": parent["economic_profit"]}
+        ],
+        "outflows": [
+            {"leg_id": f"child:{c['arm_id']}", "party": c["arm_id"], "amount": c["economic_profit"]}
+            for c in children
+        ],
+    }
+    ledger = check_conservation(settlement)
+    if not ledger["conserved"]:
+        raise RiskAdjustedProfitError(
+            f"REJECTED: org-cut '{cut}' does not reconcile to parent under IC-1 "
+            f"(parent EP={ledger['sum_in']}, child EP sum={ledger['sum_out']}, "
+            f"residual={ledger['residual']} exceeds tolerance {ledger['tolerance']})"
+        )
+    body = {
+        "cut": cut,
+        "conservation": ledger,
+        "child_count": len(children),
+        "child_arm_ids": [c["arm_id"] for c in children],
+    }
+    receipt = dict(body)
+    receipt["output_hash"] = _sha256(_canonical(body))
+    receipt["receipt_hash"] = _sha256(_canonical(receipt))
+    return receipt
+
+
+def evaluate_contract(spec: dict) -> dict:
+    """Evaluate a RiskAdjustedProfit contract: parent arm + optional decomposition."""
+    mode = spec.get("scoring_mode", "economic")
+    contract_id = spec.get("contract_id", "rap")
+    as_of = spec.get("as_of", "")
+
+    # Mode-specific provenance teeth (light-touch: presence only).
+    provenance = spec.get("provenance", {})
+    if mode == "epistemic":
+        for required in ("gkn_standing_ref", "counter_test_ref"):
+            if not provenance.get(required):
+                raise RiskAdjustedProfitError(
+                    f"REJECTED: epistemic scoring requires provenance.{required}"
+                )
+
+    parent = evaluate_arm(spec["arm"], mode, spec["arm"].get("arm_id", contract_id))
+
+    result = {
+        "contract_id": contract_id,
+        "as_of": as_of,
+        "scoring_mode": mode,
+        "arm": parent,
+    }
+
+    decomposition = spec.get("decomposition")
+    if decomposition:
+        cut = decomposition["cut"]
+        if cut not in DECOMPOSITION_CUTS:
+            raise RiskAdjustedProfitError(
+                f"REJECTED: unknown decomposition cut {cut!r}; allowed: {sorted(DECOMPOSITION_CUTS)}"
+            )
+        tolerance = float(decomposition.get("tolerance", 1e-6))
+        children = [
+            evaluate_arm(child, mode, child.get("arm_id", f"child-{i}"))
+            for i, child in enumerate(decomposition["children"])
+        ]
+        reconciliation = _reconcile_decomposition(
+            parent, children, cut, tolerance, contract_id, as_of
+        )
+        result["decomposition"] = {
+            "cut": cut,
+            "children": children,
+            "reconciliation": reconciliation,
+        }
+    return result
+
+
+def run_risk_adjusted_profit(path: str) -> dict:
+    """Load, schema-validate and evaluate a RiskAdjustedProfit contract fixture."""
+    validate_json_file(path, _SCHEMA)
+    spec = json.loads(Path(path).read_text())
+    return evaluate_contract(spec)

--- a/third_party/open_ep_framework/risk_measures.py
+++ b/third_party/open_ep_framework/risk_measures.py
@@ -1,0 +1,583 @@
+"""Unified risk-measure family over a fitted/simulated loss distribution F (RM-1).
+
+Every risk measure this module exposes is derived from ONE interface —
+``risk(F, kernel, reference, horizon, ...)`` — evaluated over the SAME loss
+distribution ``F``. There is no per-measure toggle with divergent plumbing: a
+Sharpe ratio, a Sortino ratio, a Kappa_n, a VaR, an Expected Shortfall and a
+spectral measure are all *lenses on the same F*, so results reconcile.
+
+Two families, one distribution
+------------------------------
+Reward-to-risk (a return divided by a dispersion functional of F):
+  * ``sharpe``   -- denominator = standard deviation (two-sided; NON-coherent).
+  * ``sortino``  -- denominator = downside deviation sqrt(LPM_2(MAR));
+                    penalizes only returns below the Minimum Acceptable Return.
+  * ``kappa``    -- (E[R]-tau) / LPM_n(tau)^(1/n), LPM_n(tau)=E[(tau-R)_+^n].
+                    n generalizes the family: n=0 shortfall probability,
+                    n=1 Omega-style, n=2 == Sortino, n>2 extreme-averse.
+
+Tail / coherent (a capital magnitude on the loss side of F):
+  * ``var``               -- VaR_alpha, the loss quantile. NON-coherent
+                             (subadditivity can fail); flagged accordingly.
+  * ``expected_shortfall``-- CVaR_alpha = E[loss | loss >= VaR_alpha]. Coherent.
+  * ``spectral``          -- integral phi(p) VaR_p dp. Coherent iff phi is
+                             non-increasing; ES is the flat-tail spectrum.
+
+Distribution + horizon
+----------------------
+``F`` is a functional object, not a scalar. It can be supplied as raw samples or
+simulated from credit inputs with a one-factor common shock
+(PD_short = PD_long * (w1*systematic + w2*idiosyncratic)). Risk is evaluated over
+a HORIZON via sqrt-time scaling, so ``risk_term_structure`` yields a term
+structure across horizons rather than a single number; ``largest_cumulative_gap``
+provides the LCR-style largest-cumulative-outflow gap over N days.
+
+Teeth this module makes assertable
+----------------------------------
+  * Same F, many lenses reconcile (Sortino ignores upside where Sharpe does not).
+  * ES_alpha >= VaR_alpha at the same alpha (a tail average dominates its quantile).
+  * VaR / Sharpe report ``coherent == False`` (callers gate capital on this).
+  * A distribution with n < 30 samples is flagged ``provisional`` (min-n >= 30).
+  * Every measure fingerprints its distribution, so receipts are reproducible.
+
+Deterministic and stdlib-only: analytic where possible, seeded PRNG otherwise,
+so CI is reproducible.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import random
+from dataclasses import dataclass, field
+
+MIN_SAMPLES = 30
+
+REWARD_TO_RISK_KERNELS = {"sharpe", "sortino", "kappa"}
+TAIL_KERNELS = {"var", "expected_shortfall", "spectral"}
+DISPERSION_KERNELS = {"stddev"}
+KNOWN_KERNELS = REWARD_TO_RISK_KERNELS | TAIL_KERNELS | DISPERSION_KERNELS
+
+# Coherent tail measures are the only defensible default for RAROC economic
+# capital. VaR, Sharpe's sigma and plain stddev are NOT coherent risk measures.
+COHERENT_KERNELS = {"expected_shortfall", "spectral"}
+NONCOHERENT_KERNELS = {"var", "stddev", "sharpe"}
+
+
+class RiskMeasureError(ValueError):
+    """Raised for an unusable measure request (unknown kernel, empty F, ...)."""
+
+
+# --------------------------------------------------------------------------- #
+# distribution F
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class LossDistribution:
+    """A distribution F of period returns R (positive == gain).
+
+    ``losses`` is the loss side (-R). Tail measures read ``losses``;
+    reward-to-risk measures read the return samples directly.
+    """
+
+    samples: tuple[float, ...]
+    horizon_days: int = 1
+    source: str = "samples"
+    seed: int | None = None
+    beta: float | None = None  # market beta for an equity/market return F
+
+    def __post_init__(self) -> None:
+        if not self.samples:
+            raise RiskMeasureError("loss distribution F requires at least one sample")
+
+    @property
+    def n(self) -> int:
+        return len(self.samples)
+
+    @property
+    def provisional(self) -> bool:
+        """True when F is fitted on fewer than MIN_SAMPLES observations."""
+        return self.n < MIN_SAMPLES
+
+    @property
+    def losses(self) -> tuple[float, ...]:
+        return tuple(-r for r in self.samples)
+
+    def fingerprint(self) -> str:
+        """Reproducible id for the receipt (FIPS SHA-256 over canonical F)."""
+        body = {
+            "samples": [float(x) for x in self.samples],
+            "horizon_days": self.horizon_days,
+            "source": self.source,
+            "seed": self.seed,
+            "beta": self.beta,
+        }
+        canonical = json.dumps(body, sort_keys=True, separators=(",", ":"))
+        return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    @classmethod
+    def from_samples(cls, samples, horizon_days: int = 1) -> "LossDistribution":
+        return cls(tuple(float(x) for x in samples), horizon_days=horizon_days, source="samples")
+
+    @classmethod
+    def simulate_credit(
+        cls,
+        pd_long: float,
+        lgd: float,
+        ead: float,
+        w_systematic: float,
+        w_idiosyncratic: float,
+        horizon_days: int = 1,
+        n_scenarios: int = 1000,
+        seed: int = 0,
+    ) -> "LossDistribution":
+        """Simulate a credit loss distribution under a one-factor common shock.
+
+        Each scenario draws a systematic factor Z (shared) and an idiosyncratic
+        factor e, combines them into a stressed short-horizon default rate
+        ``PD_short = PD_long * (w1*systematic + w2*idiosyncratic)`` clamped to
+        [0,1], and books a loss of ``PD_short * LGD * EAD``. Returns are stored
+        as negative losses (a loss is a negative return). Seeded for CI.
+        """
+        rng = random.Random(seed)
+        samples: list[float] = []
+        for _ in range(n_scenarios):
+            systematic = math.exp(rng.gauss(0.0, 1.0))
+            idiosyncratic = math.exp(rng.gauss(0.0, 1.0))
+            shock = w_systematic * systematic + w_idiosyncratic * idiosyncratic
+            pd_short = min(1.0, max(0.0, pd_long * shock))
+            loss = pd_short * lgd * ead
+            samples.append(-loss)
+        return cls(tuple(samples), horizon_days=horizon_days, source="credit_one_factor", seed=seed)
+
+    @classmethod
+    def simulate_equity(
+        cls,
+        mu: float,
+        sigma: float,
+        df: float = 4.0,
+        beta: float | None = None,
+        horizon_days: int = 1,
+        n_scenarios: int = 1000,
+        seed: int = 0,
+    ) -> "LossDistribution":
+        """Simulate a fat-tailed equity/market RETURN distribution F (Student-t).
+
+        Equity is a return distribution (not a loss-only credit distribution): the
+        SAME ``risk`` interface reads it for Sharpe / Sortino / drawdown / VaR / ES
+        and a market ``beta`` can be carried for market-risk aggregation. Draws are
+        Student-t with ``df`` degrees of freedom (df small == fat tails / long
+        left tail), located at ``mu`` and scaled by ``sigma``. Seeded for CI.
+        """
+        rng = random.Random(seed)
+        samples: list[float] = []
+        for _ in range(n_scenarios):
+            z = rng.gauss(0.0, 1.0)
+            chi2 = sum(rng.gauss(0.0, 1.0) ** 2 for _ in range(max(1, int(round(df)))))
+            t = z / math.sqrt(chi2 / max(1, int(round(df)))) if chi2 > 0 else z
+            samples.append(mu + sigma * t)
+        return cls(tuple(samples), horizon_days=horizon_days, source="equity_student_t", seed=seed, beta=beta)
+
+
+# --------------------------------------------------------------------------- #
+# statistics
+# --------------------------------------------------------------------------- #
+def _mean(xs) -> float:
+    return sum(xs) / len(xs)
+
+
+def _stdev(xs) -> float:
+    """Sample standard deviation (ddof=1); 0.0 for a degenerate single sample."""
+    n = len(xs)
+    if n < 2:
+        return 0.0
+    m = _mean(xs)
+    return math.sqrt(sum((x - m) ** 2 for x in xs) / (n - 1))
+
+
+def lpm(samples, tau: float, order: int) -> float:
+    """Lower partial moment LPM_n(tau) = E[(tau - R)_+^n] over F.
+
+    order == 0 is the shortfall probability P[R < tau].
+    """
+    shortfalls = [tau - x for x in samples if x < tau]
+    if order == 0:
+        return len(shortfalls) / len(samples)
+    return sum(s ** order for s in shortfalls) / len(samples)
+
+
+def downside_deviation(samples, mar: float) -> float:
+    """Downside deviation sqrt(LPM_2(MAR)) about a Minimum Acceptable Return."""
+    return math.sqrt(lpm(samples, mar, 2))
+
+
+def _central_moment(samples, order: int) -> float:
+    m = _mean(samples)
+    return sum((x - m) ** order for x in samples) / len(samples)
+
+
+def skewness(samples) -> float:
+    """Sample skewness m3 / m2^1.5 (0 for a symmetric F)."""
+    m2 = _central_moment(samples, 2)
+    if m2 <= 0:
+        return 0.0
+    return _central_moment(samples, 3) / (m2 ** 1.5)
+
+
+def excess_kurtosis(samples) -> float:
+    """Excess kurtosis m4 / m2^2 - 3 (0 for a Gaussian F; > 0 for fat tails)."""
+    m2 = _central_moment(samples, 2)
+    if m2 <= 0:
+        return 0.0
+    return _central_moment(samples, 4) / (m2 ** 2) - 3.0
+
+
+# Thresholds above which lower-moment measures (Sharpe / normal-VaR) miss risk.
+_SKEW_TOL = 0.2
+_EXCESS_KURT_TOL = 0.5
+
+
+def _higher_moment_warning(samples) -> str | None:
+    sk = skewness(samples)
+    ek = excess_kurtosis(samples)
+    if abs(sk) > _SKEW_TOL or abs(ek) > _EXCESS_KURT_TOL:
+        return (
+            f"higher-moment risk unpriced (skew={sk:.3f}, excess_kurtosis={ek:.3f}); "
+            "prefer Sortino / Expected Shortfall over Sharpe / normal-VaR"
+        )
+    return None
+
+
+def _tail(losses, alpha: float):
+    """Return (tail_losses, var_threshold) for confidence ``alpha``.
+
+    The tail is the worst ``k = ceil((1-alpha) * n)`` losses. VaR_alpha is the
+    smallest loss in that tail (the quantile); ES_alpha is the tail mean. By
+    construction ES_alpha >= VaR_alpha for every F.
+    """
+    n = len(losses)
+    ordered = sorted(losses)
+    k = max(1, math.ceil((1.0 - alpha) * n))
+    tail = ordered[n - k:]
+    return tail, min(tail)
+
+
+# --------------------------------------------------------------------------- #
+# result
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class RiskMeasure:
+    kernel: str
+    family: str  # "dispersion" | "reward_to_risk" | "tail"
+    value: float  # ratio for reward-to-risk; capital magnitude for tail/dispersion
+    risk_functional: float  # the dispersion/capital denominator used
+    coherent: bool
+    reference: float
+    alpha: float | None
+    order: int | None
+    horizon: float
+    n_samples: int
+    provisional: bool
+    distribution_id: str
+    downside_only: bool = False
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+
+    def summary(self) -> dict:
+        """Compact, receipt-ready record of the measure and its distribution."""
+        return {
+            "kernel": self.kernel,
+            "family": self.family,
+            "value": self.value,
+            "risk_functional": self.risk_functional,
+            "coherent": self.coherent,
+            "downside_only": self.downside_only,
+            "reference": self.reference,
+            "alpha": self.alpha,
+            "order": self.order,
+            "horizon": self.horizon,
+            "n_samples": self.n_samples,
+            "provisional": self.provisional,
+            "distribution_id": self.distribution_id,
+            "warnings": list(self.warnings),
+        }
+
+
+# --------------------------------------------------------------------------- #
+# the single interface
+# --------------------------------------------------------------------------- #
+def risk(
+    F: LossDistribution,
+    kernel: str,
+    *,
+    reference: float = 0.0,
+    horizon: float = 1.0,
+    alpha: float = 0.95,
+    order: int = 2,
+    phi=None,
+) -> RiskMeasure:
+    """Evaluate one risk lens ``kernel`` over the loss distribution ``F``.
+
+    ``reference`` is the MAR / risk-free hurdle for reward-to-risk kernels.
+    ``horizon`` scales magnitudes by sqrt-time (a term-structure point).
+    ``alpha`` is the tail confidence; ``order`` the Kappa/LPM moment; ``phi`` an
+    optional spectral weight vector over the tail (non-increasing == coherent).
+    """
+    if kernel not in KNOWN_KERNELS:
+        raise RiskMeasureError(
+            f"unknown risk kernel {kernel!r}; known: {sorted(KNOWN_KERNELS)}"
+        )
+    if horizon <= 0:
+        raise RiskMeasureError("horizon must be positive")
+
+    r = list(F.samples)
+    n = len(r)
+    m = _mean(r)
+    hscale = math.sqrt(horizon)
+    warnings: list[str] = []
+    if F.provisional:
+        warnings.append(
+            f"distribution fitted on n={n} < {MIN_SAMPLES}; risk estimate is provisional"
+        )
+
+    def _rm(**kw) -> RiskMeasure:
+        return RiskMeasure(
+            kernel=kernel,
+            reference=reference,
+            horizon=horizon,
+            n_samples=n,
+            provisional=F.provisional,
+            distribution_id=F.fingerprint(),
+            warnings=tuple(warnings),
+            **kw,
+        )
+
+    # -- dispersion ------------------------------------------------------- #
+    if kernel == "stddev":
+        sd = _stdev(r) * hscale
+        return _rm(family="dispersion", value=sd, risk_functional=sd,
+                   coherent=False, alpha=None, order=None)
+
+    # -- reward-to-risk --------------------------------------------------- #
+    if kernel == "sharpe":
+        warnings.append("Sharpe uses two-sided sigma; it is not a coherent risk measure and penalizes upside")
+        hm = _higher_moment_warning(r)
+        if hm:
+            warnings.append(hm)
+        denom = _stdev(r) * hscale
+        ratio = (m - reference) * horizon / denom if denom > 0 else math.inf
+        return _rm(family="reward_to_risk", value=ratio, risk_functional=denom,
+                   coherent=False, alpha=None, order=None)
+
+    if kernel == "sortino":
+        denom = downside_deviation(r, reference) * hscale
+        ratio = (m - reference) * horizon / denom if denom > 0 else math.inf
+        return _rm(family="reward_to_risk", value=ratio, risk_functional=denom,
+                   coherent=False, alpha=None, order=2, downside_only=True)
+
+    if kernel == "kappa":
+        if order < 0:
+            raise RiskMeasureError("kappa order must be >= 0")
+        moment = lpm(r, reference, order)
+        if order == 0:
+            denom = moment  # shortfall probability
+        else:
+            denom = moment ** (1.0 / order)
+        denom *= hscale
+        ratio = (m - reference) * horizon / denom if denom > 0 else math.inf
+        return _rm(family="reward_to_risk", value=ratio, risk_functional=denom,
+                   coherent=False, alpha=None, order=order, downside_only=True)
+
+    # -- tail / coherent -------------------------------------------------- #
+    losses = list(F.losses)
+    tail, var_threshold = _tail(losses, alpha)
+
+    if kernel == "var":
+        warnings.append(
+            "VaR is not subadditive; it can violate coherence and understate diversified tail risk"
+        )
+        hm = _higher_moment_warning(r)
+        if hm:
+            warnings.append(hm)
+        value = var_threshold * hscale
+        return _rm(family="tail", value=value, risk_functional=value,
+                   coherent=False, alpha=alpha, order=None)
+
+    if kernel == "expected_shortfall":
+        value = _mean(tail) * hscale
+        return _rm(family="tail", value=value, risk_functional=value,
+                   coherent=True, alpha=alpha, order=None)
+
+    # spectral
+    ordered_tail = sorted(tail, reverse=True)  # worst first
+    if phi is None:
+        # flat tail spectrum == Expected Shortfall (coherent by construction)
+        value = _mean(ordered_tail) * hscale
+        return _rm(family="tail", value=value, risk_functional=value,
+                   coherent=True, alpha=alpha, order=None)
+    weights = [float(w) for w in phi]
+    if len(weights) != len(ordered_tail):
+        raise RiskMeasureError(
+            f"spectral phi has {len(weights)} weights but tail has {len(ordered_tail)} points"
+        )
+    total = sum(weights)
+    if total <= 0:
+        raise RiskMeasureError("spectral phi weights must sum to a positive value")
+    weights = [w / total for w in weights]
+    non_increasing = all(weights[i] >= weights[i + 1] - 1e-12 for i in range(len(weights) - 1))
+    if not non_increasing:
+        warnings.append("spectral phi is not non-increasing; the resulting measure is not coherent")
+    value = sum(w * loss for w, loss in zip(weights, ordered_tail)) * hscale
+    return _rm(family="tail", value=value, risk_functional=value,
+               coherent=non_increasing, alpha=alpha, order=None)
+
+
+def is_coherent(kernel: str) -> bool:
+    """Whether ``kernel`` is a coherent risk measure by default (phi flat)."""
+    return kernel in COHERENT_KERNELS
+
+
+def risk_term_structure(
+    F: LossDistribution,
+    kernel: str,
+    horizons,
+    **kwargs,
+) -> dict:
+    """Risk as a term structure across horizons (not a scalar).
+
+    Returns ``{horizon: measure_value}`` for each requested horizon.
+    """
+    return {float(h): risk(F, kernel, horizon=float(h), **kwargs).value for h in horizons}
+
+
+def largest_cumulative_gap(daily_net_flows) -> float:
+    """LCR-style largest cumulative net-outflow gap over N days.
+
+    ``daily_net_flows`` are signed (positive == inflow). Returns the magnitude of
+    the deepest cumulative shortfall (>= 0); this is the horizon liquidity risk a
+    coherent capital buffer must cover.
+    """
+    cumulative = 0.0
+    worst = 0.0
+    for flow in daily_net_flows:
+        cumulative += float(flow)
+        worst = min(worst, cumulative)
+    return -worst
+
+
+def max_drawdown(returns) -> float:
+    """Path-dependent maximum drawdown of a return series (equity/market risk)."""
+    peak = 1.0
+    equity = 1.0
+    mdd = 0.0
+    for r in returns:
+        equity *= (1.0 + float(r))
+        peak = max(peak, equity)
+        if peak > 0:
+            mdd = max(mdd, (peak - equity) / peak)
+    return mdd
+
+
+# --------------------------------------------------------------------------- #
+# structure / issuance: a tranche F is a transform of the pool F
+# --------------------------------------------------------------------------- #
+def structural_transform(F_pool: LossDistribution, attach: float, detach: float) -> LossDistribution:
+    """Securitization waterfall: derive a tranche loss distribution from the pool.
+
+    A [attach, detach] tranche absorbs pool loss between its attach and detach
+    points: ``tranche_loss = clip(pool_loss - attach, 0, detach - attach)``. Equity
+    is simply the most-junior (first-loss) tranche of the same waterfall. Because a
+    contiguous partition of [0, cap] sums back to the pool loss on every scenario,
+    the tranche expected losses reconcile to the pool EL (conservation).
+
+    A tranche with ``detach <= attach`` is REJECTED.
+    """
+    if detach <= attach:
+        raise RiskMeasureError(
+            f"tranche detach ({detach}) must exceed attach ({attach})"
+        )
+    width = detach - attach
+    tranche_samples = tuple(
+        -min(max(loss - attach, 0.0), width) for loss in F_pool.losses
+    )
+    return LossDistribution(
+        tranche_samples,
+        horizon_days=F_pool.horizon_days,
+        source=f"tranche[{attach},{detach}]",
+        seed=F_pool.seed,
+    )
+
+
+def expected_loss(F: LossDistribution) -> float:
+    """Expected loss EL = E[loss] over F (mean of the loss side)."""
+    return _mean(F.losses)
+
+
+# --------------------------------------------------------------------------- #
+# coherent allocation: Euler/marginal component capital
+# --------------------------------------------------------------------------- #
+def euler_allocation(
+    components: dict,
+    kernel: str = "expected_shortfall",
+    *,
+    alpha: float = 0.95,
+    horizon: float = 1.0,
+    allow_noncoherent: bool = False,
+) -> dict:
+    """Euler (marginal) capital allocation of a coherent measure to components.
+
+    ``components`` maps a node name to that node's ``LossDistribution``, aligned
+    scenario-by-scenario (same length, same draws). The portfolio loss per scenario
+    is the sum of component losses. For a COHERENT measure the Euler contribution of
+    component i is ``E[loss_i | portfolio_loss in tail]``; because conditional
+    expectation is linear, the contributions SUM to the portfolio total exactly --
+    the same sum-to-total conservation the IC-1 settlement enforces. This is what
+    lets EconomicCapital aggregate up and allocate down an arbitrary hierarchy cut.
+
+    A NON-coherent measure (VaR) cannot be cleanly Euler-allocated (it is not
+    subadditive); this requires ``allow_noncoherent=True`` and emits a warning.
+    """
+    if kernel not in KNOWN_KERNELS:
+        raise RiskMeasureError(f"unknown risk kernel {kernel!r}")
+    if not components:
+        raise RiskMeasureError("euler_allocation requires at least one component")
+
+    names = list(components)
+    loss_columns = {name: list(components[name].losses) for name in names}
+    n = len(loss_columns[names[0]])
+    if any(len(col) != n for col in loss_columns.values()):
+        raise RiskMeasureError("component distributions must be scenario-aligned (equal length)")
+
+    warnings: list[str] = []
+    coherent = kernel in COHERENT_KERNELS
+    if not coherent:
+        warnings.append(
+            f"incoherence warning: '{kernel}' is not subadditive; Euler/marginal allocation "
+            "is not well defined and contributions need not sum to the total"
+        )
+        if not allow_noncoherent:
+            raise RiskMeasureError(
+                f"REJECTED: cannot Euler-allocate non-coherent measure '{kernel}' "
+                "without allow_noncoherent override"
+            )
+
+    portfolio_losses = [sum(loss_columns[name][s] for name in names) for s in range(n)]
+    order = sorted(range(n), key=lambda s: portfolio_losses[s])
+    k = max(1, math.ceil((1.0 - alpha) * n))
+    tail_idx = order[n - k:]
+    hscale = math.sqrt(horizon)
+
+    contributions = {
+        name: (sum(loss_columns[name][s] for s in tail_idx) / k) * hscale for name in names
+    }
+    total = (sum(portfolio_losses[s] for s in tail_idx) / k) * hscale
+    sum_contrib = sum(contributions.values())
+    return {
+        "kernel": kernel,
+        "alpha": alpha,
+        "horizon": horizon,
+        "coherent": coherent,
+        "total": total,
+        "contributions": contributions,
+        "sum_of_contributions": sum_contrib,
+        "sum_to_total": math.isclose(sum_contrib, total, rel_tol=1e-9, abs_tol=1e-9),
+        "warnings": warnings,
+    }

--- a/third_party/open_ep_framework/term_calculus.py
+++ b/third_party/open_ep_framework/term_calculus.py
@@ -1,0 +1,222 @@
+"""Calculus over (value x time) for the risk kernel (TC-1).
+
+The risk kernel is a calculus on two axes:
+
+  * VALUE axis -- risk measures and distributional moments are INTEGRALS over the
+    loss/return distribution F (mean, variance, skew, kurtosis, LPM_n, VaR, ES).
+    ES is the tail integral consistent with the VaR quantile.
+  * TIME axis -- a cash-flow / loss-timing schedule F(t) has time-integral
+    functionals: weighted average life (WAL, the first moment of the timing
+    distribution) and duration (Macaulay / modified / effective).
+
+Sensitivities are the DERIVATIVES of price w.r.t. a factor:
+
+  * modified duration  = -(1/P) dP/dy
+  * convexity          =  (1/P) d2P/dy2
+  * generalized Greeks =  numerical dValue/dFactor, d2Value/dFactor2.
+
+Analytic derivatives are reconciled to finite-difference bump-and-reprice
+(the teeth), so optionality / prepayment (no closed form) uses the SAME operator
+numerically. Marginal / component capital (Euler, in ``risk_measures``) is itself a
+numerical derivative of portfolio risk w.r.t. exposure.
+
+Term regime
+-----------
+The tenor curve has a regime (upward / flat / inverted; persistent vs
+mean-reverting). Persistence is read with a Hurst exponent on the tenor
+dimension. The estate memory-regime characterizer is the intended source of H;
+this module exposes an INJECTION seam (``hurst_fn``) and only falls back to a
+local rescaled-range (R/S) estimator when no characterizer is injected, so the
+characterizer is consumed rather than forked.
+
+Deterministic / stdlib only.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+class TermCalculusError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class Cashflow:
+    tenor: float  # time in years
+    amount: float  # cash flow (or loss) at this tenor
+
+
+def _flows(schedule) -> list[Cashflow]:
+    flows = [c if isinstance(c, Cashflow) else Cashflow(float(c["tenor"]), float(c["amount"]))
+             for c in schedule]
+    if not flows:
+        raise TermCalculusError("cash-flow schedule must be non-empty")
+    return flows
+
+
+# --------------------------------------------------------------------------- #
+# time-axis integrals
+# --------------------------------------------------------------------------- #
+def average_life(schedule) -> float:
+    """Weighted average life WAL = sum(t * amount) / sum(amount).
+
+    The first moment of the timing distribution. A bullet (single terminal cash
+    flow) has WAL == its maturity.
+    """
+    flows = _flows(schedule)
+    total = sum(f.amount for f in flows)
+    if total == 0:
+        raise TermCalculusError("WAL undefined for zero total cash flow")
+    return sum(f.tenor * f.amount for f in flows) / total
+
+
+def price(schedule, y: float) -> float:
+    """Present value P(y) = sum CF_t / (1+y)^t."""
+    if y <= -1.0:
+        raise TermCalculusError("yield must exceed -100%")
+    return sum(f.amount / (1.0 + y) ** f.tenor for f in _flows(schedule))
+
+
+def macaulay_duration(schedule, y: float) -> float:
+    """Macaulay duration = sum(t * PV_t) / sum(PV_t)."""
+    flows = _flows(schedule)
+    pvs = [f.amount / (1.0 + y) ** f.tenor for f in flows]
+    p = sum(pvs)
+    if p == 0:
+        raise TermCalculusError("Macaulay duration undefined for zero price")
+    return sum(f.tenor * pv for f, pv in zip(flows, pvs)) / p
+
+
+def modified_duration(schedule, y: float) -> float:
+    """Modified duration = Macaulay / (1 + y)."""
+    return macaulay_duration(schedule, y) / (1.0 + y)
+
+
+def analytic_convexity(schedule, y: float) -> float:
+    """Analytic convexity = sum(t(t+1) CF_t / (1+y)^(t+2)) / P."""
+    flows = _flows(schedule)
+    p = price(schedule, y)
+    if p == 0:
+        raise TermCalculusError("convexity undefined for zero price")
+    return sum(f.tenor * (f.tenor + 1.0) * f.amount / (1.0 + y) ** (f.tenor + 2.0)
+               for f in flows) / p
+
+
+# --------------------------------------------------------------------------- #
+# calculus operators as first-class (differentiation)
+# --------------------------------------------------------------------------- #
+def finite_difference(f, x: float, h: float = 1e-5) -> float:
+    """Central first derivative f'(x) by bump-and-reprice."""
+    return (f(x + h) - f(x - h)) / (2.0 * h)
+
+
+def second_difference(f, x: float, h: float = 1e-4) -> float:
+    """Central second derivative f''(x) by bump-and-reprice."""
+    return (f(x + h) + f(x - h) - 2.0 * f(x)) / (h * h)
+
+
+def effective_duration(reprice, y: float, bump: float = 1e-4) -> float:
+    """Effective (numerical) duration -(1/P) dP/dy for arbitrary reprice fns.
+
+    Handles optionality / prepayment where no closed form exists. ``reprice(y)``
+    returns price at yield y.
+    """
+    p0 = reprice(y)
+    if p0 == 0:
+        raise TermCalculusError("effective duration undefined for zero price")
+    return -finite_difference(reprice, y, bump) / p0
+
+
+def effective_convexity(reprice, y: float, bump: float = 1e-4) -> float:
+    """Effective (numerical) convexity (1/P) d2P/dy2."""
+    p0 = reprice(y)
+    if p0 == 0:
+        raise TermCalculusError("effective convexity undefined for zero price")
+    return second_difference(reprice, y, bump) / p0
+
+
+def greek(value_fn, factor: float, order: int = 1, bump: float = 1e-5) -> float:
+    """Generalized factor-Greek: order-1 == delta, order-2 == gamma."""
+    if order == 1:
+        return finite_difference(value_fn, factor, bump)
+    if order == 2:
+        return second_difference(value_fn, factor, max(bump, 1e-4))
+    raise TermCalculusError("greek order must be 1 (delta) or 2 (gamma)")
+
+
+def taylor_reprice(p0: float, modified_dur: float, convexity: float, dy: float) -> float:
+    """2nd-order Taylor reprice: P0 * (1 - Dmod*dy + 0.5*convexity*dy^2)."""
+    return p0 * (1.0 - modified_dur * dy + 0.5 * convexity * dy * dy)
+
+
+# --------------------------------------------------------------------------- #
+# term regime: Hurst on the tenor dimension (injectable characterizer)
+# --------------------------------------------------------------------------- #
+def _rs_hurst(series) -> float:
+    """Local rescaled-range (R/S) Hurst estimate; injection fallback only.
+
+    H ~ 0.5 random walk, H > 0.5 persistent, H < 0.5 mean-reverting. This is the
+    fallback used only when no estate memory-regime characterizer is injected.
+    """
+    xs = [float(v) for v in series]
+    n = len(xs)
+    if n < 4:
+        raise TermCalculusError("Hurst estimate needs at least 4 points")
+    mean = sum(xs) / n
+    dev = 0.0
+    cumulative = []
+    for x in xs:
+        dev += x - mean
+        cumulative.append(dev)
+    R = max(cumulative) - min(cumulative)
+    S = math.sqrt(sum((x - mean) ** 2 for x in xs) / n)
+    if S == 0 or R == 0:
+        return 0.5
+    return math.log(R / S) / math.log(n)
+
+
+def term_regime(tenor_curve, hurst_fn=None) -> dict:
+    """Classify a tenor curve's shape and persistence.
+
+    ``tenor_curve`` is a sequence of (tenor, rate/weight) points sorted by tenor.
+    Shape: upward / flat / inverted from the end-to-end slope. Persistence: from a
+    Hurst read on the rate dimension. Pass ``hurst_fn`` to bind the estate
+    memory-regime characterizer's H; otherwise the local R/S fallback is used.
+    """
+    points = [(float(t), float(v)) for t, v in tenor_curve]
+    if len(points) < 2:
+        raise TermCalculusError("term regime needs at least 2 tenor points")
+    points.sort(key=lambda p: p[0])
+    slope = points[-1][1] - points[0][1]
+    if abs(slope) < 1e-9:
+        shape = "flat"
+    elif slope > 0:
+        shape = "upward"
+    else:
+        shape = "inverted"
+    values = [v for _, v in points]
+    h_reader = hurst_fn or _rs_hurst
+    if hurst_fn is None and len(values) < 4:
+        # Not enough tenor points for the R/S fallback; shape still classifies.
+        return {
+            "shape": shape,
+            "slope": slope,
+            "hurst": None,
+            "persistence": "insufficient_data",
+            "hurst_source": "unavailable",
+        }
+    hurst = h_reader(values)
+    if hurst > 0.55:
+        persistence = "persistent"
+    elif hurst < 0.45:
+        persistence = "mean_reverting"
+    else:
+        persistence = "random_walk"
+    return {
+        "shape": shape,
+        "slope": slope,
+        "hurst": hurst,
+        "persistence": persistence,
+        "hurst_source": "injected" if hurst_fn else "local_rs_fallback",
+    }

--- a/third_party/open_ep_framework/uvmc.py
+++ b/third_party/open_ep_framework/uvmc.py
@@ -1,6 +1,5 @@
 import math
 from functools import reduce
-from operator import mul
 from typing import Iterable, Mapping, Sequence
 
 


### PR DESCRIPTION
Follows economic-prophet#56 (the upstream github-code-quality fix). Refreshes `third_party/open_ep_framework/` per its VENDOR.md — byte-faithful re-copy of `src/open_ep_framework/` @ `4c761fa` + LICENSE + SHA bump (32281bcb→4c761fa). **Drift test `tests/platform_stubs/test_risk_ep_facts.py`: 6 passed.**

**Scope flag (@mdheller):** the vendored copy was pinned at 32281bcb, which predates today's finance arc, so a *faithful* refresh also pulls in the modules added upstream since then — **8 modified, 12 added, 0 deleted**. The 12 additions: `risk_measures`, `market_instruments`, `ftp_curve`, `capital_floor`, `concern_ladder`, `aggregation_method`, `risk_adjusted_profit`, `term_calculus`, `hedging`, and the `asset_ladder/`, `crypto/`, `flow_regime/` subpackages. This is the byte-faithful behavior VENDOR.md prescribes (single upstream mirror), and the drift test stays green — but it's a larger vendored surface than just the lint fix. Holding for your review before merge: confirm the full-mirror refresh is intended, or say the word to pin narrower.