### PR TITLE
feat(eval): intelligence-superiority feature-board — sealed litmus contract

### DIFF
--- a/schemas/eval/examples/intelligence-superiority-board.json
+++ b/schemas/eval/examples/intelligence-superiority-board.json
@@ -1,0 +1,4402 @@
+{
+  "board_id": "intelligence-superiority-board",
+  "title": "Intelligence-Superiority Feature-Board",
+  "generated_ts": "2026-08-03T00:00:00Z",
+  "spec_version": "1.0.0",
+  "notes": "We can't beat what we haven't benchmarked. Governed competitive-intelligence contract; every BEAT/MEET carries evidence, thin/spec leads are provisional, all cells self_assessed. Sealed by tools/validate_intelligence_superiority_board.py.",
+  "categories": [
+    {
+      "category_id": "rag",
+      "name": "Retrieval-Augmented Generation",
+      "description": "Noetica RAG (advanced-RAG family, receipt-gated inference, GraphRAG grounded answers, embedding-space governance, temporal retrieval) vs the productized RAG field.",
+      "competitors": [
+        "Glean",
+        "Perplexity",
+        "Cohere",
+        "Vectara",
+        "Watson Discovery"
+      ],
+      "litmus_features": [
+        {
+          "feature_id": "advanced_rag_breadth",
+          "name": "Advanced-RAG pattern breadth",
+          "definition": "Number and composition of retrieval patterns fused in one governed harness.",
+          "criteria": "BEAT = >=8 fused patterns (HippoRAG/RAPTOR/HyDE/CRAG-gate/temporal) in a single live library."
+        },
+        {
+          "feature_id": "inference_receipts",
+          "name": "Replayable inference receipts",
+          "definition": "Per-turn, hash-chained, replayable evidence for every retrieved-and-generated answer.",
+          "criteria": "BEAT = open, SHA-256 hash-chained, replay-classed receipts on every turn."
+        },
+        {
+          "feature_id": "embedding_governance",
+          "name": "Embedding-space governance",
+          "definition": "Enforced embedding-dimension/space contract preventing silent index/query mismatch.",
+          "criteria": "BEAT = fail-closed EmbeddingSpaceMismatchError + dim pin + source-scan CI guard."
+        },
+        {
+          "feature_id": "graph_rag_grounding",
+          "name": "GraphRAG grounded answers",
+          "definition": "Graph-structured retrieval with per-claim grounding to a resolvable source reference.",
+          "criteria": "BEAT = MS-GraphRAG + per-claim grounding + fail-closed page-reference CI contract."
+        },
+        {
+          "feature_id": "hybrid_fusion",
+          "name": "Hybrid dense/lexical/graph fusion",
+          "definition": "Reciprocal-rank fusion across dense, lexical (BM25) and graph retrieval.",
+          "criteria": "MEET = shipping BM25 + dense RRF; BEAT requires a decisive quality edge."
+        },
+        {
+          "feature_id": "verified_grounded_citations",
+          "name": "Verified, resolvable citations",
+          "definition": "Citations that are verified against source (grounding score) and resolve to an exact locus.",
+          "criteria": "BEAT = verified + receipted + page-resolvable citation; MEET = strong UX parity."
+        },
+        {
+          "feature_id": "reranking",
+          "name": "Reranking quality",
+          "definition": "Precision of the reranker over the fused candidate set.",
+          "criteria": "BEAT = trained cross-encoder parity or better; PARTIAL = unsupervised RRF/MMR only."
+        },
+        {
+          "feature_id": "hallucination_control",
+          "name": "Hallucination control",
+          "definition": "Defenses that suppress unsupported generations (poisoned-RAG, self-consistency, grounding checks).",
+          "criteria": "BEAT = layered deterministic defense breadth; PARTIAL where a trained detector leads one axis."
+        },
+        {
+          "feature_id": "contextual_retrieval_fusion",
+          "name": "Contextual retrieval + RAG-Fusion",
+          "definition": "Contextual-chunk retrieval and query-variant RAG-Fusion.",
+          "criteria": "BEAT = merged, tested contextual retrieval + RAG-Fusion; live requires ingest/query wiring."
+        },
+        {
+          "feature_id": "temporal_retrieval",
+          "name": "Temporal retrieval correctness",
+          "definition": "Retrieval filtered/validated by temporal validity of facts.",
+          "criteria": "BEAT = general temporal-KG validity model; PARTIAL = scoped recency filter only."
+        },
+        {
+          "feature_id": "retrieval_scale",
+          "name": "Retrieval quality at scale",
+          "definition": "Retrieval quality sustained at billion-document corpora.",
+          "criteria": "BEAT = proven billion-doc scale; PARTIAL/GAP = workspace-scale in-memory scans."
+        },
+        {
+          "feature_id": "connector_breadth",
+          "name": "Connector breadth + permission sync",
+          "definition": "Breadth of source connectors with document-level permission synchronization.",
+          "criteria": "BEAT = 100+ connectors with permission-sync; PARTIAL = open audited connectors, fewer."
+        }
+      ],
+      "scores": [
+        {
+          "feature_id": "advanced_rag_breadth",
+          "competitor": "Glean",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/retrieval.ts",
+              "note": "817 LOC, 11 fused patterns incl. HippoRAG/RAPTOR/HyDE + CRAG gate + temporal"
+            },
+            {
+              "memory": "competitive_intel_localrag",
+              "note": "field CI: harness > model"
+            }
+          ]
+        },
+        {
+          "feature_id": "advanced_rag_breadth",
+          "competitor": "Perplexity",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/retrieval.ts",
+              "note": "817 LOC, 11 fused patterns incl. HippoRAG/RAPTOR/HyDE + CRAG gate + temporal"
+            },
+            {
+              "memory": "competitive_intel_localrag",
+              "note": "field CI: harness > model"
+            }
+          ]
+        },
+        {
+          "feature_id": "advanced_rag_breadth",
+          "competitor": "Cohere",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/retrieval.ts",
+              "note": "817 LOC, 11 fused patterns incl. HippoRAG/RAPTOR/HyDE + CRAG gate + temporal"
+            },
+            {
+              "memory": "competitive_intel_localrag",
+              "note": "field CI: harness > model"
+            }
+          ]
+        },
+        {
+          "feature_id": "advanced_rag_breadth",
+          "competitor": "Vectara",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/retrieval.ts",
+              "note": "817 LOC, 11 fused patterns incl. HippoRAG/RAPTOR/HyDE + CRAG gate + temporal"
+            },
+            {
+              "memory": "competitive_intel_localrag",
+              "note": "field CI: harness > model"
+            }
+          ]
+        },
+        {
+          "feature_id": "advanced_rag_breadth",
+          "competitor": "Watson Discovery",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/retrieval.ts",
+              "note": "817 LOC, 11 fused patterns incl. HippoRAG/RAPTOR/HyDE + CRAG gate + temporal"
+            },
+            {
+              "memory": "competitive_intel_localrag",
+              "note": "field CI: harness > model"
+            }
+          ]
+        },
+        {
+          "feature_id": "inference_receipts",
+          "competitor": "Glean",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/reasoning-evidence.ts",
+              "note": "SHA-256 hash-chain, replayClass, safe-trace"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/connector-receipt.ts"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/server.ts",
+              "note": "wiring @ ~4256"
+            }
+          ],
+          "rationale": "No competitor ships open replayable per-turn inference receipts."
+        },
+        {
+          "feature_id": "inference_receipts",
+          "competitor": "Perplexity",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/reasoning-evidence.ts",
+              "note": "SHA-256 hash-chain, replayClass, safe-trace"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/connector-receipt.ts"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/server.ts",
+              "note": "wiring @ ~4256"
+            }
+          ],
+          "rationale": "No competitor ships open replayable per-turn inference receipts."
+        },
+        {
+          "feature_id": "inference_receipts",
+          "competitor": "Cohere",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/reasoning-evidence.ts",
+              "note": "SHA-256 hash-chain, replayClass, safe-trace"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/connector-receipt.ts"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/server.ts",
+              "note": "wiring @ ~4256"
+            }
+          ],
+          "rationale": "No competitor ships open replayable per-turn inference receipts."
+        },
+        {
+          "feature_id": "inference_receipts",
+          "competitor": "Vectara",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/reasoning-evidence.ts",
+              "note": "SHA-256 hash-chain, replayClass, safe-trace"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/connector-receipt.ts"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/server.ts",
+              "note": "wiring @ ~4256"
+            }
+          ],
+          "rationale": "No competitor ships open replayable per-turn inference receipts."
+        },
+        {
+          "feature_id": "inference_receipts",
+          "competitor": "Watson Discovery",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/reasoning-evidence.ts",
+              "note": "SHA-256 hash-chain, replayClass, safe-trace"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/connector-receipt.ts"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/server.ts",
+              "note": "wiring @ ~4256"
+            }
+          ],
+          "rationale": "No competitor ships open replayable per-turn inference receipts."
+        },
+        {
+          "feature_id": "embedding_governance",
+          "competitor": "Glean",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "pr": "82",
+              "note": "embedding-space pin"
+            },
+            {
+              "pr": "602"
+            },
+            {
+              "pr": "605",
+              "note": "EmbeddingSpaceMismatchError, CORPUS_EMBED_DIM pin, embed-space-contract.test.ts, reindexIfDimMismatch"
+            }
+          ]
+        },
+        {
+          "feature_id": "embedding_governance",
+          "competitor": "Perplexity",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "pr": "82",
+              "note": "embedding-space pin"
+            },
+            {
+              "pr": "602"
+            },
+            {
+              "pr": "605",
+              "note": "EmbeddingSpaceMismatchError, CORPUS_EMBED_DIM pin, embed-space-contract.test.ts, reindexIfDimMismatch"
+            }
+          ]
+        },
+        {
+          "feature_id": "embedding_governance",
+          "competitor": "Cohere",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "pr": "82",
+              "note": "embedding-space pin"
+            },
+            {
+              "pr": "602"
+            },
+            {
+              "pr": "605",
+              "note": "EmbeddingSpaceMismatchError, CORPUS_EMBED_DIM pin, embed-space-contract.test.ts, reindexIfDimMismatch"
+            }
+          ]
+        },
+        {
+          "feature_id": "embedding_governance",
+          "competitor": "Vectara",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "pr": "82",
+              "note": "embedding-space pin"
+            },
+            {
+              "pr": "602"
+            },
+            {
+              "pr": "605",
+              "note": "EmbeddingSpaceMismatchError, CORPUS_EMBED_DIM pin, embed-space-contract.test.ts, reindexIfDimMismatch"
+            }
+          ]
+        },
+        {
+          "feature_id": "embedding_governance",
+          "competitor": "Watson Discovery",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "pr": "82",
+              "note": "embedding-space pin"
+            },
+            {
+              "pr": "602"
+            },
+            {
+              "pr": "605",
+              "note": "EmbeddingSpaceMismatchError, CORPUS_EMBED_DIM pin, embed-space-contract.test.ts, reindexIfDimMismatch"
+            }
+          ]
+        },
+        {
+          "feature_id": "graph_rag_grounding",
+          "competitor": "Glean",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/graph-rag.ts",
+              "note": "MS GraphRAG + per-claim grounding + trust + DRIFT"
+            },
+            {
+              "repo": "prophet-workspace",
+              "pr": "103",
+              "note": "grounded-answer-with-page-reference; graphrag-grounding.yml 32 checks; proof-artifact-spine sealed"
+            }
+          ],
+          "rationale": "Module + CI contract are live; live PageIndex->HellGraph binding is SPEC (fixtures)."
+        },
+        {
+          "feature_id": "graph_rag_grounding",
+          "competitor": "Perplexity",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/graph-rag.ts",
+              "note": "MS GraphRAG + per-claim grounding + trust + DRIFT"
+            },
+            {
+              "repo": "prophet-workspace",
+              "pr": "103",
+              "note": "grounded-answer-with-page-reference; graphrag-grounding.yml 32 checks; proof-artifact-spine sealed"
+            }
+          ],
+          "rationale": "Module + CI contract are live; live PageIndex->HellGraph binding is SPEC (fixtures)."
+        },
+        {
+          "feature_id": "graph_rag_grounding",
+          "competitor": "Cohere",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/graph-rag.ts",
+              "note": "MS GraphRAG + per-claim grounding + trust + DRIFT"
+            },
+            {
+              "repo": "prophet-workspace",
+              "pr": "103",
+              "note": "grounded-answer-with-page-reference; graphrag-grounding.yml 32 checks; proof-artifact-spine sealed"
+            }
+          ],
+          "rationale": "Module + CI contract are live; live PageIndex->HellGraph binding is SPEC (fixtures)."
+        },
+        {
+          "feature_id": "graph_rag_grounding",
+          "competitor": "Vectara",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/graph-rag.ts",
+              "note": "MS GraphRAG + per-claim grounding + trust + DRIFT"
+            },
+            {
+              "repo": "prophet-workspace",
+              "pr": "103",
+              "note": "grounded-answer-with-page-reference; graphrag-grounding.yml 32 checks; proof-artifact-spine sealed"
+            }
+          ],
+          "rationale": "Module + CI contract are live; live PageIndex->HellGraph binding is SPEC (fixtures)."
+        },
+        {
+          "feature_id": "graph_rag_grounding",
+          "competitor": "Watson Discovery",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/graph-rag.ts",
+              "note": "MS GraphRAG + per-claim grounding + trust + DRIFT"
+            },
+            {
+              "repo": "prophet-workspace",
+              "pr": "103",
+              "note": "grounded-answer-with-page-reference; graphrag-grounding.yml 32 checks; proof-artifact-spine sealed"
+            }
+          ],
+          "rationale": "Module + CI contract are live; live PageIndex->HellGraph binding is SPEC (fixtures)."
+        },
+        {
+          "feature_id": "hybrid_fusion",
+          "competitor": "Glean",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/hybrid-retrieve.ts",
+              "note": "BM25 + dense RRF"
+            },
+            {
+              "memory": "competitive_intel_localrag"
+            }
+          ],
+          "rationale": "Glean/Cohere/Vectara match on hybrid fusion."
+        },
+        {
+          "feature_id": "hybrid_fusion",
+          "competitor": "Perplexity",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/hybrid-retrieve.ts",
+              "note": "BM25 + dense RRF"
+            },
+            {
+              "memory": "competitive_intel_localrag"
+            }
+          ],
+          "rationale": "Glean/Cohere/Vectara match on hybrid fusion."
+        },
+        {
+          "feature_id": "hybrid_fusion",
+          "competitor": "Cohere",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/hybrid-retrieve.ts",
+              "note": "BM25 + dense RRF"
+            },
+            {
+              "memory": "competitive_intel_localrag"
+            }
+          ],
+          "rationale": "Glean/Cohere/Vectara match on hybrid fusion."
+        },
+        {
+          "feature_id": "hybrid_fusion",
+          "competitor": "Vectara",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/hybrid-retrieve.ts",
+              "note": "BM25 + dense RRF"
+            },
+            {
+              "memory": "competitive_intel_localrag"
+            }
+          ],
+          "rationale": "Glean/Cohere/Vectara match on hybrid fusion."
+        },
+        {
+          "feature_id": "hybrid_fusion",
+          "competitor": "Watson Discovery",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/hybrid-retrieve.ts",
+              "note": "BM25 + dense RRF"
+            },
+            {
+              "memory": "competitive_intel_localrag"
+            }
+          ],
+          "rationale": "Glean/Cohere/Vectara match on hybrid fusion."
+        },
+        {
+          "feature_id": "verified_grounded_citations",
+          "competitor": "Glean",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/research-verify.ts",
+              "note": "verifyGrounding pass@0.7 + per-chunk file#idx"
+            },
+            {
+              "repo": "prophet-workspace",
+              "pr": "103",
+              "note": "resolvable page_ref"
+            }
+          ]
+        },
+        {
+          "feature_id": "verified_grounded_citations",
+          "competitor": "Perplexity",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/research-verify.ts",
+              "note": "verifyGrounding pass@0.7 + per-chunk file#idx"
+            },
+            {
+              "repo": "prophet-workspace",
+              "pr": "103",
+              "note": "resolvable page_ref"
+            }
+          ],
+          "rationale": "Perplexity leads on citation UX/scale; estate leads on verified+receipted+page-resolvable."
+        },
+        {
+          "feature_id": "verified_grounded_citations",
+          "competitor": "Cohere",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/research-verify.ts",
+              "note": "verifyGrounding pass@0.7 + per-chunk file#idx"
+            },
+            {
+              "repo": "prophet-workspace",
+              "pr": "103",
+              "note": "resolvable page_ref"
+            }
+          ]
+        },
+        {
+          "feature_id": "verified_grounded_citations",
+          "competitor": "Vectara",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/research-verify.ts",
+              "note": "verifyGrounding pass@0.7 + per-chunk file#idx"
+            },
+            {
+              "repo": "prophet-workspace",
+              "pr": "103",
+              "note": "resolvable page_ref"
+            }
+          ]
+        },
+        {
+          "feature_id": "verified_grounded_citations",
+          "competitor": "Watson Discovery",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/research-verify.ts",
+              "note": "verifyGrounding pass@0.7 + per-chunk file#idx"
+            },
+            {
+              "repo": "prophet-workspace",
+              "pr": "103",
+              "note": "resolvable page_ref"
+            }
+          ]
+        },
+        {
+          "feature_id": "reranking",
+          "competitor": "Glean",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/rerank-rrf.ts"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/rag-rerank.ts",
+              "note": "RRF + MMR, unsupervised"
+            }
+          ]
+        },
+        {
+          "feature_id": "reranking",
+          "competitor": "Perplexity",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/rerank-rrf.ts"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/rag-rerank.ts",
+              "note": "RRF + MMR, unsupervised"
+            }
+          ]
+        },
+        {
+          "feature_id": "reranking",
+          "competitor": "Cohere",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "Cohere Rerank (trained cross-encoder) LEADS on pure relevance; estate rerank is unsupervised."
+        },
+        {
+          "feature_id": "reranking",
+          "competitor": "Vectara",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/rerank-rrf.ts"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/rag-rerank.ts",
+              "note": "RRF + MMR, unsupervised"
+            }
+          ]
+        },
+        {
+          "feature_id": "reranking",
+          "competitor": "Watson Discovery",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/rerank-rrf.ts"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/rag-rerank.ts",
+              "note": "RRF + MMR, unsupervised"
+            }
+          ]
+        },
+        {
+          "feature_id": "hallucination_control",
+          "competitor": "Glean",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/rag-trust.ts",
+              "note": "PoisonedRAG defense"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/research-verify.ts",
+              "note": "verifyGrounding + crag-gate self-consistency"
+            }
+          ]
+        },
+        {
+          "feature_id": "hallucination_control",
+          "competitor": "Perplexity",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/rag-trust.ts",
+              "note": "PoisonedRAG defense"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/research-verify.ts",
+              "note": "verifyGrounding + crag-gate self-consistency"
+            }
+          ]
+        },
+        {
+          "feature_id": "hallucination_control",
+          "competitor": "Cohere",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/rag-trust.ts",
+              "note": "PoisonedRAG defense"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/research-verify.ts",
+              "note": "verifyGrounding + crag-gate self-consistency"
+            }
+          ]
+        },
+        {
+          "feature_id": "hallucination_control",
+          "competitor": "Vectara",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "Vectara HHEM (trained hallucination model) LEADS on that single axis; estate leads on breadth."
+        },
+        {
+          "feature_id": "hallucination_control",
+          "competitor": "Watson Discovery",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/rag-trust.ts",
+              "note": "PoisonedRAG defense"
+            },
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/research-verify.ts",
+              "note": "verifyGrounding + crag-gate self-consistency"
+            }
+          ]
+        },
+        {
+          "feature_id": "contextual_retrieval_fusion",
+          "competitor": "Glean",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "pr": "607",
+              "note": "contextual-retrieval: merged + tested, NOT wired into live ingest/query"
+            },
+            {
+              "pr": "604",
+              "note": "query-variant RAG-Fusion: merged + tested, not live-wired"
+            }
+          ],
+          "rationale": "Built and tested; not yet wired into the live ingest/query path.",
+          "provisional": true
+        },
+        {
+          "feature_id": "contextual_retrieval_fusion",
+          "competitor": "Perplexity",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "pr": "607",
+              "note": "contextual-retrieval: merged + tested, NOT wired into live ingest/query"
+            },
+            {
+              "pr": "604",
+              "note": "query-variant RAG-Fusion: merged + tested, not live-wired"
+            }
+          ],
+          "rationale": "Built and tested; not yet wired into the live ingest/query path.",
+          "provisional": true
+        },
+        {
+          "feature_id": "contextual_retrieval_fusion",
+          "competitor": "Cohere",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "pr": "607",
+              "note": "contextual-retrieval: merged + tested, NOT wired into live ingest/query"
+            },
+            {
+              "pr": "604",
+              "note": "query-variant RAG-Fusion: merged + tested, not live-wired"
+            }
+          ],
+          "rationale": "Built and tested; not yet wired into the live ingest/query path.",
+          "provisional": true
+        },
+        {
+          "feature_id": "contextual_retrieval_fusion",
+          "competitor": "Vectara",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "pr": "607",
+              "note": "contextual-retrieval: merged + tested, NOT wired into live ingest/query"
+            },
+            {
+              "pr": "604",
+              "note": "query-variant RAG-Fusion: merged + tested, not live-wired"
+            }
+          ],
+          "rationale": "Built and tested; not yet wired into the live ingest/query path.",
+          "provisional": true
+        },
+        {
+          "feature_id": "contextual_retrieval_fusion",
+          "competitor": "Watson Discovery",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "pr": "607",
+              "note": "contextual-retrieval: merged + tested, NOT wired into live ingest/query"
+            },
+            {
+              "pr": "604",
+              "note": "query-variant RAG-Fusion: merged + tested, not live-wired"
+            }
+          ],
+          "rationale": "Built and tested; not yet wired into the live ingest/query path.",
+          "provisional": true
+        },
+        {
+          "feature_id": "temporal_retrieval",
+          "competitor": "Glean",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "Live 7-day SPARQL FILTER (recent-messages scoped) only, not a general temporal-KG validity model."
+        },
+        {
+          "feature_id": "temporal_retrieval",
+          "competitor": "Perplexity",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "Live 7-day SPARQL FILTER (recent-messages scoped) only, not a general temporal-KG validity model."
+        },
+        {
+          "feature_id": "temporal_retrieval",
+          "competitor": "Cohere",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "Live 7-day SPARQL FILTER (recent-messages scoped) only, not a general temporal-KG validity model."
+        },
+        {
+          "feature_id": "temporal_retrieval",
+          "competitor": "Vectara",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "Live 7-day SPARQL FILTER (recent-messages scoped) only, not a general temporal-KG validity model."
+        },
+        {
+          "feature_id": "temporal_retrieval",
+          "competitor": "Watson Discovery",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "Live 7-day SPARQL FILTER (recent-messages scoped) only, not a general temporal-KG validity model."
+        },
+        {
+          "feature_id": "retrieval_scale",
+          "competitor": "Glean",
+          "verdict": "GAP",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "Glean proven at enterprise/billion-doc scale."
+        },
+        {
+          "feature_id": "retrieval_scale",
+          "competitor": "Perplexity",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "In-memory g.allNodes() scans = workspace-scale."
+        },
+        {
+          "feature_id": "retrieval_scale",
+          "competitor": "Cohere",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "In-memory g.allNodes() scans = workspace-scale."
+        },
+        {
+          "feature_id": "retrieval_scale",
+          "competitor": "Vectara",
+          "verdict": "GAP",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "In-memory g.allNodes() scans = workspace-scale."
+        },
+        {
+          "feature_id": "retrieval_scale",
+          "competitor": "Watson Discovery",
+          "verdict": "GAP",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "In-memory g.allNodes() scans = workspace-scale."
+        },
+        {
+          "feature_id": "connector_breadth",
+          "competitor": "Glean",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "connector-receipt.ts gives open audited connectors; Glean leads on 100+ connectors with permission-sync."
+        },
+        {
+          "feature_id": "connector_breadth",
+          "competitor": "Perplexity",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "connector-receipt.ts gives open audited connectors; Glean leads on 100+ connectors with permission-sync."
+        },
+        {
+          "feature_id": "connector_breadth",
+          "competitor": "Cohere",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "connector-receipt.ts gives open audited connectors; Glean leads on 100+ connectors with permission-sync."
+        },
+        {
+          "feature_id": "connector_breadth",
+          "competitor": "Vectara",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "connector-receipt.ts gives open audited connectors; Glean leads on 100+ connectors with permission-sync."
+        },
+        {
+          "feature_id": "connector_breadth",
+          "competitor": "Watson Discovery",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "connector-receipt.ts gives open audited connectors; Glean leads on 100+ connectors with permission-sync."
+        }
+      ]
+    },
+    {
+      "category_id": "agent_framework",
+      "name": "Agent framework",
+      "description": "prophet-mesh / superconscious / AgentPassport + agent ontology + zero-trust A2A, ControlNode/ControlLoop, Crown, agentplane governed runner, memory-mesh vs the agent-framework field.",
+      "competitors": [
+        "LangGraph",
+        "CrewAI",
+        "AutoGen",
+        "MS Agent Framework",
+        "Devin",
+        "Dust"
+      ],
+      "litmus_features": [
+        {
+          "feature_id": "governance_policy_gating",
+          "name": "Governance / policy gating",
+          "definition": "Constitutional gates that can refuse an agent action (separation-of-powers invariants).",
+          "criteria": "BEAT = merged constitution + judge/objective gates that fail closed on unconstitutional acts."
+        },
+        {
+          "feature_id": "agent_identity_passport",
+          "name": "Agent identity / passport",
+          "definition": "OS-process-level agent classification and fail-closed authorization.",
+          "criteria": "BEAT = OS-process->authority binding with live fail-closed authorize gate."
+        },
+        {
+          "feature_id": "receipts_auditability",
+          "name": "Receipts / auditability",
+          "definition": "Hash-chained, deterministically-replayable proof artifacts for agent runs.",
+          "criteria": "BEAT = SHA-256 proof-artifact spine + deterministic replay + sealed hygiene passports."
+        },
+        {
+          "feature_id": "standards_conformance",
+          "name": "Standards conformance",
+          "definition": "Coverage of open agent-interop standards under a zero-trust profile.",
+          "criteria": "BEAT = HUA/AG-UI/A2A/MCP/ANP zero-trust stack + published agent-standard profiles."
+        },
+        {
+          "feature_id": "os_workspace_native",
+          "name": "OS / workspace-native",
+          "definition": "Agents bound to OS-process authority within a sovereign workspace/OS layer.",
+          "criteria": "BEAT = SourceOS + AgentPassport OS-process->authority binding."
+        },
+        {
+          "feature_id": "self_maintenance_contract",
+          "name": "Self-maintenance contract",
+          "definition": "A closed sense->model->judge->act->receipt control loop for self-maintenance.",
+          "criteria": "BEAT = specified closed-loop contract; live requires shipping runtime remediation."
+        },
+        {
+          "feature_id": "multi_agent_orchestration",
+          "name": "Multi-agent orchestration",
+          "definition": "Coordinating multiple role-specialized agents toward a shared objective.",
+          "criteria": "MEET = conductor + role choir + A2A coordination; BEAT requires a live edge."
+        },
+        {
+          "feature_id": "memory_governed",
+          "name": "Governed agent memory",
+          "definition": "Multi-type agent memory with regime characterization and governed writeback.",
+          "criteria": "BEAT = FSMS multi-type memory + regime characterizer + governed writeback; MEET = raw recall parity."
+        },
+        {
+          "feature_id": "orchestration_runtime",
+          "name": "Live orchestration runtime",
+          "definition": "A production graph/runtime that actually executes multi-step agent flows.",
+          "criteria": "BEAT = live executing graph; PARTIAL = deterministic dry-run router only."
+        },
+        {
+          "feature_id": "autonomous_execution",
+          "name": "Autonomous execution",
+          "definition": "End-to-end autonomous task execution (e.g. autonomous coding).",
+          "criteria": "BEAT = executes autonomous runs; GAP = contract carrier that does not execute."
+        }
+      ],
+      "scores": [
+        {
+          "feature_id": "governance_policy_gating",
+          "competitor": "LangGraph",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "hellgraph",
+              "pr": "52",
+              "note": "Crown constitution ADR-0004, MERGED to main"
+            },
+            {
+              "repo": "ProCybernetica",
+              "pr": "124",
+              "note": "ControlNode + ADR-0003; 7 teeth incl. NO_VALUE_JUDGMENT_GATE / JUDGE_DENIED_BUT_FIRED / UNCONSTITUTIONAL_OBJECTIVE_CROWN_K1"
+            },
+            {
+              "repo": "ProCybernetica",
+              "pr": "126",
+              "note": "agentic-execution class"
+            }
+          ],
+          "rationale": "Crown + ControlNode merged (live); the ControlLoop remediation itself is measurement/design only (SPEC)."
+        },
+        {
+          "feature_id": "governance_policy_gating",
+          "competitor": "CrewAI",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "hellgraph",
+              "pr": "52",
+              "note": "Crown constitution ADR-0004, MERGED to main"
+            },
+            {
+              "repo": "ProCybernetica",
+              "pr": "124",
+              "note": "ControlNode + ADR-0003; 7 teeth incl. NO_VALUE_JUDGMENT_GATE / JUDGE_DENIED_BUT_FIRED / UNCONSTITUTIONAL_OBJECTIVE_CROWN_K1"
+            },
+            {
+              "repo": "ProCybernetica",
+              "pr": "126",
+              "note": "agentic-execution class"
+            }
+          ],
+          "rationale": "Crown + ControlNode merged (live); the ControlLoop remediation itself is measurement/design only (SPEC)."
+        },
+        {
+          "feature_id": "governance_policy_gating",
+          "competitor": "AutoGen",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "hellgraph",
+              "pr": "52",
+              "note": "Crown constitution ADR-0004, MERGED to main"
+            },
+            {
+              "repo": "ProCybernetica",
+              "pr": "124",
+              "note": "ControlNode + ADR-0003; 7 teeth incl. NO_VALUE_JUDGMENT_GATE / JUDGE_DENIED_BUT_FIRED / UNCONSTITUTIONAL_OBJECTIVE_CROWN_K1"
+            },
+            {
+              "repo": "ProCybernetica",
+              "pr": "126",
+              "note": "agentic-execution class"
+            }
+          ],
+          "rationale": "Crown + ControlNode merged (live); the ControlLoop remediation itself is measurement/design only (SPEC)."
+        },
+        {
+          "feature_id": "governance_policy_gating",
+          "competitor": "MS Agent Framework",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "hellgraph",
+              "pr": "52",
+              "note": "Crown constitution ADR-0004, MERGED to main"
+            },
+            {
+              "repo": "ProCybernetica",
+              "pr": "124",
+              "note": "ControlNode + ADR-0003; 7 teeth incl. NO_VALUE_JUDGMENT_GATE / JUDGE_DENIED_BUT_FIRED / UNCONSTITUTIONAL_OBJECTIVE_CROWN_K1"
+            },
+            {
+              "repo": "ProCybernetica",
+              "pr": "126",
+              "note": "agentic-execution class"
+            }
+          ],
+          "rationale": "Crown + ControlNode merged (live); the ControlLoop remediation itself is measurement/design only (SPEC)."
+        },
+        {
+          "feature_id": "governance_policy_gating",
+          "competitor": "Devin",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "hellgraph",
+              "pr": "52",
+              "note": "Crown constitution ADR-0004, MERGED to main"
+            },
+            {
+              "repo": "ProCybernetica",
+              "pr": "124",
+              "note": "ControlNode + ADR-0003; 7 teeth incl. NO_VALUE_JUDGMENT_GATE / JUDGE_DENIED_BUT_FIRED / UNCONSTITUTIONAL_OBJECTIVE_CROWN_K1"
+            },
+            {
+              "repo": "ProCybernetica",
+              "pr": "126",
+              "note": "agentic-execution class"
+            }
+          ],
+          "rationale": "Crown + ControlNode merged (live); the ControlLoop remediation itself is measurement/design only (SPEC)."
+        },
+        {
+          "feature_id": "governance_policy_gating",
+          "competitor": "Dust",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "hellgraph",
+              "pr": "52",
+              "note": "Crown constitution ADR-0004, MERGED to main"
+            },
+            {
+              "repo": "ProCybernetica",
+              "pr": "124",
+              "note": "ControlNode + ADR-0003; 7 teeth incl. NO_VALUE_JUDGMENT_GATE / JUDGE_DENIED_BUT_FIRED / UNCONSTITUTIONAL_OBJECTIVE_CROWN_K1"
+            },
+            {
+              "repo": "ProCybernetica",
+              "pr": "126",
+              "note": "agentic-execution class"
+            }
+          ],
+          "rationale": "Crown + ControlNode merged (live); the ControlLoop remediation itself is measurement/design only (SPEC)."
+        },
+        {
+          "feature_id": "agent_identity_passport",
+          "competitor": "LangGraph",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "sourceos-spec",
+              "path": "AgentPassport.json",
+              "note": "5-class, T0-1, OS-process level"
+            },
+            {
+              "repo": "mcp-a2a-zero-trust",
+              "pr": "18",
+              "note": "trust-tiers"
+            },
+            {
+              "repo": "agent-registry",
+              "pr": "50",
+              "note": "live fail-closed authorize.py"
+            }
+          ],
+          "rationale": "Unique: OS-process-level agent classification."
+        },
+        {
+          "feature_id": "agent_identity_passport",
+          "competitor": "CrewAI",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "sourceos-spec",
+              "path": "AgentPassport.json",
+              "note": "5-class, T0-1, OS-process level"
+            },
+            {
+              "repo": "mcp-a2a-zero-trust",
+              "pr": "18",
+              "note": "trust-tiers"
+            },
+            {
+              "repo": "agent-registry",
+              "pr": "50",
+              "note": "live fail-closed authorize.py"
+            }
+          ],
+          "rationale": "Unique: OS-process-level agent classification."
+        },
+        {
+          "feature_id": "agent_identity_passport",
+          "competitor": "AutoGen",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "sourceos-spec",
+              "path": "AgentPassport.json",
+              "note": "5-class, T0-1, OS-process level"
+            },
+            {
+              "repo": "mcp-a2a-zero-trust",
+              "pr": "18",
+              "note": "trust-tiers"
+            },
+            {
+              "repo": "agent-registry",
+              "pr": "50",
+              "note": "live fail-closed authorize.py"
+            }
+          ],
+          "rationale": "Unique: OS-process-level agent classification."
+        },
+        {
+          "feature_id": "agent_identity_passport",
+          "competitor": "MS Agent Framework",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "sourceos-spec",
+              "path": "AgentPassport.json",
+              "note": "5-class, T0-1, OS-process level"
+            },
+            {
+              "repo": "mcp-a2a-zero-trust",
+              "pr": "18",
+              "note": "trust-tiers"
+            },
+            {
+              "repo": "agent-registry",
+              "pr": "50",
+              "note": "live fail-closed authorize.py"
+            }
+          ],
+          "rationale": "Unique: OS-process-level agent classification."
+        },
+        {
+          "feature_id": "agent_identity_passport",
+          "competitor": "Devin",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "sourceos-spec",
+              "path": "AgentPassport.json",
+              "note": "5-class, T0-1, OS-process level"
+            },
+            {
+              "repo": "mcp-a2a-zero-trust",
+              "pr": "18",
+              "note": "trust-tiers"
+            },
+            {
+              "repo": "agent-registry",
+              "pr": "50",
+              "note": "live fail-closed authorize.py"
+            }
+          ],
+          "rationale": "Unique: OS-process-level agent classification."
+        },
+        {
+          "feature_id": "agent_identity_passport",
+          "competitor": "Dust",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "sourceos-spec",
+              "path": "AgentPassport.json",
+              "note": "5-class, T0-1, OS-process level"
+            },
+            {
+              "repo": "mcp-a2a-zero-trust",
+              "pr": "18",
+              "note": "trust-tiers"
+            },
+            {
+              "repo": "agent-registry",
+              "pr": "50",
+              "note": "live fail-closed authorize.py"
+            }
+          ],
+          "rationale": "Unique: OS-process-level agent classification."
+        },
+        {
+          "feature_id": "receipts_auditability",
+          "competitor": "LangGraph",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "agentplane",
+              "pr": "327",
+              "note": "proof-artifact-spine SHA-256 hash-chained + deterministic replay (327 commits)"
+            },
+            {
+              "note": "epigov hygiene runtime: sealed CountertestRun/Bias/Calibration passports",
+              "path": "commit 559d19a"
+            }
+          ],
+          "rationale": "Strongest lead in the category."
+        },
+        {
+          "feature_id": "receipts_auditability",
+          "competitor": "CrewAI",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "agentplane",
+              "pr": "327",
+              "note": "proof-artifact-spine SHA-256 hash-chained + deterministic replay (327 commits)"
+            },
+            {
+              "note": "epigov hygiene runtime: sealed CountertestRun/Bias/Calibration passports",
+              "path": "commit 559d19a"
+            }
+          ],
+          "rationale": "Strongest lead in the category."
+        },
+        {
+          "feature_id": "receipts_auditability",
+          "competitor": "AutoGen",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "agentplane",
+              "pr": "327",
+              "note": "proof-artifact-spine SHA-256 hash-chained + deterministic replay (327 commits)"
+            },
+            {
+              "note": "epigov hygiene runtime: sealed CountertestRun/Bias/Calibration passports",
+              "path": "commit 559d19a"
+            }
+          ],
+          "rationale": "Strongest lead in the category."
+        },
+        {
+          "feature_id": "receipts_auditability",
+          "competitor": "MS Agent Framework",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "agentplane",
+              "pr": "327",
+              "note": "proof-artifact-spine SHA-256 hash-chained + deterministic replay (327 commits)"
+            },
+            {
+              "note": "epigov hygiene runtime: sealed CountertestRun/Bias/Calibration passports",
+              "path": "commit 559d19a"
+            }
+          ],
+          "rationale": "Strongest lead in the category."
+        },
+        {
+          "feature_id": "receipts_auditability",
+          "competitor": "Devin",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "agentplane",
+              "pr": "327",
+              "note": "proof-artifact-spine SHA-256 hash-chained + deterministic replay (327 commits)"
+            },
+            {
+              "note": "epigov hygiene runtime: sealed CountertestRun/Bias/Calibration passports",
+              "path": "commit 559d19a"
+            }
+          ],
+          "rationale": "Strongest lead in the category."
+        },
+        {
+          "feature_id": "receipts_auditability",
+          "competitor": "Dust",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "agentplane",
+              "pr": "327",
+              "note": "proof-artifact-spine SHA-256 hash-chained + deterministic replay (327 commits)"
+            },
+            {
+              "note": "epigov hygiene runtime: sealed CountertestRun/Bias/Calibration passports",
+              "path": "commit 559d19a"
+            }
+          ],
+          "rationale": "Strongest lead in the category."
+        },
+        {
+          "feature_id": "standards_conformance",
+          "competitor": "LangGraph",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "ProCybernetica",
+              "pr": "126",
+              "note": "agentic-execution-class"
+            },
+            {
+              "repo": "socioprophet-agent-standards",
+              "note": "HUA/AG-UI/A2A/MCP/ANP zero-trust profiles"
+            }
+          ]
+        },
+        {
+          "feature_id": "standards_conformance",
+          "competitor": "CrewAI",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "ProCybernetica",
+              "pr": "126",
+              "note": "agentic-execution-class"
+            },
+            {
+              "repo": "socioprophet-agent-standards",
+              "note": "HUA/AG-UI/A2A/MCP/ANP zero-trust profiles"
+            }
+          ]
+        },
+        {
+          "feature_id": "standards_conformance",
+          "competitor": "AutoGen",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "ProCybernetica",
+              "pr": "126",
+              "note": "agentic-execution-class"
+            },
+            {
+              "repo": "socioprophet-agent-standards",
+              "note": "HUA/AG-UI/A2A/MCP/ANP zero-trust profiles"
+            }
+          ]
+        },
+        {
+          "feature_id": "standards_conformance",
+          "competitor": "MS Agent Framework",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "ProCybernetica",
+              "pr": "126",
+              "note": "agentic-execution-class"
+            },
+            {
+              "repo": "socioprophet-agent-standards",
+              "note": "HUA/AG-UI/A2A/MCP/ANP zero-trust profiles"
+            }
+          ]
+        },
+        {
+          "feature_id": "standards_conformance",
+          "competitor": "Devin",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "ProCybernetica",
+              "pr": "126",
+              "note": "agentic-execution-class"
+            },
+            {
+              "repo": "socioprophet-agent-standards",
+              "note": "HUA/AG-UI/A2A/MCP/ANP zero-trust profiles"
+            }
+          ]
+        },
+        {
+          "feature_id": "standards_conformance",
+          "competitor": "Dust",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "ProCybernetica",
+              "pr": "126",
+              "note": "agentic-execution-class"
+            },
+            {
+              "repo": "socioprophet-agent-standards",
+              "note": "HUA/AG-UI/A2A/MCP/ANP zero-trust profiles"
+            }
+          ]
+        },
+        {
+          "feature_id": "os_workspace_native",
+          "competitor": "LangGraph",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "SourceOS",
+              "note": "OS layer"
+            },
+            {
+              "repo": "sourceos-spec",
+              "path": "AgentPassport.json",
+              "note": "OS-process->authority binding"
+            }
+          ],
+          "rationale": "agentic-os-api is a read-only seed (PARTIAL-live)."
+        },
+        {
+          "feature_id": "os_workspace_native",
+          "competitor": "CrewAI",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "SourceOS",
+              "note": "OS layer"
+            },
+            {
+              "repo": "sourceos-spec",
+              "path": "AgentPassport.json",
+              "note": "OS-process->authority binding"
+            }
+          ],
+          "rationale": "agentic-os-api is a read-only seed (PARTIAL-live)."
+        },
+        {
+          "feature_id": "os_workspace_native",
+          "competitor": "AutoGen",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "SourceOS",
+              "note": "OS layer"
+            },
+            {
+              "repo": "sourceos-spec",
+              "path": "AgentPassport.json",
+              "note": "OS-process->authority binding"
+            }
+          ],
+          "rationale": "agentic-os-api is a read-only seed (PARTIAL-live)."
+        },
+        {
+          "feature_id": "os_workspace_native",
+          "competitor": "MS Agent Framework",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "SourceOS",
+              "note": "OS layer"
+            },
+            {
+              "repo": "sourceos-spec",
+              "path": "AgentPassport.json",
+              "note": "OS-process->authority binding"
+            }
+          ],
+          "rationale": "agentic-os-api is a read-only seed (PARTIAL-live)."
+        },
+        {
+          "feature_id": "os_workspace_native",
+          "competitor": "Devin",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "SourceOS",
+              "note": "OS layer"
+            },
+            {
+              "repo": "sourceos-spec",
+              "path": "AgentPassport.json",
+              "note": "OS-process->authority binding"
+            }
+          ],
+          "rationale": "agentic-os-api is a read-only seed (PARTIAL-live)."
+        },
+        {
+          "feature_id": "os_workspace_native",
+          "competitor": "Dust",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "SourceOS",
+              "note": "OS layer"
+            },
+            {
+              "repo": "sourceos-spec",
+              "path": "AgentPassport.json",
+              "note": "OS-process->authority binding"
+            }
+          ],
+          "rationale": "agentic-os-api is a read-only seed (PARTIAL-live)."
+        },
+        {
+          "feature_id": "self_maintenance_contract",
+          "competitor": "LangGraph",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "ProCybernetica",
+              "pr": "124",
+              "note": "ControlLoop ADR-0003: sense->model->judge->act->receipt"
+            }
+          ],
+          "rationale": "No runtime remediation ships yet (SPEC).",
+          "provisional": true
+        },
+        {
+          "feature_id": "self_maintenance_contract",
+          "competitor": "CrewAI",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "ProCybernetica",
+              "pr": "124",
+              "note": "ControlLoop ADR-0003: sense->model->judge->act->receipt"
+            }
+          ],
+          "rationale": "No runtime remediation ships yet (SPEC).",
+          "provisional": true
+        },
+        {
+          "feature_id": "self_maintenance_contract",
+          "competitor": "AutoGen",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "ProCybernetica",
+              "pr": "124",
+              "note": "ControlLoop ADR-0003: sense->model->judge->act->receipt"
+            }
+          ],
+          "rationale": "No runtime remediation ships yet (SPEC).",
+          "provisional": true
+        },
+        {
+          "feature_id": "self_maintenance_contract",
+          "competitor": "MS Agent Framework",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "ProCybernetica",
+              "pr": "124",
+              "note": "ControlLoop ADR-0003: sense->model->judge->act->receipt"
+            }
+          ],
+          "rationale": "No runtime remediation ships yet (SPEC).",
+          "provisional": true
+        },
+        {
+          "feature_id": "self_maintenance_contract",
+          "competitor": "Devin",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "ProCybernetica",
+              "pr": "124",
+              "note": "ControlLoop ADR-0003: sense->model->judge->act->receipt"
+            }
+          ],
+          "rationale": "No runtime remediation ships yet (SPEC).",
+          "provisional": true
+        },
+        {
+          "feature_id": "self_maintenance_contract",
+          "competitor": "Dust",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "ProCybernetica",
+              "pr": "124",
+              "note": "ControlLoop ADR-0003: sense->model->judge->act->receipt"
+            }
+          ],
+          "rationale": "No runtime remediation ships yet (SPEC).",
+          "provisional": true
+        },
+        {
+          "feature_id": "multi_agent_orchestration",
+          "competitor": "LangGraph",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-mesh",
+              "note": "conductor + 10-role choir"
+            },
+            {
+              "repo": "ProCybernetica",
+              "note": "A2A inter-agent-coordination exec class; dry-run/validators = SPEC"
+            }
+          ],
+          "rationale": "Estate coordination is dry-run/validator level.",
+          "provisional": true
+        },
+        {
+          "feature_id": "multi_agent_orchestration",
+          "competitor": "CrewAI",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "CrewAI leads on live multi-agent loops."
+        },
+        {
+          "feature_id": "multi_agent_orchestration",
+          "competitor": "AutoGen",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "AutoGen leads on live multi-agent loops."
+        },
+        {
+          "feature_id": "multi_agent_orchestration",
+          "competitor": "MS Agent Framework",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-mesh",
+              "note": "conductor + 10-role choir"
+            },
+            {
+              "repo": "ProCybernetica",
+              "note": "A2A inter-agent-coordination exec class; dry-run/validators = SPEC"
+            }
+          ],
+          "rationale": "Estate coordination is dry-run/validator level.",
+          "provisional": true
+        },
+        {
+          "feature_id": "multi_agent_orchestration",
+          "competitor": "Devin",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-mesh",
+              "note": "conductor + 10-role choir"
+            },
+            {
+              "repo": "ProCybernetica",
+              "note": "A2A inter-agent-coordination exec class; dry-run/validators = SPEC"
+            }
+          ],
+          "rationale": "Estate coordination is dry-run/validator level.",
+          "provisional": true
+        },
+        {
+          "feature_id": "multi_agent_orchestration",
+          "competitor": "Dust",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-mesh",
+              "note": "conductor + 10-role choir"
+            },
+            {
+              "repo": "ProCybernetica",
+              "note": "A2A inter-agent-coordination exec class; dry-run/validators = SPEC"
+            }
+          ],
+          "rationale": "Estate coordination is dry-run/validator level.",
+          "provisional": true
+        },
+        {
+          "feature_id": "memory_governed",
+          "competitor": "LangGraph",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "memory-mesh",
+              "note": "FSMS 6-type + regime characterizer + governed writeback (memoryd)"
+            },
+            {
+              "repo": "memory-mesh",
+              "pr": "47"
+            },
+            {
+              "repo": "memory-mesh",
+              "pr": "50"
+            }
+          ],
+          "rationale": "Estate leads on GOVERNED writeback/regime; at parity on raw recall."
+        },
+        {
+          "feature_id": "memory_governed",
+          "competitor": "CrewAI",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "memory-mesh",
+              "note": "FSMS 6-type + regime characterizer + governed writeback (memoryd)"
+            },
+            {
+              "repo": "memory-mesh",
+              "pr": "47"
+            },
+            {
+              "repo": "memory-mesh",
+              "pr": "50"
+            }
+          ],
+          "rationale": "Estate leads on GOVERNED writeback/regime; at parity on raw recall."
+        },
+        {
+          "feature_id": "memory_governed",
+          "competitor": "AutoGen",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "memory-mesh",
+              "note": "FSMS 6-type + regime characterizer + governed writeback (memoryd)"
+            },
+            {
+              "repo": "memory-mesh",
+              "pr": "47"
+            },
+            {
+              "repo": "memory-mesh",
+              "pr": "50"
+            }
+          ],
+          "rationale": "Estate leads on GOVERNED writeback/regime; at parity on raw recall."
+        },
+        {
+          "feature_id": "memory_governed",
+          "competitor": "MS Agent Framework",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "memory-mesh",
+              "note": "FSMS 6-type + regime characterizer + governed writeback (memoryd)"
+            },
+            {
+              "repo": "memory-mesh",
+              "pr": "47"
+            },
+            {
+              "repo": "memory-mesh",
+              "pr": "50"
+            }
+          ],
+          "rationale": "Estate leads on GOVERNED writeback/regime; at parity on raw recall."
+        },
+        {
+          "feature_id": "memory_governed",
+          "competitor": "Devin",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "memory-mesh",
+              "note": "FSMS 6-type + regime characterizer + governed writeback (memoryd)"
+            },
+            {
+              "repo": "memory-mesh",
+              "pr": "47"
+            },
+            {
+              "repo": "memory-mesh",
+              "pr": "50"
+            }
+          ],
+          "rationale": "Estate leads on GOVERNED writeback/regime; at parity on raw recall."
+        },
+        {
+          "feature_id": "memory_governed",
+          "competitor": "Dust",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "memory-mesh",
+              "note": "FSMS 6-type + regime characterizer + governed writeback (memoryd)"
+            },
+            {
+              "repo": "memory-mesh",
+              "pr": "47"
+            },
+            {
+              "repo": "memory-mesh",
+              "pr": "50"
+            }
+          ],
+          "rationale": "Estate leads on GOVERNED writeback/regime; at parity on raw recall."
+        },
+        {
+          "feature_id": "orchestration_runtime",
+          "competitor": "LangGraph",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "prophet-mesh router is deterministic dry-run only; LangGraph/AutoGen/CrewAI ship live graphs."
+        },
+        {
+          "feature_id": "orchestration_runtime",
+          "competitor": "CrewAI",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "prophet-mesh router is deterministic dry-run only; LangGraph/AutoGen/CrewAI ship live graphs."
+        },
+        {
+          "feature_id": "orchestration_runtime",
+          "competitor": "AutoGen",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "prophet-mesh router is deterministic dry-run only; LangGraph/AutoGen/CrewAI ship live graphs."
+        },
+        {
+          "feature_id": "orchestration_runtime",
+          "competitor": "MS Agent Framework",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "prophet-mesh router is deterministic dry-run only; LangGraph/AutoGen/CrewAI ship live graphs."
+        },
+        {
+          "feature_id": "orchestration_runtime",
+          "competitor": "Devin",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "prophet-mesh router is deterministic dry-run only; LangGraph/AutoGen/CrewAI ship live graphs."
+        },
+        {
+          "feature_id": "orchestration_runtime",
+          "competitor": "Dust",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "prophet-mesh router is deterministic dry-run only; LangGraph/AutoGen/CrewAI ship live graphs."
+        },
+        {
+          "feature_id": "autonomous_execution",
+          "competitor": "LangGraph",
+          "verdict": "GAP",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "GovernedRunContract does not execute a run (v0 carrier + fixtures)."
+        },
+        {
+          "feature_id": "autonomous_execution",
+          "competitor": "CrewAI",
+          "verdict": "GAP",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "GovernedRunContract does not execute a run (v0 carrier + fixtures)."
+        },
+        {
+          "feature_id": "autonomous_execution",
+          "competitor": "AutoGen",
+          "verdict": "GAP",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "GovernedRunContract does not execute a run (v0 carrier + fixtures)."
+        },
+        {
+          "feature_id": "autonomous_execution",
+          "competitor": "MS Agent Framework",
+          "verdict": "GAP",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "GovernedRunContract does not execute a run (v0 carrier + fixtures)."
+        },
+        {
+          "feature_id": "autonomous_execution",
+          "competitor": "Devin",
+          "verdict": "GAP",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Devin executes autonomous coding; estate does not execute runs yet."
+        },
+        {
+          "feature_id": "autonomous_execution",
+          "competitor": "Dust",
+          "verdict": "GAP",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "GovernedRunContract does not execute a run (v0 carrier + fixtures)."
+        }
+      ]
+    },
+    {
+      "category_id": "model_lab_eval",
+      "name": "Model lab + evaluation",
+      "description": "tritfabric, lattice-forge/studio, model-plane T7, receipt-gateway/InferenceReceipts, reproduce-bench/RecipeProof vs the ML experiment/eval field.",
+      "competitors": [
+        "Weights & Biases",
+        "MLflow",
+        "Hugging Face",
+        "Galileo",
+        "Patronus",
+        "Arize"
+      ],
+      "litmus_features": [
+        {
+          "feature_id": "experiment_tracking",
+          "name": "Experiment tracking",
+          "definition": "Tracking runs, params, artifacts and comparisons across model experiments.",
+          "criteria": "BEAT = mature tracking UX + governance; PARTIAL = emerging tracking surface."
+        },
+        {
+          "feature_id": "receipted_eval",
+          "name": "Receipt-gated evaluation",
+          "definition": "Every eval/inference result carries a sealed, hash-chained receipt.",
+          "criteria": "BEAT = per-call SHA-256 hash-chained InferenceReceipts + trust-class provenance."
+        },
+        {
+          "feature_id": "reproducibility_recipeproof",
+          "name": "RecipeProof reproducibility",
+          "definition": "Deterministic, environment-pinned replay of an eval run from a recipe.",
+          "criteria": "BEAT = recipe + repro-ledger + reproduce-run-record enabling deterministic replay."
+        },
+        {
+          "feature_id": "honesty_no_laundering",
+          "name": "Anti-laundering honesty gate",
+          "definition": "Structural prevention of citing a number as if it were reproduced by us.",
+          "criteria": "BEAT = disjoint reproduced-vs-cited facts + a no_laundering submission gate."
+        },
+        {
+          "feature_id": "llm_eval_guardrails",
+          "name": "LLM eval + guardrails",
+          "definition": "Productized LLM output evaluation and guardrailing (safety/quality scorers).",
+          "criteria": "BEAT = broad governed scorers; PARTIAL where a vendor leads productization."
+        },
+        {
+          "feature_id": "model_registry_governance",
+          "name": "Governed model registry",
+          "definition": "Model registry with governance ledger over promotions/lineage.",
+          "criteria": "BEAT = registry + governance ledger; MEET = registry parity."
+        },
+        {
+          "feature_id": "production_observability",
+          "name": "Production ML observability",
+          "definition": "Live monitoring of model quality/drift in production.",
+          "criteria": "BEAT = mature drift/quality monitoring; PARTIAL = telemetry capture only."
+        }
+      ],
+      "scores": [
+        {
+          "feature_id": "experiment_tracking",
+          "competitor": "Weights & Biases",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "W&B/MLflow lead on mature tracking UX; lattice-studio leaderboard is the emerging estate surface."
+        },
+        {
+          "feature_id": "experiment_tracking",
+          "competitor": "MLflow",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "W&B/MLflow lead on mature tracking UX; lattice-studio leaderboard is the emerging estate surface."
+        },
+        {
+          "feature_id": "experiment_tracking",
+          "competitor": "Hugging Face",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "W&B/MLflow lead on mature tracking UX; lattice-studio leaderboard is the emerging estate surface."
+        },
+        {
+          "feature_id": "experiment_tracking",
+          "competitor": "Galileo",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "W&B/MLflow lead on mature tracking UX; lattice-studio leaderboard is the emerging estate surface."
+        },
+        {
+          "feature_id": "experiment_tracking",
+          "competitor": "Patronus",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "W&B/MLflow lead on mature tracking UX; lattice-studio leaderboard is the emerging estate surface."
+        },
+        {
+          "feature_id": "experiment_tracking",
+          "competitor": "Arize",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "W&B/MLflow lead on mature tracking UX; lattice-studio leaderboard is the emerging estate surface."
+        },
+        {
+          "feature_id": "receipted_eval",
+          "competitor": "Weights & Biases",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "apps/receipt-gateway",
+              "note": "hash-chained InferenceReceipts per call, SEAM-011"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/metric-fact.schema.json",
+              "note": "source_trust_class + reproduced_by_us provenance on every fact"
+            }
+          ],
+          "rationale": "Competitors do not seal per-call inference receipts."
+        },
+        {
+          "feature_id": "receipted_eval",
+          "competitor": "MLflow",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "apps/receipt-gateway",
+              "note": "hash-chained InferenceReceipts per call, SEAM-011"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/metric-fact.schema.json",
+              "note": "source_trust_class + reproduced_by_us provenance on every fact"
+            }
+          ],
+          "rationale": "Competitors do not seal per-call inference receipts."
+        },
+        {
+          "feature_id": "receipted_eval",
+          "competitor": "Hugging Face",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "apps/receipt-gateway",
+              "note": "hash-chained InferenceReceipts per call, SEAM-011"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/metric-fact.schema.json",
+              "note": "source_trust_class + reproduced_by_us provenance on every fact"
+            }
+          ],
+          "rationale": "Competitors do not seal per-call inference receipts."
+        },
+        {
+          "feature_id": "receipted_eval",
+          "competitor": "Galileo",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "apps/receipt-gateway",
+              "note": "hash-chained InferenceReceipts per call, SEAM-011"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/metric-fact.schema.json",
+              "note": "source_trust_class + reproduced_by_us provenance on every fact"
+            }
+          ],
+          "rationale": "Competitors do not seal per-call inference receipts."
+        },
+        {
+          "feature_id": "receipted_eval",
+          "competitor": "Patronus",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "apps/receipt-gateway",
+              "note": "hash-chained InferenceReceipts per call, SEAM-011"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/metric-fact.schema.json",
+              "note": "source_trust_class + reproduced_by_us provenance on every fact"
+            }
+          ],
+          "rationale": "Competitors do not seal per-call inference receipts."
+        },
+        {
+          "feature_id": "receipted_eval",
+          "competitor": "Arize",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "apps/receipt-gateway",
+              "note": "hash-chained InferenceReceipts per call, SEAM-011"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/metric-fact.schema.json",
+              "note": "source_trust_class + reproduced_by_us provenance on every fact"
+            }
+          ],
+          "rationale": "Competitors do not seal per-call inference receipts."
+        },
+        {
+          "feature_id": "reproducibility_recipeproof",
+          "competitor": "Weights & Biases",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/repro-ledger-entry.schema.json"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/reproduce-run-record.schema.json"
+            }
+          ]
+        },
+        {
+          "feature_id": "reproducibility_recipeproof",
+          "competitor": "MLflow",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/repro-ledger-entry.schema.json"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/reproduce-run-record.schema.json"
+            }
+          ]
+        },
+        {
+          "feature_id": "reproducibility_recipeproof",
+          "competitor": "Hugging Face",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/repro-ledger-entry.schema.json"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/reproduce-run-record.schema.json"
+            }
+          ]
+        },
+        {
+          "feature_id": "reproducibility_recipeproof",
+          "competitor": "Galileo",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/repro-ledger-entry.schema.json"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/reproduce-run-record.schema.json"
+            }
+          ]
+        },
+        {
+          "feature_id": "reproducibility_recipeproof",
+          "competitor": "Patronus",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/repro-ledger-entry.schema.json"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/reproduce-run-record.schema.json"
+            }
+          ]
+        },
+        {
+          "feature_id": "reproducibility_recipeproof",
+          "competitor": "Arize",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/repro-ledger-entry.schema.json"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/reproduce-run-record.schema.json"
+            }
+          ]
+        },
+        {
+          "feature_id": "honesty_no_laundering",
+          "competitor": "Weights & Biases",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "tools/validate_submission.py",
+              "note": "no_laundering gate"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/division-rules.json"
+            }
+          ],
+          "rationale": "Structural anti-laundering has no vendor equivalent."
+        },
+        {
+          "feature_id": "honesty_no_laundering",
+          "competitor": "MLflow",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "tools/validate_submission.py",
+              "note": "no_laundering gate"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/division-rules.json"
+            }
+          ],
+          "rationale": "Structural anti-laundering has no vendor equivalent."
+        },
+        {
+          "feature_id": "honesty_no_laundering",
+          "competitor": "Hugging Face",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "tools/validate_submission.py",
+              "note": "no_laundering gate"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/division-rules.json"
+            }
+          ],
+          "rationale": "Structural anti-laundering has no vendor equivalent."
+        },
+        {
+          "feature_id": "honesty_no_laundering",
+          "competitor": "Galileo",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "tools/validate_submission.py",
+              "note": "no_laundering gate"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/division-rules.json"
+            }
+          ],
+          "rationale": "Structural anti-laundering has no vendor equivalent."
+        },
+        {
+          "feature_id": "honesty_no_laundering",
+          "competitor": "Patronus",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "tools/validate_submission.py",
+              "note": "no_laundering gate"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/division-rules.json"
+            }
+          ],
+          "rationale": "Structural anti-laundering has no vendor equivalent."
+        },
+        {
+          "feature_id": "honesty_no_laundering",
+          "competitor": "Arize",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "tools/validate_submission.py",
+              "note": "no_laundering gate"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/division-rules.json"
+            }
+          ],
+          "rationale": "Structural anti-laundering has no vendor equivalent."
+        },
+        {
+          "feature_id": "llm_eval_guardrails",
+          "competitor": "Weights & Biases",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "guardrail-fabric",
+              "note": "runtime guardrails"
+            },
+            {
+              "memory": "counter_test_gate",
+              "note": "counter-test gate"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "llm_eval_guardrails",
+          "competitor": "MLflow",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "guardrail-fabric",
+              "note": "runtime guardrails"
+            },
+            {
+              "memory": "counter_test_gate",
+              "note": "counter-test gate"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "llm_eval_guardrails",
+          "competitor": "Hugging Face",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "guardrail-fabric",
+              "note": "runtime guardrails"
+            },
+            {
+              "memory": "counter_test_gate",
+              "note": "counter-test gate"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "llm_eval_guardrails",
+          "competitor": "Galileo",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Galileo leads on productized LLM eval."
+        },
+        {
+          "feature_id": "llm_eval_guardrails",
+          "competitor": "Patronus",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Patronus leads on productized LLM eval."
+        },
+        {
+          "feature_id": "llm_eval_guardrails",
+          "competitor": "Arize",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "guardrail-fabric",
+              "note": "runtime guardrails"
+            },
+            {
+              "memory": "counter_test_gate",
+              "note": "counter-test gate"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "model_registry_governance",
+          "competitor": "Weights & Biases",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "model-governance-ledger"
+            },
+            {
+              "repo": "tritfabric"
+            }
+          ],
+          "rationale": "MLflow leads on mature registry; estate leads on governance ledger.",
+          "provisional": true
+        },
+        {
+          "feature_id": "model_registry_governance",
+          "competitor": "MLflow",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "model-governance-ledger"
+            },
+            {
+              "repo": "tritfabric"
+            }
+          ],
+          "rationale": "MLflow leads on mature registry; estate leads on governance ledger.",
+          "provisional": true
+        },
+        {
+          "feature_id": "model_registry_governance",
+          "competitor": "Hugging Face",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "model-governance-ledger"
+            },
+            {
+              "repo": "tritfabric"
+            }
+          ],
+          "rationale": "MLflow leads on mature registry; estate leads on governance ledger.",
+          "provisional": true
+        },
+        {
+          "feature_id": "model_registry_governance",
+          "competitor": "Galileo",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "model-governance-ledger"
+            },
+            {
+              "repo": "tritfabric"
+            }
+          ],
+          "rationale": "MLflow leads on mature registry; estate leads on governance ledger.",
+          "provisional": true
+        },
+        {
+          "feature_id": "model_registry_governance",
+          "competitor": "Patronus",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "model-governance-ledger"
+            },
+            {
+              "repo": "tritfabric"
+            }
+          ],
+          "rationale": "MLflow leads on mature registry; estate leads on governance ledger.",
+          "provisional": true
+        },
+        {
+          "feature_id": "model_registry_governance",
+          "competitor": "Arize",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "model-governance-ledger"
+            },
+            {
+              "repo": "tritfabric"
+            }
+          ],
+          "rationale": "MLflow leads on mature registry; estate leads on governance ledger.",
+          "provisional": true
+        },
+        {
+          "feature_id": "production_observability",
+          "competitor": "Weights & Biases",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Arize leads on production ML observability; estate has telemetry capture."
+        },
+        {
+          "feature_id": "production_observability",
+          "competitor": "MLflow",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Arize leads on production ML observability; estate has telemetry capture."
+        },
+        {
+          "feature_id": "production_observability",
+          "competitor": "Hugging Face",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Arize leads on production ML observability; estate has telemetry capture."
+        },
+        {
+          "feature_id": "production_observability",
+          "competitor": "Galileo",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Arize leads on production ML observability; estate has telemetry capture."
+        },
+        {
+          "feature_id": "production_observability",
+          "competitor": "Patronus",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Arize leads on production ML observability; estate has telemetry capture."
+        },
+        {
+          "feature_id": "production_observability",
+          "competitor": "Arize",
+          "verdict": "GAP",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Arize is purpose-built for production ML observability at scale."
+        }
+      ]
+    },
+    {
+      "category_id": "ai_governance",
+      "name": "AI governance / trust / epistemics",
+      "description": "Crown Truth-Engine, SILENT firewall, counter-test-gate, hygiene runtime (bias-passport/CTEST), truth=law x evidence, receipts-everywhere vs the AI-trust field.",
+      "competitors": [
+        "Credo AI",
+        "Robust Intelligence",
+        "Fiddler",
+        "Arize",
+        "Patronus"
+      ],
+      "litmus_features": [
+        {
+          "feature_id": "truth_engine",
+          "name": "Truth engine (law x evidence)",
+          "definition": "A truth model where a verdict = law applied to evidence, not model preference.",
+          "criteria": "BEAT = an explicit law x evidence truth contract driving verdicts."
+        },
+        {
+          "feature_id": "silent_firewall",
+          "name": "SILENT runtime firewall",
+          "definition": "A fail-closed runtime firewall that blocks silent-wrong / unsafe actions.",
+          "criteria": "BEAT = live fail-closed preflight firewall with degraded->warn handling."
+        },
+        {
+          "feature_id": "counter_test_gate",
+          "name": "Counter-test gate",
+          "definition": "A gate that requires a passing counter-test (attempt to disprove) before a claim ships.",
+          "criteria": "BEAT = sealed CountertestRun required to promote a claim."
+        },
+        {
+          "feature_id": "bias_calibration_passports",
+          "name": "Bias / calibration passports",
+          "definition": "Sealed bias and calibration passports emitted by a runtime hygiene layer.",
+          "criteria": "BEAT = sealed bias/calibration passports produced at runtime."
+        },
+        {
+          "feature_id": "receipts_everywhere",
+          "name": "Receipts everywhere",
+          "definition": "Every consequential action across the estate emits a hash-chained receipt.",
+          "criteria": "BEAT = SHA-256 proof-artifact receipts spanning agent/eval/graph/governance."
+        },
+        {
+          "feature_id": "external_certification",
+          "name": "External / third-party certification",
+          "definition": "Independent, third-party certification of governance controls.",
+          "criteria": "BEAT = externally certified controls; GAP = self-assessed only."
+        }
+      ],
+      "scores": [
+        {
+          "feature_id": "truth_engine",
+          "competitor": "Credo AI",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-truth"
+            },
+            {
+              "memory": "truth_law_evidence_contract"
+            }
+          ],
+          "rationale": "No vendor ships a law x evidence truth engine.",
+          "provisional": true
+        },
+        {
+          "feature_id": "truth_engine",
+          "competitor": "Robust Intelligence",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-truth"
+            },
+            {
+              "memory": "truth_law_evidence_contract"
+            }
+          ],
+          "rationale": "No vendor ships a law x evidence truth engine.",
+          "provisional": true
+        },
+        {
+          "feature_id": "truth_engine",
+          "competitor": "Fiddler",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-truth"
+            },
+            {
+              "memory": "truth_law_evidence_contract"
+            }
+          ],
+          "rationale": "No vendor ships a law x evidence truth engine.",
+          "provisional": true
+        },
+        {
+          "feature_id": "truth_engine",
+          "competitor": "Arize",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-truth"
+            },
+            {
+              "memory": "truth_law_evidence_contract"
+            }
+          ],
+          "rationale": "No vendor ships a law x evidence truth engine.",
+          "provisional": true
+        },
+        {
+          "feature_id": "truth_engine",
+          "competitor": "Patronus",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-truth"
+            },
+            {
+              "memory": "truth_law_evidence_contract"
+            }
+          ],
+          "rationale": "No vendor ships a law x evidence truth engine.",
+          "provisional": true
+        },
+        {
+          "feature_id": "silent_firewall",
+          "competitor": "Credo AI",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "guardrail-fabric",
+              "path": "tools/validate_preflight_handoff.py"
+            },
+            {
+              "repo": "guardrail-fabric",
+              "path": "docs/trustops-preflight-handoff.md"
+            }
+          ]
+        },
+        {
+          "feature_id": "silent_firewall",
+          "competitor": "Robust Intelligence",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "guardrail-fabric",
+              "path": "tools/validate_preflight_handoff.py"
+            },
+            {
+              "repo": "guardrail-fabric",
+              "path": "docs/trustops-preflight-handoff.md"
+            }
+          ]
+        },
+        {
+          "feature_id": "silent_firewall",
+          "competitor": "Fiddler",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "guardrail-fabric",
+              "path": "tools/validate_preflight_handoff.py"
+            },
+            {
+              "repo": "guardrail-fabric",
+              "path": "docs/trustops-preflight-handoff.md"
+            }
+          ]
+        },
+        {
+          "feature_id": "silent_firewall",
+          "competitor": "Arize",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "guardrail-fabric",
+              "path": "tools/validate_preflight_handoff.py"
+            },
+            {
+              "repo": "guardrail-fabric",
+              "path": "docs/trustops-preflight-handoff.md"
+            }
+          ]
+        },
+        {
+          "feature_id": "silent_firewall",
+          "competitor": "Patronus",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "guardrail-fabric",
+              "path": "tools/validate_preflight_handoff.py"
+            },
+            {
+              "repo": "guardrail-fabric",
+              "path": "docs/trustops-preflight-handoff.md"
+            }
+          ]
+        },
+        {
+          "feature_id": "counter_test_gate",
+          "competitor": "Credo AI",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "memory": "counter_test_gate"
+            },
+            {
+              "note": "epigov CountertestRun passport",
+              "path": "commit 559d19a"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "counter_test_gate",
+          "competitor": "Robust Intelligence",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "memory": "counter_test_gate"
+            },
+            {
+              "note": "epigov CountertestRun passport",
+              "path": "commit 559d19a"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "counter_test_gate",
+          "competitor": "Fiddler",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "memory": "counter_test_gate"
+            },
+            {
+              "note": "epigov CountertestRun passport",
+              "path": "commit 559d19a"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "counter_test_gate",
+          "competitor": "Arize",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "memory": "counter_test_gate"
+            },
+            {
+              "note": "epigov CountertestRun passport",
+              "path": "commit 559d19a"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "counter_test_gate",
+          "competitor": "Patronus",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "memory": "counter_test_gate"
+            },
+            {
+              "note": "epigov CountertestRun passport",
+              "path": "commit 559d19a"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "bias_calibration_passports",
+          "competitor": "Credo AI",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "note": "epigov hygiene runtime bias-passport/CTEST, sealed passports",
+              "path": "commit 559d19a"
+            },
+            {
+              "repo": "guardrail-fabric"
+            }
+          ]
+        },
+        {
+          "feature_id": "bias_calibration_passports",
+          "competitor": "Robust Intelligence",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "note": "epigov hygiene runtime bias-passport/CTEST, sealed passports",
+              "path": "commit 559d19a"
+            },
+            {
+              "repo": "guardrail-fabric"
+            }
+          ]
+        },
+        {
+          "feature_id": "bias_calibration_passports",
+          "competitor": "Fiddler",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "note": "epigov hygiene runtime bias-passport/CTEST, sealed passports",
+              "path": "commit 559d19a"
+            },
+            {
+              "repo": "guardrail-fabric"
+            }
+          ]
+        },
+        {
+          "feature_id": "bias_calibration_passports",
+          "competitor": "Arize",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "note": "epigov hygiene runtime bias-passport/CTEST, sealed passports",
+              "path": "commit 559d19a"
+            },
+            {
+              "repo": "guardrail-fabric"
+            }
+          ]
+        },
+        {
+          "feature_id": "bias_calibration_passports",
+          "competitor": "Patronus",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "note": "epigov hygiene runtime bias-passport/CTEST, sealed passports",
+              "path": "commit 559d19a"
+            },
+            {
+              "repo": "guardrail-fabric"
+            }
+          ]
+        },
+        {
+          "feature_id": "receipts_everywhere",
+          "competitor": "Credo AI",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "agentplane",
+              "pr": "327",
+              "note": "proof-artifact-spine"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/oais-deposition.schema.json",
+              "note": "SHA-256 fixity"
+            }
+          ]
+        },
+        {
+          "feature_id": "receipts_everywhere",
+          "competitor": "Robust Intelligence",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "agentplane",
+              "pr": "327",
+              "note": "proof-artifact-spine"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/oais-deposition.schema.json",
+              "note": "SHA-256 fixity"
+            }
+          ]
+        },
+        {
+          "feature_id": "receipts_everywhere",
+          "competitor": "Fiddler",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "agentplane",
+              "pr": "327",
+              "note": "proof-artifact-spine"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/oais-deposition.schema.json",
+              "note": "SHA-256 fixity"
+            }
+          ]
+        },
+        {
+          "feature_id": "receipts_everywhere",
+          "competitor": "Arize",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "agentplane",
+              "pr": "327",
+              "note": "proof-artifact-spine"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/oais-deposition.schema.json",
+              "note": "SHA-256 fixity"
+            }
+          ]
+        },
+        {
+          "feature_id": "receipts_everywhere",
+          "competitor": "Patronus",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "agentplane",
+              "pr": "327",
+              "note": "proof-artifact-spine"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/oais-deposition.schema.json",
+              "note": "SHA-256 fixity"
+            }
+          ]
+        },
+        {
+          "feature_id": "external_certification",
+          "competitor": "Credo AI",
+          "verdict": "GAP",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Credo AI is purpose-built for third-party governance certification."
+        },
+        {
+          "feature_id": "external_certification",
+          "competitor": "Robust Intelligence",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "All estate controls are self_assessed; Credo AI / Robust Intelligence lead on external audit/certification."
+        },
+        {
+          "feature_id": "external_certification",
+          "competitor": "Fiddler",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "All estate controls are self_assessed; Credo AI / Robust Intelligence lead on external audit/certification."
+        },
+        {
+          "feature_id": "external_certification",
+          "competitor": "Arize",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "All estate controls are self_assessed; Credo AI / Robust Intelligence lead on external audit/certification."
+        },
+        {
+          "feature_id": "external_certification",
+          "competitor": "Patronus",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "All estate controls are self_assessed; Credo AI / Robust Intelligence lead on external audit/certification."
+        }
+      ]
+    },
+    {
+      "category_id": "knowledge_graph",
+      "name": "Knowledge graph",
+      "description": "HellGraph (governed, receipted, federated graph substrate) vs mature graph databases.",
+      "competitors": [
+        "Neo4j",
+        "TigerGraph"
+      ],
+      "litmus_features": [
+        {
+          "feature_id": "graph_engine_maturity",
+          "name": "Graph engine maturity / scale",
+          "definition": "Distributed, production-hardened graph storage and query at scale.",
+          "criteria": "BEAT = billion-edge distributed engine; PARTIAL = emerging engine."
+        },
+        {
+          "feature_id": "governed_graph_receipts",
+          "name": "Governed, receipted graph ops",
+          "definition": "Graph mutations/queries that emit governance receipts and honor a contract.",
+          "criteria": "BEAT = receipted, contract-bound graph operations."
+        },
+        {
+          "feature_id": "federated_graph",
+          "name": "Federated graph",
+          "definition": "Federation of graphs across repos/domains under one query plane.",
+          "criteria": "BEAT = live federated query plane; MEET = federation contract."
+        },
+        {
+          "feature_id": "graphrag_native",
+          "name": "Native GraphRAG",
+          "definition": "First-class GraphRAG retrieval over the graph substrate.",
+          "criteria": "BEAT = grounded GraphRAG bound to the graph engine."
+        }
+      ],
+      "scores": [
+        {
+          "feature_id": "graph_engine_maturity",
+          "competitor": "Neo4j",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Neo4j/TigerGraph lead on mature distributed graph-DB engines."
+        },
+        {
+          "feature_id": "graph_engine_maturity",
+          "competitor": "TigerGraph",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Neo4j/TigerGraph lead on mature distributed graph-DB engines."
+        },
+        {
+          "feature_id": "governed_graph_receipts",
+          "competitor": "Neo4j",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "hellgraph"
+            },
+            {
+              "repo": "graphbrain-contract"
+            }
+          ],
+          "rationale": "Governed/receipted graph ops have no graph-DB-vendor equivalent.",
+          "provisional": true
+        },
+        {
+          "feature_id": "governed_graph_receipts",
+          "competitor": "TigerGraph",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "hellgraph"
+            },
+            {
+              "repo": "graphbrain-contract"
+            }
+          ],
+          "rationale": "Governed/receipted graph ops have no graph-DB-vendor equivalent.",
+          "provisional": true
+        },
+        {
+          "feature_id": "federated_graph",
+          "competitor": "Neo4j",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "hellgraph",
+              "memory": "hellgraph_federated"
+            },
+            {
+              "repo": "prophet-sheaf-hellgraph"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "federated_graph",
+          "competitor": "TigerGraph",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "hellgraph",
+              "memory": "hellgraph_federated"
+            },
+            {
+              "repo": "prophet-sheaf-hellgraph"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "graphrag_native",
+          "competitor": "Neo4j",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/graph-rag.ts"
+            },
+            {
+              "repo": "hellgraph"
+            }
+          ],
+          "rationale": "Estate leads on grounded GraphRAG; graph-DB vendors leave RAG to the app layer."
+        },
+        {
+          "feature_id": "graphrag_native",
+          "competitor": "TigerGraph",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "Noetica",
+              "path": "agent-machine/lib/graph-rag.ts"
+            },
+            {
+              "repo": "hellgraph"
+            }
+          ],
+          "rationale": "Estate leads on grounded GraphRAG; graph-DB vendors leave RAG to the app layer."
+        }
+      ]
+    },
+    {
+      "category_id": "ecosystem_marketplace",
+      "name": "Ecosystem / marketplace",
+      "description": "prophet-mesh + outcome-pricing (governed agent marketplace) vs the ecosystem field.",
+      "competitors": [
+        "LangChain / LangSmith",
+        "Hugging Face Hub",
+        "OpenAI GPT Store",
+        "AWS Bedrock Marketplace"
+      ],
+      "litmus_features": [
+        {
+          "feature_id": "outcome_pricing",
+          "name": "Outcome-based pricing",
+          "definition": "Pricing bound to delivered, receipted outcomes rather than tokens/seats.",
+          "criteria": "BEAT = an outcome-priced, receipt-verified transaction model."
+        },
+        {
+          "feature_id": "governed_agent_marketplace",
+          "name": "Governed agent marketplace",
+          "definition": "A marketplace where listings are gated by passport/governance, not just uploaded.",
+          "criteria": "BEAT = passport-gated marketplace; MEET/PARTIAL = curation without governance gates."
+        },
+        {
+          "feature_id": "ecosystem_scale",
+          "name": "Ecosystem scale / network effects",
+          "definition": "Breadth of third-party contributors, integrations and downloads.",
+          "criteria": "BEAT = large live ecosystem; GAP = pre-network-effect."
+        }
+      ],
+      "scores": [
+        {
+          "feature_id": "outcome_pricing",
+          "competitor": "LangChain / LangSmith",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-mesh"
+            },
+            {
+              "memory": "portfolio_agent_choice",
+              "note": "outcome-pricing thesis"
+            }
+          ],
+          "rationale": "Outcome pricing tied to receipts has no marketplace equivalent (frontier, not shipped).",
+          "provisional": true
+        },
+        {
+          "feature_id": "outcome_pricing",
+          "competitor": "Hugging Face Hub",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-mesh"
+            },
+            {
+              "memory": "portfolio_agent_choice",
+              "note": "outcome-pricing thesis"
+            }
+          ],
+          "rationale": "Outcome pricing tied to receipts has no marketplace equivalent (frontier, not shipped).",
+          "provisional": true
+        },
+        {
+          "feature_id": "outcome_pricing",
+          "competitor": "OpenAI GPT Store",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-mesh"
+            },
+            {
+              "memory": "portfolio_agent_choice",
+              "note": "outcome-pricing thesis"
+            }
+          ],
+          "rationale": "Outcome pricing tied to receipts has no marketplace equivalent (frontier, not shipped).",
+          "provisional": true
+        },
+        {
+          "feature_id": "outcome_pricing",
+          "competitor": "AWS Bedrock Marketplace",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-mesh"
+            },
+            {
+              "memory": "portfolio_agent_choice",
+              "note": "outcome-pricing thesis"
+            }
+          ],
+          "rationale": "Outcome pricing tied to receipts has no marketplace equivalent (frontier, not shipped).",
+          "provisional": true
+        },
+        {
+          "feature_id": "governed_agent_marketplace",
+          "competitor": "LangChain / LangSmith",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Estate has governance primitives; HF Hub / GPT Store lead on live marketplace scale."
+        },
+        {
+          "feature_id": "governed_agent_marketplace",
+          "competitor": "Hugging Face Hub",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Estate has governance primitives; HF Hub / GPT Store lead on live marketplace scale."
+        },
+        {
+          "feature_id": "governed_agent_marketplace",
+          "competitor": "OpenAI GPT Store",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Estate has governance primitives; HF Hub / GPT Store lead on live marketplace scale."
+        },
+        {
+          "feature_id": "governed_agent_marketplace",
+          "competitor": "AWS Bedrock Marketplace",
+          "verdict": "PARTIAL",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Estate has governance primitives; HF Hub / GPT Store lead on live marketplace scale."
+        },
+        {
+          "feature_id": "ecosystem_scale",
+          "competitor": "LangChain / LangSmith",
+          "verdict": "GAP",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "HF Hub / OpenAI / AWS have massive live ecosystems; estate is pre-network-effect."
+        },
+        {
+          "feature_id": "ecosystem_scale",
+          "competitor": "Hugging Face Hub",
+          "verdict": "GAP",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "HF Hub / OpenAI / AWS have massive live ecosystems; estate is pre-network-effect."
+        },
+        {
+          "feature_id": "ecosystem_scale",
+          "competitor": "OpenAI GPT Store",
+          "verdict": "GAP",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "HF Hub / OpenAI / AWS have massive live ecosystems; estate is pre-network-effect."
+        },
+        {
+          "feature_id": "ecosystem_scale",
+          "competitor": "AWS Bedrock Marketplace",
+          "verdict": "GAP",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "HF Hub / OpenAI / AWS have massive live ecosystems; estate is pre-network-effect."
+        }
+      ]
+    },
+    {
+      "category_id": "reproducibility",
+      "name": "Reproducibility",
+      "description": "RecipeProof / repro-ledger / OAIS deposition + benchmark-contract vs reproducibility bodies.",
+      "competitors": [
+        "MLCommons",
+        "Collective Knowledge (CK)",
+        "Zenodo"
+      ],
+      "litmus_features": [
+        {
+          "feature_id": "reproducible_run_contract",
+          "name": "Reproducible run contract",
+          "definition": "Environment/seed/methodology pinned so a run can be replayed deterministically.",
+          "criteria": "BEAT = recipe + repro-ledger + run-record enabling deterministic replay."
+        },
+        {
+          "feature_id": "preservation_deposition",
+          "name": "Preservation / deposition",
+          "definition": "Citable, fixity-checked archival deposition of artifacts.",
+          "criteria": "BEAT = OAIS AIP with SHA-256 fixity + OAI-PMH; PARTIAL vs a DOI-minting archive."
+        },
+        {
+          "feature_id": "benchmark_governance",
+          "name": "Benchmark submission governance",
+          "definition": "A validated submission contract governing what counts as a benchmark result.",
+          "criteria": "BEAT = submission validity gate + receipts; MEET vs an established standards body."
+        },
+        {
+          "feature_id": "external_recognition",
+          "name": "External recognition",
+          "definition": "Industry/community recognition of the reproducibility artifacts.",
+          "criteria": "BEAT = widely recognized; GAP = internal only."
+        }
+      ],
+      "scores": [
+        {
+          "feature_id": "reproducible_run_contract",
+          "competitor": "MLCommons",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/recipe-proof.schema.json"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/repro-ledger-entry.schema.json"
+            }
+          ]
+        },
+        {
+          "feature_id": "reproducible_run_contract",
+          "competitor": "Collective Knowledge (CK)",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/recipe-proof.schema.json"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/repro-ledger-entry.schema.json"
+            }
+          ]
+        },
+        {
+          "feature_id": "reproducible_run_contract",
+          "competitor": "Zenodo",
+          "verdict": "BEAT",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/recipe-proof.schema.json"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/repro-ledger-entry.schema.json"
+            }
+          ]
+        },
+        {
+          "feature_id": "preservation_deposition",
+          "competitor": "MLCommons",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/oais-deposition.schema.json"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "tools/oais_deposition.py",
+              "note": "SHA-256 fixity + OAI-PMH"
+            }
+          ]
+        },
+        {
+          "feature_id": "preservation_deposition",
+          "competitor": "Collective Knowledge (CK)",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/oais-deposition.schema.json"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "tools/oais_deposition.py",
+              "note": "SHA-256 fixity + OAI-PMH"
+            }
+          ]
+        },
+        {
+          "feature_id": "preservation_deposition",
+          "competitor": "Zenodo",
+          "verdict": "PARTIAL",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "Zenodo is a mature DOI-minting archive with global recognition."
+        },
+        {
+          "feature_id": "benchmark_governance",
+          "competitor": "MLCommons",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "tools/validate_submission.py"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/benchmark-contract.schema.json"
+            }
+          ],
+          "rationale": "MLCommons is the recognized standard; estate adds receipts + anti-laundering."
+        },
+        {
+          "feature_id": "benchmark_governance",
+          "competitor": "Collective Knowledge (CK)",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "tools/validate_submission.py"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/benchmark-contract.schema.json"
+            }
+          ],
+          "rationale": "MLCommons is the recognized standard; estate adds receipts + anti-laundering."
+        },
+        {
+          "feature_id": "benchmark_governance",
+          "competitor": "Zenodo",
+          "verdict": "MEET",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "prophet-platform",
+              "path": "tools/validate_submission.py"
+            },
+            {
+              "repo": "prophet-platform",
+              "path": "schemas/eval/benchmark-contract.schema.json"
+            }
+          ],
+          "rationale": "MLCommons is the recognized standard; estate adds receipts + anti-laundering."
+        },
+        {
+          "feature_id": "external_recognition",
+          "competitor": "MLCommons",
+          "verdict": "GAP",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "MLCommons/Zenodo are industry-recognized; estate artifacts are internal/self_assessed."
+        },
+        {
+          "feature_id": "external_recognition",
+          "competitor": "Collective Knowledge (CK)",
+          "verdict": "GAP",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "MLCommons/Zenodo are industry-recognized; estate artifacts are internal/self_assessed."
+        },
+        {
+          "feature_id": "external_recognition",
+          "competitor": "Zenodo",
+          "verdict": "GAP",
+          "maturity": "live",
+          "assessment_basis": "self_assessed",
+          "rationale": "MLCommons/Zenodo are industry-recognized; estate artifacts are internal/self_assessed."
+        }
+      ]
+    },
+    {
+      "category_id": "world_model_twin",
+      "name": "World-model / twin",
+      "description": "gaia value-flow world-model + Self<->Body<->Universe twin hierarchy (largely unique) vs the nearest digital-twin/ontology platforms.",
+      "competitors": [
+        "NVIDIA Omniverse",
+        "Palantir Foundry",
+        "Generic simulation vendors"
+      ],
+      "litmus_features": [
+        {
+          "feature_id": "value_flow_world_model",
+          "name": "Value-flow world model",
+          "definition": "A world model that propagates value over value x time, not just physical state.",
+          "criteria": "BEAT = an explicit value-flow world-model substrate."
+        },
+        {
+          "feature_id": "twin_hierarchy",
+          "name": "Self<->Body<->Universe twin hierarchy",
+          "definition": "A nested twin hierarchy spanning self, body and universe scales.",
+          "criteria": "BEAT = a live nested twin hierarchy; spec where surfaces are still fixtures."
+        },
+        {
+          "feature_id": "ontogenesis_binding",
+          "name": "Ontogenesis concept binding",
+          "definition": "New capabilities routed through ontogenesis and bound upward to the world-model/twin.",
+          "criteria": "BEAT = capabilities declare world-model/twin binding via ontogenesis."
+        }
+      ],
+      "scores": [
+        {
+          "feature_id": "value_flow_world_model",
+          "competitor": "NVIDIA Omniverse",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "gaia-world-model"
+            },
+            {
+              "memory": "galactic_twin_dashboard",
+              "note": "gaia value-flow"
+            }
+          ],
+          "rationale": "No competitor ships a value-flow world model (frontier, deliberate).",
+          "provisional": true
+        },
+        {
+          "feature_id": "value_flow_world_model",
+          "competitor": "Palantir Foundry",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "gaia-world-model"
+            },
+            {
+              "memory": "galactic_twin_dashboard",
+              "note": "gaia value-flow"
+            }
+          ],
+          "rationale": "No competitor ships a value-flow world model (frontier, deliberate).",
+          "provisional": true
+        },
+        {
+          "feature_id": "value_flow_world_model",
+          "competitor": "Generic simulation vendors",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "gaia-world-model"
+            },
+            {
+              "memory": "galactic_twin_dashboard",
+              "note": "gaia value-flow"
+            }
+          ],
+          "rationale": "No competitor ships a value-flow world model (frontier, deliberate).",
+          "provisional": true
+        },
+        {
+          "feature_id": "twin_hierarchy",
+          "competitor": "NVIDIA Omniverse",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "human-digital-twin"
+            },
+            {
+              "memory": "galactic_twin_dashboard",
+              "note": "Self<->Body<->Universe 5D cube"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "twin_hierarchy",
+          "competitor": "Palantir Foundry",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "human-digital-twin"
+            },
+            {
+              "memory": "galactic_twin_dashboard",
+              "note": "Self<->Body<->Universe 5D cube"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "twin_hierarchy",
+          "competitor": "Generic simulation vendors",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "human-digital-twin"
+            },
+            {
+              "memory": "galactic_twin_dashboard",
+              "note": "Self<->Body<->Universe 5D cube"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "ontogenesis_binding",
+          "competitor": "NVIDIA Omniverse",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "memory": "bind_upward_worldmodel_ontogenesis"
+            },
+            {
+              "memory": "ontogenesis_gi_unshaped_classes"
+            }
+          ],
+          "rationale": "Concept-governance binding upward is unique to the estate.",
+          "provisional": true
+        },
+        {
+          "feature_id": "ontogenesis_binding",
+          "competitor": "Palantir Foundry",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "memory": "bind_upward_worldmodel_ontogenesis"
+            },
+            {
+              "memory": "ontogenesis_gi_unshaped_classes"
+            }
+          ],
+          "rationale": "Concept-governance binding upward is unique to the estate.",
+          "provisional": true
+        },
+        {
+          "feature_id": "ontogenesis_binding",
+          "competitor": "Generic simulation vendors",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "memory": "bind_upward_worldmodel_ontogenesis"
+            },
+            {
+              "memory": "ontogenesis_gi_unshaped_classes"
+            }
+          ],
+          "rationale": "Concept-governance binding upward is unique to the estate.",
+          "provisional": true
+        }
+      ]
+    },
+    {
+      "category_id": "risk_value",
+      "name": "Risk / value",
+      "description": "omnirisk / Economic-Prophet financial spine (regime-aware calculus over value x time) vs quant/risk vendors.",
+      "competitors": [
+        "MSCI / Barra",
+        "Bloomberg (PORT/BQuant)",
+        "RiskMetrics",
+        "Palantir"
+      ],
+      "litmus_features": [
+        {
+          "feature_id": "regime_aware_calculus",
+          "name": "Regime-aware risk calculus",
+          "definition": "Risk calculus that is explicitly regime-aware (EP kernel + FTP + vol-surface + microstructure).",
+          "criteria": "BEAT = a regime-aware calculus over value x time."
+        },
+        {
+          "feature_id": "value_time_conservation",
+          "name": "Value x time / welfare conservation",
+          "definition": "A value-energy conservation model annealing toward global quality-of-life.",
+          "criteria": "BEAT = an explicit value-conservation / welfare-annealing model."
+        },
+        {
+          "feature_id": "receipted_risk",
+          "name": "Receipted risk outputs",
+          "definition": "Risk outputs carrying governance receipts / provenance.",
+          "criteria": "BEAT = receipted risk outputs; MEET = provenance parity."
+        },
+        {
+          "feature_id": "market_data_scale",
+          "name": "Market-data breadth + regulatory acceptance",
+          "definition": "Breadth of market data and regulatory/industry acceptance of the risk models.",
+          "criteria": "BEAT = broad data + regulatory acceptance; GAP = no such footprint."
+        }
+      ],
+      "scores": [
+        {
+          "feature_id": "regime_aware_calculus",
+          "competitor": "MSCI / Barra",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "economic-prophet"
+            },
+            {
+              "memory": "omnirisk_ep_financial_spine"
+            }
+          ],
+          "rationale": "Regime-aware value x time calculus is a frontier design (SPEC).",
+          "provisional": true
+        },
+        {
+          "feature_id": "regime_aware_calculus",
+          "competitor": "Bloomberg (PORT/BQuant)",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "economic-prophet"
+            },
+            {
+              "memory": "omnirisk_ep_financial_spine"
+            }
+          ],
+          "rationale": "Regime-aware value x time calculus is a frontier design (SPEC).",
+          "provisional": true
+        },
+        {
+          "feature_id": "regime_aware_calculus",
+          "competitor": "RiskMetrics",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "economic-prophet"
+            },
+            {
+              "memory": "omnirisk_ep_financial_spine"
+            }
+          ],
+          "rationale": "Regime-aware value x time calculus is a frontier design (SPEC).",
+          "provisional": true
+        },
+        {
+          "feature_id": "regime_aware_calculus",
+          "competitor": "Palantir",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "economic-prophet"
+            },
+            {
+              "memory": "omnirisk_ep_financial_spine"
+            }
+          ],
+          "rationale": "Regime-aware value x time calculus is a frontier design (SPEC).",
+          "provisional": true
+        },
+        {
+          "feature_id": "value_time_conservation",
+          "competitor": "MSCI / Barra",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "memory": "welfare_annealing_framework"
+            },
+            {
+              "repo": "economic-prophet"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "value_time_conservation",
+          "competitor": "Bloomberg (PORT/BQuant)",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "memory": "welfare_annealing_framework"
+            },
+            {
+              "repo": "economic-prophet"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "value_time_conservation",
+          "competitor": "RiskMetrics",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "memory": "welfare_annealing_framework"
+            },
+            {
+              "repo": "economic-prophet"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "value_time_conservation",
+          "competitor": "Palantir",
+          "verdict": "BEAT",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "memory": "welfare_annealing_framework"
+            },
+            {
+              "repo": "economic-prophet"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "receipted_risk",
+          "competitor": "MSCI / Barra",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "economic-prophet"
+            },
+            {
+              "repo": "agentplane",
+              "pr": "327",
+              "note": "proof-artifact-spine reusable"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "receipted_risk",
+          "competitor": "Bloomberg (PORT/BQuant)",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "economic-prophet"
+            },
+            {
+              "repo": "agentplane",
+              "pr": "327",
+              "note": "proof-artifact-spine reusable"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "receipted_risk",
+          "competitor": "RiskMetrics",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "economic-prophet"
+            },
+            {
+              "repo": "agentplane",
+              "pr": "327",
+              "note": "proof-artifact-spine reusable"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "receipted_risk",
+          "competitor": "Palantir",
+          "verdict": "MEET",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "evidence_ref": [
+            {
+              "repo": "economic-prophet"
+            },
+            {
+              "repo": "agentplane",
+              "pr": "327",
+              "note": "proof-artifact-spine reusable"
+            }
+          ],
+          "provisional": true
+        },
+        {
+          "feature_id": "market_data_scale",
+          "competitor": "MSCI / Barra",
+          "verdict": "GAP",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Bloomberg/MSCI have vast data and regulatory acceptance; estate has neither yet."
+        },
+        {
+          "feature_id": "market_data_scale",
+          "competitor": "Bloomberg (PORT/BQuant)",
+          "verdict": "GAP",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Bloomberg/MSCI have vast data and regulatory acceptance; estate has neither yet."
+        },
+        {
+          "feature_id": "market_data_scale",
+          "competitor": "RiskMetrics",
+          "verdict": "GAP",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Bloomberg/MSCI have vast data and regulatory acceptance; estate has neither yet."
+        },
+        {
+          "feature_id": "market_data_scale",
+          "competitor": "Palantir",
+          "verdict": "GAP",
+          "maturity": "spec",
+          "assessment_basis": "self_assessed",
+          "rationale": "Bloomberg/MSCI have vast data and regulatory acceptance; estate has neither yet."
+        }
+      ]
+    }
+  ]
+}

