### PR TITLE
feat(fips): tritrpcbridge FIPS suite — HMAC-SHA256 (Mode 1) beside XChaCha20-Poly1305

### DIFF
--- a/libs/go/tritrpcbridge/binding/binding.go
+++ b/libs/go/tritrpcbridge/binding/binding.go
@@ -81,8 +81,22 @@ func MarshalJSONFrame(service, method string, payload any, key [32]byte) (nonce 
     if _, err = rand.Read(nonce[:]); err != nil {
         return nonce, nil, err
     }
-    frame, _, err = tritrpcv1.EnvelopeWithTag(service, method, payloadBytes, nil, key, nonce)
+    frame, _, err = tritrpcv1.EnvelopeWithTagMode(CryptoSuiteMode(), service, method, payloadBytes, nil, key, nonce)
     return nonce, frame, err
+}
+
+// CryptoSuiteMode selects the outbound crypto suite from $TRITRPC_SUITE: default (unset or
+// "classic") keeps XChaCha20-Poly1305 (Mode 0, wire-identical to before); "fips" selects
+// HMAC-SHA256 (Mode 1, FIPS 198-1). Receivers verify whichever suite the frame's Mode field
+// declares, so a sender may be flipped to fips only after every receiver runs a build that
+// understands Mode 1 — a safe, staged cutover.
+func CryptoSuiteMode() byte {
+    switch strings.ToLower(strings.TrimSpace(os.Getenv("TRITRPC_SUITE"))) {
+    case "fips", "hmac", "hmac-sha256":
+        return tritrpcv1.ModeHMACSHA256
+    default:
+        return tritrpcv1.ModeXChaCha20Poly1305
+    }
 }
 
 func VerifyEnvelope(frame []byte, nonce [24]byte, key [32]byte) (*tritrpcv1.Envelope, error) {
@@ -97,11 +111,11 @@ func VerifyEnvelope(frame []byte, nonce [24]byte, key [32]byte) (*tritrpcv1.Enve
     if !env.AeadOn {
         return nil, errors.New("tritrpcbridge: AEAD must be enabled")
     }
-    aead, err := chacha20poly1305.NewX(key[:])
+    mode, err := tritrpcv1.CryptoMode(env)
     if err != nil {
         return nil, err
     }
-    if _, err := aead.Open(nil, nonce[:], env.Tag, aad); err != nil {
+    if err := tritrpcv1.VerifyTag(mode, key, nonce, aad, env.Tag); err != nil {
         return nil, fmt.Errorf("tritrpcbridge: tag verification failed: %w", err)
     }
     return env, nil

--- a/libs/go/tritrpcbridge/binding/fips_suite_test.go
+++ b/libs/go/tritrpcbridge/binding/fips_suite_test.go
@@ -1,0 +1,116 @@
+package binding
+
+import (
+	"testing"
+
+	"github.com/SocioProphet/prophet-platform/libs/go/tritrpcbridge/tritrpcv1"
+)
+
+func fipsFrame(t *testing.T, key [32]byte, nonce [24]byte, payload string) []byte {
+	t.Helper()
+	frame, _, err := tritrpcv1.EnvelopeWithTagMode(tritrpcv1.ModeHMACSHA256, HealthService, HealthPingReq, []byte(payload), nil, key, nonce)
+	if err != nil {
+		t.Fatalf("encode fips frame: %v", err)
+	}
+	return frame
+}
+
+// The FIPS suite (HMAC-SHA256) round-trips, decodes as Mode 1, and carries a 32-byte tag.
+func TestFIPSSuiteRoundTrip(t *testing.T) {
+	key := DefaultDevKey()
+	var nonce [24]byte
+	for i := range nonce {
+		nonce[i] = byte(i + 1)
+	}
+	frame := fipsFrame(t, key, nonce, `{"ts_unix_ms":7}`)
+	env, err := VerifyEnvelope(frame, nonce, key)
+	if err != nil {
+		t.Fatalf("verify fips: %v", err)
+	}
+	mode, err := tritrpcv1.CryptoMode(env)
+	if err != nil || mode != tritrpcv1.ModeHMACSHA256 {
+		t.Fatalf("expected mode %d, got %d (err %v)", tritrpcv1.ModeHMACSHA256, mode, err)
+	}
+	if len(env.Tag) != 32 {
+		t.Fatalf("expected 32-byte HMAC-SHA256 tag, got %d", len(env.Tag))
+	}
+	if env.Service != HealthService || env.Method != HealthPingReq {
+		t.Fatalf("unexpected route: %s %s", env.Service, env.Method)
+	}
+}
+
+// Any tamper in the authenticated envelope fails verification (fail-closed).
+func TestFIPSSuiteTamperRejected(t *testing.T) {
+	key := DefaultDevKey()
+	var nonce [24]byte
+	frame := fipsFrame(t, key, nonce, `{"a":1}`)
+	frame[len(frame)/2] ^= 0xFF
+	if _, err := VerifyEnvelope(frame, nonce, key); err == nil {
+		t.Fatal("expected tampered fips frame to be rejected")
+	}
+}
+
+// A different shared key fails verification.
+func TestFIPSSuiteWrongKeyRejected(t *testing.T) {
+	key := DefaultDevKey()
+	var other [32]byte
+	for i := range other {
+		other[i] = byte(255 - i)
+	}
+	var nonce [24]byte
+	frame := fipsFrame(t, key, nonce, `{"a":1}`)
+	if _, err := VerifyEnvelope(frame, nonce, other); err == nil {
+		t.Fatal("expected wrong key to be rejected")
+	}
+}
+
+// The transmitted record-header nonce is authenticated: flipping it fails verification.
+func TestFIPSSuiteNonceAuthenticated(t *testing.T) {
+	key := DefaultDevKey()
+	var nonce [24]byte
+	frame := fipsFrame(t, key, nonce, `{"a":1}`)
+	var wrong [24]byte
+	wrong[0] = 0x01
+	if _, err := VerifyEnvelope(frame, wrong, key); err == nil {
+		t.Fatal("expected altered record nonce to be rejected (nonce is authenticated)")
+	}
+}
+
+// The classic suite still round-trips and reports Mode 0 (regression: default unchanged).
+func TestClassicSuiteUnchanged(t *testing.T) {
+	key := DefaultDevKey()
+	var nonce [24]byte
+	for i := range nonce {
+		nonce[i] = byte(i)
+	}
+	frame, _, err := tritrpcv1.EnvelopeWithTag(HealthService, HealthPingReq, []byte(`{"x":1}`), nil, key, nonce)
+	if err != nil {
+		t.Fatalf("encode classic: %v", err)
+	}
+	env, err := VerifyEnvelope(frame, nonce, key)
+	if err != nil {
+		t.Fatalf("verify classic: %v", err)
+	}
+	if mode, _ := tritrpcv1.CryptoMode(env); mode != tritrpcv1.ModeXChaCha20Poly1305 {
+		t.Fatalf("classic suite should be mode 0, got %d", mode)
+	}
+	if len(env.Tag) != 16 {
+		t.Fatalf("expected 16-byte Poly1305 tag, got %d", len(env.Tag))
+	}
+}
+
+// $TRITRPC_SUITE selects the outbound suite; default stays classic.
+func TestCryptoSuiteModeSelection(t *testing.T) {
+	t.Setenv("TRITRPC_SUITE", "")
+	if CryptoSuiteMode() != tritrpcv1.ModeXChaCha20Poly1305 {
+		t.Fatal("default suite must be classic (mode 0)")
+	}
+	t.Setenv("TRITRPC_SUITE", "fips")
+	if CryptoSuiteMode() != tritrpcv1.ModeHMACSHA256 {
+		t.Fatal("TRITRPC_SUITE=fips must select HMAC-SHA256 (mode 1)")
+	}
+	t.Setenv("TRITRPC_SUITE", "classic")
+	if CryptoSuiteMode() != tritrpcv1.ModeXChaCha20Poly1305 {
+		t.Fatal("TRITRPC_SUITE=classic must select mode 0")
+	}
+}

--- a/libs/go/tritrpcbridge/tritrpcv1/envelope.go
+++ b/libs/go/tritrpcbridge/tritrpcv1/envelope.go
@@ -1,6 +1,11 @@
 package tritrpcv1
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+
 	"golang.org/x/crypto/chacha20poly1305"
 )
 
@@ -9,6 +14,19 @@ var CONTEXT_ID_BYTES = []byte{230, 87, 44, 14, 97, 143, 24, 213, 114, 212, 194, 
 var MAGIC_B2 = []byte{0xF3, 0x2A}
 var SCHEMA_ID_32 = []byte{0xb2, 0xab, 0x81, 0x45, 0x88, 0xf9, 0x9c, 0x87, 0x5d, 0x37, 0xbb, 0x75, 0x46, 0xd0, 0xdf, 0x43, 0x69, 0xc2, 0x8b, 0xc5, 0xf6, 0x0c, 0xe3, 0x8a, 0x66, 0x07, 0xda, 0xc4, 0x68, 0x03, 0x43, 0x52}
 var CONTEXT_ID_32 = []byte{0xe6, 0x57, 0x2c, 0x0e, 0x61, 0x8f, 0x18, 0xd5, 0x72, 0xd4, 0xc2, 0x96, 0x9d, 0xb4, 0x90, 0x96, 0x59, 0xf0, 0x9e, 0xae, 0xf3, 0x2e, 0xc6, 0x6f, 0xbb, 0x80, 0x4b, 0xad, 0x9d, 0x89, 0xaa, 0xcd}
+
+// Crypto-suite selectors carried in the envelope Mode field. The wire format is identical across
+// suites — the payload is always cleartext and the tag is length-prefixed — so only the tag
+// algorithm differs and a decoder picks the verifier from the decoded Mode field.
+const (
+	// ModeXChaCha20Poly1305 is the classic (default) suite: golang.org/x/crypto XChaCha20-Poly1305.
+	// NOT FIPS-approved, and x/crypto is never covered by a FIPS crypto module.
+	ModeXChaCha20Poly1305 byte = 0
+	// ModeHMACSHA256 authenticates the envelope with HMAC-SHA256 over nonce||AAD (FIPS 198-1 +
+	// FIPS 180-4) using only the Go standard library, so it is covered by a FIPS crypto module
+	// (e.g. BoringCrypto). Same shared key, same cleartext payload; nonce-free construction.
+	ModeHMACSHA256 byte = 1
+)
 
 func flagsTrits(aead bool, compress bool) []byte {
 	var a, c byte
@@ -25,7 +43,13 @@ func lenPrefix(b []byte) []byte {
 	return TLEB3EncodeLen(uint64(len(b)))
 }
 
+// BuildEnvelope builds a classic (Mode 0) envelope — byte-for-byte unchanged from before.
 func BuildEnvelope(service, method string, payload []byte, aux []byte, aeadTag []byte, aeadOn bool, compress bool) []byte {
+	return BuildEnvelopeMode(ModeXChaCha20Poly1305, service, method, payload, aux, aeadTag, aeadOn, compress)
+}
+
+// BuildEnvelopeMode builds an envelope whose Mode field records the crypto suite `cryptoMode`.
+func BuildEnvelopeMode(cryptoMode byte, service, method string, payload []byte, aux []byte, aeadTag []byte, aeadOn bool, compress bool) []byte {
 	out := make([]byte, 0)
 	out = append(out, lenPrefix(MAGIC_B2)...)
 	out = append(out, MAGIC_B2...)
@@ -34,7 +58,7 @@ func BuildEnvelope(service, method string, payload []byte, aux []byte, aeadTag [
 	out = append(out, lenPrefix(ver)...)
 	out = append(out, ver...)
 
-	mode := TritPack243([]byte{0})
+	mode := TritPack243([]byte{cryptoMode})
 	out = append(out, lenPrefix(mode)...)
 	out = append(out, mode...)
 
@@ -72,14 +96,78 @@ func BuildEnvelope(service, method string, payload []byte, aux []byte, aeadTag [
 	return out
 }
 
+// EnvelopeWithTag builds a classic XChaCha20-Poly1305 authenticated envelope (Mode 0).
 func EnvelopeWithTag(service, method string, payload, aux []byte, key [32]byte, nonce [24]byte) ([]byte, []byte, error) {
-	aad := BuildEnvelope(service, method, payload, aux, nil, true, false)
-	aead, err := chacha20poly1305.NewX(key[:])
+	return EnvelopeWithTagMode(ModeXChaCha20Poly1305, service, method, payload, aux, key, nonce)
+}
+
+// EnvelopeWithTagMode builds an authenticated envelope using the crypto suite `cryptoMode`. In
+// both suites the payload is carried in cleartext and the tag authenticates the whole envelope
+// (AAD); the nonce is authenticated too, so a flipped record-header nonce is rejected.
+func EnvelopeWithTagMode(cryptoMode byte, service, method string, payload, aux []byte, key [32]byte, nonce [24]byte) ([]byte, []byte, error) {
+	aad := BuildEnvelopeMode(cryptoMode, service, method, payload, aux, nil, true, false)
+	tag, err := ComputeTag(cryptoMode, key, nonce, aad)
 	if err != nil {
 		return nil, nil, err
 	}
-	ct := aead.Seal(nil, nonce[:], []byte{}, aad)
-	tag := ct[len(ct)-16:]
-	frame := BuildEnvelope(service, method, payload, aux, tag, true, false)
+	frame := BuildEnvelopeMode(cryptoMode, service, method, payload, aux, tag, true, false)
 	return frame, tag, nil
+}
+
+// ComputeTag produces the authentication tag over an envelope's AAD for the given suite.
+func ComputeTag(cryptoMode byte, key [32]byte, nonce [24]byte, aad []byte) ([]byte, error) {
+	switch cryptoMode {
+	case ModeXChaCha20Poly1305:
+		aead, err := chacha20poly1305.NewX(key[:])
+		if err != nil {
+			return nil, err
+		}
+		ct := aead.Seal(nil, nonce[:], []byte{}, aad)
+		return ct[len(ct)-16:], nil
+	case ModeHMACSHA256:
+		mac := hmac.New(sha256.New, key[:])
+		mac.Write(nonce[:])
+		mac.Write(aad)
+		return mac.Sum(nil), nil
+	default:
+		return nil, fmt.Errorf("tritrpcv1: unsupported crypto mode %d", cryptoMode)
+	}
+}
+
+// VerifyTag checks an envelope tag for the given suite in constant time.
+func VerifyTag(cryptoMode byte, key [32]byte, nonce [24]byte, aad, tag []byte) error {
+	switch cryptoMode {
+	case ModeXChaCha20Poly1305:
+		aead, err := chacha20poly1305.NewX(key[:])
+		if err != nil {
+			return err
+		}
+		if _, err := aead.Open(nil, nonce[:], tag, aad); err != nil {
+			return err
+		}
+		return nil
+	case ModeHMACSHA256:
+		want, err := ComputeTag(ModeHMACSHA256, key, nonce, aad)
+		if err != nil {
+			return err
+		}
+		if !hmac.Equal(tag, want) {
+			return errors.New("tritrpcv1: hmac-sha256 tag mismatch")
+		}
+		return nil
+	default:
+		return fmt.Errorf("tritrpcv1: unsupported crypto mode %d", cryptoMode)
+	}
+}
+
+// CryptoMode returns the crypto-suite selector recorded in a decoded envelope's Mode field.
+func CryptoMode(env *Envelope) (byte, error) {
+	trits, err := TritUnpack243(env.Mode)
+	if err != nil {
+		return 0, err
+	}
+	if len(trits) == 0 {
+		return 0, errors.New("tritrpcv1: empty mode field")
+	}
+	return trits[0], nil
 }


### PR DESCRIPTION
## FIPS Build-2 · Go crypto surface (step 1): tritrpcbridge FIPS suite

`tritrpcbridge` authenticates every tritrpc frame with an **AEAD-as-MAC** (empty plaintext, payload carried in cleartext, tag over the whole envelope). The suite is **XChaCha20-Poly1305 via `golang.org/x/crypto`** — which is **not FIPS-approved**, and `x/crypto` is **never** covered by a FIPS crypto module (BoringCrypto / OpenSSL-FIPS). This is the single algorithm-level FIPS gap the Build-2 recon flagged on the Go surface.

### What this does (additive, default-off)
- Adds **Mode 1 = HMAC-SHA256 over `nonce || AAD`** (FIPS 198-1 + FIPS 180-4), Go **standard library only** → covered by a FIPS crypto module. Nonce-free construction (no AES-GCM nonce-reuse footgun); the transmitted record-header nonce is folded into the MAC, so a flipped nonce is rejected.
- The crypto suite is recorded in the envelope's existing **Mode** field; the decoder (`VerifyEnvelope`) picks the verifier from it. **Default stays Mode 0** (XChaCha20, wire-byte-identical) — the outbound suite changes only when **`TRITRPC_SUITE=fips`**.
- **Safe staged rollout:** every receiver running this build already verifies Mode 1, so a sender may be flipped to fips *after* all receivers deploy. **No change to live api↔gateway traffic** until the flag is flipped.

### Files
- `tritrpcv1/envelope.go` — `BuildEnvelopeMode` / `EnvelopeWithTagMode` / `ComputeTag` / `VerifyTag` / `CryptoMode`; v1 wrappers unchanged (Mode-0 frames byte-identical).
- `binding/binding.go` — `VerifyEnvelope` dispatches on the decoded Mode; `MarshalJSONFrame` uses `CryptoSuiteMode()` (reads `$TRITRPC_SUITE`).
- `binding/fips_suite_test.go` — 6 tests.

### Proof
`go test ./...` — existing binding tests + **6 new**: fips roundtrip (Mode 1, 32-byte tag), tamper rejected, wrong-key rejected, **nonce authenticated**, classic unchanged (Mode 0, 16-byte tag), env-var selection. `go vet` clean. **`apps/api` and `apps/gateway` build** against the changed lib (go.work `replace`).

### ⚠️ Crypto-sensitive — human review before merge
Touches a shared authentication library used by two live services. It is additive and default-off, but please eyeball the HMAC construction + the staged-rollout reasoning before merging. **Not armed for auto-merge.**

Build-2 step 1 for the Go crypto surface. Follow-ups (separate PRs): drop Mode 0 / `x/crypto` after full fleet rollout; Go BoringCrypto base-image cutover; `ring`→`aws-lc-rs` (sherlock-engine); the FIPS-OpenSSL Python base (compute-gateway + identity-twin).
