### PR TITLE
feat(swarm): holography disclosure gate — absent → wired (INV-22..26)

### DIFF
--- a/.github/workflows/holography-gate.yml
+++ b/.github/workflows/holography-gate.yml
@@ -1,0 +1,35 @@
+name: holography-gate
+
+# The holography disclosure gate (INV-22..26), enforced in the swarm plane: a projection's
+# domain is ALWAYS the full field set (INV-26 holographic completeness), denied fields carry
+# a structured reason + policy row (never ⊥), and trust dilates only SOFT budgets — hard
+# prohibitions never move. Library-level so any Python service on the mesh imports the same
+# gate rather than each swarm re-deriving disclosure.
+on:
+  pull_request:
+    paths:
+      - 'libs/python/holography-gate/**'
+      - 'tools/smoke_swarm_holography_gate.py'
+      - '.github/workflows/holography-gate.yml'
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  holography-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Gate invariants (INV-26 completeness, hard-facet non-dilation, monotonicity)
+        working-directory: libs/python/holography-gate
+        run: |
+          python -m pip install --upgrade pip pytest
+          python -m pytest -q
+      - name: Gate decision observable on a sample swarm dispatch (the register probe)
+        run: python3 tools/smoke_swarm_holography_gate.py

--- a/docs/design-register.yaml
+++ b/docs/design-register.yaml
@@ -148,11 +148,28 @@ register:
     wave: unassigned
 
   - id: swarm-holography-gate
-    source: agentic-swarm-holography-fabric design (3-layer gate)
-    mechanism: "holography gate enforced in the swarm plane"
+    source: agentic-swarm-holography-fabric design (3-layer gate, INV-22..26)
+    mechanism: >-
+      libs/python/holography-gate: a disclosure gate any swarm agent calls to project a
+      subject's fields. L1 legality (hard prohibitions never dilate; soft budgets dilate
+      with trust) ∧ L2 Ω-readiness, per field. INV-26 Holographic Completeness: the
+      projection domain is ALWAYS the full field set — a denied field carries a structured
+      Denial(reason, policy_ref, class), never ⊥, so a refusal shows the shape of what was
+      withheld (hologram, not a cropped photograph). Denial class distinguishes polytope
+      (architecturally illegal, unearnable) from omega (earnable by advancing readiness).
     owner: prophet-mesh / agentplane
-    status: absent
+    status: wired
+    # absent→wired 2026-08-03: gate implemented + 9 invariant tests (INV-26 completeness,
+    # hard-facet non-dilation at max trust, soft-budget dilation, permit-monotonicity =
+    # I(T;π_S(T)) non-decreasing, omega-earnability). First caller +
+    # observable decision = tools/smoke_swarm_holography_gate.py (the register's own probe,
+    # literally "gate decision observable on a sample swarm dispatch"): name/email disclosed,
+    # HEALTH∧ADS hard-denied unearnably, location soft-denied at trust 0.6. Next toward
+    # `measured`: embed in a production swarm-runtime dispatch + count real gate decisions.
     probe: "gate decision observable on a sample swarm dispatch"
+    probe_cmd: >-
+      test -f libs/python/holography-gate/src/holography_gate/__init__.py
+      && python3 tools/smoke_swarm_holography_gate.py
     wave: unassigned
 
   - id: sovereign-config-plane

--- a/libs/python/holography-gate/pyproject.toml
+++ b/libs/python/holography-gate/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "prophet-holography-gate"
+version = "0.1.0"
+description = "The holography disclosure gate (INV-22..26) — enforced in the swarm plane, for any Python service on the mesh"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=8.3"]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/libs/python/holography-gate/pytest.ini
+++ b/libs/python/holography-gate/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+# src layout: put the package on the path so `pytest -q` works without an editable
+# install, matching how the sibling libs run in CI.
+pythonpath = src

