### PR TITLE
fix(compute-gateway): pre-migration reference sinks no longer lose value_abs (#961)

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/adapters.py
+++ b/apps/compute-gateway/src/compute_gateway/adapters.py
@@ -424,10 +424,23 @@ async def _asx_prior_extraction_reference(entity: dict, field: str, period: str)
         return None
     try:
         con = sqlite3.connect(_sqlite_path(SQL_LOAD_DSN))
-        row = con.execute(f"SELECT value_abs, value FROM {table} WHERE entity=? AND period=? AND field=?",
-                          (ent_id, period, field)).fetchone()
+        try:
+            row = con.execute(f"SELECT value_abs, value FROM {table} WHERE entity=? AND period=? AND field=?",
+                              (ent_id, period, field)).fetchone()
+        except sqlite3.OperationalError as e:
+            # A sink written before `value_abs` existed (schema drift, not absent data) raises
+            # exactly this — "no such column: value_abs". Falling into the broad except below
+            # would swallow it identically to "row not found", so a real reference value already
+            # sitting in a pre-migration sink silently vanished: reconcile just reported the fact
+            # as unreconciled with no error anywhere (#961). Fall back to the pre-migration
+            # column instead, so the value the sink actually has still reaches the comparison.
+            if "no such column" in str(e):
+                row = con.execute(f"SELECT value FROM {table} WHERE entity=? AND period=? AND field=?",
+                                  (ent_id, period, field)).fetchone()
+            else:
+                raise
         con.close()
-    except Exception:  # noqa: BLE001
+    except Exception:  # noqa: BLE001 — table/db genuinely unavailable: nothing to reconcile against
         return None
     if row is None:
         return None

--- a/apps/compute-gateway/tests/test_reference_backends.py
+++ b/apps/compute-gateway/tests/test_reference_backends.py
@@ -129,6 +129,34 @@ def test_au_reference_missing_row_cannot_reach_verified(tmp_path, monkeypatch):
     assert rec["warrant"] == "observed"                         # keeps its warrant, no promotion
 
 
+def test_au_reference_resolves_from_a_pre_migration_sink_missing_value_abs(tmp_path, monkeypatch):
+    """Copilot #961: a `reference_facts` table written before the `value_abs` column existed
+    raises `OperationalError: no such column: value_abs` on the SELECT, which the broad
+    `except Exception: return None` around it swallowed identically to "no such row" — a real
+    reference value already sitting in the sink silently vanished, with no error anywhere, and
+    reconcile just reported the fact as unreconciled/not-flagged. Build that exact pre-migration
+    schema by hand (no `value_abs` column at all) and confirm the value is still found."""
+    import sqlite3
+
+    db = tmp_path / "legacy.db"
+    con = sqlite3.connect(db)
+    con.execute("CREATE TABLE reference_facts (entity TEXT, period TEXT, field TEXT, value TEXT, "
+                "warrant TEXT, reference TEXT, within_tol INTEGER, source TEXT, loaded_at TEXT, "
+                "PRIMARY KEY(entity, period, field))")
+    con.execute("INSERT INTO reference_facts VALUES (?,?,?,?,?,?,?,?,?)",
+                ("GYG", "FY26", "revenue", "1204.0", "observed", None, 0, "asx-appendix-4e", "now"))
+    con.commit()
+    con.close()
+    monkeypatch.setattr(adapters, "SQL_LOAD_DSN", f"sqlite:///{db}")
+
+    r = _compute({"kind": "reconcile", "spec": {
+        "entity": {"asx": "GYG"}, "period": "FY26",
+        "facts": [{"field": "revenue", "value": 1204.0}]}})
+    rec = r["outputs"][0]["data"]["reconciliations"][0]
+    assert rec["reference"] == 1204.0            # found despite the missing value_abs column
+    assert rec["within_tol"] and rec["warrant"] == "verified"
+
+
 # ── unit normalization (the validate-stage unit check) ──
 def test_unit_scaling_to_absolute():
     assert adapters._fact_abs_value(1204, "m") == 1_204_000_000


### PR DESCRIPTION
## Summary
Tier-2 re-verification finding #961: `_asx_prior_extraction_reference`'s `SELECT value_abs, value FROM {table}` raises `sqlite3.OperationalError("no such column: value_abs")` against any `reference_facts` table written before that column was added. The broad `except Exception: return None` around the query swallowed that identically to "no matching row" — a real reference value already sitting in a pre-migration sink silently disappeared, with no error surfaced anywhere. Downstream, `reconcile()` reports the fact as unreconciled/not-flagged (`ref=None` reads exactly like "nothing to compare"), so a schema-drift bug looked like ordinary missing data.

- The "no such column" case is now caught specifically and falls back to the pre-migration `SELECT value FROM {table}` query, so the value the sink actually has reaches the comparison instead of vanishing.
- The broad except around the whole block stays, for the genuinely-nothing-to-reconcile-against cases (missing table, unreachable db).

## Test plan
- [x] New test builds the exact pre-migration schema (`reference_facts` with no `value_abs` column) by hand and confirms the value is still found and reconciled — fails against pre-fix code with `assert None == 1204.0`, passes with the fix.
- [x] Full compute-gateway suite: 242 passed.