### PR TITLE
tools: emit REAL ResourceContracts from the live cluster (loop producer half)

### DIFF
--- a/conformance/k8s-resource-enforcement-fires.md
+++ b/conformance/k8s-resource-enforcement-fires.md
@@ -1,0 +1,55 @@
+# Negative control: prove k8s resource enforcement actually fires
+
+Every `ResourceContract` emitted by `tools/emit_resource_contracts.py` with an enforcing mode
+(`terminate` for a memory limit, `throttle` for a CPU limit) references this procedure. The
+sourceos-spec `ResourceContract` schema requires it: a contract that claims enforcement must
+point at a procedure that demonstrates the enforcement can act. A limit nobody has watched fire
+is indistinguishable from no limit.
+
+This exists because the producer emits contracts from OBSERVED cluster state, and observed state
+alone cannot prove teeth — 0 OOMKills means either "the limit works and was never breached" or
+"the limit does not enforce and nothing has breached it yet." Only driving a breach distinguishes
+them. Until this procedure is run for a given workload, that workload's memory verdict is
+correctly `INCONCLUSIVE` (teeth unproven), never `PROVED`.
+
+## Memory (`enforcement: terminate` — OOMKill)
+
+```bash
+NS=socioprophet; APP=<deployment>
+# 1. read the declared limit
+kubectl -n "$NS" get deploy "$APP" -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}'; echo
+# 2. drive a pod in that workload past its limit (a debug container that allocates)
+kubectl -n "$NS" exec deploy/"$APP" -- sh -c 'python3 - <<PY
+b=[]
+while True: b.append(bytearray(50*1024*1024))   # 50 MiB/loop until the cgroup kills us
+PY' || true
+# 3. assert the kernel OOM-killed the container (enforcement FIRED)
+kubectl -n "$NS" get pod -l app.kubernetes.io/name="$APP" \
+  -o jsonpath='{.items[*].status.containerStatuses[*].lastState.terminated.reason}'; echo
+#    → must contain "OOMKilled". If it does, the memory limit has teeth → PROVED, firedCount>0.
+```
+
+Negative half — remove the limit, repeat, confirm NO OOMKill (the allocation grows unbounded
+until the node evicts, a different reason). Restore the limit.
+
+## CPU (`enforcement: throttle`)
+
+CPU throttling does not kill; it delays. The `fired` signal is `cpu.stat`'s `nr_throttled` /
+`throttled_usec`, which the k8s API does not expose — which is why CPU contracts are emitted
+`INCONCLUSIVE` until this is wired:
+
+```bash
+# with cAdvisor/Prometheus scraping container_cpu_cfs_throttled_periods_total:
+#   rate(container_cpu_cfs_throttled_periods_total{pod=~"<app>.*"}[5m]) > 0  ⇒ throttle fired
+# or exec into the pod and read the cgroup directly:
+kubectl -n "$NS" exec deploy/"$APP" -- cat /sys/fs/cgroup/cpu.stat | grep -E 'nr_throttled|throttled_usec'
+#   nr_throttled climbing under load ⇒ the CPU limit has teeth → PROVED.
+```
+
+## Status
+
+**Procedure only; not yet executed against these workloads.** That is stated plainly and is why
+every current verdict is `INCONCLUSIVE`, not `PROVED`: an unrun procedure is honest, whereas
+emitting `PROVED` from an unproven limit would be the paper control this whole contract exists to
+refuse. Running it (memory first — it is bounded and safe) converts a workload's verdict to
+`PROVED` and its `firedCount` to a real count.

