### PR TITLE
feat(review): JIT scale-to-zero review gate (Review stage) — re-homed on main + scope fail-closed

### DIFF
--- a/tools/review_gate.py
+++ b/tools/review_gate.py
@@ -124,11 +124,16 @@ def check_consumers_atomic(receipt: dict, root: Path) -> tuple[bool, dict]:
 
 
 def check_scope_contained(receipt: dict, changed_paths: list[str] | None) -> tuple[bool, dict]:
-    """If a diff of changed paths is supplied, a re-vendor may only touch vendored tarballs,
-    the engine dependency pin, and the engine floor. Anything else rides in on the change and
-    is rejected. Without a diff this is advisory (the executor is trusted to have that scope)."""
+    """A re-vendor may only touch vendored tarballs, the engine dependency pin, and the engine
+    floor. Anything else rides in on the change and is rejected.
+
+    Fail-closed: without a diff, scope CANNOT be verified, so it is not a pass. Trusting the
+    executor's own receipt to bound its scope would be circular — the whole point is to catch
+    a change that also touched something the receipt does not mention. A promotion-grade review
+    must therefore be handed the actual changed paths; absent them, this is REJECT, not APPROVE."""
     if changed_paths is None:
-        return True, {"note": "no diff supplied; scope check advisory only"}
+        return False, {"reason": "no changed-paths diff supplied — scope cannot be verified; "
+                                 "a promotion-grade review must be given the diff"}
     allowed = re.compile(r"apps/[^/]+/(vendor/socioprophet-hellgraph-[\d.]+\.tgz|package\.json|scripts/check-engine-version\.mjs)$")
     out_of_scope = [p for p in changed_paths if not allowed.fullmatch(p)]
     return (not out_of_scope), {"out_of_scope": out_of_scope, "changed_count": len(changed_paths)}

--- a/tools/test_review_gate.py
+++ b/tools/test_review_gate.py
@@ -81,12 +81,28 @@ def _check(v, name):
     return next(c for c in v["checks"] if c["check"] == name)
 
 
+def _valid_changed():
+    """The exact paths a faithful 0.4.45 re-vendor of both consumers touches."""
+    return [f"apps/{c}/vendor/socioprophet-hellgraph-0.4.45.tgz" for c in CONSUMERS] \
+        + [f"apps/{c}/package.json" for c in CONSUMERS] \
+        + [f"apps/{c}/scripts/check-engine-version.mjs" for c in CONSUMERS]
+
+
 def test_faithful_revendor_is_approved(tmp_path):
     root = _fixture(tmp_path)
-    v = review_gate.review(_applied(root), root)
+    v = review_gate.review(_applied(root), root, changed_paths=_valid_changed())
     assert v["verdict"] == review_gate.APPROVE, json.dumps(v, indent=2)
     assert all(c["ok"] for c in v["checks"])
     assert v["review_digest"].startswith("sha256:")
+
+
+def test_scope_unverified_without_diff_is_rejected(tmp_path):
+    # Fail-closed: no diff -> scope cannot be verified -> REJECT, not a silent pass.
+    root = _fixture(tmp_path)
+    v = review_gate.review(_applied(root), root)
+    assert v["verdict"] == review_gate.REJECT
+    assert not _check(v, "scope_contained")["ok"]
+    assert "no changed-paths diff" in _check(v, "scope_contained")["evidence"]["reason"]
 
 
 def test_tampered_seal_is_rejected(tmp_path):
@@ -158,14 +174,14 @@ def test_model_concern_needs_human(tmp_path):
         def judge(self, receipt, findings):
             return {"verdict": "concern", "rationale": "a semantic smell the checks can't see"}
 
-    v = review_gate.review(receipt, root, model=Concerned())
+    v = review_gate.review(receipt, root, model=Concerned(), changed_paths=_valid_changed())
     assert v["deterministic_ok"] is True
     assert v["verdict"] == review_gate.NEEDS_HUMAN
 
 
 def test_review_seal_is_tamper_evident(tmp_path):
     root = _fixture(tmp_path)
-    v = review_gate.review(_applied(root), root)
+    v = review_gate.review(_applied(root), root, changed_paths=_valid_changed())
     sealed = v["review_digest"]
     v["verdict"] = "APPROVE-tampered"
     assert review_gate._seal_review(dict(v))["review_digest"] != sealed


### PR DESCRIPTION
Re-opens the Review stage: the original #1125 was **auto-closed** the moment its stacked base (#1062, the executor) merged and its base branch was deleted. Re-homed directly on main.

## What
`tools/review_gate.py` — JIT, scale-to-zero reviewer. Deterministic **fail-closed** checks + a thin **pluggable model**, sealed verdict, exit. Nothing kept warm. It **re-proves** the executor's claims against the repo (marker re-asserted from the tarball on disk, pins/floors re-read) — never trusts the receipt.

## Adversarial-review fix included
`scope_contained` was **toothless by default** — with no diff it silently returned pass. Now **fail-closed**: no diff → scope unverifiable → REJECT. Trusting the receipt to bound its own scope is circular; the check exists to catch a change that touched something the receipt omits.

## Verdict + tests
all checks + model approve → APPROVE(0) · any check fails → REJECT(1) · checks pass + model concern → NEEDS_HUMAN(2). **10 tests** — real receipt → APPROVE; tampered seal / failed step / marker-broken-on-disk / non-atomic / out-of-scope / **no-diff** each → REJECT; model concern → NEEDS_HUMAN.

Pairs with the executor (#1062, merged) and its contract fix (#1321), and the continuum promotion gate (sourceos-continuum#11).