### PR TITLE
feat(advisory): fail-closed OSV advisory gate — don't re-vendor blind (march #6/#7)

### DIFF
--- a/tools/advisory_check.py
+++ b/tools/advisory_check.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Don't re-vendor blind: gate a package@version on open vulnerability data (OSV) before vendoring.
+
+The re-vendor loop pins digests and proves the marker, but had no notion of whether the version it
+moves TO is known-vulnerable or malicious — the competitive research called this out (we detect
+staleness, not malice). This adds a fail-closed advisory gate over OSV.dev — the open, aggregated
+vulnerability database (GitHub Advisory, PyPI, npm, Go, crates.io, ...). Sovereign by design: we
+CONSUME the open data over a plain query, we do not depend on a SaaS scanner.
+
+Fail-closed: if a version has known advisories it is BLOCKED; and if the advisory service cannot be
+reached at all, it is also BLOCKED — you do not re-vendor into the unknown. An explicit override
+(--allow-unverified) exists for air-gapped runs, and is recorded as such.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+OSV_QUERY_URL = "https://api.osv.dev/v1/query"
+
+
+def _http_post(url: str, body: dict) -> dict:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _severity(vuln: dict) -> str:
+    # OSV puts a CVSS vector under severity[]; the human label often rides in database_specific.
+    ds = vuln.get("database_specific") or {}
+    return ds.get("severity") or (vuln.get("severity") or [{}])[0].get("type") or "unknown"
+
+
+def assess(name: str, ecosystem: str, version: str, *, http_post=None) -> dict:
+    """Query OSV for name@version in ecosystem; return advisories + a fail-closed recommendation."""
+    http_post = http_post or _http_post  # resolved at call time so the default is patchable
+    result = {"package": name, "ecosystem": ecosystem, "version": version}
+    try:
+        resp = http_post(OSV_QUERY_URL, {"version": version, "package": {"name": name, "ecosystem": ecosystem}})
+    except Exception as exc:  # network / parse / timeout — cannot verify safety
+        result.update({"checked": False, "recommendation": "block",
+                       "reason": f"advisory service unreachable ({type(exc).__name__}); fail-closed",
+                       "advisories": []})
+        return result
+
+    vulns = resp.get("vulns") or []
+    advisories = [{"id": v.get("id"), "summary": (v.get("summary") or "")[:200], "severity": _severity(v),
+                   "aliases": v.get("aliases", [])} for v in vulns]
+    vulnerable = bool(advisories)
+    result.update({
+        "checked": True,
+        "vulnerable": vulnerable,
+        "advisories": advisories,
+        "recommendation": "block" if vulnerable else "allow",
+        "reason": (f"{len(advisories)} known advisor{'y' if len(advisories) == 1 else 'ies'} for "
+                   f"{name}@{version}" if vulnerable else f"no known advisories for {name}@{version}"),
+    })
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Fail-closed OSV advisory gate for a package@version.")
+    ap.add_argument("--package", required=True)
+    ap.add_argument("--ecosystem", required=True, help="OSV ecosystem, e.g. npm, PyPI, Go, crates.io")
+    ap.add_argument("--version", required=True)
+    ap.add_argument("--allow-unverified", action="store_true",
+                    help="permit promotion when the advisory service is unreachable (air-gapped); recorded as such")
+    ap.add_argument("--out", type=Path, help="write the assessment JSON here")
+    args = ap.parse_args(argv)
+
+    r = assess(args.package, args.ecosystem, args.version)
+    if r["recommendation"] == "block" and not r.get("checked") and args.allow_unverified:
+        r["recommendation"] = "allow-unverified"
+        r["reason"] += " — overridden by --allow-unverified"
+    text = json.dumps(r, indent=2, sort_keys=True)
+    (args.out.write_text(text + "\n") if args.out else print(text))
+    if r["recommendation"] == "block":
+        print(f"BLOCK: {r['reason']}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/revendor_engine.py
+++ b/tools/revendor_engine.py
@@ -433,7 +433,8 @@ def _rollback(state: dict) -> None:
                 f.unlink()
 
 
-def execute(plan: RevendorPlan, root: Path, apply: bool = False, human_approved: bool = False) -> dict:
+def execute(plan: RevendorPlan, root: Path, apply: bool = False, human_approved: bool = False,
+            advisory_assessor=None) -> dict:
     """Run the disciplined re-vendor. Returns a sealed receipt. Fail-closed AND atomic under
     apply: read-only proofs (marker, precheck) run before any mutation, and if a later step
     fails — including verify_guard, which necessarily runs against the mutated files — every
@@ -470,6 +471,18 @@ def execute(plan: RevendorPlan, root: Path, apply: bool = False, human_approved:
         record(abort.step, False, {"reason": abort.reason, **abort.evidence})
         receipt["status"] = "failed"
         return _seal(receipt)
+
+    # Fail-closed advisory gate: never re-vendor INTO a version with known advisories, and never
+    # into one we cannot check (advisory_check.assess is itself fail-closed on an unreachable
+    # service). The assessor is injectable/skippable (air-gap); a read-only proof, so it runs
+    # before any mutation. Given only a version, so private-package re-vendors pass cleanly.
+    if advisory_assessor is not None:
+        assessment = advisory_assessor(plan.to_version)
+        gate_ok = assessment.get("recommendation") != "block"
+        record("advisory_gate", gate_ok, assessment)
+        if not gate_ok:
+            receipt["status"] = "failed"
+            return _seal(receipt)
 
     if _already_current(plan, root):
         receipt["status"] = "noop"
@@ -572,6 +585,8 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--human-approved", action="store_true",
                     help="an approving EffectDecision is present; permits applying an effect whose "
                          "EffectRequest set requiresHumanApproval")
+    ap.add_argument("--skip-advisory", action="store_true",
+                    help="skip the fail-closed OSV advisory gate (air-gapped runs only)")
     args = ap.parse_args(argv)
 
     if args.from_effect_request:
@@ -587,8 +602,16 @@ def main(argv: list[str] | None = None) -> int:
     else:
         ap.error("provide --from-effect-request, or both --to-version and --tarball")
 
+    advisory_assessor = None
+    if not args.skip_advisory:
+        adv = importlib.util.module_from_spec(
+            importlib.util.spec_from_file_location("advisory_check", _HERE / "advisory_check.py"))
+        importlib.util.spec_from_file_location("advisory_check", _HERE / "advisory_check.py").loader.exec_module(adv)
+        advisory_assessor = lambda v, _a=adv: _a.assess("@socioprophet/hellgraph", "npm", v)
+
     apply = args.apply or args.open_pr
-    receipt = execute(plan, args.root, apply=apply, human_approved=args.human_approved)
+    receipt = execute(plan, args.root, apply=apply, human_approved=args.human_approved,
+                      advisory_assessor=advisory_assessor)
     if receipt["status"] == "applied" and args.open_pr:
         # Copilot #1062 round 2: the receipt IS the deliverable. If open_pr raises
         # (RevendorAbort for a non-applied state, subprocess.CalledProcessError from

--- a/tools/test_advisory_check.py
+++ b/tools/test_advisory_check.py
@@ -1,0 +1,72 @@
+"""Coverage for tools/advisory_check.py — the fail-closed OSV advisory gate.
+
+Injects the HTTP transport so no live OSV is needed. Pins the load-bearing behaviour: a version
+with known advisories is BLOCKED; a clean version is ALLOWED; an unreachable service is BLOCKED
+(fail-closed — no re-vendor into the unknown); the OSV query shape is correct; and the air-gapped
+override is explicit.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("advisory_check", ROOT / "tools" / "advisory_check.py")
+    m = importlib.util.module_from_spec(spec)
+    sys.modules["advisory_check"] = m
+    spec.loader.exec_module(m)
+    return m
+
+
+ac = _load()
+
+
+def test_vulnerable_version_is_blocked():
+    def post(url, body):
+        return {"vulns": [{"id": "GHSA-xxxx", "summary": "RCE in parser",
+                           "database_specific": {"severity": "CRITICAL"}}]}
+    r = ac.assess("lodash", "npm", "4.17.4", http_post=post)
+    assert r["checked"] and r["vulnerable"] and r["recommendation"] == "block"
+    assert r["advisories"][0]["id"] == "GHSA-xxxx" and r["advisories"][0]["severity"] == "CRITICAL"
+
+
+def test_clean_version_is_allowed():
+    r = ac.assess("lodash", "npm", "4.17.21", http_post=lambda u, b: {})
+    assert r["checked"] and r["vulnerable"] is False and r["recommendation"] == "allow"
+
+
+def test_unreachable_service_fails_closed():
+    def post(u, b):
+        raise OSError("no network")
+    r = ac.assess("x", "npm", "1.0.0", http_post=post)
+    assert r["checked"] is False and r["recommendation"] == "block" and "fail-closed" in r["reason"]
+
+
+def test_osv_query_shape_is_correct():
+    seen = {}
+
+    def post(url, body):
+        seen["url"], seen["body"] = url, body
+        return {}
+    ac.assess("hellgraph", "npm", "0.4.45", http_post=post)
+    assert seen["url"] == ac.OSV_QUERY_URL
+    assert seen["body"] == {"version": "0.4.45", "package": {"name": "hellgraph", "ecosystem": "npm"}}
+
+
+def test_main_exit_codes(monkeypatch):
+    monkeypatch.setattr(ac, "_http_post", lambda u, b: {"vulns": [{"id": "GHSA-1"}]})
+    assert ac.main(["--package", "p", "--ecosystem", "npm", "--version", "1.0.0"]) == 1  # blocked
+    monkeypatch.setattr(ac, "_http_post", lambda u, b: {})
+    assert ac.main(["--package", "p", "--ecosystem", "npm", "--version", "1.0.1"]) == 0  # allowed
+
+
+def test_allow_unverified_override(monkeypatch):
+    def boom(u, b):
+        raise OSError("offline")
+    monkeypatch.setattr(ac, "_http_post", boom)
+    assert ac.main(["--package", "p", "--ecosystem", "npm", "--version", "1.0.0"]) == 1
+    assert ac.main(["--package", "p", "--ecosystem", "npm", "--version", "1.0.0", "--allow-unverified"]) == 0

--- a/tools/test_revendor_engine.py
+++ b/tools/test_revendor_engine.py
@@ -415,3 +415,27 @@ def test_a_failed_verify_guard_rolls_back_all_mutations(tmp_path, monkeypatch):
         vd = root / "apps" / consumer / "vendor"
         assert not (vd / "socioprophet-hellgraph-0.4.45.tgz").exists(), "new tarball not removed on rollback"
         assert (vd / "socioprophet-hellgraph-0.4.40.tgz").exists(), "old tarball not restored on rollback"
+
+
+# ── advisory gate wired into execute: don't re-vendor a known-vulnerable version ────
+
+def test_advisory_gate_blocks_a_vulnerable_version_before_mutating(tmp_path):
+    root = _fixture(tmp_path)
+    plan = eng.RevendorPlan(to_version="0.4.45", tarball=REAL_045, expect_markers=[MARKER], consumers=CONSUMERS)
+    block = lambda v: {"recommendation": "block", "reason": f"known advisory for {v}",
+                       "advisories": [{"id": "GHSA-x"}]}
+    r = eng.execute(plan, root, apply=True, advisory_assessor=block)
+    assert r["status"] == "failed"
+    gate = next(s for s in r["steps"] if s["step"] == "advisory_gate")
+    assert gate["ok"] is False and "advisory" in gate["evidence"]["reason"]
+    for c in CONSUMERS:  # fail-closed: nothing mutated
+        assert (root / "apps" / c / "vendor" / "socioprophet-hellgraph-0.4.40.tgz").exists()
+
+
+def test_advisory_gate_allows_a_clean_version(tmp_path):
+    root = _fixture(tmp_path)
+    plan = eng.RevendorPlan(to_version="0.4.45", tarball=REAL_045, expect_markers=[MARKER], consumers=CONSUMERS)
+    allow = lambda v: {"recommendation": "allow", "reason": "no known advisories", "advisories": []}
+    r = eng.execute(plan, root, apply=True, advisory_assessor=allow)
+    assert r["status"] in ("applied", "noop")
+    assert any(s["step"] == "advisory_gate" and s["ok"] for s in r["steps"])


### PR DESCRIPTION
**Superiority-march #6/#7, first slice.** The loop pinned digests + proved the marker but had no idea whether the version it moves TO is **known-vulnerable or malicious** (research: we detect *staleness*, not *malice*). This closes that.

`tools/advisory_check.py` — a **fail-closed** gate over **OSV.dev** (the open aggregated vuln DB across GitHub Advisory/PyPI/npm/Go/crates.io). Sovereign by design: **consume the open data**, no SaaS scanner.

- known advisory for name@version → **BLOCK**; service unreachable → **also BLOCK** (never re-vendor into the unknown); `--allow-unverified` is an explicit, recorded air-gap override.
- transport injectable; **6 tests** (vulnerable/clean/unreachable/query-shape/exit-codes/override), no live OSV needed.

Next in #6/#7: wire this into the executor's precheck + reachability + fix-and-verify.