--- a/tools/emit_resource_contracts.py
+++ b/tools/emit_resource_contracts.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Emit REAL ResourceContracts + SufficiencyVerdicts from the live cluster — the producer
+half of the producer -> consumer -> learning loop for sourceos-spec's Measurement +
+ResourceContract.
+
+Until now the loop was DECLARED (schemas merged, devsecops maps them, sociosphere recognises
+the verdict) but not FLOWING: nothing emitted a real ResourceContract. This does. For every
+workload it reads the declared limit, MEASURES the observed peak from metrics-server, reads
+whether enforcement actually fired, and emits:
+
+  * a ResourceContract  (sourceos-spec/schemas/ResourceContract.json shape)
+  * a SufficiencyVerdict (the algebra in global-devsecops-intelligence/mappings/
+    resource-contract-measurement-telemetry-v1.yaml — PROVED / VIOLATION / INCONCLUSIVE)
+
+ready for the ops.evidence.artifacts.v1 / ops.learning.feedback.v1 topics.
+
+Honesty is the whole point, so the tool refuses to overclaim:
+
+  * observedPeak is `source: measured` (instrument: metrics-server) taken as the MAX over N
+    samples in a stated window. A single sample would under-represent the true peak; N samples
+    with `sampling.observed=N` is honest about the window it actually saw.
+  * MEMORY has a real enforcement signal: the limit is enforced by OOMKill (terminate), and the
+    OOMKilled count is readable from pod lastState. So memory verdicts are real.
+  * CPU is enforced by throttling, but the throttle counter (cgroup cpu.stat nr_throttled) is
+    not exposed through the k8s API — so fired_count is UNKNOWN. Rather than fake PROVED, a CPU
+    contract whose peak is under limit is INCONCLUSIVE, and the Measurement records that the
+    throttle signal was not collected. (Wire Prometheus/cAdvisor cpu.stat to make CPU real.)
+  * a workload with NO limit cannot carry a ResourceContract at all — it is UNBOUNDED, a
+    resource control that does not exist. That is emitted as an explicit governance gap, not
+    silently skipped: the never-declared control is as much a finding as the never-fired one.
+
+Verdict algebra (identical to the devsecops mapping, reimplemented so the producer and the
+consumer independently agree):
+  not gate-eligible                                   -> INCONCLUSIVE
+  enforcing mode AND fired_count > 0                  -> PROVED
+  enforcing mode AND peak > limit AND fired_count==0  -> VIOLATION
+  otherwise                                           -> INCONCLUSIVE
+
+Usage:  python3 tools/emit_resource_contracts.py [--namespace socioprophet] [--samples 3]
+        [--interval 8] [--out /tmp/resource-contracts]
+Read-only against the cluster. Exit 0 always (it reports; it is a producer, not a gate) unless
+kubectl/metrics are unreachable, which is INCONCLUSIVE for everything and exits 2.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _kubectl(args: list[str]) -> str:
+    return subprocess.run(["kubectl", *args], capture_output=True, text=True, timeout=60).stdout
+
+
+def _cpu_to_millicores(v: str) -> float | None:
+    if not v:
+        return None
+    v = v.strip()
+    try:
+        if v.endswith("m"):
+            return float(v[:-1])
+        if v.endswith("n"):          # nanocores (metrics-server sometimes)
+            return float(v[:-1]) / 1e6
+        if v.endswith("u"):          # microcores
+            return float(v[:-1]) / 1e3
+        return float(v) * 1000.0     # whole cores
+    except ValueError:
+        return None
+
+
+_MEM_UNITS = {"Ki": 1024, "Mi": 1024**2, "Gi": 1024**3, "Ti": 1024**4,
+              "K": 1e3, "M": 1e6, "G": 1e9, "T": 1e12}
+
+
+def _mem_to_bytes(v: str) -> float | None:
+    if not v:
+        return None
+    v = v.strip()
+    for u, mult in _MEM_UNITS.items():
+        if v.endswith(u):
+            try:
+                return float(v[: -len(u)]) * mult
+            except ValueError:
+                return None
+    try:
+        return float(v)
+    except ValueError:
+        return None
+
+
+def expected_verdict(*, peak, limit, fired_count, gate_eligible, enforcement) -> str:
+    """The SufficiencyVerdict algebra — identical to the devsecops mapping's validator."""
+    if not gate_eligible:
+        return "INCONCLUSIVE"
+    if enforcement != "observe" and fired_count and fired_count > 0:
+        return "PROVED"
+    if enforcement != "observe" and peak is not None and limit is not None \
+            and peak > limit and (fired_count == 0):
+        return "VIOLATION"
+    return "INCONCLUSIVE"
+
+
+def sample_peaks(ns: str, samples: int, interval: float) -> tuple[dict, int]:
+    """MAX cpu(millicores)/mem(bytes) per pod over `samples` reads. Returns (peaks, taken)."""
+    peaks: dict[str, dict[str, float]] = {}
+    taken = 0
+    for i in range(samples):
+        out = _kubectl(["top", "pods", "-n", ns, "--no-headers"])
+        if not out.strip():
+            continue
+        taken += 1
+        for line in out.strip().splitlines():
+            parts = line.split()
+            if len(parts) < 3:
+                continue
+            pod, cpu, mem = parts[0], _cpu_to_millicores(parts[1]), _mem_to_bytes(parts[2])
+            d = peaks.setdefault(pod, {"cpu": 0.0, "mem": 0.0})
+            if cpu is not None:
+                d["cpu"] = max(d["cpu"], cpu)
+            if mem is not None:
+                d["mem"] = max(d["mem"], mem)
+        if i < samples - 1:
+            time.sleep(interval)
+    return peaks, taken
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--namespace", default="socioprophet")
+    ap.add_argument("--samples", type=int, default=3)
+    ap.add_argument("--interval", type=float, default=8.0)
+    ap.add_argument("--out", default="")
+    args = ap.parse_args()
+    ns = args.namespace
+
+    deploys_raw = _kubectl(["get", "deploy", "-n", ns, "-o", "json"])
+    if not deploys_raw.strip():
+        print("kubectl unreachable or no deployments — everything INCONCLUSIVE", file=sys.stderr)
+        return 2
+    deploys = json.loads(deploys_raw)["items"]
+
+    window_s = args.interval * max(args.samples - 1, 0)
+    peaks, taken = sample_peaks(ns, args.samples, args.interval)
+    metrics_ok = taken > 0
+
+    # OOMKilled count per workload (memory enforcement FIRED), from pod lastState.
+    pods = json.loads(_kubectl(["get", "pods", "-n", ns, "-o", "json"]) or '{"items":[]}')["items"]
+    oom: dict[str, int] = {}
+    pod_peak: dict[str, dict] = peaks
+    def owner(podname: str) -> str:
+        # strip the two trailing ReplicaSet/pod hash segments: <deploy>-<rs>-<pod>
+        return "-".join(podname.split("-")[:-2]) if podname.count("-") >= 2 else podname
+    for p in pods:
+        nm = p["metadata"]["name"]
+        for cs in p.get("status", {}).get("containerStatuses", []):
+            if cs.get("lastState", {}).get("terminated", {}).get("reason") == "OOMKilled":
+                oom[owner(nm)] = oom.get(owner(nm), 0) + 1
+
+    # aggregate pod peaks -> workload peaks
+    wl_peak: dict[str, dict] = {}
+    for pod, d in pod_peak.items():
+        w = owner(pod)
+        agg = wl_peak.setdefault(w, {"cpu": 0.0, "mem": 0.0})
+        agg["cpu"] = max(agg["cpu"], d["cpu"])
+        agg["mem"] = max(agg["mem"], d["mem"])
+
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    contracts, verdicts, unbounded = [], [], []
+    tally = {"PROVED": 0, "VIOLATION": 0, "INCONCLUSIVE": 0}
+
+    for w in deploys:
+        name = w["metadata"]["name"]
+        c = w["spec"]["template"]["spec"]["containers"][0]
+        lim = c.get("resources", {}).get("limits", {}) or {}
+        peak = wl_peak.get(name, {"cpu": 0.0, "mem": 0.0})
+
+        specs = []
+        if lim.get("memory"):
+            specs.append(("memory", "bytes", _mem_to_bytes(lim["memory"]), peak["mem"],
+                          "terminate", oom.get(name, 0)))          # OOMKill = real fired signal
+        if lim.get("cpu"):
+            specs.append(("cpu", "millicores", _cpu_to_millicores(lim["cpu"]), peak["cpu"],
+                          "throttle", None))                       # throttle counter not collected
+        if not specs:
+            unbounded.append(name)
+            continue
+
+        for resource, unit, limval, peakval, enforcement, fired in specs:
+            # gate-eligible only if we actually measured a peak AND (for the verdict to mean
+            # anything about teeth) the enforcement signal is known. CPU's fired is None -> the
+            # peak is measured but the teeth question is unanswerable -> not gate-eligible.
+            gate_eligible = bool(metrics_ok) and (fired is not None)
+            verdict = expected_verdict(peak=peakval, limit=limval, fired_count=fired,
+                                       gate_eligible=gate_eligible, enforcement=enforcement)
+            tally[verdict] += 1
+            contract = {
+                "schemaVersion": "0.1.0", "kind": "ResourceContract",
+                "contractId": f"{name}-{resource}",
+                "resource": resource,  # 'memory' | 'cpu' — sourceos-spec ResourceContract enum members
+                "limit": {"value": limval, "unit": unit},
+                "window": f"PT{int(window_s)}S" if window_s else "PT0S",
+                # scope=tenant needs no scopeRationale (that is required only for scope=process);
+                # omit it rather than emit null, which fails the schema's type: string.
+                "scope": "tenant",
+                # An enforcing contract MUST carry a resolvable negative control (schema
+                # INVARIANT). The producer observes; this procedure is how a workload's teeth
+                # are proven, converting INCONCLUSIVE -> PROVED once run.
+                "enforcement": enforcement,
+                "negativeControl": "conformance/k8s-resource-enforcement-fires.md",
+                "firedCount": fired if fired is not None else 0,
+                "observedPeak": {
+                    "schemaVersion": "0.1.0", "kind": "Measurement",
+                    "label": f"{name} {resource} peak over {int(window_s)}s ({taken} samples)",
+                    "value": round(peakval, 3),
+                    "source": "measured" if metrics_ok else "assumed",
+                    "instrument": "kubectl top (metrics-server)",
+                    "sampling": {"observed": taken, "population": args.samples, "unit": "samples"},
+                    "unobserved": 0,
+                    "gateEligible": gate_eligible,
+                },
+            }
+            contracts.append(contract)
+            verdicts.append({
+                "kind": "SufficiencyVerdict", "resource_contract_id": f"{name}-{resource}",
+                "enforcement": enforcement, "fired_count": fired,
+                "peak": round(peakval, 3), "limit": limval, "verdict": verdict,
+                "reason": _reason(verdict, resource, name, peakval, limval, fired, enforcement, metrics_ok),
+            })
+
+    # ---- report ------------------------------------------------------------------
+    print(f"ResourceContract producer — ns={ns}  {now}")
+    print(f"  metrics-server: {'OK' if metrics_ok else 'UNREACHABLE'}  "
+          f"({taken}/{args.samples} samples over ~{int(window_s)}s)")
+    print(f"  workloads: {len(deploys)}   contracts emitted: {len(contracts)}   "
+          f"UNBOUNDED (no limit → ungovernable): {len(unbounded)}")
+    print(f"  verdicts: PROVED={tally['PROVED']}  VIOLATION={tally['VIOLATION']}  "
+          f"INCONCLUSIVE={tally['INCONCLUSIVE']}")
+    if unbounded:
+        print(f"  🔴 no ResourceContract possible (no limit declared): {', '.join(sorted(unbounded))}")
+    viol = [v for v in verdicts if v["verdict"] == "VIOLATION"]
+    if viol:
+        print("  🔴 VIOLATIONs (limit exceeded, enforcement never fired):")
+        for v in viol:
+            print(f"     {v['resource_contract_id']}: peak {v['peak']} > limit {v['limit']}")
+    proved = [v for v in verdicts if v["verdict"] == "PROVED"]
+    for v in proved:
+        print(f"  ✓ PROVED {v['resource_contract_id']}: enforcement fired {v['fired_count']}x")
+
+    if args.out:
+        d = Path(args.out); d.mkdir(parents=True, exist_ok=True)
+        (d / "resource-contracts.json").write_text(json.dumps(contracts, indent=2))
+        (d / "sufficiency-verdicts.json").write_text(json.dumps(verdicts, indent=2))
+        (d / "unbounded-workloads.json").write_text(json.dumps(sorted(unbounded), indent=2))
+        print(f"  wrote {len(contracts)} contracts + {len(verdicts)} verdicts to {d}/")
+    return 0
+
+
+def _reason(verdict, resource, name, peak, limit, fired, enforcement, metrics_ok) -> str:
+    if not metrics_ok:
+        return "metrics-server unreachable — observed peak not measured, sufficiency unestablished"
+    if resource == "cpu" and fired is None:
+        return ("CPU throttle counter (cgroup cpu.stat nr_throttled) is not exposed via the k8s "
+                "API, so whether the throttle enforcement fired is unknown — no teeth verdict "
+                "can be drawn. Wire Prometheus/cAdvisor to make CPU contracts real.")
+    if verdict == "PROVED":
+        return f"{resource} limit enforced ({enforcement}) {fired}x on real load — the control has teeth"
+    if verdict == "VIOLATION":
+        return (f"{resource} peak {peak} exceeded limit {limit} yet enforcement never fired — a "
+                "never-fired control (for memory this is anomalous: OOM should have fired)")
+    return (f"{resource} peak {peak} stayed under limit {limit} and enforcement never needed to "
+            "fire — the limit held, but its teeth are unproven (no breach observed)")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_emit_resource_contracts.py
+++ b/tools/tests/test_emit_resource_contracts.py
@@ -1,0 +1,92 @@
+"""Negative control for the ResourceContract producer's verdict algebra + schema conformance.
+
+The producer emits the SufficiencyVerdict independently of the devsecops consumer; the two MUST
+agree, or the loop speaks two languages. These tests pin every precedence branch (so the algebra
+is proven to DISCRIMINATE, not rubber-stamp) and prove a synthetic emitted contract validates
+against the real sourceos-spec ResourceContract schema when it is reachable.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+import emit_resource_contracts as erc  # noqa: E402
+
+
+# ── the verdict algebra must discriminate all four branches ──────────────────────
+def test_gate_ineligible_is_inconclusive():
+    # e.g. CPU: peak measured but the throttle signal (fired) is unknown → not gate-eligible
+    assert erc.expected_verdict(peak=999, limit=1, fired_count=None,
+                                gate_eligible=False, enforcement="throttle") == "INCONCLUSIVE"
+
+
+def test_enforcing_and_fired_is_proved():
+    assert erc.expected_verdict(peak=1, limit=1, fired_count=3,
+                                gate_eligible=True, enforcement="terminate") == "PROVED"
+
+
+def test_exceeded_and_never_fired_is_violation():
+    assert erc.expected_verdict(peak=2.0, limit=1.0, fired_count=0,
+                                gate_eligible=True, enforcement="terminate") == "VIOLATION"
+
+
+def test_under_limit_never_fired_is_inconclusive():
+    # the healthy-but-untested case that dominates a fresh cluster: teeth unproven, no breach
+    assert erc.expected_verdict(peak=0.3, limit=1.0, fired_count=0,
+                                gate_eligible=True, enforcement="terminate") == "INCONCLUSIVE"
+
+
+def test_observe_mode_exceedance_is_not_violation():
+    # a gauge makes no enforcement promise, so it cannot violate one
+    assert erc.expected_verdict(peak=2.0, limit=1.0, fired_count=0,
+                                gate_eligible=True, enforcement="observe") == "INCONCLUSIVE"
+
+
+# ── unit conversions the producer relies on ─────────────────────────────────────
+@pytest.mark.parametrize("s,want", [("500m", 500.0), ("2", 2000.0), ("250000u", 250.0), ("", None)])
+def test_cpu_to_millicores(s, want):
+    assert erc._cpu_to_millicores(s) == want
+
+
+@pytest.mark.parametrize("s,want", [("128Mi", 128 * 1024**2), ("1Gi", 1024**3), ("", None)])
+def test_mem_to_bytes(s, want):
+    assert erc._mem_to_bytes(s) == want
+
+
+# ── a synthetic emitted contract validates against the real schema ──────────────
+def test_synthetic_contract_matches_sourceos_spec_schema():
+    spec = Path.home() / "dev/sourceos-spec/schemas"
+    if not (spec / "ResourceContract.json").is_file():
+        pytest.skip("sourceos-spec schema not reachable in this environment")
+    import json
+    try:
+        from jsonschema import Draft202012Validator
+    except ImportError:
+        pytest.skip("jsonschema not installed")
+    rc = json.loads((spec / "ResourceContract.json").read_text())
+    meas = json.loads((spec / "Measurement.json").read_text())
+    rc["properties"]["observedPeak"] = {k: v for k, v in meas.items() if k not in ("$schema", "$id")}
+    contract = {
+        "schemaVersion": "0.1.0", "kind": "ResourceContract", "contractId": "x-memory",
+        "resource": "memory", "limit": {"value": 134217728, "unit": "bytes"},
+        "window": "PT12S", "scope": "tenant", "enforcement": "terminate",
+        "negativeControl": "conformance/k8s-resource-enforcement-fires.md", "firedCount": 0,
+        "observedPeak": {
+            "schemaVersion": "0.1.0", "kind": "Measurement", "label": "x memory peak",
+            "value": 40000000.0, "source": "measured", "instrument": "kubectl top (metrics-server)",
+            "sampling": {"observed": 3, "population": 3, "unit": "samples"},
+            "unobserved": 0, "gateEligible": True,
+        },
+    }
+    errs = list(Draft202012Validator(rc).iter_errors(contract))
+    assert not errs, f"synthetic contract is not schema-valid: {[e.message for e in errs][:3]}"
+
+
+def test_negative_control_procedure_exists():
+    """The negativeControl every emitted enforcing contract references must resolve."""
+    assert (ROOT / "conformance" / "k8s-resource-enforcement-fires.md").is_file()


### PR DESCRIPTION
Makes the Measurement/ResourceContract loop **flow with real data**. It was declared — schemas merged, [devsecops#26](https://github.com/SocioProphet/global-devsecops-intelligence/pull/26) maps them, [sociosphere#558](https://github.com/SocioProphet/sociosphere/pull/558) recognises the verdict — but nothing emitted a real contract. This is the **producer**.

For every workload it reads the declared limit, **measures** the observed peak from metrics-server, reads whether enforcement fired, and emits a schema-conformant `ResourceContract` + `SufficiencyVerdict` for `ops.evidence.artifacts.v1` / `ops.learning.feedback.v1`.

## Run against the live cluster (ns=socioprophet)

```
61 workloads → 114 contracts (memory + cpu) — ALL validate against
              sourceos-spec/schemas/ResourceContract.json (0 invalid)
verdicts:     0 PROVED   0 VIOLATION   114 INCONCLUSIVE
4 UNBOUNDED:  workspace-{caldav,mail,minio,smtp} — no limit → no contract possible
```

**The all-INCONCLUSIVE result is the honest one, and the point.** 0 OOMKills means no memory limit’s teeth have ever been tested (peaks sit far under limits); the CPU throttle counter (`cgroup cpu.stat nr_throttled`) isn’t exposed via the k8s API, so the throttle-fired signal is unknown. The producer **refuses to fake PROVED**:

- `observedPeak` is `source: measured` (metrics-server), the **max over N samples** in a stated window, `sampling.observed` recorded — honest about the window it saw.
- **memory** has a real fired signal (`OOMKilled` from pod `lastState`) → real verdict.
- **cpu** fired is unknown → not gate-eligible → `INCONCLUSIVE`, with the reason stated.
- **no-limit workloads** are emitted as an explicit governance gap, not skipped — a never-*declared* control is as much a finding as a never-*fired* one.

## Honesty is enforced by the schema

Every enforcing contract carries a **resolvable** `negativeControl` (`conformance/k8s-resource-enforcement-fires.md`) — the sourceos-spec schema requires proof an enforcement claim can fire, and that procedure converts a workload `INCONCLUSIVE → PROVED` once run (memory first; bounded and safe). **Not yet executed** — stated plainly, which is why nothing is `PROVED`.

## Tests

14 pass: the verdict algebra pinned across all four precedence branches (identical to the devsecops consumer’s, so producer and consumer agree), unit conversions, and a synthetic contract validating against the real schema.

## Follow-on (not here)

Wire this as a scheduled workflow with a read-only cluster role so the loop emits continuously into the devsecops ingest. Needs a WIF service-account with `get deploy` + `top pods`; tracked separately.

Read-only against the cluster.