### PR TITLE
feat(policy): install Kyverno controller (held, audit-first) — enforce image signing for real

### DIFF
--- a/deploy/argocd/kyverno.yaml
+++ b/deploy/argocd/kyverno.yaml
@@ -1,0 +1,41 @@
+# Kyverno controller — AUDIT-FIRST, HELD install.
+#
+# Closes the controller half of the sovereign-registry-policy-enforced gap (git-ops-standards
+# control): the estate has a committed image-signature ClusterPolicy
+# (infra/policy/cloudshell-fog/kyverno/verify-signed-images.yaml, delivered by the cloudshell-fog
+# stack) but NO Kyverno controller, so nothing admits or evaluates it — signing is *declared, not
+# enforced*.
+#
+# HELD by design: no `syncPolicy.automated`, so merging this changes NOTHING live. ArgoCD registers
+# the app OutOfSync and waits. The operator syncs it deliberately (audit-first rollout, not an
+# auto-apply on merge). This app lives under deploy/argocd/ (the tofu root app-of-apps only
+# recurses deploy/argocd — infra/argocd/ is never reconciled by it).
+#
+# Rollout: sync this app -> confirm the controller is Ready -> ensure the cloudshell-fog policy
+# stack reconciles the ClusterPolicy (it ships validationFailureAction: Audit — non-blocking) ->
+# observe Audit logs -> flip verify-signed-images to Enforce in a follow-up PR.
+# Full runbook: infra/policy/cloudshell-fog/kyverno/ROLLOUT.md
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kyverno
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"   # controller + CRDs are foundation, before any ClusterPolicy
+    socioprophet.io/tier: "foundation"
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kyverno
+  source:
+    repoURL: https://kyverno.github.io/kyverno
+    chart: kyverno
+    targetRevision: 3.8.2   # appVersion v1.18.2 (latest stable; confirmed via the kyverno helm index)
+    helm:
+      releaseName: kyverno
+  syncPolicy:
+    # HELD: no `automated` — installs only on a deliberate operator sync (audit-first).
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true   # Kyverno CRDs exceed the client-side apply annotation-size limit

