### PR TITLE
fix(socbase): register the schema bootstrap Job in ArgoCD — it never ran

### DIFF
--- a/deploy/argocd/platform-services.yaml
+++ b/deploy/argocd/platform-services.yaml
@@ -119,9 +119,11 @@ spec:
           # socbase-auth / socbase-rest are third-party images (supabase/gotrue,
           # postgrest/postgrest) with tags pinned directly in their values files —
           # NOT touched by the build-image/gitops-promote SHA pipeline above, since
-          # we don't build them. Install the charts/socbase-schema Job (separately;
-          # it isn't part of this ApplicationSet — see its NOTES.txt) AFTER
-          # socbase-auth is live, since it waits on GoTrue's auth schema.
+          # we don't build them. The charts/socbase-schema bootstrap Job is NOT
+          # here (this ApplicationSet renders charts/socioprophet-service per
+          # element and has no Job/hook shape) — it is registered in
+          # deploy/argocd/socbase-services.yaml at sync-wave 1. It used to say
+          # "install separately", which meant it never ran at all.
           - { name: socbase-auth, tier: foundation }             # sovereign auth (GoTrue) — the identity door
           - { name: socbase-rest, tier: foundation }             # sovereign data surface (PostgREST) — the data door
   template:

--- a/deploy/argocd/socbase-services.yaml
+++ b/deploy/argocd/socbase-services.yaml
@@ -24,7 +24,26 @@
 # Prereqs (created out of band, NOT in git — same convention as zot):
 #   * `zot-pull` secret — the gateway image is pulled through zot
 #   * socbase-auth / socbase-rest running (platform-services)
-# Sync-wave 2 so the gateway lands after the services it fronts.
+#   * `postgres-admin` secret (key: password) — schema Job connects as admin
+#   * `socbase-authenticator` secret (key: password) — the login role PostgREST
+#     uses. Generate: openssl rand -base64 24. WITHOUT THIS THE SCHEMA JOB FAILS.
+#
+# Sync waves: 1 = schema bootstrap, 2 = gateway (lands after the services it
+# fronts, and after the roles the data door needs exist).
+#
+# WHY THE SCHEMA JOB IS HERE. It was previously left as a MANUAL step — the only
+# reference to charts/socbase-schema anywhere in deploy/ was a comment in
+# platform-services.yaml saying to "install it separately". Nobody did, so the
+# authenticator/anon/service_role roles were never created and socbase has been
+# reported DOWN (see docs/design/estate-unified-sso.md). A bootstrap step that
+# depends on someone remembering is not a bootstrap step. It could not join the
+# platform-services ApplicationSet because that one renders the generic
+# charts/socioprophet-service chart per element and has no Job/hook shape; this
+# ApplicationSet takes a path per element, and ArgoCD detects the Helm chart from
+# its Chart.yaml, so it fits here without changing either chart.
+#
+# Re-running is SAFE: socbase-schema.sql guards every role with
+# `if not exists (select 1 from pg_roles ...)`, so selfHeal cannot corrupt state.
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
@@ -38,6 +57,10 @@ spec:
         elements:
           # foundation: the ONE base URL contract @supabase/supabase-js requires
           # (/auth/v1 + /rest/v1) — the auth/data door in front of socbase-auth/rest.