--- a/libs/python/holography-gate/src/holography_gate/__init__.py
+++ b/libs/python/holography-gate/src/holography_gate/__init__.py
@@ -1,0 +1,140 @@
+"""The holography disclosure gate — enforced in the swarm plane (INV-22..26).
+
+When a swarm agent asks for a projection ``π_S(T)`` of a subject ``T`` at scope ``S``,
+this gate decides, per field, whether the field is disclosed. Two things make it a
+*holography* gate rather than an ordinary allow-list:
+
+**INV-26 — Holographic Completeness (the genuinely new invariant).** The domain of the
+projection is ALWAYS the full field set ``F``. A denied field is not dropped to ``⊥``
+(absent); it is present as a structured :class:`Denial` carrying the reason and the
+policy row that denied it. A photograph cropped to a region shows nothing outside the
+frame; a hologram shard still reconstructs the whole scene, blurrier. So a denial here
+still reveals the *shape* of what was withheld and *why* — you can always tell a field
+was refused apart from a field that does not exist.
+
+**Trust dilates soft budgets, never hard prohibitions.** Legality (L1) is a polytope
+``K = {v : A_hard·v ≤ b_hard  ∧  A_soft·v ≤ t·b_soft}``. The hard facets are absolute
+prohibitions (e.g. ``¬(HEALTH ∧ ADS)``) and do NOT move with trust ``t`` — a governance
+control a dropdown could raise trust past is not a control. Only the soft budget facets
+dilate. Readiness (L2) is the Ω lattice. Admission of a field is ``L1 ∧ L2``.
+
+Pure and dependency-free so it drops into any Python service on the mesh, and so the
+invariants below are unit-tested rather than asserted.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field as _field
+from typing import Mapping, Sequence, Union
+
+# ── Ω readiness lattice (L2) ────────────────────────────────────────────────
+# ABSENT is the bottom; a field must have reached at least its required state to disclose.
+OMEGA: tuple[str, ...] = (
+    "ABSENT", "SEEDED", "NORMALIZED", "LINKED", "TRUSTED", "ACTIONABLE", "DELIVERED",
+)
+
+
+def _omega_rank(state: str) -> int:
+    try:
+        return OMEGA.index(state)
+    except ValueError:
+        return 0  # an unknown state is treated as the bottom (fail-closed)
+
+
+@dataclass(frozen=True)
+class Permit:
+    """A disclosed field and the handle to its value."""
+    value_ref: str
+
+
+@dataclass(frozen=True)
+class Denial:
+    """A withheld field — present in the projection, never absent (INV-26)."""
+    reason: str
+    policy_ref: str
+    # Failure CLASS, so a caller can tell an architecturally-illegal field (never
+    # earnable, at any trust) from one that is merely not-yet-ready (earnable):
+    #   "polytope" → L1 legality  ·  "omega" → L2 readiness
+    cls: str
+
+    @property
+    def earnable(self) -> bool:
+        """omega denials can be earned by advancing readiness; polytope denials cannot."""
+        return self.cls == "omega"
+
+
+Decision = Mapping[str, Union[Permit, Denial]]
+
+
+@dataclass(frozen=True)
+class Policy:
+    """The disclosure polytope + readiness requirements for a subject class."""
+    # Fields that are ABSOLUTELY prohibited — hard facets. Never dilate with trust.
+    hard_prohibitions: frozenset[str] = _field(default_factory=frozenset)
+    # Per-field soft cost in [0, 1]; disclosed only when cost ≤ trust·soft_budget.
+    soft_costs: Mapping[str, float] = _field(default_factory=dict)
+    soft_budget: float = 1.0
+    # Minimum Ω state a field must have reached to be disclosed.
+    required_readiness: Mapping[str, str] = _field(default_factory=dict)
+
+
+def _l1(field: str, trust: float, policy: Policy) -> Denial | None:
+    """L1 legality — hard prohibitions are absolute; soft budgets dilate with trust."""
+    if field in policy.hard_prohibitions:
+        return Denial(
+            reason=f"{field} is an absolute prohibition (hard facet — never dilates)",
+            policy_ref=f"polytope:hard:{field}", cls="polytope",
+        )
+    cost = policy.soft_costs.get(field, 0.0)
+    if cost > trust * policy.soft_budget + 1e-9:
+        return Denial(
+            reason=f"{field} exceeds the soft budget at trust {trust:g} "
+                   f"(cost {cost:g} > {trust * policy.soft_budget:g})",
+            policy_ref=f"polytope:soft:{field}", cls="polytope",
+        )
+    return None
+
+
+def _l2(field: str, readiness: Mapping[str, str], policy: Policy) -> Denial | None:
+    """L2 readiness — the field must have reached its required Ω state."""
+    required = policy.required_readiness.get(field)
+    if required is None:
+        return None
+    have = readiness.get(field, "ABSENT")
+    if _omega_rank(have) < _omega_rank(required):
+        return Denial(
+            reason=f"{field} not ready ({have} < required {required})",
+            policy_ref=f"omega:{field}:{required}", cls="omega",
+        )
+    return None
+
+
+def holographic_project(
+    fields: Sequence[str],
+    *,
+    trust: float,
+    readiness: Mapping[str, str] | None = None,
+    policy: Policy,
+) -> Decision:
+    """Project ``fields`` under ``policy`` at ``trust`` and ``readiness``.
+
+    Returns a decision whose domain is EXACTLY ``fields`` (INV-26): each field maps to a
+    :class:`Permit` or a :class:`Denial` — never to nothing. L1 (legality) is checked
+    before L2 (readiness), so an architecturally-illegal field is reported as such even
+    when it happens to be ready.
+    """
+    readiness = readiness or {}
+    out: dict[str, Union[Permit, Denial]] = {}
+    for f in fields:
+        denial = _l1(f, trust, policy) or _l2(f, readiness, policy)
+        out[f] = denial if denial is not None else Permit(value_ref=f"ref:{f}")
+    return out
+
+
+def disclosed(decision: Decision) -> frozenset[str]:
+    """The fields actually disclosed (permitted)."""
+    return frozenset(k for k, v in decision.items() if isinstance(v, Permit))
+
+
+def denials(decision: Decision) -> dict[str, Denial]:
+    """The withheld fields and their structured reasons."""
+    return {k: v for k, v in decision.items() if isinstance(v, Denial)}

--- a/libs/python/holography-gate/tests/test_holography_gate.py
+++ b/libs/python/holography-gate/tests/test_holography_gate.py
@@ -1,0 +1,90 @@
+"""The holography gate's invariants, pinned. Each maps to an INV-2x from the design."""
+from __future__ import annotations
+
+from holography_gate import (
+    Policy, Permit, Denial, holographic_project, disclosed, denials, OMEGA,
+)
+
+FIELDS = ["name", "email", "health_status", "ad_targeting", "location"]
+
+POLICY = Policy(
+    # ¬(HEALTH ∧ ADS): both are hard-prohibited from this projection class, at any trust.
+    hard_prohibitions=frozenset({"health_status", "ad_targeting"}),
+    soft_costs={"email": 0.4, "location": 0.9},   # location is expensive; email cheap
+    soft_budget=1.0,
+    required_readiness={"email": "TRUSTED", "location": "LINKED"},
+)
+
+
+def test_inv26_completeness_domain_is_always_the_full_field_set():
+    """INV-26: even when everything is denied, every field is PRESENT (never ⊥)."""
+    for trust in (0.0, 0.5, 1.0):
+        d = holographic_project(FIELDS, trust=trust, policy=POLICY)
+        assert set(d.keys()) == set(FIELDS)
+        # nothing is absent — each field is a Permit or a Denial, never missing/None
+        assert all(isinstance(v, (Permit, Denial)) for v in d.values())
+
+
+def test_a_denied_field_carries_reason_and_policy_ref_not_absence():
+    d = holographic_project(["health_status"], trust=1.0, policy=POLICY)
+    v = d["health_status"]
+    assert isinstance(v, Denial)
+    assert v.reason and v.policy_ref  # the SHAPE of the withheld field is visible
+
+
+def test_hard_prohibition_never_dilates_even_at_max_trust():
+    """A hard facet stays denied at trust 1.0 with full readiness — not earnable."""
+    d = holographic_project(
+        ["health_status", "ad_targeting"], trust=1.0,
+        readiness={"health_status": "DELIVERED", "ad_targeting": "DELIVERED"},
+        policy=POLICY,
+    )
+    for f in ("health_status", "ad_targeting"):
+        assert isinstance(d[f], Denial)
+        assert d[f].cls == "polytope"
+        assert d[f].earnable is False   # architecturally illegal, unearnable
+
+
+def test_soft_budget_dilates_with_trust():
+    """`location` (cost 0.9) is denied at low trust, permitted once trust buys the budget."""
+    ready = {"location": "DELIVERED"}   # L2 satisfied so we isolate L1
+    low = holographic_project(["location"], trust=0.5, readiness=ready, policy=POLICY)
+    high = holographic_project(["location"], trust=1.0, readiness=ready, policy=POLICY)
+    assert isinstance(low["location"], Denial) and low["location"].cls == "polytope"
+    assert isinstance(high["location"], Permit)
+
+
+def test_permits_are_monotone_non_decreasing_in_trust():
+    """I(T; π_S(T)) monotone: raising trust never REVOKES a disclosed field."""
+    ready = {f: "DELIVERED" for f in FIELDS}
+    prev: frozenset[str] = frozenset()
+    for trust in (0.0, 0.25, 0.5, 0.75, 1.0):
+        got = disclosed(holographic_project(FIELDS, trust=trust, readiness=ready, policy=POLICY))
+        assert prev <= got, f"trust {trust} revoked a previously-disclosed field: {prev - got}"
+        prev = got
+
+
+def test_readiness_denial_is_earnable_and_classed_omega():
+    """A not-yet-ready field is denied with cls 'omega' and IS earnable by advancing Ω."""
+    not_ready = holographic_project(["email"], trust=1.0, readiness={"email": "SEEDED"}, policy=POLICY)
+    assert isinstance(not_ready["email"], Denial)
+    assert not_ready["email"].cls == "omega" and not_ready["email"].earnable is True
+    now_ready = holographic_project(["email"], trust=1.0, readiness={"email": "TRUSTED"}, policy=POLICY)
+    assert isinstance(now_ready["email"], Permit)
+
+
+def test_l1_is_checked_before_l2():
+    """A hard-prohibited field reports polytope (legality), not omega, even when unready."""
+    d = holographic_project(["health_status"], trust=1.0, readiness={"health_status": "ABSENT"}, policy=POLICY)
+    assert d["health_status"].cls == "polytope"
+
+
+def test_disclosed_and_denials_partition_the_fields():
+    d = holographic_project(FIELDS, trust=0.5, readiness={"email": "TRUSTED"}, policy=POLICY)
+    assert disclosed(d) | set(denials(d)) == set(FIELDS)
+    assert disclosed(d).isdisjoint(set(denials(d)))
+
+
+def test_omega_lattice_is_a_total_order_bottom_absent():
+    assert OMEGA[0] == "ABSENT" and OMEGA[-1] == "DELIVERED"
+    assert len(set(OMEGA)) == len(OMEGA)   # no duplicate states

