### PR TITLE
fix(gitops-promote): self-complete promote PRs (publish gate/check) + auto-close superseded

### DIFF
--- a/.github/workflows/gitops-promote.yml
+++ b/.github/workflows/gitops-promote.yml
@@ -25,8 +25,9 @@ permissions:
                          # branch (see the long note in the push step). The repo default workflow
                          # permission is read-only, so without this the dispatch 403s and every
                          # promote PR sits BLOCKED forever waiting for diagnostics-gate.
-  statuses: write        # REQUIRED to POST the `diagnostics-gate` commit status that the
-                         # `main-required-checks` ruleset actually reads (see the push step).
+  statuses: write        # REQUIRED to POST the BOTH required commit statuses the push step
+                         # publishes: `diagnostics-gate` (the main-required-checks ruleset)
+                         # AND `gate / check` (classic branch protection, app_id 15368).
                          # Without it the POST 403s and the PR sits BLOCKED — same symptom as
                          # before, so the step treats a failed POST as fatal rather than warning.
 
@@ -126,7 +127,43 @@ jobs:
           git push origin "$BRANCH"
           gh pr create --base main --head "$BRANCH" \
             --title "gitops: promote${bumped} → sha-${SHA:0:12}" \
-            --body "Automated image-pin promotion (values-only). Auto-merges when diagnostics-gate passes."
+            --body "Automated image-pin promotion (values-only). Auto-merges when the required checks (diagnostics-gate + gate / check) pass."
+
+          # ── Genetic-superset self-selection: auto-close the promotes this one dominates ──
+          # gitops-promote opens one values-only PR per built commit. When a service is
+          # rebuilt again before its earlier promote PR merges, that earlier PR is strictly
+          # DOMINATED — every values file it touches is re-pinned here to a NEWER sha, so
+          # merging it later would land a stale pin, and it meanwhile occupies the (backed-up)
+          # self-hosted runner pool. Close every OPEN promote PR whose changed files are a
+          # subset of this one's: newest-per-service wins. The domination rule is pure and
+          # unit-tested in tools/gitops_supersede.py (tools/tests/test_gitops_supersede.py);
+          # this step only gathers live PR/file data and closes. Best-effort by design —
+          # run in a subshell so its `set +e` cannot leak into the fail-fast gate logic
+          # below, and never fatal: self-selection is an optimisation, not the merge gate.
+          select_superset() {
+            local NEW_PR new_files cand others_with_files verdict n files
+            NEW_PR="$(gh pr view "$BRANCH" --json number --jq '.number')" || return 0
+            [ -n "$NEW_PR" ] || return 0
+            new_files="$(printf '%s\n' $FILES | jq -R . | jq -cs '.')"
+            others_with_files='[]'
+            cand="$(gh pr list --state open --json number,title \
+                      --jq '.[] | select(.title|startswith("gitops: promote")) | .number' \
+                    | grep -vx "$NEW_PR")"
+            for n in $cand; do
+              files="$(gh pr view "$n" --json files --jq '[.files[].path]')"
+              [ -n "$files" ] || files='[]'
+              others_with_files="$(printf '%s' "$others_with_files" \
+                | jq -c --argjson number "$n" --argjson files "$files" '. + [{number:$number, files:$files}]')"
+            done
+            verdict="$(jq -cn --argjson new_files "$new_files" --argjson others "$others_with_files" \
+                        '{new_files:$new_files, others:$others}' | python3 tools/gitops_supersede.py)"
+            for n in $(printf '%s' "$verdict" | jq -r '.superseded[]'); do
+              echo "closing superseded promote PR #$n (dominated by #$NEW_PR)"
+              gh pr close "$n" --delete-branch \
+                --comment "Superseded by #$NEW_PR — a newer promote re-pins these services to a fresher image sha (genetic-superset self-selection)."
+            done
+          }
+          ( set +e; select_superset ) || echo "::warning::genetic-superset self-selection skipped (non-fatal)"
 
           # ── The required check must be PUBLISHED WHERE THE RULESET READS, not merely produced ──
           # A PR opened by this job never gets its required check on its own. Two failure modes
