### PR TITLE
fix(health-twin): the epistemic-tier proof check now actually gates on epistemic (#938)

### DIFF
--- a/apps/health-twin/src/connectors/recordProof.ts
+++ b/apps/health-twin/src/connectors/recordProof.ts
@@ -1,0 +1,16 @@
+// Pure predicates for the connector proof harness (verify.ts) — split out so they're unit-testable
+// without executing verify.ts itself (which runs every connector and calls process.exit()).
+//
+// Copilot #938: verify.ts asserted `!!(r.epistemic || r.provenance)`, two lines after already
+// asserting `!!r.provenance` unconditionally. Since every record that reaches that point has
+// ALREADY been proven to carry provenance, the `|| r.provenance` branch is always true — the
+// assertion could never fail, regardless of whether `r.epistemic` (a REQUIRED field per data.ts:
+// Observation/Condition/Medication/... all declare `epistemic: EpistemicMode`) was actually set.
+// It read as a real gate on the epistemic tier and gated nothing.
+//
+// `epistemic` tracks HOW a record was normalized (verified/attested/observed) — a different axis
+// from `provenance`, which tracks WHERE it came from. A connector that stamps provenance but
+// forgets to set epistemic is exactly the regression this check exists to catch.
+export function carriesEpistemicTier(r: { epistemic?: unknown }): boolean {
+  return typeof r.epistemic === 'string' && r.epistemic.length > 0;
+}

--- a/apps/health-twin/src/connectors/verify.ts
+++ b/apps/health-twin/src/connectors/verify.ts
@@ -3,6 +3,7 @@
 // LIVE path is proven too — no paid feed, no real PHI. Run: `npx tsx src/connectors/verify.ts`.
 import { CONNECTORS, runConnector } from './index.js';
 import { resultCounts, type IngestResult } from '../ingest.js';
+import { carriesEpistemicTier } from './recordProof.js';
 
 let failures = 0;
 const assert = (cond: boolean, msg: string) => { if (!cond) { console.error(`  ✗ ${msg}`); failures++; } };
@@ -23,7 +24,9 @@ for (const c of CONNECTORS) {
     assert(r.provenance?.source === c.id, `record ${r.id} provenance.source === ${c.id}`);
     assert(!!r.provenance?.uscdi, `record ${r.id} has a USCDI class`);
     assert(!!r.provenance?.sourceShape, `record ${r.id} names its source shape`);
-    assert(!!(r.epistemic || r.provenance), `record ${r.id} carries an epistemic tier or provenance`);
+    // A REAL gate on the epistemic tier — not OR'd with provenance (already asserted just
+    // above), which made the old check unfailable regardless of whether epistemic was set.
+    assert(carriesEpistemicTier(r), `record ${r.id} carries an epistemic tier`);
   }
   // codes are present where the type demands them
   for (const o of res.observations) assert(o.code !== '' && o.codeSystem === 'LOINC', `obs ${o.id} is LOINC-coded`);

--- a/apps/health-twin/src/connectorsRecordProof.test.ts
+++ b/apps/health-twin/src/connectorsRecordProof.test.ts
@@ -1,0 +1,33 @@
+/**
+ * connectors/verify.ts's per-record epistemic-tier check (Copilot #938).
+ *
+ * The bug this pins: verify.ts asserted `!!(r.epistemic || r.provenance)` two lines after
+ * already asserting `!!r.provenance` unconditionally on the same record. Since every record
+ * that reaches that line has ALREADY been proven to carry provenance, the `|| r.provenance`
+ * branch is always true — the assertion could never fail no matter what `r.epistemic` was,
+ * including missing entirely. `carriesEpistemicTier()` is the extracted, pure predicate now
+ * used in its place: it must depend on `epistemic` alone.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { carriesEpistemicTier } from './connectors/recordProof.js';
+
+test('a record with a real epistemic tier passes', () => {
+  assert.equal(carriesEpistemicTier({ epistemic: 'verified' }), true);
+});
+
+test('a record missing epistemic fails even though it carries provenance — the exact regression', () => {
+  // This is the case the pre-fix predicate `!!(r.epistemic || r.provenance)` could never catch:
+  // r.epistemic is undefined, but r.provenance is truthy, so the OR made the whole thing truthy.
+  const r = { provenance: { source: 'oura', uscdi: 'Observation', sourceShape: 'oura-v2' } };
+  assert.equal(carriesEpistemicTier(r as { epistemic?: unknown }), false);
+});
+
+test('an empty-string epistemic also fails (a connector that sets the field to "" is still not tiered)', () => {
+  assert.equal(carriesEpistemicTier({ epistemic: '' }), false);
+});
+
+test('a non-string epistemic fails', () => {
+  assert.equal(carriesEpistemicTier({ epistemic: null }), false);
+  assert.equal(carriesEpistemicTier({ epistemic: undefined }), false);
+});


### PR DESCRIPTION
## Summary
Tier-2 re-verification finding #938: `connectors/verify.ts` asserted `!!(r.epistemic || r.provenance)` two lines after already asserting `!!r.provenance` unconditionally on the same record. Every record that reaches that line has therefore ALREADY been proven to carry provenance, so the `|| r.provenance` branch is always true — the assertion could never fail regardless of whether `r.epistemic` (a REQUIRED field per `data.ts`: every `Observation`/`Condition`/`Medication`/... type declares `epistemic: EpistemicMode`) was actually set by a connector's `normalize()`. It read as a real gate and caught nothing.

- Extracted the predicate into `connectors/recordProof.ts` (pure, unit-tested) as `carriesEpistemicTier()`, which depends on `epistemic` alone.
- `verify.ts` now calls it directly instead of the OR.

## Test plan
- [x] `connectorsRecordProof.test.ts` reproduces the exact regression: a record with provenance but no epistemic field passes the old predicate (`true`) and fails the new one (`false`).
- [x] `npx tsx src/connectors/verify.ts` still passes with 0 failures across all 5 real connectors (they do set `epistemic` correctly) — this closes a check that was silently disarmed, not a defect in the connectors themselves.
- [x] Full `npm test`: 27/27 pass.