--- a/infra/policy/cloudshell-fog/kyverno/ROLLOUT.md
+++ b/infra/policy/cloudshell-fog/kyverno/ROLLOUT.md
@@ -1,0 +1,43 @@
+# Kyverno signature-enforcement rollout (audit-first, held)
+
+Closes the `sovereign-registry-policy-enforced` gap (git-ops-standards): the estate has a
+committed image-signature `ClusterPolicy` (`verify-signed-images.yaml`) but no Kyverno controller,
+so signing was **declared, not enforced**. This rollout installs the controller and turns
+enforcement on *safely*, in stages — nothing here auto-applies to the cluster.
+
+## Why audit-first + held
+
+Kyverno's image-verification runs as a **validating admission webhook**. In `Enforce` mode any Pod
+whose images fail signature verification is **rejected at admission** — a coverage gap (an unsigned
+base image, a registry the policy doesn't cover) blocks legitimate deploys cluster-wide. So we
+install the controller **held** (no ArgoCD auto-sync) and ship the policy at
+`validationFailureAction: Audit` (logs violations, blocks nothing) until the Audit logs are clean.
+
+## Steps
+
+1. **Sync the controller (deliberate).** `deploy/argocd/kyverno.yaml` is a held ArgoCD Application.
+   Sync it in the ArgoCD UI/CLI (`argocd app sync kyverno`). Confirm Ready:
+   ```
+   kubectl -n kyverno get deploy
+   kubectl get crd | grep kyverno.io
+   ```
+2. **Ensure the ClusterPolicy is reconciled.** The `cloudshell-fog` policy stack delivers
+   `verify-signed-images.yaml` (Audit). Confirm it admitted once the CRDs exist:
+   ```
+   kubectl get clusterpolicy cloudshell-verify-signed-images -o jsonpath='{.status.ready}'
+   ```
+   (This is exactly what `git-ops-standards/estate-sovereign-governance` checks in-cluster; once
+   `ready=true` the `sovereign-registry-policy-enforced` finding clears.)
+3. **Observe.** Watch Kyverno's policy reports for `fail` results on real workloads:
+   ```
+   kubectl get policyreport,clusterpolicyreport -A
+   ```
+   Every failing image is a signing-coverage gap to fix (sign it, or scope the policy), NOT a
+   reason to leave enforcement off.
+4. **Flip to Enforce (follow-up PR).** When Audit is clean, change
+   `verify-signed-images.yaml` `validationFailureAction: Audit -> Enforce` in its own reviewed PR.
+
+## Rollback
+
+Set the policy back to `Audit` (or disable the app) — admission stops blocking immediately. The
+controller can be left installed; only the policy's failure action gates workloads.

--- a/infra/policy/cloudshell-fog/kyverno/verify-signed-images.yaml
+++ b/infra/policy/cloudshell-fog/kyverno/verify-signed-images.yaml
@@ -12,7 +12,10 @@ metadata:
       runtime and service images. Images are signed by the estate's reusable
       GitHub Actions build workflow via OIDC — no long-lived key to manage.
 spec:
-  validationFailureAction: Enforce
+  # AUDIT-FIRST rollout: logs signature violations, blocks nothing. Flip to Enforce in a
+  # follow-up PR once the Audit logs are clean (see ROLLOUT.md). The controller is installed
+  # HELD via deploy/argocd/kyverno.yaml.
+  validationFailureAction: Audit
   background: false
   webhookTimeoutSeconds: 30
   rules:

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -137,9 +137,10 @@ KNOWN_BROKEN = {
     # sha-9fd245401789 (#1017) after its first CI build, exactly as this entry predicted.
     # The ratchet only shrinks, and it had already begun FAILING the gate on main for
     # this reason: fixed → removed, so the warden can never silently regress to `:latest`.
-    "entity-resolution:moving-tag": (
-        "New service — Dockerfile + images.yml entry added this PR. Pin tag:latest -> sha- after first CI build."
-    ),
+    # RESOLVED 2026-08-03: entity-resolution — sha-pinned after its first CI build, so its
+    # moving-tag entry now passes. The ratchet caught it as "now passes" on an UNRELATED PR
+    # (the Kyverno controller install), exactly the lifecycle-warden precedent above: caught on an
+    # unrelated PR; fixed → removed, so it can never silently regress to `:latest`.
     # RESOLVED 2026-07-31: agent-activity-ledger and gbrg-containment both got sha-pinned
     # (their first CI builds landed) after these entries were written. The ratchet caught
     # both as "now passes — delete from KNOWN_BROKEN" on an unrelated PR; fixed → removed,


### PR DESCRIPTION
Closes the controller half of the sovereign registry gap (`git-ops-standards` control `sovereign-registry-policy-enforced`): the estate has a committed image-signature `ClusterPolicy` (`verify-signed-images`) but **no Kyverno controller**, so signing was *declared, not enforced*. **Nothing is applied to the cluster here — config only, held.**

cc @mdheller

## What
- **`deploy/argocd/kyverno.yaml`** — Kyverno controller ArgoCD Application, chart **3.8.2** (appVersion v1.18.2, latest stable, confirmed via the helm index). **HELD**: no `syncPolicy.automated`, so merging changes **nothing live** — an operator syncs it deliberately (audit-first). `CreateNamespace` + `ServerSideApply` (Kyverno CRDs exceed the client-side annotation limit). Under `deploy/argocd/` because the tofu root app-of-apps only recurses that dir (not `infra/argocd/`).
- **`verify-signed-images.yaml`** — `validationFailureAction: Enforce → Audit` (logs violations, blocks nothing) until the Audit logs are clean; flip back to Enforce in a follow-up PR.
- **`ROLLOUT.md`** — staged runbook (sync controller → confirm Ready → reconcile policy → observe Audit → Enforce) + rollback.

## Why audit-first + held
Kyverno image-verification is a **validating admission webhook**; in Enforce mode any Pod with an unsigned/uncovered image is rejected at admission — a coverage gap blocks legitimate deploys cluster-wide. Held install + Audit posture makes the rollout safe and deliberate (the estate's held-decision discipline).

## Scope
Controller + audit posture only. The `ClusterPolicy` stays managed by the existing cloudshell-fog stack (**not** double-managed here). Once synced and reconciled, `git-ops-standards`' `estate-sovereign-governance` in-cluster kyverno check flips `ready`, clearing the finding.

## Verified locally
`validate-cloudshell-fog-policy.sh` + `validate-cloudshell-fog-bundle.sh` pass; `check_workflow_path_filters.py` clean (0 failures); YAML valid; no validator asserts `Enforce`.