### PR TITLE
fix(revendor): consume the REAL EffectRequest 0.1.0 + resolve the pinned tarball from zot (end-to-end)

### DIFF
--- a/tools/revendor_engine.py
+++ b/tools/revendor_engine.py
@@ -29,13 +29,16 @@ performs the file changes; --open-pr additionally opens the (idempotent) re-vend
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import importlib.util
 import json
+import os
 import re
 import shutil
 import subprocess
 import sys
+import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -52,6 +55,70 @@ def _load_marker_tool():
 
 
 marker_tool = _load_marker_tool()
+
+
+# ── resolving the artifact the EffectRequest names but does not carry ────────────────
+
+_OCI_MANIFEST_ACCEPT = ("application/vnd.oci.image.manifest.v1+json, "
+                        "application/vnd.docker.distribution.manifest.v2+json")
+
+
+def _oci_auth_header() -> dict:
+    """Bearer token, or HTTP Basic — the same secrets the publisher uses (OCI_TOKEN, or
+    OCI_USERNAME/OCI_PASSWORD; in CI the ZOT_CI_* repository secrets)."""
+    token = os.environ.get("OCI_TOKEN")
+    if token:
+        return {"Authorization": f"Bearer {token}"}
+    user, password = os.environ.get("OCI_USERNAME"), os.environ.get("OCI_PASSWORD")
+    if user and password:
+        return {"Authorization": "Basic " + base64.b64encode(f"{user}:{password}".encode()).decode()}
+    return {}
+
+
+def _http_get(url: str, headers: dict) -> bytes:
+    with urllib.request.urlopen(urllib.request.Request(url, headers=headers), timeout=30) as resp:
+        return resp.read()
+
+
+def resolve_tarball(effect_request: dict, dest_dir: Path, *, http_get=_http_get) -> Path:
+    """Obtain the digest-pinned engine tarball an EffectRequest NAMES but does not carry, from
+    the sovereign registry (zot). The plane publishes the artifact (sociosphere
+    tools/publish_vendor_artifact_oci.py); this fetches it by the same coordinates:
+
+        registry = $OCI_REGISTRY, scheme = $OCI_SCHEME (https in prod),
+        repo     = $OCI_REPO or "socioprophet/<packageName>", reference = parameters.toVersion.
+
+    It pulls the OCI manifest, takes the single gzipped-tar layer, fetches that blob, and
+    VERIFIES sha256(blob) == the layer digest before writing. A mismatch is fatal: the whole
+    point of a pinned artifact is that you never re-vendor bytes you did not verify against the
+    digest the registry attests. `http_get(url, headers) -> bytes` is injectable for tests."""
+    p = effect_request.get("parameters") or {}
+    to_version = p.get("toVersion")
+    if not to_version:
+        raise ValueError("EffectRequest parameters.toVersion is required to resolve the artifact")
+    package = p.get("packageName") or (p.get("sourceRepo") or "").split("/")[-1] or "hellgraph"
+    registry = os.environ.get("OCI_REGISTRY", "localhost:15000")
+    scheme = os.environ.get("OCI_SCHEME", "http")
+    repo = os.environ.get("OCI_REPO", f"socioprophet/{package}")
+    base = f"{scheme}://{registry}/v2/{repo}"
+    auth = _oci_auth_header()
+
+    manifest = json.loads(http_get(f"{base}/manifests/{to_version}", {"Accept": _OCI_MANIFEST_ACCEPT, **auth}))
+    layers = [layer for layer in manifest.get("layers", []) if layer.get("digest")]
+    tar_layers = [layer for layer in layers if "tar" in layer.get("mediaType", "").lower()] or layers
+    if len(tar_layers) != 1:
+        raise ValueError(f"expected exactly one tarball layer in {repo}:{to_version}, found {len(tar_layers)}")
+    digest = tar_layers[0]["digest"]  # e.g. "sha256:abcd…"
+    blob = http_get(f"{base}/blobs/{digest}", dict(auth))
+    algo, _, want_hex = digest.partition(":")
+    got_hex = hashlib.new(algo, blob).hexdigest()
+    if got_hex != want_hex:
+        raise ValueError(f"digest mismatch for {repo}:{to_version} — manifest attests {digest}, "
+                         f"blob is {algo}:{got_hex}; refusing to vendor unverified bytes")
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    out = dest_dir / f"socioprophet-{package}-{to_version}.tgz"
+    out.write_bytes(blob)
+    return out
 
 SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
 
