### PR TITLE
deploy: pin gateway → moving-tag ratchet now EMPTY

### DIFF
--- a/deploy/values/gateway.yaml
+++ b/deploy/values/gateway.yaml
@@ -1,5 +1,5 @@
 # socioprophet-gateway — HTTP edge gateway
-image: { repository: socioprophet-gateway, tag: latest }
+image: { repository: socioprophet-gateway, tag: sha-d3566908a3d0aea902e5649aff772fa9abfa9d3a }
 service: { port: 8080, portName: http }
 # The binary reads GATEWAY_PORT (cmd/tritrpc-gateway/main.go:30) and binds ":"+port.
 # A Service named `gateway` makes Kubernetes inject GATEWAY_PORT=tcp://<clusterIP>:8080

--- a/tools/preflight_deploy_contract.py
+++ b/tools/preflight_deploy_contract.py
@@ -190,13 +190,11 @@ KNOWN_BROKEN = {
     # gateway remains: its values still say `tag: latest` AND its pod is NOT Ready (already
     # running a sha- tag out of sync with values) — a separate crash to fix, not a moving-tag
     # pin, so it stays tracked here until that is resolved.
-    **{f"{svc}:moving-tag": (
-        "Pre-existing `tag: latest`, and the pod is NOT Ready — a crash to resolve before "
-        "pinning (values already disagree with the running sha- tag). Not a clean moving-tag "
-        "pin; fix the crash, then pin to the running digest and delete this line."
-    ) for svc in [
-        "gateway",
-    ]},
+    # RESOLVED 2026-08-03: gateway — pinned to sha-d3566908 (its running digest, a no-op
+    # pin like the other 10). The moving-tag ratchet is now EMPTY: no first-party service
+    # deploys a moving `latest` tag. gateway is healthy (1/1, 20h uptime); the earlier
+    # 'not ready' reading was a substring mismatch with arcticdb-gateway (a separate
+    # missing-secret crash, tracked elsewhere).
     # eval-fabric-api sha-pinned by gitops-promote (sha-e72d47ce…) after its first CI
     # build → removed from the ratchet 2026-08-03 (it only shrinks; leaving it FAILs "now passes").
 }


### PR DESCRIPTION
gateway was the last first-party service on `image.tag: latest`. Pinned to `sha-d3566908…` — the **exact digest it is already running** (`socioprophet-gateway@sha256:cb8c4530…` == that sha- tag), a no-op rollout like the batch of 10 in #1326. gateway is healthy (1/1, 20h uptime).

With gateway pinned, the `KNOWN_BROKEN` moving-tag comprehension is removed: **the ratchet is now EMPTY**. No first-party service deploys a moving `latest` tag, enforced going forward by `preflight_deploy_contract.py` with its hermetic self-test intact.

(The earlier "gateway not ready" reading was a substring mismatch with `arcticdb-gateway` — a separate missing-secret crash, now healed via the provision-secrets CI mint: the pod is 1/1 Running after 20h in CreateContainerConfigError.)

preflight passes with **zero moving-tag deferrals remaining**.