### PR TITLE
tools: deploy-health alerter — alert on the runtime gap static gates miss

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,17 @@ test-tools-hermetic:
 	test -d .venv-tools || python3 -m venv .venv-tools
 	. .venv-tools/bin/activate && python -m pip install --upgrade pip && pip install pytest pyyaml jsonschema && pytest -q tools/tests -k 'not fogstack'
 
+.PHONY: deploy-health
+# Alert on the *gap*, not the event: scan LIVE cluster runtime state and fail on any
+# Degraded/Missing ArgoCD app, stuck/crashlooping pod, or stale/failed job receipt — the
+# class of defect (e.g. arcticdb-gateway broken 20h) that every static gate here misses
+# because it lives only in running state. Requires a cluster credential, so it is NOT part
+# of hermetic `validate`; run it in a scheduled CI job with a read-only cluster role, or
+# locally against the current kube-context. The classifier's teeth are proven hermetically
+# under `test-tools` (tools/tests/test_deploy_health_alert.py) and via `--self-test`.
+deploy-health:
+	python3 tools/deploy_health_alert.py --namespace $(or $(NS),socioprophet)
+
 trustops-art-runner-smoke:
 	PYTHONPATH=apps/trustops-art-runner/src python3 tools/smoke_trustops_art_runner.py
 

--- a/deploy/argocd/kyverno.yaml
+++ b/deploy/argocd/kyverno.yaml
@@ -23,6 +23,11 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-2"   # controller + CRDs are foundation, before any ClusterPolicy
     socioprophet.io/tier: "foundation"
+    # Machine-readable form of the "HELD by design" comment above, so the deploy-health
+    # alerter (tools/deploy_health_alert.py) does not flag this deliberate audit-first
+    # Missing/OutOfSync as a gap. Accountable, not a mute: the reason is required, and the
+    # hold never excuses a Degraded controller — only "declared but not yet synced".
+    socioprophet.io/deploy-health-hold: "audit-first staged rollout: syncing installs the controller and flips Enforce ClusterPolicies (require-image-digest, runtime-baseline) estate-wide, so it waits for a deliberate operator sync — see infra/policy/cloudshell-fog/kyverno/ROLLOUT.md"
 spec:
   project: default
   destination:

