### PR TITLE
deploy: pin 10 moving-tag services to their RUNNING digest (no-op rollout)

### DIFF
--- a/deploy/values/agentic-os-api.yaml
+++ b/deploy/values/agentic-os-api.yaml
@@ -1,5 +1,5 @@
 # agentic-os-api
-image: { repository: agentic-os-api, tag: latest }
+image: { repository: agentic-os-api, tag: sha-d3566908a3d0aea902e5649aff772fa9abfa9d3a }
 service: { port: 8080, portName: http }
 # The app exposes @app.get("/health") (app/main.py:19), not the chart's default
 # /healthz — so every probe 404'd and the kubelet killed it: 939 restarts over

--- a/deploy/values/api.yaml
+++ b/deploy/values/api.yaml
@@ -1,5 +1,5 @@
 # socioprophet-api — tritRPC core API
-image: { repository: socioprophet-api, tag: latest }
+image: { repository: socioprophet-api, tag: sha-d3566908a3d0aea902e5649aff772fa9abfa9d3a }
 service: { port: 9000, portName: tritrpc }
 probes: { enabled: true, httpGet: false }   # raw tritRPC, no HTTP health
 config:

--- a/deploy/values/embeddings.yaml
+++ b/deploy/values/embeddings.yaml
@@ -3,7 +3,7 @@
 # vectors. The model is baked into the image (no runtime HuggingFace egress, no PVC). tag:latest is
 # sha-pinned by gitops-promote after the first CI build.
 nameOverride: embeddings
-image: { repository: embeddings, tag: latest }
+image: { repository: embeddings, tag: sha-d3566908a3d0aea902e5649aff772fa9abfa9d3a }
 service: { port: 8080, portName: http }
 
 probes:

--- a/deploy/values/evidence-receipts.yaml
+++ b/deploy/values/evidence-receipts.yaml
@@ -1,3 +1,3 @@
 # evidence-receipts
-image: { repository: evidence-receipts, tag: latest }
+image: { repository: evidence-receipts, tag: sha-d3566908a3d0aea902e5649aff772fa9abfa9d3a }
 service: { port: 8080, portName: http }

--- a/deploy/values/liberty-stack-readout.yaml
+++ b/deploy/values/liberty-stack-readout.yaml
@@ -1,5 +1,5 @@
 # liberty-stack-readout — Liberty Stack subject/combined readout API (apps/liberty-stack-readout). Real FastAPI
 # service (built + 9 tests but never shipped). Vendored into CI this PR. tag:latest → sha-pin next build.
-image: { repository: liberty-stack-readout, tag: latest }
+image: { repository: liberty-stack-readout, tag: sha-d3566908a3d0aea902e5649aff772fa9abfa9d3a }
 service: { port: 8080, portName: http }
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }

--- a/deploy/values/memoryd.yaml
+++ b/deploy/values/memoryd.yaml
@@ -2,7 +2,7 @@
 # CI so it builds with the estate's WIF like every other service. Recall/write/retract over a pluggable store;
 # defaults to in-memory (MEMORYMESH_STORE_URI=memory://) so it boots with no database. Point at a Postgres DSN
 # to persist. tag:latest → sha-pinned after first build.
-image: { repository: memoryd, tag: latest }
+image: { repository: memoryd, tag: sha-d3566908a3d0aea902e5649aff772fa9abfa9d3a }
 service: { port: 8787, portName: http }
 config:
   MEMORYMESH_STORE_URI: "memory://"

--- a/deploy/values/node-commander.yaml
+++ b/deploy/values/node-commander.yaml
@@ -1,5 +1,5 @@
 # node-commander — node runtime control API (status/heartbeat over the node runtime), vendored into CI this PR.
 # apps/node-commander. Real FastAPI service (was built + tested but never shipped). tag:latest → sha-pin next build.
-image: { repository: node-commander, tag: latest }
+image: { repository: node-commander, tag: sha-d3566908a3d0aea902e5649aff772fa9abfa9d3a }
 service: { port: 8080, portName: http }
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }

--- a/deploy/values/osm-map-api.yaml
+++ b/deploy/values/osm-map-api.yaml
@@ -1,4 +1,4 @@
 # osm-map-api
-image: { repository: osm-map-api, tag: latest }
+image: { repository: osm-map-api, tag: sha-85d830cd278ee7584e7b1ebad0dd78f6be476c4e }
 service: { port: 8088, portName: http }  # app binds 8088 (uvicorn); chart uses this for containerPort + probes
 enableServiceLinks: false   # k8s injects OSM_MAP_API_PORT=tcp://<svc> otherwise → app int() crash

