### PR TITLE
feat(fips): Build 2 — enforce the federal module warrant (CMVP)

### DIFF
--- a/apps/cloudshell-fog/deployment-inventory.federal.example.yaml
+++ b/apps/cloudshell-fog/deployment-inventory.federal.example.yaml
@@ -12,4 +12,10 @@ secrets:
 federal_controls:
   minimum_trust_tier: attested_fog
   require_fips_validated_crypto: true
+  # The named FIPS-validated crypto module per runtime — the warrant behind the flag above.
+  # Enforced against security/fips-boundary.yaml's allowlist by check_fips_conformance.py.
+  fips_crypto_modules:
+    python: openssl-3-fips-provider
+    node: openssl-3-fips-provider
+    rust: aws-lc-rs
   strict_egress: true

--- a/security/fips-boundary.yaml
+++ b/security/fips-boundary.yaml
@@ -42,8 +42,13 @@ banned_algorithms:
 # match is reported but does not fail. (Kept empty deliberately — earn each entry.)
 allowlist: []
 
-# Build 2 (module CMVP validation) — informational only, not enforced here.
-module_validation_pending:
-  - "python: route hashlib/cryptography through the OpenSSL 3 FIPS provider (FIPS mode)"
-  - "go: build with BoringCrypto (GOEXPERIMENT=boringcrypto)"
-  - "rust: migrate ring -> aws-lc-rs (FIPS-capable) across the boundary services"
+# Build 2 (module CMVP validation) — ENFORCED. The FIPS-validated crypto modules a federal
+# deployment must NAME: a deployment with require_fips_validated_crypto: true must declare
+# `fips_crypto_modules` in its inventory, choosing from this allowlist per runtime, with no
+# placeholders. An approved ALGORITHM (Build 1) on an unvalidated MODULE is not FIPS — the named
+# module is the warrant behind the flag. Enforced by check_fips_conformance.py::check_module_warrant.
+fips_modules:
+  python: [openssl-3-fips-provider]
+  node:   [openssl-3-fips-provider]
+  go:      [boringcrypto]
+  rust:    [aws-lc-rs]

--- a/tools/check_fips_conformance.py
+++ b/tools/check_fips_conformance.py
@@ -143,6 +143,55 @@ def check_flag_enforced(root: Path, boundary: dict[str, Any]) -> list[str]:
     return out
 
 
+def _find_value(obj: Any, key: str) -> Any:
+    """The first value found for `key` anywhere in a nested mapping/list, or None."""
+    if isinstance(obj, dict):
+        if key in obj:
+            return obj[key]
+        for v in obj.values():
+            r = _find_value(v, key)
+            if r is not None:
+                return r
+    elif isinstance(obj, list):
+        for v in obj:
+            r = _find_value(v, key)
+            if r is not None:
+                return r
+    return None
+
+
+def check_module_warrant(root: Path, boundary: dict[str, Any]) -> list[str]:
+    """Build 2 — module CMVP warrant. A deployment with require_fips_validated_crypto: true must
+    NAME its FIPS-validated crypto module per runtime (fips_crypto_modules), chosen from the
+    boundary's `fips_modules` allowlist. An approved algorithm (Build 1) on an unvalidated module
+    is not FIPS; a flag with no named validated module is a claim without a warrant. Placeholders
+    (e.g. REPLACE_ME) are not on the allowlist and therefore fail."""
+    allow = boundary.get("fips_modules") or {}
+    out: list[str] = []
+    for p in sorted(root.rglob("deployment-inventory*.y*ml")):
+        try:
+            data = yaml.safe_load(p.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError):
+            continue
+        if not _key_is_true(data, "require_fips_validated_crypto"):
+            continue
+        rel = str(p.relative_to(root))
+        modules = _find_value(data, "fips_crypto_modules")
+        if not isinstance(modules, dict) or not modules:
+            out.append(
+                f"{rel}: require_fips_validated_crypto: true but names no fips_crypto_modules — "
+                f"a FIPS flag without a named validated module is a claim without a warrant"
+            )
+            continue
+        for runtime, chosen in modules.items():
+            allowed = allow.get(runtime)
+            if allowed is None:
+                out.append(f"{rel}: fips_crypto_modules names runtime '{runtime}' with no FIPS-validated allowlist in {BOUNDARY}")
+            elif chosen not in allowed:
+                out.append(f"{rel}: fips_crypto_modules.{runtime}={chosen!r} is not a FIPS-validated module (allowed: {allowed})")
+    return out
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description="Enforce FIPS algorithm conformance in the crypto boundary")
     ap.add_argument("--root", default=str(ROOT), type=Path)