--- a/schemas/eval/intelligence-superiority-board.schema.json
+++ b/schemas/eval/intelligence-superiority-board.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schema://eval/intelligence-superiority-board.schema.json",
+  "title": "IntelligenceSuperiorityBoard",
+  "description": "Governed, receipted competitive-intelligence contract: the estate's Intelligence-Superiority feature-board. For every capability category it declares the top competitors, the litmus features that decide the category (each with a definition and pass criteria), and a scored estate-vs-each verdict (BEAT|MEET|PARTIAL|GAP) carrying its evidence, maturity (live|spec) and assessment_basis (self_assessed|externally_certified). This is the machine-readable dataset the cockpit boards render; validate_intelligence_superiority_board.py applies the teeth and seals it with a SHA-256 receipt.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["board_id", "title", "generated_ts", "spec_version", "categories"],
+  "properties": {
+    "board_id": {"type": "string", "minLength": 1},
+    "title": {"type": "string", "minLength": 1},
+    "generated_ts": {"type": "string", "format": "date-time"},
+    "spec_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "notes": {"type": "string"},
+    "categories": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/category"}
+    }
+  },
+  "$defs": {
+    "category": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["category_id", "name", "description", "competitors", "litmus_features", "scores"],
+      "properties": {
+        "category_id": {"type": "string", "pattern": "^[a-z0-9_]+$"},
+        "name": {"type": "string", "minLength": 1},
+        "description": {"type": "string", "minLength": 1},
+        "competitors": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "litmus_features": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/litmus_feature"}
+        },
+        "scores": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/score"}
+        }
+      }
+    },
+    "litmus_feature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["feature_id", "name", "definition", "criteria"],
+      "properties": {
+        "feature_id": {"type": "string", "pattern": "^[a-z0-9_]+$"},
+        "name": {"type": "string", "minLength": 1},
+        "definition": {"type": "string", "minLength": 1},
+        "criteria": {"type": "string", "minLength": 1}
+      }
+    },
+    "score": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["feature_id", "competitor", "verdict", "maturity", "assessment_basis"],
+      "properties": {
+        "feature_id": {"type": "string", "pattern": "^[a-z0-9_]+$"},
+        "competitor": {"type": "string", "minLength": 1},
+        "verdict": {"enum": ["BEAT", "MEET", "PARTIAL", "GAP"]},
+        "maturity": {"enum": ["live", "spec"]},
+        "assessment_basis": {"enum": ["self_assessed", "externally_certified"]},
+        "provisional": {"type": "boolean"},
+        "cert_ref": {"type": "string"},
+        "rationale": {"type": "string"},
+        "evidence_ref": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/evidence"}
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "A pointer to the estate artifact backing an estate claim. At least one of repo/path/pr/memory must be present; the validator enforces that a BEAT/MEET score carries a non-empty evidence_ref.",
+      "properties": {
+        "repo": {"type": "string"},
+        "path": {"type": "string"},
+        "pr": {"type": "string"},
+        "memory": {"type": "string"},
+        "note": {"type": "string"}
+      },
+      "anyOf": [
+        {"required": ["repo"]},
+        {"required": ["path"]},
+        {"required": ["pr"]},
+        {"required": ["memory"]}
+      ]
+    }
+  }
+}

