### PR TITLE
feat(lattice): serve the sovereign model board via the BFF (/api/model-board)

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -35,6 +35,7 @@ from fastapi import Depends, FastAPI, Header, HTTPException, Response
 from pydantic import BaseModel
 
 from lattice_studio import gaia, hdt, ontology, product_spine, shacl
+from lattice_studio.inference_gateway_leaderboard import notebook_fixture
 
 SERVICE_VERSION = "0.2.0"
 HELLGRAPH_URL = os.getenv("HELLGRAPH_URL", "http://hellgraph-service:8090")
@@ -134,6 +135,14 @@ def _sherlock_request(project: str) -> dict[str, Any]:
 @app.get("/healthz")
 def healthz() -> dict[str, Any]:
     return {"ok": True, "service": "lattice-studio", "version": SERVICE_VERSION}
+
+
+@app.get("/api/model-board")
+def model_board(_auth: dict[str, Any] | None = Depends(require_read)) -> dict[str, Any]:
+    """The sovereign model board — foundation + business models, sovereignty-ranked, with the
+    champion/challenger leaderboard. The render surface the lattice UI consumes (one board,
+    cloud ∩ local, on the shared InferenceGateway catalog)."""
+    return notebook_fixture()
 
 
 @app.get("/api/studio")

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -1556,3 +1556,16 @@ def test_hdt_ontology_closes_the_three_twin_triangle():
     assert deliv["epistemic_human"] == "attested" and deliv["canonical"]
     assert set(b["three_twins_closed"]) >= {"knowledge", "human", "earth"}
     assert set(b["kfs_triad"]) == {"CBD", "CGT", "NHY"}
+
+
+def test_model_board_endpoint_serves_the_sovereign_board():
+    r = client.get("/api/model-board")
+    assert r.status_code == 200
+    b = r.json()
+    assert b["kind"] == "ModelBoardNotebook"
+    assert b["entryCount"] >= 8
+    lb = b["leaderboard"]
+    assert lb[0]["rank"] == 1
+    by = {row["model_id"]: row for row in lb}
+    # sovereign-local outranks the vendor-cloud model — the thesis, served
+    assert by["gemma-2-9b-it"]["score"] > by["claude-opus-4-8"]["score"]


### PR DESCRIPTION
The **render surface** for the model board — a real API the lattice/Vue UI consumes (not a blind component).

- `GET /api/model-board` on the Lattice Studio BFF returns `notebook_fixture()`: foundation **+** business models, sovereignty-ranked, with the champion/challenger leaderboard. One board, cloud ∩ local, on the shared InferenceGateway catalog. Guarded by the standard `require_read` dependency.
- TestClient test: endpoint serves the board, leaderboard ranked, **sovereign-local outranks vendor-cloud** (the thesis, served).

Completes the cloud fan-out: catalog (#1298) → leaderboard+notebook (#1301) → **served endpoint**. Verified: 88 server tests pass.