--- a/deploy/values/regis-acr-api.yaml
+++ b/deploy/values/regis-acr-api.yaml
@@ -1,6 +1,6 @@
 # regis-acr-api — Regis Attested Concordance Record API (apps/regis-acr-api). The provenance/registry surface
 # for the entity-resolution + evidence spine (ACR concordance records, decision-ledger reads). It BUILDS in CI
 # but was never scheduled — this wires it into the ApplicationSet. tag:latest → sha-pinned after next build.
-image: { repository: regis-acr-api, tag: latest }
+image: { repository: regis-acr-api, tag: sha-cadaba356440d164e43d2b7d90fab6f6934ad896 }
 service: { port: 8080, portName: http }
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }

--- a/deploy/values/tritfabric-consumption-api.yaml
+++ b/deploy/values/tritfabric-consumption-api.yaml
@@ -2,6 +2,6 @@
 # Reports readiness for the four TritFabric surfaces (community-learning intake, framework catalog, promotion
 # evidence, serve readiness) from the integration contract — deliberately NON-mutating (mutation_authorized:false),
 # a pre-infrastructure readiness reporter, not the Serve runtime. tag:latest → sha-pinned after first build.
-image: { repository: tritfabric-consumption-api, tag: latest }
+image: { repository: tritfabric-consumption-api, tag: sha-d3566908a3d0aea902e5649aff772fa9abfa9d3a }
 service: { port: 8080, portName: http }
 autoscaling: { enabled: true, minReplicas: 1, maxReplicas: 2 }

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -150,30 +150,13 @@ KNOWN_BROKEN = {
     # (their first CI builds landed) after these entries were written. The ratchet caught
     # both as "now passes — delete from KNOWN_BROKEN" on an unrelated PR; fixed → removed,
     # same precedent as lifecycle-warden above.
-    "liberty-stack-readout:moving-tag": (
-        "New service — liberty-stack-readout vendored into prophet-platform CI this PR. Pin tag:latest -> the "
-        "sha- tag after the first build; none exists until merge."
-    ),
-    "node-commander:moving-tag": (
-        "New service — node-commander (node runtime control API) vendored into prophet-platform CI this PR. "
-        "Pin tag:latest -> the sha- tag after the first build; none exists until merge."
-    ),
-    "regis-acr-api:moving-tag": (
-        "Build-orphan fixed — regis-acr-api already BUILT in CI but was never in the ApplicationSet; this PR "
-        "adds the deploy. Pin tag:latest -> the sha- tag after the next build; none exists for the deploy yet."
-    ),
-    "memoryd:moving-tag": (
-        "New service — memory-mesh's memoryd vendored into prophet-platform CI this PR, so it BUILDS with the "
-        "estate WIF. Pin tag:latest -> the sha- tag after the first CI build; no sha exists until merge."
-    ),
-    "tritfabric-consumption-api:moving-tag": (
-        "New service — TritFabric consumption API containerized + wired to prophet-platform CI this PR (it had "
-        "app code but no image build). Pin tag:latest -> the sha- tag after the first CI build; none exists yet."
-    ),
-    "embeddings:moving-tag": (
-        "New service — first-party embeddings image (apps/embeddings, FastAPI + nomic-embed-text) added to CI "
-        "this PR. Pin tag:latest -> the sha- tag after the first CI build; no sha exists until merge."
-    ),
+    # RESOLVED 2026-08-03: liberty-stack-readout, node-commander, regis-acr-api, memoryd,
+    # tritfabric-consumption-api and embeddings were all sha-pinned in deploy/values/<svc>.yaml
+    # to the sha- tag matching each service's CURRENTLY-RUNNING digest (verified against the
+    # live cluster: kubectl imageID → the GAR sha- tag on that exact digest). Pinning to the
+    # running digest is a NO-OP rollout — it makes the implicit explicit without changing which
+    # bytes run — which is why this batch was safe to do together (see the block below). The
+    # ratchet only shrinks: fixed → removed so none can silently regress to `:latest` again.
     # RESOLVED 2026-08-03: receipt-gateway, catalog-gateway, nugget-extractor and
     # device-service were all sha-pinned by gitops-promote after their first CI builds
     # (receipt-gateway → sha-d3566908…, catalog-gateway → sha-e6301c68…, nugget-extractor
@@ -198,20 +181,22 @@ KNOWN_BROKEN = {
     # sha-32f5996a06f6) after their first CI build, so they no longer violate — the
     # ratchet requires removing them here (it only shrinks).
     # The chart has said "Immutable tag = the commit SHA" since it was written; these
-    # 9 predate the check. Pinning them is mechanical BUT NOT SAFE TO BATCH: `latest`
-    # + IfNotPresent means nodes may be running an older cached digest than `latest`
-    # now resolves to, so pinning ROLLS each service to whatever the newest build is.
-    # That is the correct end state and exactly how a latent breakage surfaces — which
-    # is why it wants a deliberate pass with per-service verification, not one commit
-    # that rolls 9 services at once. Each line here is removed as its service is pinned.
+    # predate the check. The earlier worry was that pinning ROLLS each service to whatever
+    # the newest build is (because `latest` + IfNotPresent means a node may cache an older
+    # digest than `latest` now resolves to). That risk is avoided entirely by pinning to the
+    # digest EACH SERVICE IS ALREADY RUNNING, resolved from the live cluster — a no-op
+    # rollout, not a roll to newest. api, agentic-os-api, evidence-receipts and osm-map-api
+    # were pinned that way 2026-08-03 and removed from the ratchet.
+    # gateway remains: its values still say `tag: latest` AND its pod is NOT Ready (already
+    # running a sha- tag out of sync with values) — a separate crash to fix, not a moving-tag
+    # pin, so it stays tracked here until that is resolved.
     **{f"{svc}:moving-tag": (
-        "Pre-existing `tag: latest`. Pin to the sha- tag the build publishes, then "
-        "delete this line. Do it per-service and verify the rollout: pinning changes "
-        "which digest actually runs, because the node cache may be older than `latest`."
+        "Pre-existing `tag: latest`, and the pod is NOT Ready — a crash to resolve before "
+        "pinning (values already disagree with the running sha- tag). Not a clean moving-tag "
+        "pin; fix the crash, then pin to the running digest and delete this line."
     ) for svc in [
-        "api", "agentic-os-api",
-        "evidence-receipts", "gateway", "osm-map-api",
-    ]},  # hellgraph-service + evidence-console + search-orchestrator (academy sha-pin) → removed from the ratchet
+        "gateway",
+    ]},
     # eval-fabric-api sha-pinned by gitops-promote (sha-e72d47ce…) after its first CI
     # build → removed from the ratchet 2026-08-03 (it only shrinks; leaving it FAILs "now passes").
 }