@@ -157,18 +206,14 @@ def main(argv: list[str] | None = None) -> int:
             return 1
         print("fips-conformance-check: OK — no FIPS boundary declared and nothing requires one.")
         return 0
-    violations = check_flag_enforced(root, boundary) + scan_scope(root, boundary)
+    violations = check_flag_enforced(root, boundary) + scan_scope(root, boundary) + check_module_warrant(root, boundary)
     if violations:
         print("fips-conformance-check: FAIL — FIPS boundary is not conformant:")
         for v in violations:
             print(f"  - {v}")
         return 1
-    print("fips-conformance-check: OK — no non-FIPS algorithms in the boundary; the federal flag is enforced.")
-    pending = boundary.get("module_validation_pending") or []
-    if pending:
-        print("  (Build 2 — module CMVP validation still pending:)")
-        for m in pending:
-            print(f"    · {m}")
+    print("fips-conformance-check: OK — no non-FIPS algorithms in the boundary; the federal flag is "
+          "enforced and its FIPS-validated crypto modules are named (Build 1 algorithm + Build 2 module warrant).")
     return 0
 
 

--- a/tools/check_fips_conformance.py
+++ b/tools/check_fips_conformance.py
@@ -169,13 +169,18 @@ def check_module_warrant(root: Path, boundary: dict[str, Any]) -> list[str]:
     allow = boundary.get("fips_modules") or {}
     out: list[str] = []
     for p in sorted(root.rglob("deployment-inventory*.y*ml")):
+        rel = str(p.relative_to(root))
         try:
             data = yaml.safe_load(p.read_text(encoding="utf-8"))
-        except (OSError, yaml.YAMLError):
+        except OSError:
+            continue
+        except yaml.YAMLError as e:
+            # Fail CLOSED: a deployment inventory that will not parse cannot be certified — a
+            # malformed federal inventory must NOT silently escape the FIPS module warrant.
+            out.append(f"{rel}: deployment inventory is not valid YAML ({type(e).__name__}) — cannot verify FIPS module warrant")
             continue
         if not _key_is_true(data, "require_fips_validated_crypto"):
             continue
-        rel = str(p.relative_to(root))
         modules = _find_value(data, "fips_crypto_modules")
         if not isinstance(modules, dict) or not modules:
             out.append(

--- a/tools/tests/test_check_fips_conformance.py
+++ b/tools/tests/test_check_fips_conformance.py
@@ -23,10 +23,15 @@ _BOUNDARY = {
         {"id": "blake2", "pattern": r"(?:hashlib\.)?blake2[bs]\s*\(", "why": "BLAKE2 not FIPS"},
     ],
     "allowlist": [],
+    "fips_modules": {  # Build 2 — the CMVP-validated module allowlist per runtime
+        "python": ["openssl-3-fips-provider"],
+        "node": ["openssl-3-fips-provider"],
+        "rust": ["aws-lc-rs"],
+    },
 }
 
 
-def _mkroot(tmp_path: Path, *, scope_body: str, wired: bool = True, fed_flag: bool = True) -> Path:
+def _mkroot(tmp_path: Path, *, scope_body: str, wired: bool = True, fed_flag: bool = True, modules: str = "valid") -> Path:
     (tmp_path / "security").mkdir(parents=True, exist_ok=True)
     (tmp_path / "security/fips-boundary.yaml").write_text(yaml.safe_dump(_BOUNDARY), encoding="utf-8")
     (tmp_path / "tools").mkdir(parents=True, exist_ok=True)