--- a/tools/smoke_swarm_holography_gate.py
+++ b/tools/smoke_swarm_holography_gate.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Sample swarm dispatch through the holography gate — the register's probe made real.
+
+The register entry `swarm-holography-gate` says the bar is "gate decision observable on a
+sample swarm dispatch." This is that dispatch: a Tier-2 swarm agent asks for a projection
+of a subject's fields; the gate decides per field; the decision is printed (observable) and
+its holographic-completeness invariant is asserted. Also the first caller of the gate
+library, so the capability is `wired`, not a library nobody imports.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Import the gate library from the monorepo (no install needed for the smoke).
+_LIB = Path(__file__).resolve().parents[1] / "libs" / "python" / "holography-gate" / "src"
+sys.path.insert(0, str(_LIB))
+
+from holography_gate import Policy, holographic_project, disclosed, denials, Permit  # noqa: E402
+
+
+def sample_dispatch() -> dict:
+    """A swarm agent projecting a person-twin for a marketing intent: name/email are
+    disclosable, but HEALTH∧ADS is a hard prohibition and location needs earned trust."""
+    policy = Policy(
+        hard_prohibitions=frozenset({"health_status", "ad_targeting"}),
+        soft_costs={"email": 0.4, "location": 0.9},
+        soft_budget=1.0,
+        required_readiness={"email": "TRUSTED", "location": "LINKED"},
+    )
+    fields = ["name", "email", "health_status", "ad_targeting", "location"]
+    decision = holographic_project(
+        fields,
+        trust=0.6,   # a mid-trust agent
+        readiness={"name": "DELIVERED", "email": "TRUSTED", "location": "SEEDED"},
+        policy=policy,
+    )
+    # INV-26: the decision's domain is the WHOLE field set — never a photograph crop.
+    assert set(decision.keys()) == set(fields), "holographic completeness violated"
+    return {
+        "dispatch": "swarm-agent:tier2 → project(person-twin, scope=marketing)",
+        "disclosed": sorted(disclosed(decision)),
+        "withheld": {
+            f: {"reason": d.reason, "policy_ref": d.policy_ref, "class": d.cls, "earnable": d.earnable}
+            for f, d in denials(decision).items()
+        },
+        "completeness": {
+            "domain_size": len(decision),
+            "field_count": len(fields),
+            "holographically_complete": set(decision.keys()) == set(fields),
+        },
+    }
+
+
+def main() -> int:
+    out = sample_dispatch()
+    print(json.dumps(out, indent=2))
+    # A well-formed, observable gate decision on a sample swarm dispatch.
+    ok = out["completeness"]["holographically_complete"] and "name" in out["disclosed"] and "health_status" in out["withheld"]
+    print(("OK" if ok else "FAIL") + " swarm-holography-gate: decision observable on a sample dispatch")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes the one real *build* gap in the design register: `swarm-holography-gate` was `absent` — a one-line mechanism, nothing implemented. The reference artifacts were authored + verified but never landed. This lands the core as a mesh-level library.