### PR DESCRIPTION
Fixes the **moving-tag deploy defect** for 10 first-party services: they deployed `image.tag: latest` with `imagePullPolicy: IfNotPresent`, so once a node caches `latest`, kubelet **never pulls a newer build** and `rollout restart` re-runs the stale image. The deploys silently never update. Tracked in `preflight_deploy_contract.py` `KNOWN_BROKEN` as `<svc>:moving-tag`.

## Why this is safe to batch (the deferral’s fear, answered)

The ratchet deferred these because pinning naively ROLLS each service to *whatever the newest build is* (a node may cache an older digest than `latest` now resolves to) — so it wanted per-service on-cluster verification, not one commit.

**That risk is avoided entirely.** Each service is pinned to the sha- tag whose digest is **exactly what it is already running**, resolved from the live cluster:

```
kubectl imageID (running digest)  →  the GAR sha- tag on that same digest
```

Verified per service (tag → digest == running digest). Pinning to the running digest is a **no-op rollout** — it makes the implicit explicit without changing which bytes run; ArgoCD’s sync is a rolling restart onto **identical** pods.

| services | pinned to |
|---|---|
| agentic-os-api, api, embeddings, evidence-receipts, liberty-stack-readout, memoryd, node-commander, tritfabric-consumption-api | `sha-d3566908…` (one monorepo build) |
| osm-map-api | `sha-85d830cd…` |
| regis-acr-api | `sha-cadaba356…` |

## Ratchet

Shrunk by these 10 (it only shrinks). **`gateway` is retained**: its values still say `tag: latest` **and** its pod is **NOT Ready** (already running a sha- tag out of sync with values) — a separate crash to fix before it can be cleanly pinned. `preflight_deploy_contract.py` passes.

## Post-merge verification

Because every pin equals the running digest, readiness should be unaffected. I will verify `/healthz`/readiness stays green across the 10 after ArgoCD syncs.