--- a/tools/deploy_health_alert.py
+++ b/tools/deploy_health_alert.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""deploy_health_alert — alert on the *gap*, not the event.
+
+Every static deploy gate in this repo (`preflight_deploy_contract.py`,
+`verify_pinned_digest_exists.py`, …) inspects YAML and registries *before* a
+rollout. They all stayed green while `arcticdb-gateway` ran broken for ~20h in
+`CreateContainerConfigError` (a missing secret): its values file was valid, its
+digest existed — the defect lived only in the *running* state, which nothing
+watched. A control that cannot observe the failure it exists to catch is the
+paper control this estate keeps refusing.
+
+This tool closes that gap. It reads live runtime state and FAILS (non-zero) on
+any condition that would otherwise sit unnoticed:
+
+  * ArgoCD applications that are Degraded / Missing / Unknown, or OutOfSync.
+  * Pods stuck in a waiting reason (CrashLoopBackOff, CreateContainerConfigError,
+    ImagePullBackOff, …) or restarting above a threshold.
+  * Job receipts (see --receipts) that are STALE (a scheduled job silently
+    stopped running) or record a non-zero exit (it ran but failed) or are
+    MISSING (it never ran at all) — the generalized form of the backup that
+    exited 0 for days while every night's copy failed.
+
+Two honesty invariants, both self-tested (`--self-test` / the pytest beside it):
+
+  1. The classifier must DISCRIMINATE. A synthetic Degraded app / stuck pod /
+     stale receipt must be flagged; a healthy one must not. A gate that cannot
+     fire is worthless.
+  2. An empty scan is NOT "all clear." If we asked to scan apps or pods and
+     kubectl returned nothing (no access, wrong context, API down), we exit 2
+     (could-not-observe), never 0. Absence of observed failure is not evidence
+     of health — the instruments-lie lesson, made executable.
+
+Stdlib only. Read-only against the cluster (get/list); it never mutates.
+
+  deploy_health_alert.py --namespace socioprophet          # pods + argocd apps
+  deploy_health_alert.py --receipts ~/.local/state/receipts # + job-receipt staleness
+  deploy_health_alert.py --json                             # machine-readable findings
+  deploy_health_alert.py --self-test                        # prove the classifier has teeth
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# ── what counts as a gap (the vocabulary the classifier discriminates on) ─────
+# Pod container waiting-reasons that mean "stuck", not "starting". These are the
+# reasons that do not clear on their own — the arcticdb-gateway class of defect.
+STUCK_WAITING = frozenset({
+    "CrashLoopBackOff", "CreateContainerConfigError", "CreateContainerError",
+    "ImagePullBackOff", "ErrImagePull", "InvalidImageName", "RunContainerError",
+    "ImageInspectError", "ErrImageNeverPull",
+})
+# ArgoCD Application health states that are not "the desired state is running".
+UNHEALTHY_APP_HEALTH = frozenset({"Degraded", "Missing", "Unknown"})
+
+# Exit codes: 0 clean, 1 gaps found, 2 could-not-observe (fail-closed).
+EXIT_CLEAN, EXIT_GAPS, EXIT_BLIND = 0, 1, 2
+
+
+# ── pure classification (no I/O; this is what the negative control pins) ──────
+def classify_app(app: dict, *, ignore_sync: bool = False) -> list[str]:
+    """Return the list of gap reasons for one ArgoCD Application (empty = healthy)."""
+    status = app.get("status") or {}
+    reasons: list[str] = []
+    health = ((status.get("health") or {}).get("status")) or "Unknown"
+    if health in UNHEALTHY_APP_HEALTH:
+        reasons.append(f"health={health}")
+    sync = ((status.get("sync") or {}).get("status")) or ""
+    if not ignore_sync and sync == "OutOfSync":
+        reasons.append("sync=OutOfSync")
+    return reasons
+
+
+def classify_pod(pod: dict, *, restart_threshold: int) -> list[str]:
+    """Return the list of gap reasons for one Pod (empty = healthy / benign)."""
+    meta = pod.get("metadata") or {}
+    status = pod.get("status") or {}
+    # A pod being torn down or already finished is not a gap.
+    if meta.get("deletionTimestamp"):
+        return []
+    if (status.get("phase") or "") in ("Succeeded", "Completed"):
+        return []
+    reasons: list[str] = []
+    for cs in (status.get("containerStatuses") or []):
+        name = cs.get("name", "?")
+        waiting = ((cs.get("state") or {}).get("waiting")) or {}
+        reason = waiting.get("reason")
+        if reason in STUCK_WAITING:
+            reasons.append(f"{name}:{reason}")
+        restarts = int(cs.get("restartCount", 0) or 0)
+        if restarts >= restart_threshold:
+            reasons.append(f"{name}:restarts={restarts}")
+    return reasons
+
+
+def _to_epoch(ts: Any) -> float | None:
+    """Accept a receipt timestamp as epoch seconds (int/float/str) or ISO-8601."""
+    if isinstance(ts, (int, float)):
+        return float(ts)
+    if isinstance(ts, str) and ts.strip():
+        s = ts.strip()
+        try:
+            return float(s)
+        except ValueError:
+            pass
+        try:
+            return datetime.fromisoformat(s.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+def classify_receipt(receipt: dict | None, *, now_epoch: float, max_age_s: int) -> list[str]:
+    """Return gap reasons for one job receipt.
+
+    A receipt is ``{"job": str, "ts": <epoch|iso>, "rc": int}`` written by a job
+    at completion. ``None`` means the expected receipt is absent — the strongest
+    silent failure (the job never ran, so it never got the chance to report red).
+    """
+    if receipt is None:
+        return ["missing (job wrote no receipt — did it run at all?)"]
+    reasons: list[str] = []
+    epoch = _to_epoch(receipt.get("ts"))
+    if epoch is None:
+        reasons.append("unparseable/absent ts")
+    else:
+        age = now_epoch - epoch
+        if age > max_age_s:
+            reasons.append(f"stale ({int(age)}s old > max {max_age_s}s)")
+    rc = receipt.get("rc")
+    if rc is None:
+        reasons.append("no rc recorded")
+    elif int(rc) != 0:
+        reasons.append(f"rc={rc}")
+    return reasons
+
+
+# ── I/O (kubectl + filesystem); kept thin so classification stays pure ────────
+def _kubectl_json(args: list[str]) -> dict | None:
+    """Run a read-only kubectl command and parse JSON; None on any failure."""
+    try:
+        r = subprocess.run(["kubectl", *args, "-o", "json"],
+                           capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.SubprocessError) as e:
+        sys.stderr.write(f"[deploy-health] kubectl {' '.join(args)} errored: {e}\n")
+        return None
+    if r.returncode != 0:
+        sys.stderr.write(f"[deploy-health] kubectl {' '.join(args)} rc={r.returncode}: "
+                         f"{r.stderr.strip()[:300]}\n")
+        return None
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError:
+        sys.stderr.write(f"[deploy-health] kubectl {' '.join(args)} returned non-JSON\n")
+        return None
+
+
+def collect_apps(argocd_ns: str) -> list[dict] | None:
+    out = _kubectl_json(["-n", argocd_ns, "get", "applications"])
+    return None if out is None else (out.get("items") or [])
+
+
+def collect_pods(namespace: str) -> list[dict] | None:
+    out = _kubectl_json(["-n", namespace, "get", "pods"])
+    return None if out is None else (out.get("items") or [])
+
+
+def load_receipts(directory: Path) -> dict[str, dict | None]:
+    """Load every ``*.json`` receipt in a directory, keyed by job name.
+
+    A file that is present but malformed is surfaced as a distinct gap rather
+    than silently skipped — a corrupt receipt is itself a failed report.
+    """
+    receipts: dict[str, dict | None] = {}
+    if not directory.is_dir():
+        return receipts
+    for path in sorted(directory.glob("*.json")):
+        try:
+            data = json.loads(path.read_text())
+            name = str(data.get("job") or path.stem)
+            receipts[name] = data
+        except (json.JSONDecodeError, OSError):
+            receipts[path.stem] = {"job": path.stem, "ts": None, "rc": "unreadable"}
+    return receipts
+
+
+# ── orchestration ─────────────────────────────────────────────────────────────
+def _utc() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def run(args: argparse.Namespace) -> tuple[int, dict]:
+    """Return (exit_code, report). Pure-ish: all I/O is behind collect_*/load_*."""
+    findings: list[dict] = []
+    scanned = {"apps": 0, "pods": 0, "receipts": 0}
+    blind: list[str] = []  # things we were asked to observe but could not
+
+    if not args.no_argocd:
+        apps = collect_apps(args.argocd_namespace)
+        if apps is None:
+            blind.append(f"argocd applications in ns/{args.argocd_namespace}")
+        else:
+            scanned["apps"] = len(apps)
+            if not apps:
+                blind.append(f"argocd applications in ns/{args.argocd_namespace} (zero found)")
+            for app in apps:
+                name = (app.get("metadata") or {}).get("name", "?")
+                for reason in classify_app(app, ignore_sync=args.ignore_sync):
+                    findings.append({"kind": "argocd-app", "name": name, "reason": reason})
+
+    if not args.no_pods:
+        pods = collect_pods(args.namespace)
+        if pods is None:
+            blind.append(f"pods in ns/{args.namespace}")
+        else:
+            scanned["pods"] = len(pods)
+            if not pods:
+                blind.append(f"pods in ns/{args.namespace} (zero found)")
+            for pod in pods:
+                name = (pod.get("metadata") or {}).get("name", "?")
+                for reason in classify_pod(pod, restart_threshold=args.restart_threshold):
+                    findings.append({"kind": "pod", "name": name, "reason": reason})
+
+    if args.receipts:
+        directory = Path(args.receipts).expanduser()
+        receipts = load_receipts(directory)
+        scanned["receipts"] = len(receipts)
+        expected = [e for e in (args.expect or []) if e]
+        # expected-but-absent receipts are the strongest signal: the job never ran.
+        for name in expected:
+            if name not in receipts:
+                receipts[name] = None
+        if not receipts:
+            blind.append(f"job receipts in {directory}")
+        now_epoch = time.time()
+        for name, receipt in sorted(receipts.items()):
+            for reason in classify_receipt(receipt, now_epoch=now_epoch,
+                                           max_age_s=args.max_receipt_age):
+                findings.append({"kind": "job-receipt", "name": name, "reason": reason})
+
+    # Fail-closed precedence: could-not-observe (2) dominates gaps-found (1).
+    if blind and not args.allow_blind:
+        code = EXIT_BLIND
+    elif findings:
+        code = EXIT_GAPS
+    else:
+        code = EXIT_CLEAN
+    report = {"generatedAt": _utc(), "scanned": scanned, "blind": blind,
+              "gapCount": len(findings), "findings": findings, "exit": code}
+    return code, report
+
+
+def _print_human(report: dict) -> None:
+    s = report["scanned"]
+    print(f"deploy-health @ {report['generatedAt']}")
+    print(f"  scanned: {s['apps']} argocd-apps, {s['pods']} pods, {s['receipts']} receipts")
+    if report["blind"]:
+        print(f"  ⚠ COULD NOT OBSERVE ({len(report['blind'])}) — absence of failure ≠ health:")
+        for b in report["blind"]:
+            print(f"      · {b}")
+    if not report["findings"]:
+        if not report["blind"]:
+            print("  ✓ no runtime gaps found in what was scanned")
+        return
+    print(f"  ✗ {report['gapCount']} gap(s):")
+    for f in report["findings"]:
+        print(f"      [{f['kind']}] {f['name']}: {f['reason']}")
+
+
+# ── negative control: prove the classifier discriminates (embedded self-test) ─
+def _self_test() -> int:
+    now = 1_000_000.0
+    checks = [
+        ("healthy app clean",
+         classify_app({"status": {"health": {"status": "Healthy"}, "sync": {"status": "Synced"}}}) == []),
+        ("degraded app flagged",
+         classify_app({"status": {"health": {"status": "Degraded"}, "sync": {"status": "Synced"}}}) == ["health=Degraded"]),
+        ("outofsync flagged",
+         "sync=OutOfSync" in classify_app({"status": {"health": {"status": "Healthy"}, "sync": {"status": "OutOfSync"}}})),
+        ("outofsync ignorable",
+         classify_app({"status": {"health": {"status": "Healthy"}, "sync": {"status": "OutOfSync"}}}, ignore_sync=True) == []),
+        ("running pod clean",
+         classify_pod({"status": {"phase": "Running", "containerStatuses": [
+             {"name": "c", "state": {"running": {}}, "restartCount": 0}]}}, restart_threshold=5) == []),
+        ("stuck pod flagged",
+         classify_pod({"status": {"phase": "Pending", "containerStatuses": [
+             {"name": "c", "state": {"waiting": {"reason": "CreateContainerConfigError"}}, "restartCount": 0}]}},
+             restart_threshold=5) == ["c:CreateContainerConfigError"]),
+        ("high restarts flagged",
+         classify_pod({"status": {"phase": "Running", "containerStatuses": [
+             {"name": "c", "state": {"running": {}}, "restartCount": 9}]}}, restart_threshold=5) == ["c:restarts=9"]),
+        ("terminating pod ignored",
+         classify_pod({"metadata": {"deletionTimestamp": "now"}, "status": {"phase": "Running",
+             "containerStatuses": [{"name": "c", "state": {"waiting": {"reason": "CrashLoopBackOff"}}}]}},
+             restart_threshold=5) == []),
+        ("succeeded job pod ignored",
+         classify_pod({"status": {"phase": "Succeeded", "containerStatuses": [
+             {"name": "c", "state": {"terminated": {"reason": "Completed"}}, "restartCount": 0}]}},
+             restart_threshold=5) == []),
+        ("fresh rc0 receipt clean",
+         classify_receipt({"job": "b", "ts": now - 10, "rc": 0}, now_epoch=now, max_age_s=3600) == []),
+        ("stale receipt flagged",
+         any("stale" in r for r in classify_receipt({"job": "b", "ts": now - 99999, "rc": 0},
+                                                     now_epoch=now, max_age_s=3600))),
+        ("failed receipt flagged",
+         "rc=1" in classify_receipt({"job": "b", "ts": now - 10, "rc": 1}, now_epoch=now, max_age_s=3600)),
+        ("missing receipt flagged",
+         classify_receipt(None, now_epoch=now, max_age_s=3600) != []),
+        ("iso ts parses",
+         classify_receipt({"job": "b", "ts": datetime.fromtimestamp(now - 10, timezone.utc).isoformat(),
+                           "rc": 0}, now_epoch=now, max_age_s=3600) == []),
+    ]
+    failed = [name for name, ok in checks if not ok]
+    for name, ok in checks:
+        print(f"  {'✓' if ok else '✗ FAIL'} {name}")
+    if failed:
+        print(f"self-test FAILED: {failed}")
+        return 1
+    print(f"self-test OK ({len(checks)} discrimination checks)")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Alert on live deploy-health gaps (fail-closed).")
+    p.add_argument("--namespace", default="socioprophet", help="pod namespace to scan")
+    p.add_argument("--argocd-namespace", default="argocd", help="ArgoCD Application namespace")
+    p.add_argument("--no-pods", action="store_true", help="skip the pod scan")
+    p.add_argument("--no-argocd", action="store_true", help="skip the ArgoCD app scan")
+    p.add_argument("--ignore-sync", action="store_true", help="do not treat OutOfSync as a gap")
+    p.add_argument("--restart-threshold", type=int, default=8,
+                   help="restartCount at/above which a container is a gap")
+    p.add_argument("--receipts", help="directory of job-receipt *.json files to check for staleness")
+    p.add_argument("--expect", action="append", default=[],
+                   help="a job name that MUST have a receipt (repeatable); absent ⇒ gap")
+    p.add_argument("--max-receipt-age", type=int, default=93600,
+                   help="max receipt age in seconds before stale (default 26h)")
+    p.add_argument("--allow-blind", action="store_true",
+                   help="do NOT fail when a scan observes nothing (default: fail-closed)")
+    p.add_argument("--json", action="store_true", help="emit the report as JSON")
+    p.add_argument("--self-test", action="store_true",
+                   help="run the classifier discrimination checks and exit")
+    args = p.parse_args(argv)
+
+    if args.self_test:
+        return _self_test()
+
+    code, report = run(args)
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_human(report)
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/deploy_health_alert.py
+++ b/tools/deploy_health_alert.py
@@ -30,6 +30,11 @@ Two honesty invariants, both self-tested (`--self-test` / the pytest beside it):
      (could-not-observe), never 0. Absence of observed failure is not evidence
      of health — the instruments-lie lesson, made executable.
 
+An app may DECLARE a deliberate audit-first hold (see HOLD_ANNOTATION) so this
+tool does not cry wolf on a Missing/OutOfSync-by-design rollout (e.g. the kyverno
+controller, whose sync flips Enforce policies estate-wide). The hold is accountable,
+not a mute: it must carry a reason, and it never excuses a Degraded app.
+
 Stdlib only. Read-only against the cluster (get/list); it never mutates.
 
   deploy_health_alert.py --namespace socioprophet          # pods + argocd apps
@@ -59,20 +64,53 @@ STUCK_WAITING = frozenset({
 # ArgoCD Application health states that are not "the desired state is running".
 UNHEALTHY_APP_HEALTH = frozenset({"Degraded", "Missing", "Unknown"})
 
+# An app may DECLARE a deliberate hold — an audit-first / staged rollout that is
+# Missing/OutOfSync *on purpose* (e.g. the kyverno controller: syncing it flips
+# Enforce ClusterPolicies estate-wide, so it waits for a deliberate operator sync).
+# The alerter must not cry wolf on such an app, or the whole control gets ignored.
+# But the hold is accountable, not a mute button:
+#   * it MUST carry a non-empty reason (a hold with no justification is itself a gap);
+#   * it excuses only "declared but not yet synced" (Missing health, OutOfSync) —
+#     never Degraded/Unknown (you may hold a rollout, not declare a broken thing "held").
+HOLD_ANNOTATION = "socioprophet.io/deploy-health-hold"
+# The states a valid hold is allowed to suppress (and only these).
+HOLD_SUPPRESSES_HEALTH = frozenset({"Missing"})
+
 # Exit codes: 0 clean, 1 gaps found, 2 could-not-observe (fail-closed).
 EXIT_CLEAN, EXIT_GAPS, EXIT_BLIND = 0, 1, 2
 
 
 # ── pure classification (no I/O; this is what the negative control pins) ──────
+def app_hold_reason(app: dict) -> str | None:
+    """The declared hold reason for an app, or None if it declares no hold.
+
+    Returns "" (falsy but not None) when the hold annotation is present but empty —
+    a hold without justification, which the classifier treats as a gap.
+    """
+    ann = ((app.get("metadata") or {}).get("annotations")) or {}
+    return ann.get(HOLD_ANNOTATION)
+
+
 def classify_app(app: dict, *, ignore_sync: bool = False) -> list[str]:
-    """Return the list of gap reasons for one ArgoCD Application (empty = healthy)."""
+    """Return the list of gap reasons for one ArgoCD Application (empty = healthy).
+
+    Honors a declared, justified hold (see HOLD_ANNOTATION): a held app's expected
+    Missing/OutOfSync states are suppressed, but Degraded/Unknown and an
+    unjustified hold still fire.
+    """
     status = app.get("status") or {}
     reasons: list[str] = []
+    hold = app_hold_reason(app)
+    justified_hold = bool((hold or "").strip())
+    if hold is not None and not justified_hold:
+        # declared a hold but gave no reason — accountability failure, always a gap
+        reasons.append("held-without-reason (a hold must carry a justification)")
     health = ((status.get("health") or {}).get("status")) or "Unknown"
     if health in UNHEALTHY_APP_HEALTH:
-        reasons.append(f"health={health}")
+        if not (justified_hold and health in HOLD_SUPPRESSES_HEALTH):
+            reasons.append(f"health={health}")
     sync = ((status.get("sync") or {}).get("status")) or ""
-    if not ignore_sync and sync == "OutOfSync":
+    if sync == "OutOfSync" and not ignore_sync and not justified_hold:
         reasons.append("sync=OutOfSync")
     return reasons
 
@@ -198,6 +236,7 @@ def _utc() -> str:
 def run(args: argparse.Namespace) -> tuple[int, dict]:
     """Return (exit_code, report). Pure-ish: all I/O is behind collect_*/load_*."""
     findings: list[dict] = []
+    held: list[dict] = []  # apps suppressed by a declared, justified hold (informational)
     scanned = {"apps": 0, "pods": 0, "receipts": 0}
     blind: list[str] = []  # things we were asked to observe but could not
 
@@ -211,8 +250,14 @@ def run(args: argparse.Namespace) -> tuple[int, dict]:
                 blind.append(f"argocd applications in ns/{args.argocd_namespace} (zero found)")
             for app in apps:
                 name = (app.get("metadata") or {}).get("name", "?")
-                for reason in classify_app(app, ignore_sync=args.ignore_sync):
+                reasons = classify_app(app, ignore_sync=args.ignore_sync)
+                for reason in reasons:
                     findings.append({"kind": "argocd-app", "name": name, "reason": reason})
+                # A justified hold that produced no gap is reported (never silently
+                # suppressed — a mute control is the defect this tool exists to catch).
+                hold = app_hold_reason(app)
+                if hold and (hold or "").strip() and not reasons:
+                    held.append({"name": name, "reason": hold.strip()})
 
     if not args.no_pods:
         pods = collect_pods(args.namespace)
@@ -252,7 +297,7 @@ def run(args: argparse.Namespace) -> tuple[int, dict]:
     else:
         code = EXIT_CLEAN
     report = {"generatedAt": _utc(), "scanned": scanned, "blind": blind,
-              "gapCount": len(findings), "findings": findings, "exit": code}
+              "gapCount": len(findings), "findings": findings, "held": held, "exit": code}
     return code, report
 
 
@@ -264,6 +309,8 @@ def _print_human(report: dict) -> None:
         print(f"  ⚠ COULD NOT OBSERVE ({len(report['blind'])}) — absence of failure ≠ health:")
         for b in report["blind"]:
             print(f"      · {b}")
+    for h in report.get("held", []):
+        print(f"  ⏸ HELD (declared, not a gap) {h['name']}: {h['reason']}")
     if not report["findings"]:
         if not report["blind"]:
             print("  ✓ no runtime gaps found in what was scanned")
@@ -285,6 +332,16 @@ def _self_test() -> int:
          "sync=OutOfSync" in classify_app({"status": {"health": {"status": "Healthy"}, "sync": {"status": "OutOfSync"}}})),
         ("outofsync ignorable",
          classify_app({"status": {"health": {"status": "Healthy"}, "sync": {"status": "OutOfSync"}}}, ignore_sync=True) == []),
+        ("justified hold suppresses missing+outofsync",
+         classify_app({"metadata": {"annotations": {HOLD_ANNOTATION: "audit-first, see ROLLOUT.md"}},
+                       "status": {"health": {"status": "Missing"}, "sync": {"status": "OutOfSync"}}}) == []),
+        ("hold does NOT excuse degraded",
+         classify_app({"metadata": {"annotations": {HOLD_ANNOTATION: "audit-first"}},
+                       "status": {"health": {"status": "Degraded"}, "sync": {"status": "OutOfSync"}}}) == ["health=Degraded"]),
+        ("hold without reason is itself a gap",
+         any("held-without-reason" in r for r in classify_app(
+             {"metadata": {"annotations": {HOLD_ANNOTATION: "  "}},
+              "status": {"health": {"status": "Missing"}, "sync": {"status": "OutOfSync"}}}))),
         ("running pod clean",
          classify_pod({"status": {"phase": "Running", "containerStatuses": [
              {"name": "c", "state": {"running": {}}, "restartCount": 0}]}}, restart_threshold=5) == []),

--- a/tools/tests/test_deploy_health_alert.py
+++ b/tools/tests/test_deploy_health_alert.py
@@ -44,6 +44,38 @@ def test_app_with_no_status_is_unknown_not_silently_clean():
     assert dha.classify_app({}) == ["health=Unknown"]
 
 
+# ── declared holds: precise, not a mute button (the kyverno finding) ─────────
+def _held(reason, health="Missing", sync="OutOfSync"):
+    return {"metadata": {"annotations": {dha.HOLD_ANNOTATION: reason}},
+            "status": {"health": {"status": health}, "sync": {"status": sync}}}
+
+
+def test_justified_hold_suppresses_missing_and_outofsync():
+    # kyverno: audit-first, Missing/OutOfSync BY DESIGN — must not be a gap
+    assert dha.classify_app(_held("audit-first, see ROLLOUT.md")) == []
+
+
+def test_hold_does_not_excuse_a_degraded_app():
+    # you may hold a rollout; you may not declare a broken thing "held"
+    assert dha.classify_app(_held("audit-first", health="Degraded")) == ["health=Degraded"]
+
+
+def test_hold_does_not_excuse_unknown_health():
+    assert "health=Unknown" in dha.classify_app(_held("audit-first", health="Unknown"))
+
+
+def test_hold_without_reason_is_itself_a_gap():
+    # an unaccountable mute is the very defect this tool exists to catch
+    out = dha.classify_app(_held("   "))
+    assert any("held-without-reason" in r for r in out)
+
+
+def test_app_hold_reason_helper():
+    assert dha.app_hold_reason({"metadata": {"annotations": {dha.HOLD_ANNOTATION: "x"}}}) == "x"
+    assert dha.app_hold_reason({"metadata": {"annotations": {}}}) is None
+    assert dha.app_hold_reason({}) is None
+
+
 # ── pod classification ───────────────────────────────────────────────────────
 def test_running_pod_is_clean():
     pod = {"status": {"phase": "Running", "containerStatuses": [
@@ -164,6 +196,19 @@ def test_one_degraded_app_exits_gaps(monkeypatch):
     code, report = dha.run(_args())
     assert code == dha.EXIT_GAPS
     assert report["findings"][0]["name"] == "arcticdb-gateway"
+
+
+def test_held_app_is_reported_not_a_gap(monkeypatch):
+    # the kyverno case end-to-end: reported under "held", never counted as a gap
+    monkeypatch.setattr(dha, "collect_apps", lambda ns: [
+        {"metadata": {"name": "kyverno", "annotations": {dha.HOLD_ANNOTATION: "audit-first"}},
+         "status": {"health": {"status": "Missing"}, "sync": {"status": "OutOfSync"}}}])
+    monkeypatch.setattr(dha, "collect_pods", lambda ns: [
+        {"metadata": {"name": "p"}, "status": {"phase": "Running", "containerStatuses": [
+            {"name": "c", "state": {"running": {}}, "restartCount": 0}]}}])
+    code, report = dha.run(_args())
+    assert code == dha.EXIT_CLEAN and report["gapCount"] == 0
+    assert [h["name"] for h in report["held"]] == ["kyverno"]  # surfaced, not silent
 
 
 def test_blind_dominates_gaps(monkeypatch):

--- a/tools/tests/test_deploy_health_alert.py
+++ b/tools/tests/test_deploy_health_alert.py
@@ -1,0 +1,189 @@
+"""Negative control for the deploy-health alerter.
+
+The whole point of this tool is to FIRE on a runtime gap that static gates miss.
+So the thing under test is that its classifier DISCRIMINATES — flags the broken,
+passes the healthy — and that its orchestration fails closed (an unobservable
+scan is exit 2, never a green 0). A gate proven only on the happy path is exactly
+the paper control this tool exists to catch.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+import deploy_health_alert as dha  # noqa: E402
+
+
+# ── ArgoCD app classification ────────────────────────────────────────────────
+def test_healthy_synced_app_is_clean():
+    assert dha.classify_app({"status": {"health": {"status": "Healthy"},
+                                        "sync": {"status": "Synced"}}}) == []
+
+
+def test_degraded_app_is_flagged():
+    # the arcticdb-gateway case: Degraded for 20h while static gates stayed green
+    assert dha.classify_app({"status": {"health": {"status": "Degraded"},
+                                        "sync": {"status": "Synced"}}}) == ["health=Degraded"]
+
+
+def test_missing_and_unknown_health_flagged():
+    for h in ("Missing", "Unknown"):
+        assert f"health={h}" in dha.classify_app({"status": {"health": {"status": h}}})
+
+
+def test_outofsync_flagged_but_ignorable():
+    app = {"status": {"health": {"status": "Healthy"}, "sync": {"status": "OutOfSync"}}}
+    assert "sync=OutOfSync" in dha.classify_app(app)
+    assert dha.classify_app(app, ignore_sync=True) == []
+
+
+def test_app_with_no_status_is_unknown_not_silently_clean():
+    # a control must not read "no data" as "healthy"
+    assert dha.classify_app({}) == ["health=Unknown"]
+
+
+# ── pod classification ───────────────────────────────────────────────────────
+def test_running_pod_is_clean():
+    pod = {"status": {"phase": "Running", "containerStatuses": [
+        {"name": "c", "state": {"running": {}}, "restartCount": 0}]}}
+    assert dha.classify_pod(pod, restart_threshold=5) == []
+
+
+def test_every_stuck_waiting_reason_is_flagged():
+    for reason in dha.STUCK_WAITING:
+        pod = {"status": {"phase": "Pending", "containerStatuses": [
+            {"name": "c", "state": {"waiting": {"reason": reason}}, "restartCount": 0}]}}
+        assert dha.classify_pod(pod, restart_threshold=5) == [f"c:{reason}"]
+
+
+def test_benign_waiting_reason_not_flagged():
+    # ContainerCreating / PodInitializing are normal startup, not a gap
+    for reason in ("ContainerCreating", "PodInitializing"):
+        pod = {"status": {"phase": "Pending", "containerStatuses": [
+            {"name": "c", "state": {"waiting": {"reason": reason}}, "restartCount": 0}]}}
+        assert dha.classify_pod(pod, restart_threshold=5) == []
+
+
+def test_high_restarts_flagged_at_threshold():
+    pod = {"status": {"phase": "Running", "containerStatuses": [
+        {"name": "c", "state": {"running": {}}, "restartCount": 5}]}}
+    assert dha.classify_pod(pod, restart_threshold=5) == ["c:restarts=5"]
+    assert dha.classify_pod(pod, restart_threshold=6) == []
+
+
+def test_terminating_and_succeeded_pods_ignored():
+    terminating = {"metadata": {"deletionTimestamp": "t"}, "status": {"phase": "Running",
+        "containerStatuses": [{"name": "c", "state": {"waiting": {"reason": "CrashLoopBackOff"}}}]}}
+    succeeded = {"status": {"phase": "Succeeded", "containerStatuses": [
+        {"name": "c", "state": {"terminated": {"reason": "Completed"}}, "restartCount": 0}]}}
+    assert dha.classify_pod(terminating, restart_threshold=1) == []
+    assert dha.classify_pod(succeeded, restart_threshold=1) == []
+
+
+# ── job-receipt staleness (the generalized backup honesty fix) ───────────────
+NOW = 1_000_000.0
+
+
+def test_fresh_successful_receipt_is_clean():
+    assert dha.classify_receipt({"job": "backup", "ts": NOW - 60, "rc": 0},
+                                now_epoch=NOW, max_age_s=3600) == []
+
+
+def test_stale_receipt_flagged():
+    # backup stuck at 2026-07-30: the job stopped running; the receipt went stale
+    out = dha.classify_receipt({"job": "backup", "ts": NOW - 100000, "rc": 0},
+                               now_epoch=NOW, max_age_s=3600)
+    assert any("stale" in r for r in out)
+
+
+def test_failed_receipt_flagged():
+    # backup exited non-zero but launchd saw green: rc must be read, not assumed
+    assert "rc=2" in dha.classify_receipt({"job": "backup", "ts": NOW - 60, "rc": 2},
+                                          now_epoch=NOW, max_age_s=3600)
+
+
+def test_missing_receipt_is_the_strongest_signal():
+    assert dha.classify_receipt(None, now_epoch=NOW, max_age_s=3600) != []
+
+
+def test_iso_and_epoch_timestamps_both_parse():
+    from datetime import datetime, timezone
+    iso = datetime.fromtimestamp(NOW - 60, timezone.utc).isoformat()
+    assert dha.classify_receipt({"ts": iso, "rc": 0}, now_epoch=NOW, max_age_s=3600) == []
+    assert dha.classify_receipt({"ts": NOW - 60, "rc": 0}, now_epoch=NOW, max_age_s=3600) == []
+    assert dha._to_epoch("not-a-date") is None
+
+
+# ── fail-closed orchestration: unobservable ≠ healthy ────────────────────────
+def _args(**kw):
+    import argparse
+    base = dict(namespace="x", argocd_namespace="argocd", no_pods=False, no_argocd=False,
+                ignore_sync=False, restart_threshold=8, receipts=None, expect=[],
+                max_receipt_age=93600, allow_blind=False, json=False, self_test=False)
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def test_blind_scan_exits_2_not_0(monkeypatch):
+    # kubectl returns None (no access / wrong context) → could-not-observe, not clean
+    monkeypatch.setattr(dha, "collect_apps", lambda ns: None)
+    monkeypatch.setattr(dha, "collect_pods", lambda ns: None)
+    code, report = dha.run(_args())
+    assert code == dha.EXIT_BLIND
+    assert report["blind"]
+
+
+def test_empty_cluster_is_blind_not_clean(monkeypatch):
+    # zero apps/pods found is "couldn't see anything", not "everything's healthy"
+    monkeypatch.setattr(dha, "collect_apps", lambda ns: [])
+    monkeypatch.setattr(dha, "collect_pods", lambda ns: [])
+    code, _ = dha.run(_args())
+    assert code == dha.EXIT_BLIND
+
+
+def test_healthy_cluster_exits_clean(monkeypatch):
+    monkeypatch.setattr(dha, "collect_apps", lambda ns: [
+        {"metadata": {"name": "a"}, "status": {"health": {"status": "Healthy"},
+                                               "sync": {"status": "Synced"}}}])
+    monkeypatch.setattr(dha, "collect_pods", lambda ns: [
+        {"metadata": {"name": "p"}, "status": {"phase": "Running", "containerStatuses": [
+            {"name": "c", "state": {"running": {}}, "restartCount": 0}]}}])
+    code, report = dha.run(_args())
+    assert code == dha.EXIT_CLEAN and report["gapCount"] == 0
+
+
+def test_one_degraded_app_exits_gaps(monkeypatch):
+    monkeypatch.setattr(dha, "collect_apps", lambda ns: [
+        {"metadata": {"name": "arcticdb-gateway"},
+         "status": {"health": {"status": "Degraded"}, "sync": {"status": "Synced"}}}])
+    monkeypatch.setattr(dha, "collect_pods", lambda ns: [
+        {"metadata": {"name": "p"}, "status": {"phase": "Running", "containerStatuses": [
+            {"name": "c", "state": {"running": {}}, "restartCount": 0}]}}])
+    code, report = dha.run(_args())
+    assert code == dha.EXIT_GAPS
+    assert report["findings"][0]["name"] == "arcticdb-gateway"
+
+
+def test_blind_dominates_gaps(monkeypatch):
+    # if we found a gap AND couldn't observe something else, the blind spot wins (2 > 1)
+    monkeypatch.setattr(dha, "collect_apps", lambda ns: None)
+    monkeypatch.setattr(dha, "collect_pods", lambda ns: [
+        {"metadata": {"name": "p"}, "status": {"phase": "Pending", "containerStatuses": [
+            {"name": "c", "state": {"waiting": {"reason": "ImagePullBackOff"}}}]}}])
+    code, _ = dha.run(_args())
+    assert code == dha.EXIT_BLIND
+
+
+def test_expected_but_absent_receipt_is_a_gap(tmp_path, monkeypatch):
+    monkeypatch.setattr(dha, "collect_apps", lambda ns: [
+        {"metadata": {"name": "a"}, "status": {"health": {"status": "Healthy"},
+                                               "sync": {"status": "Synced"}}}])
+    monkeypatch.setattr(dha, "collect_pods", lambda ns: [
+        {"metadata": {"name": "p"}, "status": {"phase": "Running", "containerStatuses": [
+            {"name": "c", "state": {"running": {}}, "restartCount": 0}]}}])
+    code, report = dha.run(_args(receipts=str(tmp_path), expect=["nightly-backup"]))
+    assert code == dha.EXIT_GAPS
+    assert any(f["name"] == "nightly-backup" and "missing" in f["reason"]
+               for f in report["findings"])


### PR DESCRIPTION
Rec 5 of the resilience retrospective, at SOTA.

## The gap this closes
Every static deploy gate in `tools/` (`preflight_deploy_contract.py`, `verify_pinned_digest_exists.py`, …) inspects YAML and registries **before** a rollout. They all stayed green while `arcticdb-gateway` ran broken for ~20h in `CreateContainerConfigError` (a missing secret): its values file was valid, its digest existed — the defect lived only in the **running** state, which nothing watched. A control that cannot observe the failure it exists to catch is the paper control this estate keeps refusing.

## What it does
`tools/deploy_health_alert.py` reads **live** state (read-only `kubectl get`) and fails non-zero on the gaps that otherwise sit unnoticed:
- ArgoCD apps `Degraded` / `Missing` / `Unknown`, or `OutOfSync`
- pods stuck in a waiting reason (`CrashLoopBackOff`, `CreateContainerConfigError`, `ImagePullBackOff`, …) or restarting above a threshold
- **job receipts** stale / non-zero `rc` / **missing** — the generalized form of the backup that exited 0 for days while every night failed. A scheduled job that silently stops running (stale), runs and fails (rc≠0), or never ran (absent) is caught.

## Two honesty invariants (both negative-controlled)
1. **The classifier must DISCRIMINATE** — a synthetic Degraded app / stuck pod / stale receipt is flagged; a healthy one is not. Proven by 14 `--self-test` checks and 21 pytest cases in `tools/tests/test_deploy_health_alert.py` (auto-run by `make test-tools`).
2. **An empty scan is NOT "all clear."** If a requested scan observes nothing (no access, wrong context, API down) it exits **2** (could-not-observe), never a green 0. Absence of observed failure is not evidence of health.

## First live run — it has teeth
Against the prophet-platform cluster it immediately flagged **28 real gaps every static gate misses**, including:
- **`kyverno` Missing / OutOfSync**, namespace absent — the policy admission engine is declared in GitOps but not running, so every Kyverno `ClusterPolicy` is currently a paper control (declared ≠ enforced, at infra scale).
- `gitea` and `dashboard-bff` crashlooping at **221** and **54** restarts.
- 6 Degraded services + a dozen OutOfSync apps.

(These findings are surfaced, not auto-remediated — several may be intentional or mid-migration. The deliverable is the control that makes them impossible to miss.)

## Wiring
`make deploy-health` runs it. Deliberately **not** in hermetic `validate` (it needs a cluster credential); the intended home is a scheduled CI job with a read-only cluster role — the same shape as the ResourceContract producer (#1337).