### PR TITLE
fix(studio): factsheet receipt now hashes every fact the summary reports (#930)

### DIFF
--- a/apps/socioprophet-web/src/__tests__/factsheetAttest.test.ts
+++ b/apps/socioprophet-web/src/__tests__/factsheetAttest.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Studio catalog "attested factsheet" receipt (Copilot #930).
+ *
+ * The bug this suite pins: the receipt used to hash only [id, connector, epistemic_mode,
+ * columns.length, dir] while the rendered summary ALSO reports the dataset's name, its labels,
+ * and the snapshot count (s.length). None of those three were in the hash, so two datasets whose
+ * SUMMARIES genuinely differ — a different name, different labels, or a different snapshot count
+ * with the same up/down direction — could mint the identical receipt. A receipt that doesn't cover
+ * everything it attests isn't tamper-evident; it just looks like it is.
+ */
+import { describe, it, expect } from 'vitest';
+import { attestFacts, attestReceipt, attestSummary } from '../pages/studio/factsheetAttest';
+import type { Dataset } from '../services/studioApi';
+
+function ds(over: Partial<Dataset> = {}): Dataset {
+  return {
+    id: 'proj-demo:ingest:people', name: 'people', labels: ['Person', 'Ingested'],
+    connector: 'csv', epistemic_mode: 'observed', columns: ['id', 'name', 'age'],
+    ...over,
+  };
+}
+
+const SERIES = [10, 12, 14, 16]; // rising
+
+describe('factsheet attestation receipt', () => {
+  it('changes when the dataset NAME changes, even though everything the old receipt hashed stays the same', () => {
+    const a = attestFacts(ds({ name: 'people' }), SERIES);
+    const b = attestFacts(ds({ name: 'customers' }), SERIES);
+    expect(a.summary).not.toBe(b.summary);          // the summary text really did change...
+    expect(a.receipt).not.toBe(b.receipt);           // ...so the receipt must too
+  });
+
+  it('changes when the LABELS change', () => {
+    const a = attestFacts(ds({ labels: ['Person'] }), SERIES);
+    const b = attestFacts(ds({ labels: ['Person', 'VIP'] }), SERIES);
+    expect(a.summary).not.toBe(b.summary);
+    expect(a.receipt).not.toBe(b.receipt);
+  });
+
+  it('changes when the snapshot COUNT changes, even with the same direction', () => {
+    const a = attestFacts(ds(), [10, 20]);           // rising, 2 snapshots
+    const b = attestFacts(ds(), [10, 12, 14, 20]);    // rising, 4 snapshots
+    expect(attestSummary(ds(), [10, 20])).not.toBe(attestSummary(ds(), [10, 12, 14, 20]));
+    expect(a.receipt).not.toBe(b.receipt);
+  });
+
+  it('is stable and recomputable: same facts in, same receipt out', () => {
+    const d = ds();
+    expect(attestReceipt(d, SERIES)).toBe(attestReceipt(ds(), [...SERIES]));
+  });
+
+  it('is not fooled by a naive "|"-join: a part containing "|" cannot collide with its neighbour', () => {
+    const a = attestFacts(ds({ name: 'a|b', labels: ['c'] }), SERIES);
+    const b = attestFacts(ds({ name: 'a', labels: ['b|c'] }), SERIES);
+    expect(a.receipt).not.toBe(b.receipt);
+  });
+});

--- a/apps/socioprophet-web/src/pages/studio/StudioCatalog.vue
+++ b/apps/socioprophet-web/src/pages/studio/StudioCatalog.vue
@@ -8,6 +8,7 @@ import { ref, computed, onMounted, watch } from 'vue';
 import { loadCatalog, EPISTEMIC_COLORS, type Dataset } from '../../services/studioApi';
 import Sparkline from '../../components/Sparkline.vue';
 import FactsheetDrawer from './FactsheetDrawer.vue';
+import { attestFacts } from './factsheetAttest';
 
 const props = defineProps<{ project: string }>();
 
@@ -59,13 +60,10 @@ function openSheet(d: Dataset) { sheet.value = d; }
 // Attested factsheet — a deterministic, recomputable summary built from the dataset's OWN facts
 // (not model-generated prose), with a content-id receipt = a hash of those facts. Honest "attested
 // AI": the attestation is real (recompute the hash to verify), the text is extractive/templated.
-function djb2(s: string): string { let h = 5381; for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) & 0xffffffff; return (h >>> 0).toString(16).padStart(8, '0'); }
+// Hashing logic lives in factsheetAttest.ts (pure + unit-tested): the receipt must cover every fact
+// the summary reports, or two differing summaries can share one receipt (Copilot #930).
 function attest(d: Dataset): { summary: string; receipt: string; live: boolean } {
-  const s = series(d);
-  const dir = s.length > 1 ? (s[s.length - 1] > s[0] ? 'rising' : s[s.length - 1] < s[0] ? 'falling' : 'flat') : 'flat';
-  const summary = `${d.name} is a ${d.epistemic_mode} dataset${d.connector ? ` ingested via ${d.connector}` : ''} with ${d.columns.length} column${d.columns.length === 1 ? '' : 's'}${d.labels.length ? ` (${d.labels.join(', ')})` : ''}. Ingest volume is ${dir} across the ${s.length} most recent snapshots.`;
-  const receipt = `fs-${djb2([d.id, d.connector || '', d.epistemic_mode, String(d.columns.length), dir].join('|'))}`;
-  return { summary, receipt, live: isLive(d) };
+  return { ...attestFacts(d, series(d)), live: isLive(d) };
 }
 </script>
 

--- a/apps/socioprophet-web/src/pages/studio/factsheetAttest.ts
+++ b/apps/socioprophet-web/src/pages/studio/factsheetAttest.ts
@@ -1,0 +1,41 @@
+// The Studio catalog's "attested factsheet": a deterministic, recomputable summary built from a
+// dataset's own facts, plus a content-id receipt meant to let a viewer verify the summary wasn't
+// tampered with by recomputing the hash.
+//
+// Copilot #930: the receipt only hashed [id, connector, epistemic_mode, columns.length, dir] while
+// the summary text ALSO reports d.name, d.labels and the snapshot count (s.length) — none of which
+// were in the hash. Two datasets whose summaries genuinely differ (a different name, different
+// labels, a different snapshot count with the same direction) could mint the IDENTICAL receipt,
+// which defeats the point of a receipt: "recompute the hash to verify" only works if the hash
+// actually covers everything being verified. Fixed by hashing every fact the summary reports, and
+// JSON-encoding the parts (not '|'-joining them) so a value containing '|' can't collide with its
+// neighbour either.
+import type { Dataset } from '../../services/studioApi';
+
+export function djb2(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) & 0xffffffff;
+  return (h >>> 0).toString(16).padStart(8, '0');
+}
+
+export function seriesDirection(s: number[]): 'rising' | 'falling' | 'flat' {
+  return s.length > 1 ? (s[s.length - 1] > s[0] ? 'rising' : s[s.length - 1] < s[0] ? 'falling' : 'flat') : 'flat';
+}
+
+export function attestSummary(d: Dataset, s: number[]): string {
+  const dir = seriesDirection(s);
+  return `${d.name} is a ${d.epistemic_mode} dataset${d.connector ? ` ingested via ${d.connector}` : ''} with ${d.columns.length} column${d.columns.length === 1 ? '' : 's'}${d.labels.length ? ` (${d.labels.join(', ')})` : ''}. Ingest volume is ${dir} across the ${s.length} most recent snapshots.`;
+}
+
+// Every fact the summary reports, in one JSON-encoded array — so the receipt actually covers what
+// it attests. (id + epistemic_mode are included too, even though epistemic_mode alone is already in
+// the summary text, so the receipt also binds identity, not just prose content.)
+export function attestReceipt(d: Dataset, s: number[]): string {
+  const dir = seriesDirection(s);
+  const facts = [d.id, d.name, d.connector || '', d.epistemic_mode, d.columns.length, d.labels, dir, s.length];
+  return `fs-${djb2(JSON.stringify(facts))}`;
+}
+
+export function attestFacts(d: Dataset, s: number[]): { summary: string; receipt: string } {
+  return { summary: attestSummary(d, s), receipt: attestReceipt(d, s) };
+}


### PR DESCRIPTION
## Summary
Tier-2 re-verification finding #930: `StudioCatalog.vue`'s `attest()` minted a receipt over only `[id, connector, epistemic_mode, columns.length, dir]` while the summary text it's supposed to attest also reports the dataset's `name`, its `labels`, and the snapshot count (`s.length`). None of those three were hashed, so two datasets with genuinely different summaries could mint the identical receipt — not tamper-evident, just looks like it.

- Extracted the hashing into `factsheetAttest.ts` (pure, unit-tested): the receipt now covers every fact the summary reports.
- Parts are JSON-encoded rather than `'|'`-joined, so a value containing `|` can't collide with its neighbour either.

## Test plan
- [x] `factsheetAttest.test.ts` reproduces the collision (name/labels/snapshot-count changing while the receipt stayed put) against the pre-fix logic — 4/5 assertions fail there, all 5 pass against the fix.
- [x] `vue-tsc --noEmit` clean on the touched files.
- [x] Full `vitest run`: 600 passed (pre-existing unrelated failures on `main` too — confirmed via stash).