--- a/tools/emit_intelligence_superiority_board.py
+++ b/tools/emit_intelligence_superiority_board.py
@@ -1,0 +1,600 @@
+#!/usr/bin/env python3
+"""emit_intelligence_superiority_board — build the canonical Intelligence-Superiority feature-board
+dataset (schemas/eval/examples/intelligence-superiority-board.json) that the cockpit boards render.
+
+"We can't beat what we haven't benchmarked." This is the competitive-intelligence contract: for every
+capability category it declares the top competitors, the litmus features that decide the category, and
+a scored estate-vs-each verdict (BEAT|MEET|PARTIAL|GAP) with evidence, maturity (live|spec) and
+assessment_basis. The dataset is emitted from a compact table (per-feature default verdict + explicit
+per-competitor overrides) so a lead is stated ONCE and only the cells that differ are broken out.
+
+Honesty discipline baked into emission:
+  * assessment_basis is self_assessed for every cell — none of these are externally certified, and the
+    schema/validator would REJECT an externally_certified cell without a cert_ref.
+  * a BEAT/MEET cell that is thin — maturity=='spec' OR fewer than 2 evidence pointers — is emitted with
+    provisional=true (the validator REJECTS a thin lead that forgets the flag). This is what keeps
+    "capable, not yet released (a deliberate choice)" honestly distinct from "battle-tested and live".
+  * evidence_ref points at real estate artifacts (repo / path / PR / memory node). PARTIAL/GAP cells
+    need no evidence — you don't have to prove you are behind.
+
+Every emitted board is run through validate_intelligence_superiority_board.validate_board BEFORE it is
+written; emission fails loudly if the board would not pass the gate.
+
+Run:  python3 tools/emit_intelligence_superiority_board.py [--out PATH] [--check]
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUT = ROOT / "schemas" / "eval" / "examples" / "intelligence-superiority-board.json"
+# Deterministic stamp — a re-emit must be byte-identical so the drift guard has meaning.
+GENERATED_TS = "2026-08-03T00:00:00Z"
+SPEC_VERSION = "1.0.0"
+MIN_EVIDENCE_REFS = 2
+
+
+def _load_validator():
+    path = ROOT / "tools" / "validate_intelligence_superiority_board.py"
+    spec = importlib.util.spec_from_file_location("is_board_validator", path)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    # dataclasses on 3.12 resolve cls.__module__ via sys.modules; the module must be
+    # registered before exec_module or that lookup returns None.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ─────────────────────────────────────────────────────────────────────────────────────────────
+# The compact scoring table. Each feature carries a `default` cell applied to every competitor,
+# plus `overrides` for the competitors whose cell differs. Evidence lives on the estate claim (the
+# default) and is inherited unless an override supplies its own.
+# ─────────────────────────────────────────────────────────────────────────────────────────────
+def _c(verdict, maturity, evidence=None, rationale=None):
+    cell: dict[str, Any] = {"verdict": verdict, "maturity": maturity}
+    if evidence:
+        cell["evidence_ref"] = evidence
+    if rationale:
+        cell["rationale"] = rationale
+    return cell
+
+
+CATEGORIES: list[dict[str, Any]] = [
+    # ── 1. RAG ─────────────────────────────────────────────────────────────────────────────────
+    {
+        "category_id": "rag",
+        "name": "Retrieval-Augmented Generation",
+        "description": "Noetica RAG (advanced-RAG family, receipt-gated inference, GraphRAG grounded answers, "
+                       "embedding-space governance, temporal retrieval) vs the productized RAG field.",
+        "competitors": ["Glean", "Perplexity", "Cohere", "Vectara", "Watson Discovery"],
+        "features": [
+            {"feature_id": "advanced_rag_breadth", "name": "Advanced-RAG pattern breadth",
+             "definition": "Number and composition of retrieval patterns fused in one governed harness.",
+             "criteria": "BEAT = >=8 fused patterns (HippoRAG/RAPTOR/HyDE/CRAG-gate/temporal) in a single live library.",
+             "default": _c("BEAT", "live",
+                           [{"repo": "Noetica", "path": "agent-machine/lib/retrieval.ts",
+                             "note": "817 LOC, 11 fused patterns incl. HippoRAG/RAPTOR/HyDE + CRAG gate + temporal"},
+                            {"memory": "competitive_intel_localrag", "note": "field CI: harness > model"}])},
+            {"feature_id": "inference_receipts", "name": "Replayable inference receipts",
+             "definition": "Per-turn, hash-chained, replayable evidence for every retrieved-and-generated answer.",
+             "criteria": "BEAT = open, SHA-256 hash-chained, replay-classed receipts on every turn.",
+             "default": _c("BEAT", "live",
+                           [{"repo": "Noetica", "path": "agent-machine/lib/reasoning-evidence.ts",
+                             "note": "SHA-256 hash-chain, replayClass, safe-trace"},
+                            {"repo": "Noetica", "path": "agent-machine/lib/connector-receipt.ts"},
+                            {"repo": "Noetica", "path": "agent-machine/server.ts", "note": "wiring @ ~4256"}],
+                           rationale="No competitor ships open replayable per-turn inference receipts.")},
+            {"feature_id": "embedding_governance", "name": "Embedding-space governance",
+             "definition": "Enforced embedding-dimension/space contract preventing silent index/query mismatch.",
+             "criteria": "BEAT = fail-closed EmbeddingSpaceMismatchError + dim pin + source-scan CI guard.",
+             "default": _c("BEAT", "live",
+                           [{"pr": "82", "note": "embedding-space pin"}, {"pr": "602"}, {"pr": "605",
+                             "note": "EmbeddingSpaceMismatchError, CORPUS_EMBED_DIM pin, embed-space-contract.test.ts, reindexIfDimMismatch"}])},
+            {"feature_id": "graph_rag_grounding", "name": "GraphRAG grounded answers",
+             "definition": "Graph-structured retrieval with per-claim grounding to a resolvable source reference.",
+             "criteria": "BEAT = MS-GraphRAG + per-claim grounding + fail-closed page-reference CI contract.",
+             "default": _c("BEAT", "live",
+                           [{"repo": "Noetica", "path": "agent-machine/lib/graph-rag.ts",
+                             "note": "MS GraphRAG + per-claim grounding + trust + DRIFT"},
+                            {"repo": "prophet-workspace", "pr": "103",
+                             "note": "grounded-answer-with-page-reference; graphrag-grounding.yml 32 checks; proof-artifact-spine sealed"}],
+                           rationale="Module + CI contract are live; live PageIndex->HellGraph binding is SPEC (fixtures).")},
+            {"feature_id": "hybrid_fusion", "name": "Hybrid dense/lexical/graph fusion",
+             "definition": "Reciprocal-rank fusion across dense, lexical (BM25) and graph retrieval.",
+             "criteria": "MEET = shipping BM25 + dense RRF; BEAT requires a decisive quality edge.",
+             "default": _c("MEET", "live",
+                           [{"repo": "Noetica", "path": "agent-machine/lib/hybrid-retrieve.ts", "note": "BM25 + dense RRF"},
+                            {"memory": "competitive_intel_localrag"}],
+                           rationale="Glean/Cohere/Vectara match on hybrid fusion.")},
+            {"feature_id": "verified_grounded_citations", "name": "Verified, resolvable citations",
+             "definition": "Citations that are verified against source (grounding score) and resolve to an exact locus.",
+             "criteria": "BEAT = verified + receipted + page-resolvable citation; MEET = strong UX parity.",
+             "default": _c("BEAT", "live",
+                           [{"repo": "Noetica", "path": "agent-machine/lib/research-verify.ts",
+                             "note": "verifyGrounding pass@0.7 + per-chunk file#idx"},
+                            {"repo": "prophet-workspace", "pr": "103", "note": "resolvable page_ref"}]),
+             "overrides": {"Perplexity": _c("MEET", "live",
+                           rationale="Perplexity leads on citation UX/scale; estate leads on verified+receipted+page-resolvable.")}},
+            {"feature_id": "reranking", "name": "Reranking quality",
+             "definition": "Precision of the reranker over the fused candidate set.",
+             "criteria": "BEAT = trained cross-encoder parity or better; PARTIAL = unsupervised RRF/MMR only.",
+             "default": _c("MEET", "live",
+                           [{"repo": "Noetica", "path": "agent-machine/lib/rerank-rrf.ts"},
+                            {"repo": "Noetica", "path": "agent-machine/lib/rag-rerank.ts", "note": "RRF + MMR, unsupervised"}]),
+             "overrides": {"Cohere": _c("PARTIAL", "live",
+                           rationale="Cohere Rerank (trained cross-encoder) LEADS on pure relevance; estate rerank is unsupervised.")}},
+            {"feature_id": "hallucination_control", "name": "Hallucination control",
+             "definition": "Defenses that suppress unsupported generations (poisoned-RAG, self-consistency, grounding checks).",
+             "criteria": "BEAT = layered deterministic defense breadth; PARTIAL where a trained detector leads one axis.",
+             "default": _c("BEAT", "live",
+                           [{"repo": "Noetica", "path": "agent-machine/lib/rag-trust.ts", "note": "PoisonedRAG defense"},
+                            {"repo": "Noetica", "path": "agent-machine/lib/research-verify.ts", "note": "verifyGrounding + crag-gate self-consistency"}]),
+             "overrides": {"Vectara": _c("PARTIAL", "live",
+                           rationale="Vectara HHEM (trained hallucination model) LEADS on that single axis; estate leads on breadth.")}},
+            {"feature_id": "contextual_retrieval_fusion", "name": "Contextual retrieval + RAG-Fusion",
+             "definition": "Contextual-chunk retrieval and query-variant RAG-Fusion.",
+             "criteria": "BEAT = merged, tested contextual retrieval + RAG-Fusion; live requires ingest/query wiring.",
+             "default": _c("BEAT", "spec",
+                           [{"pr": "607", "note": "contextual-retrieval: merged + tested, NOT wired into live ingest/query"},
+                            {"pr": "604", "note": "query-variant RAG-Fusion: merged + tested, not live-wired"}],
+                           rationale="Built and tested; not yet wired into the live ingest/query path.")},
+            {"feature_id": "temporal_retrieval", "name": "Temporal retrieval correctness",
+             "definition": "Retrieval filtered/validated by temporal validity of facts.",
+             "criteria": "BEAT = general temporal-KG validity model; PARTIAL = scoped recency filter only.",
+             "default": _c("PARTIAL", "live",
+                           rationale="Live 7-day SPARQL FILTER (recent-messages scoped) only, not a general temporal-KG validity model.")},
+            {"feature_id": "retrieval_scale", "name": "Retrieval quality at scale",
+             "definition": "Retrieval quality sustained at billion-document corpora.",
+             "criteria": "BEAT = proven billion-doc scale; PARTIAL/GAP = workspace-scale in-memory scans.",
+             "default": _c("PARTIAL", "live",
+                           rationale="In-memory g.allNodes() scans = workspace-scale."),
+             "overrides": {"Glean": _c("GAP", "live", rationale="Glean proven at enterprise/billion-doc scale."),
+                           "Vectara": _c("GAP", "live"), "Watson Discovery": _c("GAP", "live")}},
+            {"feature_id": "connector_breadth", "name": "Connector breadth + permission sync",
+             "definition": "Breadth of source connectors with document-level permission synchronization.",
+             "criteria": "BEAT = 100+ connectors with permission-sync; PARTIAL = open audited connectors, fewer.",
+             "default": _c("PARTIAL", "live",
+                           rationale="connector-receipt.ts gives open audited connectors; Glean leads on 100+ connectors with permission-sync.")},
+        ],
+    },
+    # ── 2. Agent framework ──────────────────────────────────────────────────────────────────────
+    {
+        "category_id": "agent_framework",
+        "name": "Agent framework",
+        "description": "prophet-mesh / superconscious / AgentPassport + agent ontology + zero-trust A2A, "
+                       "ControlNode/ControlLoop, Crown, agentplane governed runner, memory-mesh vs the agent-framework field.",
+        "competitors": ["LangGraph", "CrewAI", "AutoGen", "MS Agent Framework", "Devin", "Dust"],
+        "features": [
+            {"feature_id": "governance_policy_gating", "name": "Governance / policy gating",
+             "definition": "Constitutional gates that can refuse an agent action (separation-of-powers invariants).",
+             "criteria": "BEAT = merged constitution + judge/objective gates that fail closed on unconstitutional acts.",
+             "default": _c("BEAT", "live",
+                           [{"repo": "hellgraph", "pr": "52", "note": "Crown constitution ADR-0004, MERGED to main"},
+                            {"repo": "ProCybernetica", "pr": "124",
+                             "note": "ControlNode + ADR-0003; 7 teeth incl. NO_VALUE_JUDGMENT_GATE / JUDGE_DENIED_BUT_FIRED / UNCONSTITUTIONAL_OBJECTIVE_CROWN_K1"},
+                            {"repo": "ProCybernetica", "pr": "126", "note": "agentic-execution class"}],
+                           rationale="Crown + ControlNode merged (live); the ControlLoop remediation itself is measurement/design only (SPEC).")},
+            {"feature_id": "agent_identity_passport", "name": "Agent identity / passport",
+             "definition": "OS-process-level agent classification and fail-closed authorization.",
+             "criteria": "BEAT = OS-process->authority binding with live fail-closed authorize gate.",
+             "default": _c("BEAT", "live",
+                           [{"repo": "sourceos-spec", "path": "AgentPassport.json", "note": "5-class, T0-1, OS-process level"},
+                            {"repo": "mcp-a2a-zero-trust", "pr": "18", "note": "trust-tiers"},
+                            {"repo": "agent-registry", "pr": "50", "note": "live fail-closed authorize.py"}],
+                           rationale="Unique: OS-process-level agent classification.")},
+            {"feature_id": "receipts_auditability", "name": "Receipts / auditability",
+             "definition": "Hash-chained, deterministically-replayable proof artifacts for agent runs.",
+             "criteria": "BEAT = SHA-256 proof-artifact spine + deterministic replay + sealed hygiene passports.",
+             "default": _c("BEAT", "live",
+                           [{"repo": "agentplane", "pr": "327", "note": "proof-artifact-spine SHA-256 hash-chained + deterministic replay (327 commits)"},
+                            {"note": "epigov hygiene runtime: sealed CountertestRun/Bias/Calibration passports", "path": "commit 559d19a"}],
+                           rationale="Strongest lead in the category.")},
+            {"feature_id": "standards_conformance", "name": "Standards conformance",
+             "definition": "Coverage of open agent-interop standards under a zero-trust profile.",
+             "criteria": "BEAT = HUA/AG-UI/A2A/MCP/ANP zero-trust stack + published agent-standard profiles.",
+             "default": _c("BEAT", "live",
+                           [{"repo": "ProCybernetica", "pr": "126", "note": "agentic-execution-class"},
+                            {"repo": "socioprophet-agent-standards", "note": "HUA/AG-UI/A2A/MCP/ANP zero-trust profiles"}])},
+            {"feature_id": "os_workspace_native", "name": "OS / workspace-native",
+             "definition": "Agents bound to OS-process authority within a sovereign workspace/OS layer.",
+             "criteria": "BEAT = SourceOS + AgentPassport OS-process->authority binding.",
+             "default": _c("BEAT", "live",
+                           [{"repo": "SourceOS", "note": "OS layer"},
+                            {"repo": "sourceos-spec", "path": "AgentPassport.json", "note": "OS-process->authority binding"}],
+                           rationale="agentic-os-api is a read-only seed (PARTIAL-live).")},
+            {"feature_id": "self_maintenance_contract", "name": "Self-maintenance contract",
+             "definition": "A closed sense->model->judge->act->receipt control loop for self-maintenance.",
+             "criteria": "BEAT = specified closed-loop contract; live requires shipping runtime remediation.",
+             "default": _c("BEAT", "spec",
+                           [{"repo": "ProCybernetica", "pr": "124", "note": "ControlLoop ADR-0003: sense->model->judge->act->receipt"}],
+                           rationale="No runtime remediation ships yet (SPEC).")},
+            {"feature_id": "multi_agent_orchestration", "name": "Multi-agent orchestration",
+             "definition": "Coordinating multiple role-specialized agents toward a shared objective.",
+             "criteria": "MEET = conductor + role choir + A2A coordination; BEAT requires a live edge.",
+             "default": _c("MEET", "spec",
+                           [{"repo": "prophet-mesh", "note": "conductor + 10-role choir"},
+                            {"repo": "ProCybernetica", "note": "A2A inter-agent-coordination exec class; dry-run/validators = SPEC"}],
+                           rationale="Estate coordination is dry-run/validator level."),
+             "overrides": {"CrewAI": _c("PARTIAL", "spec", rationale="CrewAI leads on live multi-agent loops."),
+                           "AutoGen": _c("PARTIAL", "spec", rationale="AutoGen leads on live multi-agent loops.")}},
+            {"feature_id": "memory_governed", "name": "Governed agent memory",
+             "definition": "Multi-type agent memory with regime characterization and governed writeback.",
+             "criteria": "BEAT = FSMS multi-type memory + regime characterizer + governed writeback; MEET = raw recall parity.",
+             "default": _c("MEET", "live",
+                           [{"repo": "memory-mesh", "note": "FSMS 6-type + regime characterizer + governed writeback (memoryd)"},
+                            {"repo": "memory-mesh", "pr": "47"}, {"repo": "memory-mesh", "pr": "50"}],
+                           rationale="Estate leads on GOVERNED writeback/regime; at parity on raw recall.")},
+            {"feature_id": "orchestration_runtime", "name": "Live orchestration runtime",
+             "definition": "A production graph/runtime that actually executes multi-step agent flows.",
+             "criteria": "BEAT = live executing graph; PARTIAL = deterministic dry-run router only.",
+             "default": _c("PARTIAL", "spec",
+                           rationale="prophet-mesh router is deterministic dry-run only; LangGraph/AutoGen/CrewAI ship live graphs.")},
+            {"feature_id": "autonomous_execution", "name": "Autonomous execution",
+             "definition": "End-to-end autonomous task execution (e.g. autonomous coding).",
+             "criteria": "BEAT = executes autonomous runs; GAP = contract carrier that does not execute.",
+             "default": _c("GAP", "spec",
+                           rationale="GovernedRunContract does not execute a run (v0 carrier + fixtures)."),
+             "overrides": {"Devin": _c("GAP", "spec", rationale="Devin executes autonomous coding; estate does not execute runs yet.")}},
+        ],
+    },
+    # ── 3. Model lab + eval ─────────────────────────────────────────────────────────────────────
+    {
+        "category_id": "model_lab_eval",
+        "name": "Model lab + evaluation",
+        "description": "tritfabric, lattice-forge/studio, model-plane T7, receipt-gateway/InferenceReceipts, "
+                       "reproduce-bench/RecipeProof vs the ML experiment/eval field.",
+        "competitors": ["Weights & Biases", "MLflow", "Hugging Face", "Galileo", "Patronus", "Arize"],
+        "features": [
+            {"feature_id": "experiment_tracking", "name": "Experiment tracking",
+             "definition": "Tracking runs, params, artifacts and comparisons across model experiments.",
+             "criteria": "BEAT = mature tracking UX + governance; PARTIAL = emerging tracking surface.",
+             "default": _c("PARTIAL", "live",
+                           rationale="W&B/MLflow lead on mature tracking UX; lattice-studio leaderboard is the emerging estate surface.")},
+            {"feature_id": "receipted_eval", "name": "Receipt-gated evaluation",
+             "definition": "Every eval/inference result carries a sealed, hash-chained receipt.",
+             "criteria": "BEAT = per-call SHA-256 hash-chained InferenceReceipts + trust-class provenance.",
+             "default": _c("BEAT", "live",
+                           [{"repo": "prophet-platform", "path": "apps/receipt-gateway", "note": "hash-chained InferenceReceipts per call, SEAM-011"},
+                            {"repo": "prophet-platform", "path": "schemas/eval/metric-fact.schema.json",
+                             "note": "source_trust_class + reproduced_by_us provenance on every fact"}],
+                           rationale="Competitors do not seal per-call inference receipts.")},
+            {"feature_id": "reproducibility_recipeproof", "name": "RecipeProof reproducibility",
+             "definition": "Deterministic, environment-pinned replay of an eval run from a recipe.",
+             "criteria": "BEAT = recipe + repro-ledger + reproduce-run-record enabling deterministic replay.",
+             "default": _c("BEAT", "live",
+                           [{"repo": "prophet-platform", "path": "schemas/eval/repro-ledger-entry.schema.json"},
+                            {"repo": "prophet-platform", "path": "schemas/eval/reproduce-run-record.schema.json"}])},
+            {"feature_id": "honesty_no_laundering", "name": "Anti-laundering honesty gate",
+             "definition": "Structural prevention of citing a number as if it were reproduced by us.",
+             "criteria": "BEAT = disjoint reproduced-vs-cited facts + a no_laundering submission gate.",
+             "default": _c("BEAT", "live",
+                           [{"repo": "prophet-platform", "path": "tools/validate_submission.py", "note": "no_laundering gate"},
+                            {"repo": "prophet-platform", "path": "schemas/eval/division-rules.json"}],
+                           rationale="Structural anti-laundering has no vendor equivalent.")},
+            {"feature_id": "llm_eval_guardrails", "name": "LLM eval + guardrails",
+             "definition": "Productized LLM output evaluation and guardrailing (safety/quality scorers).",
+             "criteria": "BEAT = broad governed scorers; PARTIAL where a vendor leads productization.",
+             "default": _c("MEET", "spec",
+                           [{"repo": "guardrail-fabric", "note": "runtime guardrails"},
+                            {"memory": "counter_test_gate", "note": "counter-test gate"}]),
+             "overrides": {"Galileo": _c("PARTIAL", "spec", rationale="Galileo leads on productized LLM eval."),
+                           "Patronus": _c("PARTIAL", "spec", rationale="Patronus leads on productized LLM eval.")}},
+            {"feature_id": "model_registry_governance", "name": "Governed model registry",
+             "definition": "Model registry with governance ledger over promotions/lineage.",
+             "criteria": "BEAT = registry + governance ledger; MEET = registry parity.",
+             "default": _c("MEET", "spec",
+                           [{"repo": "model-governance-ledger"}, {"repo": "tritfabric"}],
+                           rationale="MLflow leads on mature registry; estate leads on governance ledger.")},
+            {"feature_id": "production_observability", "name": "Production ML observability",
+             "definition": "Live monitoring of model quality/drift in production.",
+             "criteria": "BEAT = mature drift/quality monitoring; PARTIAL = telemetry capture only.",
+             "default": _c("PARTIAL", "spec",
+                           rationale="Arize leads on production ML observability; estate has telemetry capture."),
+             "overrides": {"Arize": _c("GAP", "spec", rationale="Arize is purpose-built for production ML observability at scale.")}},
+        ],
+    },
+    # ── 4. AI governance / trust / epistemics ───────────────────────────────────────────────────
+    {
+        "category_id": "ai_governance",
+        "name": "AI governance / trust / epistemics",
+        "description": "Crown Truth-Engine, SILENT firewall, counter-test-gate, hygiene runtime "
+                       "(bias-passport/CTEST), truth=law x evidence, receipts-everywhere vs the AI-trust field.",
+        "competitors": ["Credo AI", "Robust Intelligence", "Fiddler", "Arize", "Patronus"],
+        "features": [
+            {"feature_id": "truth_engine", "name": "Truth engine (law x evidence)",
+             "definition": "A truth model where a verdict = law applied to evidence, not model preference.",
+             "criteria": "BEAT = an explicit law x evidence truth contract driving verdicts.",
+             "default": _c("BEAT", "spec",
+                           [{"repo": "prophet-truth"}, {"memory": "truth_law_evidence_contract"}],
+                           rationale="No vendor ships a law x evidence truth engine.")},
+            {"feature_id": "silent_firewall", "name": "SILENT runtime firewall",
+             "definition": "A fail-closed runtime firewall that blocks silent-wrong / unsafe actions.",
+             "criteria": "BEAT = live fail-closed preflight firewall with degraded->warn handling.",
+             "default": _c("BEAT", "live",
+                           [{"repo": "guardrail-fabric", "path": "tools/validate_preflight_handoff.py"},
+                            {"repo": "guardrail-fabric", "path": "docs/trustops-preflight-handoff.md"}])},
+            {"feature_id": "counter_test_gate", "name": "Counter-test gate",
+             "definition": "A gate that requires a passing counter-test (attempt to disprove) before a claim ships.",
+             "criteria": "BEAT = sealed CountertestRun required to promote a claim.",
+             "default": _c("BEAT", "spec",
+                           [{"memory": "counter_test_gate"},
+                            {"note": "epigov CountertestRun passport", "path": "commit 559d19a"}])},
+            {"feature_id": "bias_calibration_passports", "name": "Bias / calibration passports",
+             "definition": "Sealed bias and calibration passports emitted by a runtime hygiene layer.",
+             "criteria": "BEAT = sealed bias/calibration passports produced at runtime.",
+             "default": _c("BEAT", "live",
+                           [{"note": "epigov hygiene runtime bias-passport/CTEST, sealed passports", "path": "commit 559d19a"},
+                            {"repo": "guardrail-fabric"}])},
+            {"feature_id": "receipts_everywhere", "name": "Receipts everywhere",
+             "definition": "Every consequential action across the estate emits a hash-chained receipt.",
+             "criteria": "BEAT = SHA-256 proof-artifact receipts spanning agent/eval/graph/governance.",
+             "default": _c("BEAT", "live",
+                           [{"repo": "agentplane", "pr": "327", "note": "proof-artifact-spine"},
+                            {"repo": "prophet-platform", "path": "schemas/eval/oais-deposition.schema.json", "note": "SHA-256 fixity"}])},
+            {"feature_id": "external_certification", "name": "External / third-party certification",
+             "definition": "Independent, third-party certification of governance controls.",
+             "criteria": "BEAT = externally certified controls; GAP = self-assessed only.",
+             "default": _c("PARTIAL", "spec",
+                           rationale="All estate controls are self_assessed; Credo AI / Robust Intelligence lead on external audit/certification."),
+             "overrides": {"Credo AI": _c("GAP", "spec", rationale="Credo AI is purpose-built for third-party governance certification.")}},
+        ],
+    },
+    # ── 5. Knowledge graph ──────────────────────────────────────────────────────────────────────
+    {
+        "category_id": "knowledge_graph",
+        "name": "Knowledge graph",
+        "description": "HellGraph (governed, receipted, federated graph substrate) vs mature graph databases.",
+        "competitors": ["Neo4j", "TigerGraph"],
+        "features": [
+            {"feature_id": "graph_engine_maturity", "name": "Graph engine maturity / scale",
+             "definition": "Distributed, production-hardened graph storage and query at scale.",
+             "criteria": "BEAT = billion-edge distributed engine; PARTIAL = emerging engine.",
+             "default": _c("PARTIAL", "spec",
+                           rationale="Neo4j/TigerGraph lead on mature distributed graph-DB engines.")},
+            {"feature_id": "governed_graph_receipts", "name": "Governed, receipted graph ops",
+             "definition": "Graph mutations/queries that emit governance receipts and honor a contract.",
+             "criteria": "BEAT = receipted, contract-bound graph operations.",
+             "default": _c("BEAT", "spec",
+                           [{"repo": "hellgraph"}, {"repo": "graphbrain-contract"}],
+                           rationale="Governed/receipted graph ops have no graph-DB-vendor equivalent.")},
+            {"feature_id": "federated_graph", "name": "Federated graph",
+             "definition": "Federation of graphs across repos/domains under one query plane.",
+             "criteria": "BEAT = live federated query plane; MEET = federation contract.",
+             "default": _c("MEET", "spec",
+                           [{"repo": "hellgraph", "memory": "hellgraph_federated"},
+                            {"repo": "prophet-sheaf-hellgraph"}])},
+            {"feature_id": "graphrag_native", "name": "Native GraphRAG",
+             "definition": "First-class GraphRAG retrieval over the graph substrate.",
+             "criteria": "BEAT = grounded GraphRAG bound to the graph engine.",
+             "default": _c("MEET", "live",
+                           [{"repo": "Noetica", "path": "agent-machine/lib/graph-rag.ts"},
+                            {"repo": "hellgraph"}],
+                           rationale="Estate leads on grounded GraphRAG; graph-DB vendors leave RAG to the app layer.")},
+        ],
+    },
+    # ── 6. Ecosystem / marketplace ──────────────────────────────────────────────────────────────
+    {
+        "category_id": "ecosystem_marketplace",
+        "name": "Ecosystem / marketplace",
+        "description": "prophet-mesh + outcome-pricing (governed agent marketplace) vs the ecosystem field.",
+        "competitors": ["LangChain / LangSmith", "Hugging Face Hub", "OpenAI GPT Store", "AWS Bedrock Marketplace"],
+        "features": [
+            {"feature_id": "outcome_pricing", "name": "Outcome-based pricing",
+             "definition": "Pricing bound to delivered, receipted outcomes rather than tokens/seats.",
+             "criteria": "BEAT = an outcome-priced, receipt-verified transaction model.",
+             "default": _c("BEAT", "spec",
+                           [{"repo": "prophet-mesh"}, {"memory": "portfolio_agent_choice", "note": "outcome-pricing thesis"}],
+                           rationale="Outcome pricing tied to receipts has no marketplace equivalent (frontier, not shipped).")},
+            {"feature_id": "governed_agent_marketplace", "name": "Governed agent marketplace",
+             "definition": "A marketplace where listings are gated by passport/governance, not just uploaded.",
+             "criteria": "BEAT = passport-gated marketplace; MEET/PARTIAL = curation without governance gates.",
+             "default": _c("PARTIAL", "spec",
+                           [{"repo": "prophet-mesh"}, {"repo": "agent-registry"}],
+                           rationale="Estate has governance primitives; HF Hub / GPT Store lead on live marketplace scale.")},
+            {"feature_id": "ecosystem_scale", "name": "Ecosystem scale / network effects",
+             "definition": "Breadth of third-party contributors, integrations and downloads.",
+             "criteria": "BEAT = large live ecosystem; GAP = pre-network-effect.",
+             "default": _c("GAP", "spec",
+                           rationale="HF Hub / OpenAI / AWS have massive live ecosystems; estate is pre-network-effect.")},
+        ],
+    },
+    # ── 7. Reproducibility ──────────────────────────────────────────────────────────────────────
+    {
+        "category_id": "reproducibility",
+        "name": "Reproducibility",
+        "description": "RecipeProof / repro-ledger / OAIS deposition + benchmark-contract vs reproducibility bodies.",
+        "competitors": ["MLCommons", "Collective Knowledge (CK)", "Zenodo"],
+        "features": [
+            {"feature_id": "reproducible_run_contract", "name": "Reproducible run contract",
+             "definition": "Environment/seed/methodology pinned so a run can be replayed deterministically.",
+             "criteria": "BEAT = recipe + repro-ledger + run-record enabling deterministic replay.",
+             "default": _c("BEAT", "live",
+                           [{"repo": "prophet-platform", "path": "schemas/eval/recipe-proof.schema.json"},
+                            {"repo": "prophet-platform", "path": "schemas/eval/repro-ledger-entry.schema.json"}])},
+            {"feature_id": "preservation_deposition", "name": "Preservation / deposition",
+             "definition": "Citable, fixity-checked archival deposition of artifacts.",
+             "criteria": "BEAT = OAIS AIP with SHA-256 fixity + OAI-PMH; PARTIAL vs a DOI-minting archive.",
+             "default": _c("MEET", "live",
+                           [{"repo": "prophet-platform", "path": "schemas/eval/oais-deposition.schema.json"},
+                            {"repo": "prophet-platform", "path": "tools/oais_deposition.py", "note": "SHA-256 fixity + OAI-PMH"}]),
+             "overrides": {"Zenodo": _c("PARTIAL", "live", rationale="Zenodo is a mature DOI-minting archive with global recognition.")}},
+            {"feature_id": "benchmark_governance", "name": "Benchmark submission governance",
+             "definition": "A validated submission contract governing what counts as a benchmark result.",
+             "criteria": "BEAT = submission validity gate + receipts; MEET vs an established standards body.",
+             "default": _c("MEET", "live",
+                           [{"repo": "prophet-platform", "path": "tools/validate_submission.py"},
+                            {"repo": "prophet-platform", "path": "schemas/eval/benchmark-contract.schema.json"}],
+                           rationale="MLCommons is the recognized standard; estate adds receipts + anti-laundering.")},
+            {"feature_id": "external_recognition", "name": "External recognition",
+             "definition": "Industry/community recognition of the reproducibility artifacts.",
+             "criteria": "BEAT = widely recognized; GAP = internal only.",
+             "default": _c("GAP", "live",
+                           rationale="MLCommons/Zenodo are industry-recognized; estate artifacts are internal/self_assessed.")},
+        ],
+    },
+    # ── 8. World-model / twin ───────────────────────────────────────────────────────────────────
+    {
+        "category_id": "world_model_twin",
+        "name": "World-model / twin",
+        "description": "gaia value-flow world-model + Self<->Body<->Universe twin hierarchy (largely unique) "
+                       "vs the nearest digital-twin/ontology platforms.",
+        "competitors": ["NVIDIA Omniverse", "Palantir Foundry", "Generic simulation vendors"],
+        "features": [
+            {"feature_id": "value_flow_world_model", "name": "Value-flow world model",
+             "definition": "A world model that propagates value over value x time, not just physical state.",
+             "criteria": "BEAT = an explicit value-flow world-model substrate.",
+             "default": _c("BEAT", "spec",
+                           [{"repo": "gaia-world-model"}, {"memory": "galactic_twin_dashboard", "note": "gaia value-flow"}],
+                           rationale="No competitor ships a value-flow world model (frontier, deliberate).")},
+            {"feature_id": "twin_hierarchy", "name": "Self<->Body<->Universe twin hierarchy",
+             "definition": "A nested twin hierarchy spanning self, body and universe scales.",
+             "criteria": "BEAT = a live nested twin hierarchy; spec where surfaces are still fixtures.",
+             "default": _c("BEAT", "spec",
+                           [{"repo": "human-digital-twin"},
+                            {"memory": "galactic_twin_dashboard", "note": "Self<->Body<->Universe 5D cube"}])},
+            {"feature_id": "ontogenesis_binding", "name": "Ontogenesis concept binding",
+             "definition": "New capabilities routed through ontogenesis and bound upward to the world-model/twin.",
+             "criteria": "BEAT = capabilities declare world-model/twin binding via ontogenesis.",
+             "default": _c("BEAT", "spec",
+                           [{"memory": "bind_upward_worldmodel_ontogenesis"},
+                            {"memory": "ontogenesis_gi_unshaped_classes"}],
+                           rationale="Concept-governance binding upward is unique to the estate.")},
+        ],
+    },
+    # ── 9. Risk / value ─────────────────────────────────────────────────────────────────────────
+    {
+        "category_id": "risk_value",
+        "name": "Risk / value",
+        "description": "omnirisk / Economic-Prophet financial spine (regime-aware calculus over value x time) "
+                       "vs quant/risk vendors.",
+        "competitors": ["MSCI / Barra", "Bloomberg (PORT/BQuant)", "RiskMetrics", "Palantir"],
+        "features": [
+            {"feature_id": "regime_aware_calculus", "name": "Regime-aware risk calculus",
+             "definition": "Risk calculus that is explicitly regime-aware (EP kernel + FTP + vol-surface + microstructure).",
+             "criteria": "BEAT = a regime-aware calculus over value x time.",
+             "default": _c("BEAT", "spec",
+                           [{"repo": "economic-prophet"}, {"memory": "omnirisk_ep_financial_spine"}],
+                           rationale="Regime-aware value x time calculus is a frontier design (SPEC).")},
+            {"feature_id": "value_time_conservation", "name": "Value x time / welfare conservation",
+             "definition": "A value-energy conservation model annealing toward global quality-of-life.",
+             "criteria": "BEAT = an explicit value-conservation / welfare-annealing model.",
+             "default": _c("BEAT", "spec",
+                           [{"memory": "welfare_annealing_framework"}, {"repo": "economic-prophet"}])},
+            {"feature_id": "receipted_risk", "name": "Receipted risk outputs",
+             "definition": "Risk outputs carrying governance receipts / provenance.",
+             "criteria": "BEAT = receipted risk outputs; MEET = provenance parity.",
+             "default": _c("MEET", "spec",
+                           [{"repo": "economic-prophet"}, {"repo": "agentplane", "pr": "327", "note": "proof-artifact-spine reusable"}])},
+            {"feature_id": "market_data_scale", "name": "Market-data breadth + regulatory acceptance",
+             "definition": "Breadth of market data and regulatory/industry acceptance of the risk models.",
+             "criteria": "BEAT = broad data + regulatory acceptance; GAP = no such footprint.",
+             "default": _c("GAP", "spec",
+                           rationale="Bloomberg/MSCI have vast data and regulatory acceptance; estate has neither yet.")},
+        ],
+    },
+]
+
+
+def _expand_score(feature: dict, competitor: str) -> dict:
+    """Merge the feature default with any per-competitor override into one score row."""
+    default = feature["default"]
+    ov = (feature.get("overrides") or {}).get(competitor, {})
+    verdict = ov.get("verdict", default["verdict"])
+    maturity = ov.get("maturity", default["maturity"])
+    evidence = ov.get("evidence_ref", default.get("evidence_ref"))
+    rationale = ov.get("rationale", default.get("rationale"))
+
+    score: dict[str, Any] = {
+        "feature_id": feature["feature_id"],
+        "competitor": competitor,
+        "verdict": verdict,
+        "maturity": maturity,
+        "assessment_basis": "self_assessed",
+    }
+    if verdict in ("BEAT", "MEET") and evidence:
+        score["evidence_ref"] = [dict(e) for e in evidence]
+    if rationale:
+        score["rationale"] = rationale
+    # Honesty flag: a thin lead (spec, or fewer than MIN_EVIDENCE_REFS pointers) is provisional.
+    if verdict in ("BEAT", "MEET"):
+        n_ev = len(score.get("evidence_ref") or [])
+        if maturity == "spec" or n_ev < MIN_EVIDENCE_REFS:
+            score["provisional"] = True
+    return score
+
+
+def build_board() -> dict:
+    categories = []
+    for cat in CATEGORIES:
+        features = cat["features"]
+        litmus = [{"feature_id": f["feature_id"], "name": f["name"],
+                   "definition": f["definition"], "criteria": f["criteria"]} for f in features]
+        scores = []
+        for f in features:
+            for comp in cat["competitors"]:
+                scores.append(_expand_score(f, comp))
+        categories.append({
+            "category_id": cat["category_id"],
+            "name": cat["name"],
+            "description": cat["description"],
+            "competitors": list(cat["competitors"]),
+            "litmus_features": litmus,
+            "scores": scores,
+        })
+    return {
+        "board_id": "intelligence-superiority-board",
+        "title": "Intelligence-Superiority Feature-Board",
+        "generated_ts": GENERATED_TS,
+        "spec_version": SPEC_VERSION,
+        "notes": "We can't beat what we haven't benchmarked. Governed competitive-intelligence contract; "
+                 "every BEAT/MEET carries evidence, thin/spec leads are provisional, all cells self_assessed. "
+                 "Sealed by tools/validate_intelligence_superiority_board.py.",
+        "categories": categories,
+    }
+
+
+def render(board: dict) -> str:
+    return json.dumps(board, indent=2, ensure_ascii=False) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Emit the canonical Intelligence-Superiority feature-board.")
+    ap.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    ap.add_argument("--check", action="store_true", help="verify committed dataset matches emission (no write)")
+    args = ap.parse_args(argv)
+
+    board = build_board()
+
+    # Gate emission on the validator — never write a board that would be REJECTED.
+    validator = _load_validator()
+    verdict = validator.validate_board(board)
+    if not verdict.valid:
+        print("EMISSION REJECTED by validator:", *(f"\n  - {r}" for r in verdict.rejections))
+        return 1
+
+    text = render(board)
+    if args.check:
+        current = args.out.read_text(encoding="utf-8") if args.out.exists() else ""
+        if current != text:
+            print(f"DRIFT: {args.out} is out of sync with emit_intelligence_superiority_board.py")
+            return 1
+        print(f"OK: {args.out} in sync ({verdict.tally['scores']} scores across {verdict.tally['categories']} categories)")
+        return 0
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(text, encoding="utf-8")
+    t = verdict.tally
+    vc = t["verdicts"]
+    print(f"WROTE {args.out}: {t['categories']} categories, {t['scores']} scores "
+          f"(BEAT={vc['BEAT']} MEET={vc['MEET']} PARTIAL={vc['PARTIAL']} GAP={vc['GAP']}, {t['provisional']} provisional)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_intelligence_superiority_board.py
+++ b/tools/validate_intelligence_superiority_board.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""validate_intelligence_superiority_board — the contract-with-teeth for the estate's
+Intelligence-Superiority feature-board (schemas/eval/intelligence-superiority-board.schema.json).
+
+"We can't beat what we haven't benchmarked." The board is a governed competitive-intelligence
+dataset: per capability category it declares competitors, the litmus features that decide the
+category, and a scored estate-vs-each verdict (BEAT|MEET|PARTIAL|GAP). This validator refuses to
+let an unsupported superiority claim ship, then SEALS the board with a SHA-256 receipt so the
+cockpit renders exactly the bytes that passed.
+
+TEETH (each is proven both ways in tests/platform_stubs/test_intelligence_superiority_board.py):
+  1. A category with NO litmus_features is REJECTED — you cannot score a category you never defined.
+  2. A BEAT or MEET verdict with NO evidence_ref is REJECTED — a lead without evidence is a boast.
+  3. A score marked externally_certified with NO cert_ref is REJECTED — certification needs a cert.
+  4. A score whose feature_id is not a declared litmus_feature, or whose competitor is not in the
+     category's competitors[], is REJECTED — no orphan scores.
+  5. MIN-N / PROVISIONAL: a BEAT/MEET claim that is thin — maturity=='spec' OR fewer than
+     MIN_EVIDENCE_REFS evidence pointers — MUST carry provisional=true, else it is REJECTED. This
+     is what keeps "capable, not yet released (a choice)" honestly separated from "battle-tested".
+
+Pure-stdlib and deterministic so it runs as a GitHub-hosted CI gate with no third-party deps; the
+JSON-Schema shape check is layered on top by the test suite (jsonschema) and is not required here.
+
+Usage:
+    python tools/validate_intelligence_superiority_board.py <board.json> [--seal OUT.receipt.json]
+    # exit 0 = VALID (sealed if --seal), exit 1 = REJECTED, exit 2 = malformed input
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# A BEAT/MEET claim backed by a single pointer is "thin" and must be flagged provisional.
+MIN_EVIDENCE_REFS = 2
+VALID_VERDICTS = {"BEAT", "MEET", "PARTIAL", "GAP"}
+LEAD_VERDICTS = {"BEAT", "MEET"}
+
+
+@dataclass
+class Verdict:
+    valid: bool
+    rejections: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    tally: dict[str, Any] = field(default_factory=dict)
+
+    def reject(self, msg: str) -> None:
+        self.valid = False
+        self.rejections.append(msg)
+
+
+def _evidence_ref(score: dict) -> list:
+    ev = score.get("evidence_ref") or []
+    return ev if isinstance(ev, list) else []
+
+
+def validate_board(board: dict) -> Verdict:
+    v = Verdict(valid=True)
+
+    for key in ("board_id", "title", "generated_ts", "spec_version", "categories"):
+        if key not in board:
+            v.reject(f"board is missing required field '{key}'")
+    categories = board.get("categories")
+    if not isinstance(categories, list) or not categories:
+        v.reject("board has no categories")
+        return v
+
+    verdict_counts: dict[str, int] = {k: 0 for k in VALID_VERDICTS}
+    per_category: dict[str, dict[str, int]] = {}
+    n_scores = 0
+    n_provisional = 0
+
+    for ci, cat in enumerate(categories):
+        cid = cat.get("category_id", f"<index {ci}>")
+        loc = f"category '{cid}'"
+
+        features = cat.get("litmus_features") or []
+        # TOOTH 1: no litmus features → cannot score the category.
+        if not isinstance(features, list) or not features:
+            v.reject(f"{loc}: no litmus_features defined (a category with no litmus test is REJECTED)")
+            continue
+        feature_ids = {f.get("feature_id") for f in features if isinstance(f, dict)}
+        for f in features:
+            if not (f.get("definition") and f.get("criteria")):
+                v.reject(f"{loc}: litmus_feature '{f.get('feature_id')}' missing definition or criteria")
+
+        competitors = set(cat.get("competitors") or [])
+        if not competitors:
+            v.reject(f"{loc}: no competitors declared")
+
+        cat_counts = {k: 0 for k in VALID_VERDICTS}
+        for score in cat.get("scores") or []:
+            n_scores += 1
+            fid = score.get("feature_id")
+            comp = score.get("competitor")
+            verdict = score.get("verdict")
+            sloc = f"{loc} score [{fid} vs {comp}]"
+
+            if verdict not in VALID_VERDICTS:
+                v.reject(f"{sloc}: invalid verdict {verdict!r}")
+                continue
+            verdict_counts[verdict] += 1
+            cat_counts[verdict] += 1
+
+            # TOOTH 4: orphan scores.
+            if fid not in feature_ids:
+                v.reject(f"{sloc}: feature_id {fid!r} is not a declared litmus_feature")
+            if comp not in competitors:
+                v.reject(f"{sloc}: competitor {comp!r} is not in the category competitors[]")
+
+            evidence = _evidence_ref(score)
+            basis = score.get("assessment_basis")
+            maturity = score.get("maturity")
+            provisional = bool(score.get("provisional"))
+            if provisional:
+                n_provisional += 1
+
+            # TOOTH 3: externally_certified needs a cert_ref.
+            if basis == "externally_certified" and not score.get("cert_ref"):
+                v.reject(f"{sloc}: assessment_basis=externally_certified but no cert_ref")
+
+            if verdict in LEAD_VERDICTS:
+                # TOOTH 2: a BEAT/MEET lead with no evidence is a boast.
+                if not evidence:
+                    v.reject(f"{sloc}: {verdict} claim has no evidence_ref")
+                else:
+                    # TOOTH 5: thin evidence must be flagged provisional.
+                    thin = maturity == "spec" or len(evidence) < MIN_EVIDENCE_REFS
+                    if thin and not provisional:
+                        reason = "maturity=spec" if maturity == "spec" else f"only {len(evidence)} evidence_ref(s)"
+                        v.reject(f"{sloc}: {verdict} claim is thin ({reason}) and must set provisional=true")
+
+        per_category[cid] = cat_counts
+
+    v.tally = {
+        "categories": len(categories),
+        "scores": n_scores,
+        "provisional": n_provisional,
+        "verdicts": verdict_counts,
+        "per_category": per_category,
+    }
+    return v
+
+
+def _canonical_bytes(board: dict) -> bytes:
+    """Deterministic serialization for the seal: sorted keys, compact separators, UTF-8."""
+    return json.dumps(board, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def seal(board: dict, verdict: Verdict) -> dict:
+    digest = hashlib.sha256(_canonical_bytes(board)).hexdigest()
+    return {
+        "board_id": board.get("board_id"),
+        "spec_version": board.get("spec_version"),
+        "generated_ts": board.get("generated_ts"),
+        "sha256": digest,
+        "algorithm": "SHA-256 (FIPS 180-4 via stdlib hashlib; not a FIPS 140-validated module)",
+        "canonicalization": "json.dumps(sort_keys=True, separators=(',',':'), ensure_ascii=False) UTF-8",
+        "valid": verdict.valid,
+        "tally": verdict.tally,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Validate + seal the Intelligence-Superiority feature-board.")
+    ap.add_argument("board", type=Path, help="path to the board dataset JSON")
+    ap.add_argument("--seal", type=Path, default=None, help="write a SHA-256 receipt here when VALID")
+    args = ap.parse_args(argv)
+
+    try:
+        board = json.loads(args.board.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"MALFORMED: cannot read/parse {args.board}: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(board, dict):
+        print("MALFORMED: board root is not an object", file=sys.stderr)
+        return 2
+
+    v = validate_board(board)
+
+    if v.valid:
+        t = v.tally
+        vc = t["verdicts"]
+        print(f"VALID: {t['categories']} categories, {t['scores']} scores "
+              f"(BEAT={vc['BEAT']} MEET={vc['MEET']} PARTIAL={vc['PARTIAL']} GAP={vc['GAP']}, "
+              f"{t['provisional']} provisional)")
+        for w in v.warnings:
+            print(f"  warn: {w}")
+        if args.seal:
+            receipt = seal(board, v)
+            args.seal.parent.mkdir(parents=True, exist_ok=True)
+            args.seal.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+            print(f"SEALED: sha256={receipt['sha256']} -> {args.seal}")
+        return 0
+
+    print(f"REJECTED: {len(v.rejections)} violation(s):", file=sys.stderr)
+    for r in v.rejections:
+        print(f"  - {r}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- "We can't beat what we haven't benchmarked." Adds the governed intelligence-superiority board: 9 categories scoring the estate against named competitors on litmus features (BEAT/MEET/PARTIAL/GAP), each cell carrying evidence + maturity (live/spec) + assessment_basis.
- Honesty discipline enforced by the validator, not just documented: `assessment_basis` is always `self_assessed` (schema rejects `externally_certified` without a `cert_ref`); a thin BEAT/MEET (spec maturity or <2 evidence pointers) must carry `provisional=true`; emission is gated on the validator and refuses to write a board it would reject.
- Corrects the model-lab category to merged evidence: `receipted_eval` now cites the live `receipt-gateway` (SEAM-011) instead of a schema-only claim, `experiment_tracking` points at the live `lattice-studio` leaderboard instead of the retired `lattice-forge` stub.
- Fixes a Python 3.12 regression in the dynamic validator loader (dataclass `cls.__module__` resolution needs the module registered in `sys.modules` before `exec_module`) — emission was silently broken until this fix.

## Test plan
- [x] `python3 tools/emit_intelligence_superiority_board.py` — validator-clean, 249 scores across 9 categories (BEAT=138 MEET=43 PARTIAL=46 GAP=22, 64 provisional)
- [x] `--check` confirms committed dataset is byte-identical to emission (drift guard has meaning)
- [ ] Not yet wired to a live board producer for the cockpit boards UI (see [socioprophet#545](https://github.com/SocioProphet/socioprophet/pull/545), which currently renders a bundled fixture)