+          # foundation: creates authenticator/anon/service_role + app tables and
+          # RLS. Waits for GoTrue to create auth.users first (the Job polls, it
+          # does not assume ordering), so wave 1 is safe even on a cold cluster.
+          - { name: schema, path: charts/socbase-schema, wave: "1", tier: foundation }
           - { name: gateway, path: infra/k8s/socbase-gateway/base, wave: "2", tier: foundation }
   template:
     metadata:

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -97,6 +97,10 @@ NON_CHART_SERVICES = {
     "search-gateway-ingress",  # public HTTPS edge (ManagedCertificate + Ingress) for search-gateway
     "studio-ingress",  # public HTTPS edge (ManagedCertificate + Ingress) for lattice-studio (Studio BFF)
     "mesh-qdrant",  # shared platform vector store, deploys from infra/k8s/mesh-qdrant (kustomize)
+    "schema",  # socbase-schema bootstrap Job (deploy/argocd/socbase-services.yaml): a bare
+               # `charts/socbase-schema` path element, not deploy/values/schema.yaml-shaped.
+               # Its image is the stock `postgres:16-alpine` (charts/socbase-schema/templates/
+               # schema-job.yaml) — no first-party image to check against `built`.
 }
 
 # Registry hosts this platform actually publishes to. An image ref pointing anywhere
@@ -137,10 +141,11 @@ KNOWN_BROKEN = {
     # sha-9fd245401789 (#1017) after its first CI build, exactly as this entry predicted.
     # The ratchet only shrinks, and it had already begun FAILING the gate on main for
     # this reason: fixed → removed, so the warden can never silently regress to `:latest`.
-    # RESOLVED 2026-08-03: entity-resolution — sha-pinned after its first CI build, so its
-    # moving-tag entry now passes. The ratchet caught it as "now passes" on an UNRELATED PR
-    # (the Kyverno controller install), exactly the lifecycle-warden precedent above: caught on an
-    # unrelated PR; fixed → removed, so it can never silently regress to `:latest`.
+    # RESOLVED 2026-08-03: entity-resolution — deploy/values/entity-resolution.yaml is
+    # sha-pinned (sha-b5af12022446b831d2641701c7f3e59836c639ad) after its first CI build.
+    # The ratchet caught it as "now passes" on an UNRELATED PR (the Kyverno controller
+    # install), exactly the lifecycle-warden precedent above: caught on an unrelated PR;
+    # fixed → removed, so it can never silently regress to `:latest`.
     # RESOLVED 2026-07-31: agent-activity-ledger and gbrg-containment both got sha-pinned
     # (their first CI builds landed) after these entries were written. The ratchet caught
     # both as "now passes — delete from KNOWN_BROKEN" on an unrelated PR; fixed → removed,


### PR DESCRIPTION
## Root cause

`docs/design/estate-unified-sso.md` records socbase as **DOWN — "bootstrap Job never ran → missing authenticator/anon/service_role roles"**.

The reason is in the manifests. The **only** reference to `charts/socbase-schema` anywhere under `deploy/` was a *comment* in `platform-services.yaml` telling a human to **"install it separately"**. Nobody did.

> A bootstrap step that depends on someone remembering is not a bootstrap step.

The chart itself was fine — it was never wired to anything that runs.

## Fix

Register it as an element of the **socbase-services** ApplicationSet at **sync-wave 1** (schema), ahead of the gateway at wave 2.

It couldn't join `platform-services` because that ApplicationSet renders the generic `charts/socioprophet-service` chart per element and has no Job/hook shape. `socbase-services` takes a **path** per element, and ArgoCD detects the Helm chart from its `Chart.yaml` — so it fits with **no change to either chart**.

## Two things I checked rather than assumed

**Cold-cluster ordering is safe.** The Job *polls* for GoTrue's `auth.users` (60 attempts × 5s) instead of trusting wave ordering — GoTrue owns the `auth` schema and our tables FK into it.

**Re-running under `selfHeal` is safe.** `socbase-schema.sql` guards every role with an `if not exists` lookup against `pg_roles`. I verified this *before* wiring auto-sync.

## Prereqs now documented

In the house *"Prereqs (created out of band, NOT in git)"* style:
- `postgres-admin` (key: `password`)
- `socbase-authenticator` (key: `password`) — **the Job fails loudly without this**

## Verification

Both files parse as valid ApplicationSets · the new element renders · `helm template charts/socbase-schema` produces the ConfigMap + Job.

**Not applied to the cluster from here** — GitOps change; ArgoCD reconciles on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