@@ -174,12 +211,33 @@ jobs:
           # yet have a diagnostics run to point at.
           PROMOTE_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           DIAG_URL=""
-          post_status() {   # $1=state $2=description
-            local url="${DIAG_URL:-$PROMOTE_URL}"
-            gh api -X POST "repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
-              -f state="$1" -f context='diagnostics-gate' \
-              -f description="$(printf '%.140s' "$2")" \
-              -f target_url="$url" >/dev/null
+          # main requires TWO contexts, and a bot-authored promote PR gets NEITHER from an
+          # event-triggered run (GITHUB_TOKEN no-recursion):
+          #   • diagnostics-gate  — the main-required-checks ruleset
+          #   • gate / check      — classic branch protection, pinned to app_id 15368
+          # gitops-promote already dispatches the real validate-target-diagnostics run and
+          # reads its outcome; it MIRRORS that one verdict onto BOTH required contexts as
+          # commit statuses (part of the PR rollup by construction — the same mechanism that
+          # already makes diagnostics-gate land). Publishing only diagnostics-gate is exactly
+          # what left promote PRs at mergeStateStatus=UNKNOWN — auto-merge armed but never
+          # firing — until a human admin-merged them in batches (measured on #1313: every
+          # check green EXCEPT `gate / check`, which was simply ABSENT).
+          # gate.yml (the workflow_run mirror) can NOT cover this: a run dispatched via
+          # GITHUB_TOKEN emits no workflow_run event, so gate.yml never fires for a promote
+          # branch — measured, zero gate.yml runs on any gitops/promote-* head SHA. Because a
+          # commit status created with GITHUB_TOKEN is attributed to the github-actions app
+          # (15368), it satisfies the app_id-pinned `gate / check` just as it satisfies
+          # diagnostics-gate. Fail-closed is preserved: both contexts move in lockstep and
+          # only a measured green run downgrades them to success.
+          REQUIRED_CONTEXTS=('diagnostics-gate' 'gate / check')
+          post_status() {   # $1=state $2=description — drives BOTH required contexts in lockstep
+            local url="${DIAG_URL:-$PROMOTE_URL}" ctx
+            for ctx in "${REQUIRED_CONTEXTS[@]}"; do
+              gh api -X POST "repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
+                -f state="$1" -f context="$ctx" \
+                -f description="$(printf '%.140s' "$2")" \
+                -f target_url="$url" >/dev/null
+            done
           }
           # Publish `pending` FIRST. If this job dies at any point below, the PR is left with an
           # explicitly pending required check (visibly blocked) rather than an absent one

--- a/tools/gitops_supersede.py
+++ b/tools/gitops_supersede.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Genetic-superset selection for gitops-promote PRs.
+
+Pure, deterministic, no-network logic. gitops-promote opens one values-only PR per
+built commit, re-pinning the CHANGED services to the fresh image sha. When a service
+is rebuilt again before its earlier promote PR merges, the earlier PR is strictly
+DOMINATED — every values file it touches is re-pinned (to a newer sha) by the newer
+PR. Keeping it open wastes the self-hosted runner pool and lands a stale pin if merged
+out of order.
+
+This module decides which OPEN promote PRs a newer promote PR supersedes:
+
+    a promote PR P is superseded by the new PR N iff
+      * P touches at least one file, and
+      * every file P touches is also touched by N        (files(P) ⊆ files(N)), and
+      * P and N are both values-only promotes            (all files under deploy/values/).
+
+Equal filesets are dominated too (same services, newer sha wins) — N is by construction
+the newest, so an older equal-set promote is closed in favour of it: "newest-per-service".
+
+The workflow feeds live PR/file data in on stdin and CLOSES the returned PRs; the
+domination rule itself lives here so it is unit-tested and cannot regress silently.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Iterable
+
+VALUES_PREFIX = "deploy/values/"
+
+
+def _is_values_only(files: Iterable[str]) -> bool:
+    files = list(files)
+    return bool(files) and all(f.startswith(VALUES_PREFIX) for f in files)
+
+
+def superseded_prs(new_files: Iterable[str], others: Iterable[dict]) -> dict:
+    """Return {'superseded': [numbers], 'kept': [numbers]} — deterministic, sorted.
+
+    new_files : the values files the NEW promote PR changes.
+    others    : [{'number': int, 'files': [str, ...]}, ...] — the other OPEN promote PRs.
+    """
+    new_set = set(new_files)
+    new_is_values_only = _is_values_only(new_set)
+    superseded: list[int] = []
+    kept: list[int] = []
+    for pr in others:
+        number = pr["number"]
+        pr_files = set(pr.get("files") or [])
+        dominated = (
+            new_is_values_only
+            and _is_values_only(pr_files)
+            and pr_files  # non-empty
+            and pr_files <= new_set  # every file also re-pinned by the newer PR
+        )
+        (superseded if dominated else kept).append(number)
+    return {"superseded": sorted(superseded), "kept": sorted(kept)}
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Read {'new_files': [...], 'others': [...]} from stdin; write the verdict to stdout."""
+    payload = json.load(sys.stdin)
+    verdict = superseded_prs(payload["new_files"], payload.get("others", []))
+    json.dump(verdict, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_gitops_promote_gate_contract.py
+++ b/tools/tests/test_gitops_promote_gate_contract.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Contract tooth: gitops-promote must publish BOTH required contexts, fail-closed.
+
+The whole self-completing-promote fix is: a bot-authored promote PR can never get its
+required checks from an event-triggered run (GITHUB_TOKEN no-recursion), so gitops-promote
+publishes them itself as commit statuses. main requires TWO contexts:
+  * `diagnostics-gate` — the main-required-checks ruleset
+  * `gate / check`     — classic branch protection (app_id 15368)
+Publishing only the first is exactly the bug that left promote PRs BLOCKED at
+mergeStateStatus=UNKNOWN until a human admin-merged them. This test parses the workflow
+and asserts both contexts are posted, that a `pending` is posted before any `success`
+(fail-closed by construction), and that the genetic-superset self-selection is wired in.
+
+Run: python3 -m pytest -q tools/tests/test_gitops_promote_gate_contract.py
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "gitops-promote.yml"
+
+
+def _promote_run_script() -> str:
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = doc["jobs"]["promote"]["steps"]
+    return "\n".join(s.get("run", "") for s in steps)
+
+
+def test_both_required_contexts_are_published() -> None:
+    script = _promote_run_script()
+    assert "diagnostics-gate" in script, "the ruleset context must still be published"
+    assert "gate / check" in script, (
+        "classic branch protection requires the `gate / check` context; without it a "
+        "promote PR sits at mergeStateStatus=UNKNOWN and never auto-merges"
+    )
+
+
+def test_pending_is_published_before_success() -> None:
+    script = _promote_run_script()
+    # Fail-closed: the required checks must be driven to `pending` first, so a job that
+    # dies mid-flight leaves the PR visibly blocked, not invisibly absent.
+    assert "post_status pending" in script
+    first_pending = script.index("post_status pending")
+    first_success = script.index("post_status success")
+    assert first_pending < first_success, "must post pending before success (fail-closed)"
+
+
+def test_success_is_the_only_certifying_state() -> None:
+    script = _promote_run_script()
+    # The certifying line only runs after the fail-closed per-job allowlist check.
+    assert "post_status success" in script
+    assert 'select(.conclusion != "success")' in script, (
+        "verdict must be an allowlist on `success`, never a denylist of known-bad states"
+    )
+
+
+def test_genetic_superset_selfselection_is_wired() -> None:
+    script = _promote_run_script()
+    assert "gitops_supersede.py" in script, (
+        "newer promotes must auto-close dominated (superseded) promote PRs"
+    )
+
+
+def test_statuses_write_permission_declared() -> None:
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    perms = doc["jobs"]["promote"].get("permissions") or doc.get("permissions") or {}
+    assert perms.get("statuses") == "write", (
+        "posting commit statuses for both required contexts needs statuses: write"
+    )
+
+
+if __name__ == "__main__":
+    import subprocess
+
+    raise SystemExit(subprocess.call(["python3", "-m", "pytest", "-q", __file__]))

--- a/tools/tests/test_gitops_supersede.py
+++ b/tools/tests/test_gitops_supersede.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Teeth for gitops-promote's genetic-superset self-selection.
+
+A self-selection rule that has never been shown to CLOSE a dominated promote, nor to
+KEEP an independent one, is as suspect as an unenforced rule. superseded_prs is pure,
+so we drive it directly and assert both directions. Deterministic, no network.
+
+Run: python3 -m pytest -q tools/tests/test_gitops_supersede.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import gitops_supersede as gs  # noqa: E402
+
+
+def test_equal_fileset_is_superseded_newest_per_service() -> None:
+    # Same service re-pinned to a newer sha: the older promote PR is dominated.
+    out = gs.superseded_prs(
+        ["deploy/values/hellgraph-service.yaml"],
+        [{"number": 1301, "files": ["deploy/values/hellgraph-service.yaml"]}],
+    )
+    assert out == {"superseded": [1301], "kept": []}
+
+
+def test_strict_subset_is_superseded() -> None:
+    # New PR re-pins A and B; an older PR that only touched A is dominated.
+    out = gs.superseded_prs(
+        ["deploy/values/a.yaml", "deploy/values/b.yaml"],
+        [{"number": 10, "files": ["deploy/values/a.yaml"]}],
+    )
+    assert out["superseded"] == [10] and out["kept"] == []
+
+
+def test_independent_service_is_kept() -> None:
+    # Older PR touches C, which the new PR does not re-pin -> NOT dominated, keep it.
+    out = gs.superseded_prs(
+        ["deploy/values/a.yaml"],
+        [{"number": 20, "files": ["deploy/values/c.yaml"]}],
+    )
+    assert out == {"superseded": [], "kept": [20]}
+
+
+def test_superset_pr_is_kept() -> None:
+    # Older PR touches A and B; new PR only re-pins A -> older is NOT a subset, keep it.
+    out = gs.superseded_prs(
+        ["deploy/values/a.yaml"],
+        [{"number": 30, "files": ["deploy/values/a.yaml", "deploy/values/b.yaml"]}],
+    )
+    assert out == {"superseded": [], "kept": [30]}
+
+
+def test_empty_pr_is_never_closed() -> None:
+    # A PR with no recorded files must never be auto-closed (fail-safe).
+    out = gs.superseded_prs(
+        ["deploy/values/a.yaml"],
+        [{"number": 40, "files": []}],
+    )
+    assert out == {"superseded": [], "kept": [40]}
+
+
+def test_non_values_new_pr_closes_nothing() -> None:
+    # If the "new" change is not a pure values promote, refuse to close anything.
+    out = gs.superseded_prs(
+        ["deploy/values/a.yaml", "services/a/main.go"],
+        [{"number": 50, "files": ["deploy/values/a.yaml"]}],
+    )
+    assert out == {"superseded": [], "kept": [50]}
+
+
+def test_non_values_candidate_is_kept() -> None:
+    # A candidate PR touching source (not a pure values promote) is never auto-closed.
+    out = gs.superseded_prs(
+        ["deploy/values/a.yaml"],
+        [{"number": 60, "files": ["deploy/values/a.yaml", "services/a/main.go"]}],
+    )
+    assert out == {"superseded": [], "kept": [60]}
+
+
+def test_mixed_batch_is_deterministic_and_sorted() -> None:
+    out = gs.superseded_prs(
+        ["deploy/values/a.yaml", "deploy/values/b.yaml"],
+        [
+            {"number": 3, "files": ["deploy/values/b.yaml"]},
+            {"number": 1, "files": ["deploy/values/a.yaml"]},
+            {"number": 2, "files": ["deploy/values/z.yaml"]},
+        ],
+    )
+    assert out == {"superseded": [1, 3], "kept": [2]}
+
+
+if __name__ == "__main__":
+    import subprocess
+
+    raise SystemExit(subprocess.call(["python3", "-m", "pytest", "-q", __file__]))


### PR DESCRIPTION
> [!IMPORTANT]
> **REVIEW-GATED — do NOT auto-merge. @mdheller please review.** This edits the **live deploy pipeline** (`gitops-promote.yml`). It was opened for review only; no admin-merge, no live-infra mutation was performed. Please confirm the `gate / check` commit-status attribution against a real promote PR before merging.

## Root cause (verified live today)
Bot-authored `gitops: promote` PRs pass every check but sit at `mergeStateStatus=UNKNOWN`, auto-merge armed but never firing — they pile up until a human admin-merges them in batches. Measured on **#1313** (merged by `mdheller`): rollup shows `diagnostics-gate`, CodeQL, GitGuardian, all Analyze legs green, but the required **`gate / check` context is ABSENT**.

- main's **classic branch protection** requires `gate / check` (app_id 15368); the **ruleset** requires `diagnostics-gate`.
- gitops-promote publishes `diagnostics-gate` itself as a commit status (works). It does **not** publish `gate / check`.
- `gate / check` is produced only by `gate.yml`'s `workflow_run` mirror — which **never fires for a promote branch**: a `validate-target-diagnostics` run dispatched via GITHUB_TOKEN emits **no** `workflow_run` event (no-recursion). Confirmed live: **zero `gate.yml` runs on any `gitops/promote-*` head SHA**. (PR #1211 added the `workflow_dispatch` filter to gate.yml, but the event it filters for never arrives for these branches — necessary but not sufficient.)

## Fix (one reviewable change)
1. **Publish both required contexts.** gitops-promote already dispatches the real diagnostics run and reads its outcome; `post_status` now mirrors that **one** verdict onto **both** `diagnostics-gate` **and** `gate / check` as commit statuses, in lockstep. Commit statuses via GITHUB_TOKEN are attributed to the github-actions app (15368), satisfying the app_id-pinned `gate / check`, and are in the PR rollup by construction — the same mechanism that already makes `diagnostics-gate` land. **Fail-closed preserved:** pending first, `success` only after the measured per-job `success` allowlist.
2. **Genetic-superset self-selection.** After opening a promote PR, auto-close any open promote PR whose values files are a **subset** of this one's (newest-per-service wins) — relieving the backed-up runner pool and the CLOSED-superseded pileup (#1300/#1307/#1308/#1309/#1311). Pure domination logic in `tools/gitops_supersede.py` (unit-tested); the workflow only gathers live data and closes, **best-effort, never fatal** (runs in a subshell so its `set +e` can't leak into the fail-fast gate logic).

## Tooth / tests (deterministic, stdlib, no-network — run by the `tools-tests` diagnostics leg)
- `tools/tests/test_gitops_supersede.py` (8) — closes dominated, keeps independent/superset/empty/non-values.
- `tools/tests/test_gitops_promote_gate_contract.py` (5) — asserts **both** contexts are published, `pending` before `success`, allowlist-on-success, self-selection wired, `statuses: write` declared.
- Local: 13/13 pass; `bash -n` clean on the run script; full `tools/tests` collects 751 with no errors.

## Infra follow-up (noted, NOT fixed here)
The **self-hosted runner pool backs up** under promote cascades. Relieve by moving stdlib/no-network diagnostics legs to GitHub-hosted runners where safe. Tracked separately.

## How it seats under the control plane
This is the concrete **Day-2 self-heal** instance of the governed ControlLoop (ProCybernetica#127): sensor = promote PR stuck-BLOCKED signal; value_judgment = the real diagnostics gate (unchanged, fail-closed); actuator = publish-both-contexts + auto-close-superseded; audit_receipt = the commit statuses + close comments. It adds **no** ungoverned autonomy — the merge decision remains the existing required gate; this only delivers that same verdict to the context the ruleset reads.