## The mechanism
`libs/python/holography-gate` — a disclosure gate any swarm agent calls to project a subject's fields. Per field:
- **L1 legality** — hard prohibitions (`¬(HEALTH∧ADS)`) that **never dilate**, ∧ soft budgets that **dilate with trust `t`** (`K = {v : A_hard·v ≤ b_hard ∧ A_soft·v ≤ t·b_soft}`). A governance control a dropdown could raise trust past is not a control.
- **L2 readiness** — the Ω 7-state lattice.
- **INV-26 Holographic Completeness** (the genuinely new one) — the projection domain is **always the full field set**. A denied field is present as a structured `Denial(reason, policy_ref, class)`, **never `⊥`** — a refusal reveals the *shape* of what was withheld and *why*. Hologram, not a cropped photograph. `class` separates `polytope` (architecturally illegal, unearnable) from `omega` (earnable by advancing readiness).

## Wired, not just declared
`tools/smoke_swarm_holography_gate.py` is the **first caller** and the register's literal probe — *"gate decision observable on a sample swarm dispatch"*. It runs a Tier-2 agent projecting a person-twin: name/email disclosed, HEALTH∧ADS hard-denied unearnably, location soft-denied at trust 0.6. **The register gate executes it — PASS**, so the entry is truthfully `wired`.

## Tests (9 invariants, `libs/python/holography-gate` CI)
completeness holds even when everything is denied · a hard facet stays denied at max trust + full readiness · a soft budget opens as trust buys it · **permits are monotone non-decreasing in trust** (`I(T;π_S(T))` never revokes a disclosed field) · omega denials are earnable · L1 checked before L2.

New workflow is path-filtered with an unfiltered push-on-main safety net (per the CI-path-filter doctrine). Next toward `measured`: embed in a production swarm-runtime dispatch and count real decisions.