@@ -508,10 +575,11 @@ def main(argv: list[str] | None = None) -> int:
     args = ap.parse_args(argv)
 
     if args.from_effect_request:
-        if not args.tarball:
-            ap.error("--from-effect-request also needs --tarball: an EffectRequest carries no tarball; "
-                     "resolve the digest-pinned artifact from the sovereign registry (zot) first")
-        plan = RevendorPlan.from_effect_request(json.loads(args.from_effect_request.read_text()), args.tarball)
+        doc = json.loads(args.from_effect_request.read_text())
+        # The request carries no tarball; resolve the digest-pinned artifact from the sovereign
+        # registry (zot) unless one was supplied explicitly (tests / air-gapped runs).
+        tarball = args.tarball or resolve_tarball(doc, args.root / ".revendor-cache")
+        plan = RevendorPlan.from_effect_request(doc, tarball)
     elif args.to_version and args.tarball:
         plan = RevendorPlan(to_version=args.to_version, tarball=args.tarball, expect_markers=args.expect,
                             forbid_markers=args.forbid,

--- a/tools/revendor_engine.py
+++ b/tools/revendor_engine.py
@@ -82,10 +82,16 @@ class RevendorPlan:
     forbid_markers: list[str] = field(default_factory=list)
     member: str = marker_tool.DEFAULT_MEMBER
     requested_by_event_ref: str | None = None
+    # Honoured only when the plan came from an EffectRequest:
+    requires_human_approval: bool = False
+    idempotency_key_override: str | None = None
 
     @property
     def idempotency_key(self) -> str:
-        return f"engine@{self.to_version}"
+        # Prefer the EffectRequest's own key (artifact@from->to) so a re-emitted finding
+        # collides with its prior PR; the manual/CLI path with no request falls back to a
+        # version-scoped key.
+        return self.idempotency_key_override or f"engine@{self.to_version}"
 
     def __post_init__(self):
         if not SEMVER.match(self.to_version):
@@ -95,21 +101,48 @@ class RevendorPlan:
             raise ValueError("at least one expect marker is required — a version field is not evidence")
 
     @classmethod
-    def from_effect_request(cls, doc: dict) -> "RevendorPlan":
-        """Build from the EffectRequest the plane emits (schema specVersion 0.1.0):
-        capability vendor.revendor, parameters carry from/to versions, the register's
-        version_marker rides in parameters.expectMarkers."""
+    def from_effect_request(cls, doc: dict, tarball: Path) -> "RevendorPlan":
+        """Build from the EffectRequest the vendor-freshness plane actually emits
+        (EffectRequest.json specVersion 0.1.0, as produced by sociosphere
+        tools/detect_vendor_freshness.py). Field mapping, verified against that emitter:
+
+          - capability            == "vendor.revendor"
+          - parameters.toVersion  -> to_version
+          - parameters.versionMarker.marker      -> the discriminating marker (an OBJECT,
+            not a string: {marker, presentIn, absentIn, assertInside, note})
+          - parameters.versionMarker.assertInside -> the dist member to read
+          - parameters.consumerApp -> the ONE consumer this request targets (the detector
+            emits one EffectRequest per stale artifact == per consumer)
+          - idempotencyKey         -> the request's key (top-level), honoured verbatim
+          - requiresHumanApproval  -> top-level; a true value blocks apply (see execute)
+
+        The request does NOT carry the tarball — the plane's `parameters` are evidence, not a
+        payload. The digest-pinned artifact is obtained from the sovereign registry (zot) in a
+        separate resolution step and passed in here, so this method takes `tarball` explicitly."""
         if doc.get("capability") != "vendor.revendor":
             raise ValueError(f"not a vendor.revendor EffectRequest (capability={doc.get('capability')!r})")
-        p = doc.get("parameters", {})
-        markers = p.get("expectMarkers") or ([p["versionMarker"]] if p.get("versionMarker") else [])
+        p = doc.get("parameters") or {}
+        version_marker = p.get("versionMarker")
+        # versionMarker is an object {marker, presentIn, ...}; a bare string is the old
+        # wrong shape and must fail loudly, not AttributeError.
+        marker = version_marker.get("marker") if isinstance(version_marker, dict) else None
+        if not marker:
+            raise ValueError("EffectRequest parameters.versionMarker.marker is required — a version field is not evidence")
+        consumer = p.get("consumerApp")
+        if not consumer:
+            raise ValueError("EffectRequest parameters.consumerApp is required to know which consumer to re-vendor")
+        to_version = p.get("toVersion")
+        if not to_version:
+            raise ValueError("EffectRequest parameters.toVersion is required")
         return cls(
-            to_version=p["toVersion"],
-            tarball=Path(p["tarball"]),
-            expect_markers=list(markers),
-            forbid_markers=list(p.get("forbidMarkers", [])),
-            consumers=list(p.get("consumers", ["hellgraph-service", "lifecycle-warden"])),
+            to_version=to_version,
+            tarball=tarball,
+            expect_markers=[marker],
+            consumers=[consumer],
+            member=version_marker.get("assertInside") or marker_tool.DEFAULT_MEMBER,
             requested_by_event_ref=doc.get("requestedByEventRef"),
+            requires_human_approval=bool(doc.get("requiresHumanApproval")),
+            idempotency_key_override=doc.get("idempotencyKey"),
         )
 
 
@@ -333,7 +366,7 @@ def _rollback(state: dict) -> None:
                 f.unlink()
 
 
-def execute(plan: RevendorPlan, root: Path, apply: bool = False) -> dict:
+def execute(plan: RevendorPlan, root: Path, apply: bool = False, human_approved: bool = False) -> dict:
     """Run the disciplined re-vendor. Returns a sealed receipt. Fail-closed AND atomic under
     apply: read-only proofs (marker, precheck) run before any mutation, and if a later step
     fails — including verify_guard, which necessarily runs against the mutated files — every
@@ -351,6 +384,17 @@ def execute(plan: RevendorPlan, root: Path, apply: bool = False) -> dict:
 
     def record(step: str, ok: bool, evidence: dict):
         receipt["steps"].append({"step": step, "ok": ok, "evidence": evidence})
+
+    # Fail-closed on human approval. A contract-crossing re-vendor carries
+    # requiresHumanApproval=true on its EffectRequest; the membrane's EffectDecision grants
+    # it. Until an approving decision is passed through (human_approved), apply refuses to
+    # touch anything. Dry-run still plans, so the decision has a receipt to weigh.
+    if apply and plan.requires_human_approval and not human_approved:
+        receipt["requires_human_approval"] = True
+        receipt["status"] = "blocked_pending_human_approval"
+        receipt["note"] = ("this effect requires human approval (e.g. contract-crossing); "
+                           "re-run under an approving EffectDecision")
+        return _seal(receipt)
 
     # Marker proof first: it never mutates and it is the gate on everything after it.
     try:
@@ -458,10 +502,16 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--root", type=Path, default=_HERE.parent, help="repo root (default: this repo)")
     ap.add_argument("--apply", action="store_true", help="perform the file changes (default: dry-run)")
     ap.add_argument("--open-pr", action="store_true", help="open the idempotent re-vendor PR (implies --apply)")
+    ap.add_argument("--human-approved", action="store_true",
+                    help="an approving EffectDecision is present; permits applying an effect whose "
+                         "EffectRequest set requiresHumanApproval")
     args = ap.parse_args(argv)
 
     if args.from_effect_request:
-        plan = RevendorPlan.from_effect_request(json.loads(args.from_effect_request.read_text()))
+        if not args.tarball:
+            ap.error("--from-effect-request also needs --tarball: an EffectRequest carries no tarball; "
+                     "resolve the digest-pinned artifact from the sovereign registry (zot) first")
+        plan = RevendorPlan.from_effect_request(json.loads(args.from_effect_request.read_text()), args.tarball)
     elif args.to_version and args.tarball:
         plan = RevendorPlan(to_version=args.to_version, tarball=args.tarball, expect_markers=args.expect,
                             forbid_markers=args.forbid,
@@ -470,7 +520,7 @@ def main(argv: list[str] | None = None) -> int:
         ap.error("provide --from-effect-request, or both --to-version and --tarball")
 
     apply = args.apply or args.open_pr
-    receipt = execute(plan, args.root, apply=apply)
+    receipt = execute(plan, args.root, apply=apply, human_approved=args.human_approved)
     if receipt["status"] == "applied" and args.open_pr:
         # Copilot #1062 round 2: the receipt IS the deliverable. If open_pr raises
         # (RevendorAbort for a non-applied state, subprocess.CalledProcessError from

--- a/tools/test_revendor_engine.py
+++ b/tools/test_revendor_engine.py
@@ -148,21 +148,73 @@ def test_receipt_seal_is_tamper_evident(tmp_path):
     assert eng._seal(dict(receipt))["receipt_digest"] != sealed
 
 
-def test_from_effect_request_maps_the_contract(tmp_path):
-    tgz = _engine_tarball(tmp_path / "e.tgz", "0.4.46", with_marker=True)
-    doc = {
-        "type": "EffectRequest", "capability": "vendor.revendor",
-        "requestedByEventRef": "evt-123",
-        "parameters": {"toVersion": "0.4.46", "tarball": str(tgz), "versionMarker": MARKER},
+def _real_effect_request(to="0.4.46", consumer="hellgraph-service", crossings=False):
+    """Shaped exactly as sociosphere tools/detect_vendor_freshness.py emits it (the merged
+    EffectRequest.json 0.1.0): versionMarker is an OBJECT, the consumer rides in consumerApp,
+    idempotencyKey/requiresHumanApproval are top-level, and there is NO tarball field."""
+    return {
+        "type": "EffectRequest", "specVersion": "0.1.0", "effectKind": "update",
+        "capability": "vendor.revendor",
+        "target": {"kind": "vendor-pin", "identifier": f"hellgraph-engine@{consumer}",
+                   "location": f"prophet-platform/apps/{consumer}/vendor"},
+        "idempotencyKey": f"hellgraph-engine@{consumer}@0.4.40->{to}",
+        "requestedByEventRef": "vendor-freshness-observation/2026-07-30/hellgraph-engine",
+        "requiresHumanApproval": crossings,
+        "riskLabels": ["contract-crossing"] if crossings else [],
+        "parameters": {
+            "artifactId": f"hellgraph-engine@{consumer}", "consumerApp": consumer,
+            "toVersion": to, "fromVersion": "0.4.40",
+            "versionMarker": {"marker": MARKER, "presentIn": to, "absentIn": "0.4.40",
+                              "assertInside": "package/ts/dist/index.js", "note": None},
+        },
     }
-    plan = eng.RevendorPlan.from_effect_request(doc)
-    assert plan.to_version == "0.4.46" and plan.expect_markers == [MARKER]
-    assert plan.idempotency_key == "engine@0.4.46" and plan.requested_by_event_ref == "evt-123"
 
 
-def test_wrong_capability_is_rejected():
+def test_from_effect_request_maps_the_real_contract(tmp_path):
+    tgz = _engine_tarball(tmp_path / "e.tgz", "0.4.46", with_marker=True)
+    plan = eng.RevendorPlan.from_effect_request(_real_effect_request(), tgz)
+    assert plan.to_version == "0.4.46"
+    assert plan.expect_markers == [MARKER]                        # versionMarker.marker (object), not the object
+    assert plan.consumers == ["hellgraph-service"]                # consumerApp — one per request, not both
+    assert plan.member == "package/ts/dist/index.js"             # versionMarker.assertInside
+    assert plan.idempotency_key == "hellgraph-engine@hellgraph-service@0.4.40->0.4.46"  # request's own key
+    assert plan.requires_human_approval is False
+    assert plan.tarball == tgz                                    # supplied separately (not in the request)
+
+
+def test_from_effect_request_rejects_a_bare_string_marker(tmp_path):
+    # The old bug: treating parameters.versionMarker as a string. The real field is an object.
+    tgz = _engine_tarball(tmp_path / "e.tgz", "0.4.46", with_marker=True)
+    doc = _real_effect_request()
+    doc["parameters"]["versionMarker"] = MARKER
+    with pytest.raises(ValueError, match="versionMarker.marker"):
+        eng.RevendorPlan.from_effect_request(doc, tgz)
+
+
+def test_from_effect_request_requires_consumer_app(tmp_path):
+    tgz = _engine_tarball(tmp_path / "e.tgz", "0.4.46", with_marker=True)
+    doc = _real_effect_request()
+    del doc["parameters"]["consumerApp"]
+    with pytest.raises(ValueError, match="consumerApp"):
+        eng.RevendorPlan.from_effect_request(doc, tgz)
+
+
+def test_wrong_capability_is_rejected(tmp_path):
+    tgz = _engine_tarball(tmp_path / "e.tgz", "0.4.46", with_marker=True)
     with pytest.raises(ValueError, match="vendor.revendor"):
-        eng.RevendorPlan.from_effect_request({"capability": "something.else", "parameters": {}})
+        eng.RevendorPlan.from_effect_request({"capability": "something.else", "parameters": {}}, tgz)
+
+
+def test_requires_human_approval_blocks_apply_until_approved(tmp_path):
+    root = _fixture(tmp_path)
+    plan = eng.RevendorPlan.from_effect_request(_real_effect_request(to="0.4.45", crossings=True), REAL_045)
+    blocked = eng.execute(plan, root, apply=True)
+    assert blocked["status"] == "blocked_pending_human_approval" and blocked["requires_human_approval"] is True
+    # nothing was touched — the old 0.4.40 tarball is still in place for the targeted consumer
+    assert (root / "apps" / "hellgraph-service" / "vendor" / "socioprophet-hellgraph-0.4.40.tgz").exists()
+    # an approving EffectDecision (human_approved) lets it proceed
+    approved = eng.execute(plan, root, apply=True, human_approved=True)
+    assert approved["status"] in ("applied", "noop")
 
 
 # ── Copilot #1062 round 2: fail-closed AND receipt-producing ──────────────────

--- a/tools/test_revendor_engine.py
+++ b/tools/test_revendor_engine.py
@@ -8,6 +8,7 @@ because each corresponds to a way this has gone wrong before.
 """
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import io
 import json
@@ -215,6 +216,57 @@ def test_requires_human_approval_blocks_apply_until_approved(tmp_path):
     # an approving EffectDecision (human_approved) lets it proceed
     approved = eng.execute(plan, root, apply=True, human_approved=True)
     assert approved["status"] in ("applied", "noop")
+
+
+# ── resolve_tarball: pull the digest-pinned artifact the request only names ──────────
+
+def _fake_registry(tarball_bytes, media="application/vnd.oci.image.layer.v1.tar+gzip"):
+    """An injectable http_get that serves a one-layer OCI manifest + the blob."""
+    digest = "sha256:" + hashlib.sha256(tarball_bytes).hexdigest()
+
+    def http_get(url, headers):
+        if "/manifests/" in url:
+            return json.dumps({"layers": [{"mediaType": media, "digest": digest,
+                                           "size": len(tarball_bytes)}]}).encode()
+        if url.endswith(digest):
+            return tarball_bytes
+        raise AssertionError(f"unexpected url: {url}")
+
+    return http_get, digest
+
+
+def test_resolve_tarball_pulls_and_verifies(tmp_path):
+    data = b"pretend-this-is-a-gzipped-tar"
+    http_get, _ = _fake_registry(data)
+    doc = {"parameters": {"toVersion": "0.4.46", "packageName": "hellgraph"}}
+    out = eng.resolve_tarball(doc, tmp_path, http_get=http_get)
+    assert out.read_bytes() == data
+    assert out.name == "socioprophet-hellgraph-0.4.46.tgz"
+
+
+def test_resolve_tarball_refuses_a_digest_mismatch(tmp_path):
+    # The manifest attests a digest the returned blob does NOT hash to — never vendor it.
+    wrong_digest = "sha256:" + hashlib.sha256(b"a different artifact").hexdigest()
+
+    def http_get(url, headers):
+        if "/manifests/" in url:
+            return json.dumps({"layers": [{"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                                           "digest": wrong_digest}]}).encode()
+        return b"the actual bytes, which do not match wrong_digest"
+
+    with pytest.raises(ValueError, match="digest mismatch"):
+        eng.resolve_tarball({"parameters": {"toVersion": "0.4.46"}}, tmp_path, http_get=http_get)
+
+
+def test_resolve_tarball_requires_exactly_one_tar_layer(tmp_path):
+    with pytest.raises(ValueError, match="one tarball layer"):
+        eng.resolve_tarball({"parameters": {"toVersion": "0.4.46"}}, tmp_path,
+                            http_get=lambda url, headers: json.dumps({"layers": []}).encode())
+
+
+def test_resolve_tarball_requires_to_version(tmp_path):
+    with pytest.raises(ValueError, match="toVersion"):
+        eng.resolve_tarball({"parameters": {}}, tmp_path, http_get=lambda url, headers: b"")
 
 
 # ── Copilot #1062 round 2: fail-closed AND receipt-producing ──────────────────


### PR DESCRIPTION
**Adversarial re-review of my own merged #1062 found a real, serious gap:** the executor could not consume an actual EffectRequest.

## The bug (was on main)
`from_effect_request` was written against an *invented* shape and would `KeyError`/misbehave on a real request (as `sociosphere/tools/detect_vendor_freshness.py` emits it, against the merged `EffectRequest.json` 0.1.0):
- read `parameters.tarball` — **no such field** (the request is evidence, not a payload)
- treated `parameters.versionMarker` as a **string** — it's an **object** `{marker, presentIn, absentIn, assertInside, note}`
- ignored `target` / `parameters.consumerApp` (the actual consumer)
- minted its own `idempotencyKey` instead of the request's

## The fix
- Maps the **real** fields: `toVersion`, marker = `versionMarker.marker`, dist member = `versionMarker.assertInside`, consumer = `consumerApp` (detector emits **one request per stale artifact**), the request's own `idempotencyKey`, and `requiresHumanApproval`. Tarball is passed in (resolved from zot separately — follow-up).
- **`requiresHumanApproval` is now fail-closed**: a contract-crossing re-vendor **blocks under apply** (`blocked_pending_human_approval`, nothing mutated) until an approving EffectDecision is passed (`--human-approved`). Previously it would have auto-executed.
- A bare-string `versionMarker` (the old wrong shape) fails loudly, not with `AttributeError`.

## Tests (15)
Real detector-shaped request mapping · marker-object-not-string · missing `consumerApp` · wrong capability · **human-approval blocks-then-proceeds**. Plus the existing executor suite.

Follow-ups from the same re-review: `resolve_tarball` (pull the digest-pinned tarball from zot — the request carries none), and the reviewer's `scope_contained` fail-closed default.