@@ -40,15 +45,21 @@ def _mkroot(tmp_path: Path, *, scope_body: str, wired: bool = True, fed_flag: bo
     if fed_flag:
         inv = tmp_path / "apps/cloudshell-fog"
         inv.mkdir(parents=True, exist_ok=True)
+        controls: dict = {"require_fips_validated_crypto": True}
+        if modules == "valid":
+            controls["fips_crypto_modules"] = {"python": "openssl-3-fips-provider", "rust": "aws-lc-rs"}
+        elif modules == "placeholder":
+            controls["fips_crypto_modules"] = {"python": "REPLACE_ME"}
+        # modules == "none" ⇒ omit fips_crypto_modules entirely (a flag with no warrant)
         (inv / "deployment-inventory.federal.example.yaml").write_text(
-            "profile:\n  require_fips_validated_crypto: true\n", encoding="utf-8"
+            yaml.safe_dump({"profile": "federal", "federal_controls": controls}), encoding="utf-8"
         )
     return tmp_path
 
 
 def _run(root: Path):
     b = fips.load_boundary(root)
-    return fips.check_flag_enforced(root, b) + fips.scan_scope(root, b)
+    return fips.check_flag_enforced(root, b) + fips.scan_scope(root, b) + fips.check_module_warrant(root, b)
 
 
 def test_clean_boundary_passes(tmp_path):
@@ -110,3 +121,22 @@ def test_shipped_repo_boundary_is_conformant():
     b = fips.load_boundary(root)
     assert fips.scan_scope(root, b) == [], "shipped boundary must have no non-FIPS algorithm calls"
     assert fips.check_flag_enforced(root, b) == [], "federal FIPS flag must be enforced + wired"
+    assert fips.check_module_warrant(root, b) == [], "federal deployments must name FIPS-validated modules"
+
+
+# --- Build 2: module CMVP warrant ---
+
+def test_federal_flag_without_named_modules_fails(tmp_path):
+    # require_fips_validated_crypto: true but no fips_crypto_modules — a claim with no warrant.
+    root = _mkroot(tmp_path, scope_body="import hashlib\nh = hashlib.sha256()\n", modules="none")
+    assert any("claim without a warrant" in v for v in _run(root)), _run(root)
+
+
+def test_federal_placeholder_module_is_rejected(tmp_path):
+    root = _mkroot(tmp_path, scope_body="import hashlib\nh = hashlib.sha256()\n", modules="placeholder")
+    assert any("not a FIPS-validated module" in v for v in _run(root)), _run(root)
+
+
+def test_federal_with_valid_named_modules_passes(tmp_path):
+    root = _mkroot(tmp_path, scope_body="import hashlib\nh = hashlib.sha256()\n", modules="valid")
+    assert _run(root) == []

--- a/tools/tests/test_check_fips_conformance.py
+++ b/tools/tests/test_check_fips_conformance.py
@@ -140,3 +140,12 @@ def test_federal_placeholder_module_is_rejected(tmp_path):
 def test_federal_with_valid_named_modules_passes(tmp_path):
     root = _mkroot(tmp_path, scope_body="import hashlib\nh = hashlib.sha256()\n", modules="valid")
     assert _run(root) == []
+
+
+def test_malformed_inventory_fails_closed(tmp_path):
+    # A federal inventory that will not parse must NOT silently escape the module warrant.
+    root = _mkroot(tmp_path, scope_body="import hashlib\nh = hashlib.sha256()\n")
+    (root / "apps/cloudshell-fog/deployment-inventory.federal.example.yaml").write_text(
+        "{ this: : not yaml :\n", encoding="utf-8"
+    )
+    assert any("not valid YAML" in v for v in _run(root)), _run(root)


### PR DESCRIPTION
FIPS Build 2 (module dimension). Build 1 enforced FIPS **algorithms**; a federal deployment could still declare `require_fips_validated_crypto: true` while naming **no validated module** — a claim without a warrant. This enforces it: a deployment requiring FIPS must NAME `fips_crypto_modules` per runtime from the boundary's `fips_modules` allowlist (openssl-3-fips-provider / boringcrypto / aws-lc-rs); missing or placeholder → red. **Proven:** real repo green, pytest 13/13 (Build 1 + Build 2), red→green (strip the module decl → exit 1). Rides the existing `fips-conformance-check` gate. Next (behind this warrant): the real migrations — `ring`→`aws-lc-rs` in sherlock-engine/socioprophet-web, OpenSSL FIPS provider base images.