### PR TITLE
docs(health-twin): cross-reference estate-safety-kit's mintId.ts

### DIFF
--- a/apps/health-twin/src/ids.ts
+++ b/apps/health-twin/src/ids.ts
@@ -37,6 +37,17 @@
 // label. 128 bits would be ample and would trip that ratchet for no gain, so the mint is 32 bytes and
 // the existing guard keeps working unchanged. The width matches a sha256 digest; the bytes do not
 // come from one, and this comment is the only place that distinction is recoverable from the string.
+//
+// ESTATE SAFETY KIT CROSS-REFERENCE. This exact pattern — mint, don't derive — was independently
+// re-derived a third time for `bootProofRecord` in socioprophet's server contracts (socioprophet#484),
+// with no code shared between here and there. SourceOS-Linux/sourceos-spec#276 generalizes this file
+// into `estate-safety-kit/js/mintId.ts`: same mint-not-derive decision, default width 128 bits with a
+// `bytes` parameter so a caller can ask for this file's own stricter 256-bit/64-hex shape explicitly
+// (`mintId(prefix, 32)`) instead of forking the helper. This file is NOT vendored from that kit yet —
+// converting it is a fast-follow (tracked: prophet-platform#1335) rather than done here, because a
+// blind file-swap would silently narrow every id this service mints from 256 to the kit's 128-bit
+// default unless every call site below is updated to pass `bytes: 32` explicitly, and that deserves
+// its own reviewed change, not a rushed one bundled into unrelated work.
 import { randomBytes } from 'node:crypto';
 
 /** 256 CSPRNG bits, hex, behind a human-readable prefix: `grant-…`, `consult-…`, `op-…`, `more-…`. */


### PR DESCRIPTION
## What this is

Comment-only change to `apps/health-twin/src/ids.ts`, cross-referencing
[SourceOS-Linux/sourceos-spec#276](https://github.com/SourceOS-Linux/sourceos-spec/pull/276),
which generalizes this file's mint-not-derive id pattern (fixed here in
#1070, independently re-derived a third time for `bootProofRecord` in
`socioprophet#484`) into `estate-safety-kit/js/mintId.ts`.

Deliberately **not** converting `ids.ts` to a vendored copy here: the kit's
`mintId` defaults to 128 bits, while this file mints 256 (`ID_PATTERN` is
64 hex chars) to satisfy the estate's "every emitted id carries a full
64 hex" ratchet. The kit's helper does support that width
(`mintId(prefix, 32)`), but a blind file-swap would silently narrow every
id this service mints unless `server.ts`, `consult.ts`, and `invariants.ts`
are all updated in the same change to request 32 bytes explicitly — a real
reviewable refactor, tracked as
[#1335](https://github.com/SocioProphet/prophet-platform/issues/1335),
not something to do as a rushed comment-adjacent edit.

## Verification

23/23 `apps/health-twin` tests pass (`npm test`) — comment-only change, no
behavior touched.

## Status

Small, low-risk, informational. Not part of the "held for human review of
the vendoring convention" set (#276, socioprophet#550/#551) since it makes
no vendoring decision — happy to have this merge on its own timeline.