### PR TITLE
feat(health-twin): deploy multimodal vision + patient identity plane

### DIFF
--- a/apps/health-twin/src/audit.ts
+++ b/apps/health-twin/src/audit.ts
@@ -1,0 +1,48 @@
+// audit.ts — HIPAA-shaped audit controls (45 CFR §164.312(b)). An APPEND-ONLY trail of every access to
+// the twin's records: who acted, what they did, on what, the outcome, and the receipt it produced.
+// Successes AND blocks are recorded — a denied access is itself a security event worth keeping. The log
+// is append-only by construction: there is NO exported way to mutate or delete a past entry, and the
+// cap drops the OLDEST while counting what was dropped (never a silent loss of the count). Queryable for
+// compliance review. In production this persists to tamper-evident storage; here it is an in-memory
+// append-only ring. This is the audit CONTROL — a real HIPAA safeguard, distinct from full certification.
+import { mintId } from './ids.js';
+
+export type AuditOutcome = 'ok' | 'blocked';
+export interface AuditEvent {
+  id: string;
+  at: string;
+  actor: string;        // the acting identity (patient id, grant holder digest, 'operator', 'anonymous')
+  action: string;       // e.g. 'doctor-view', 'patient-auth', 'vision', 'evidence-read'
+  resource: string;     // what was accessed (e.g. 'twin', a grant id, 'population')
+  outcome: AuditOutcome;
+  reason?: string;      // why, for a block
+  receipt?: string;     // the receipt id this access produced, tying the trail to the record layer
+}
+
+const LOG: AuditEvent[] = [];
+const CAP = Math.max(100, Number(process.env.HEALTH_TWIN_AUDIT_MAX ?? 50_000));
+let dropped = 0; // count of oldest entries evicted at the cap — reported, never silently lost
+
+// Append an access to the trail. The ONLY mutator, and it only ever appends (+ bounded eviction).
+export function audit(e: Omit<AuditEvent, 'id' | 'at'>): AuditEvent {
+  const entry: AuditEvent = { id: mintId('audit'), at: new Date().toISOString(), ...e };
+  LOG.push(entry);
+  if (LOG.length > CAP) { LOG.shift(); dropped++; }
+  return entry;
+}
+
+export interface AuditQuery { actor?: string; action?: string; outcome?: AuditOutcome; limit?: number }
+// Read the trail for compliance review. Returns a COPY (callers cannot reach in and mutate the log).
+export function auditQuery(q: AuditQuery = {}): { events: AuditEvent[]; total: number; droppedAtCap: number; cap: number } {
+  let events = LOG;
+  if (q.actor) events = events.filter((e) => e.actor === q.actor);
+  if (q.action) events = events.filter((e) => e.action === q.action);
+  if (q.outcome) events = events.filter((e) => e.outcome === q.outcome);
+  const limit = Math.max(1, Math.min(1000, q.limit ?? 200));
+  return {
+    events: events.slice(-limit).reverse().map((e) => ({ ...e })), // newest first, defensive copy
+    total: events.length, droppedAtCap: dropped, cap: CAP,
+  };
+}
+
+export const auditSize = () => LOG.length;

--- a/apps/health-twin/src/drugsafety-live.ts
+++ b/apps/health-twin/src/drugsafety-live.ts
@@ -1,0 +1,62 @@
+// drugsafety-live.ts — live drug reference from the FREE public FDA label API (openFDA) and RxNorm
+// (RxNav). This augments the curated interaction dataset (drugsafety.ts) with REAL, maintained,
+// authoritative label data — boxed warnings, contraindications, the FDA's own drug-interaction text,
+// indications — and a real RxCUI, without any commercial license. Non-diagnostic reference. Network is
+// deliberately kept OUT of the hermetic CI invariants; graceful degradation means offline → null, never
+// a fabricated label. The honest step from "curated 33-pair table" toward a maintained drug knowledge base.
+const OPENFDA = 'https://api.fda.gov/drug/label.json';
+const RXNAV = 'https://rxnav.nlm.nih.gov/REST';
+
+const clip = (s: unknown, n = 600): string => (typeof s === 'string' ? s : Array.isArray(s) ? String(s[0] ?? '') : '').replace(/\s+/g, ' ').trim().slice(0, n);
+
+export interface DrugLabel {
+  ok: boolean;
+  query: string;
+  genericName?: string;
+  brandNames?: string[];
+  rxcui?: string;
+  boxedWarning?: string;
+  contraindications?: string;
+  drugInteractions?: string;
+  indications?: string;
+  source: string;
+  degraded: boolean;
+  disclaimer: string;
+}
+
+async function getJson(url: string, ms = 12_000): Promise<any | null> {
+  try {
+    const ac = new AbortController(); const t = setTimeout(() => ac.abort(), ms);
+    const r = await fetch(url, { headers: { accept: 'application/json' }, signal: ac.signal });
+    clearTimeout(t);
+    return r.ok ? await r.json() : null;
+  } catch { return null; }
+}
+
+// Live FDA label for a drug name. Falls back to RxNav for the RxCUI when the label omits it.
+export async function fdaLabel(name: string): Promise<DrugLabel> {
+  const q = (name ?? '').trim();
+  const disclaimer = 'Live FDA drug-label reference (openFDA) — authoritative but summarized; non-diagnostic. Confirm dosing/interactions against the full label and a pharmacist.';
+  const degraded = (): DrugLabel => ({ ok: false, query: q, source: 'openFDA', degraded: true, disclaimer: `${disclaimer} (label service unavailable)` });
+  if (!q) return degraded();
+
+  const label = await getJson(`${OPENFDA}?search=openfda.generic_name:${encodeURIComponent(q.toLowerCase())}&limit=1`);
+  const r = label?.results?.[0];
+  if (!r) return degraded();
+  const of = r.openfda ?? {};
+
+  let rxcui: string | undefined = Array.isArray(of.rxcui) ? of.rxcui[0] : undefined;
+  if (!rxcui) { const rx = await getJson(`${RXNAV}/rxcui.json?name=${encodeURIComponent(q)}`); rxcui = rx?.idGroup?.rxnormId?.[0]; }
+
+  return {
+    ok: true, query: q,
+    genericName: Array.isArray(of.generic_name) ? of.generic_name[0] : undefined,
+    brandNames: Array.isArray(of.brand_name) ? of.brand_name.slice(0, 3) : undefined,
+    rxcui,
+    boxedWarning: r.boxed_warning ? clip(r.boxed_warning, 400) : undefined,
+    contraindications: r.contraindications ? clip(r.contraindications) : undefined,
+    drugInteractions: r.drug_interactions ? clip(r.drug_interactions) : undefined,
+    indications: r.indications_and_usage ? clip(r.indications_and_usage, 300) : undefined,
+    source: 'openFDA drug label API + RxNorm (RxNav)', degraded: false, disclaimer,
+  };
+}

--- a/apps/health-twin/src/identity.ts
+++ b/apps/health-twin/src/identity.ts
@@ -1,0 +1,88 @@
+// identity.ts — the PATIENT identity plane. The vision doc flags that "no patient identity plane
+// exists here" — consent is issued by whoever operates the node. This closes that gap: a real person
+// ENROLLS, receives a one-time patient credential, and thereafter authenticates as the OWNER of their
+// twin. It's the third distinct actor, cleanly separated from the two the grant layer already has:
+//   • operator (HEALTH_TWIN_TOKEN) — runs the node, may issue consent
+//   • grant holder (x-health-grant) — a clinician a patient granted scoped, time-boxed access
+//   • PATIENT (x-health-patient, here) — the person who OWNS the record and grants that access
+// Reuses the proven grantauth holder-secret crypto (mint→digest→present a token; the secret is shown
+// ONCE and never stored, so a stolen registry authenticates nobody). Fail-closed. Non-diagnostic.
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { mintId } from './ids.js';
+
+export const PATIENT_HEADER = 'x-health-patient';
+
+function mintPatientSecret(): string { return randomBytes(32).toString('base64url'); }
+function patientDigest(secret: string): string { return `sha256-${createHash('sha256').update(secret, 'utf8').digest('hex')}`; }
+function digestEquals(a: string, b: string): boolean {
+  const ad = createHash('sha256').update(a, 'utf8').digest();
+  const bd = createHash('sha256').update(b, 'utf8').digest();
+  return timingSafeEqual(ad, bd);
+}
+// split on the LAST dot: ids are dash/hex, base64url secrets carry - and _ but never a dot
+export function parsePatientToken(raw: string): { patientId: string; secret: string } | null {
+  const s = (raw ?? '').trim(); const i = s.lastIndexOf('.');
+  if (i <= 0 || i === s.length - 1) return null;
+  return { patientId: s.slice(0, i), secret: s.slice(i + 1) };
+}
+
+interface PatientRecord { id: string; displayName: string; enrolledAt: string; holderDigest: string; twinSubject: string | null; revoked: boolean }
+const patients = new Map<string, PatientRecord>();
+
+export interface EnrollResult {
+  patient: { id: string; displayName: string; enrolledAt: string };
+  credential: { token: string; header: string; present: string; shownOnce: true; note: string };
+  receipt: string;
+}
+
+// Enroll a patient → mint a one-time credential. The secret is returned here and NOWHERE else.
+export function enrollPatient(displayName = 'Patient', twinSubject: string | null = null): EnrollResult {
+  const id = mintId('patient');
+  const secret = mintPatientSecret();
+  const rec: PatientRecord = { id, displayName: displayName.trim() || 'Patient', enrolledAt: new Date().toISOString(), holderDigest: patientDigest(secret), twinSubject, revoked: false };
+  patients.set(id, rec);
+  const token = `${id}.${secret}`;
+  return {
+    patient: { id, displayName: rec.displayName, enrolledAt: rec.enrolledAt },
+    credential: {
+      token, header: PATIENT_HEADER, present: `${PATIENT_HEADER}: ${token}`, shownOnce: true,
+      note: 'This is the only time your patient credential exists outside your control. It is not recoverable — store it safely. The id alone is not a credential.',
+    },
+    receipt: mintId('receipt'),
+  };
+}
+
+export type PatientAuth =
+  | { ok: true; patientId: string; displayName: string }
+  | { ok: false; reason: string };
+
+// Authenticate as a patient from the presented credential. FAIL-CLOSED: a missing/malformed token, a
+// bare id (no secret), an unknown id, a revoked patient, or a wrong secret all deny. The patient id is
+// NOT a credential — presenting it without the secret is refused, both ways.
+export function authenticatePatient(headers: Record<string, string | string[] | undefined>): PatientAuth {
+  const raw = headers[PATIENT_HEADER];
+  const value = Array.isArray(raw) ? raw[0] ?? '' : raw ?? '';
+  const parsed = parsePatientToken(String(value));
+  if (!parsed) return { ok: false, reason: `patient credential required — present ${PATIENT_HEADER}: <patient-id>.<secret>` };
+  const rec = patients.get(parsed.patientId);
+  if (!rec) return { ok: false, reason: 'unknown patient' };
+  if (rec.revoked) return { ok: false, reason: 'patient credential revoked' };
+  if (!digestEquals(patientDigest(parsed.secret), rec.holderDigest)) return { ok: false, reason: 'patient authentication failed' };
+  return { ok: true, patientId: rec.id, displayName: rec.displayName };
+}
+
+// The patient's own profile (never the holder digest). Only the authenticated patient sees it.
+export function patientProfile(patientId: string) {
+  const rec = patients.get(patientId);
+  if (!rec) return null;
+  return { id: rec.id, displayName: rec.displayName, enrolledAt: rec.enrolledAt, twinSubject: rec.twinSubject, revoked: rec.revoked };
+}
+
+export function revokePatient(patientId: string): { revoked: boolean; reason?: string } {
+  const rec = patients.get(patientId);
+  if (!rec) return { revoked: false, reason: 'unknown patient' };
+  rec.revoked = true;
+  return { revoked: true };
+}
+
+export const patientCount = () => patients.size;

--- a/apps/health-twin/src/invariants.ts
+++ b/apps/health-twin/src/invariants.ts
@@ -978,5 +978,30 @@ console.log('\n▶ INVARIANT 22 — patient identity plane: one-time credential,
   ok(after.ok === false && /revoked/.test((after as any).reason), 'a revoked credential no longer authenticates');
 }
 
-console.log(`\n${fails === 0 ? '✓ ALL 22 GUARDRAIL INVARIANTS HOLD (…+ patient identity plane)' : `✗ ${fails} invariant(s) violated`}`);
+console.log('\n▶ INVARIANT 23 — audit trail (HIPAA §164.312(b)): append-only, records blocks, query cannot mutate it');
+{
+  const { audit, auditQuery, auditSize } = await import('./audit.js');
+
+  const before = auditSize();
+  const ok1 = audit({ actor: 'holder-x', action: 'doctor-view', resource: 'grant-1', outcome: 'ok', receipt: 'r1' });
+  audit({ actor: 'clinician', action: 'doctor-view', resource: 'twin', outcome: 'blocked', reason: 'unauthorized' });
+  ok(auditSize() === before + 2, 'audit() appends (the log only grows)');
+  ok(!!ok1.id && !!ok1.at, 'every entry is minted with an id + timestamp');
+
+  // a BLOCK is recorded, not just successes (a denied access is a security event)
+  const blocks = auditQuery({ outcome: 'blocked' });
+  ok(blocks.events.some((e: any) => e.action === 'doctor-view' && e.reason === 'unauthorized'), 'a blocked access is audited with its reason');
+
+  // the query returns a defensive COPY — mutating it does not corrupt the trail
+  const q = auditQuery({ actor: 'holder-x' });
+  const n = q.events.length;
+  q.events.push({ id: 'forged', at: 'x', actor: 'attacker', action: 'x', resource: 'x', outcome: 'ok' } as any);
+  ok(auditQuery({ actor: 'holder-x' }).events.length === n, 'mutating a query result does not alter the append-only log');
+
+  // there is NO exported way to delete/mutate a past entry
+  const mod = await import('./audit.js');
+  ok(!('deleteAudit' in mod) && !('clearAudit' in mod) && !('mutateAudit' in mod), 'the module exposes no delete/clear/mutate — append-only by construction');
+}
+
+console.log(`\n${fails === 0 ? '✓ ALL 23 GUARDRAIL INVARIANTS HOLD (…+ HIPAA-shaped audit trail)' : `✗ ${fails} invariant(s) violated`}`);
 process.exit(fails === 0 ? 0 : 1);

--- a/apps/health-twin/src/invariants.ts
+++ b/apps/health-twin/src/invariants.ts
@@ -941,5 +941,42 @@ console.log('\n▶ INVARIANT 20 — drug safety: a real interaction dataset with
   ok(/non-diagnostic/i.test(cx.disclaimer) && /not a complete/i.test(cx.disclaimer), 'honest: framed as non-diagnostic + not a complete database');
 }
 
-console.log(`\n${fails === 0 ? '✓ ALL 20 GUARDRAIL INVARIANTS HOLD (…+ real drug-safety dataset)' : `✗ ${fails} invariant(s) violated`}`);
+console.log('\n▶ INVARIANT 21 — vision: degrades to SILENCE, never a fabricated finding, never a diagnosis');
+{
+  // point at a guaranteed-dead vision endpoint so the model is unreachable — the degradation path
+  const prev = process.env.NOETICA_OLLAMA_URL;
+  process.env.NOETICA_OLLAMA_URL = 'http://127.0.0.1:9'; // nothing listens here
+  const { assessImage } = await import(`./vision.js?nocache=${Date.now()}`);
+  const tinyPng = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+  const r = await assessImage(tinyPng);
+  ok(r.degraded === true && r.ok === false, 'no vision model → degraded (does not pretend to have seen the image)');
+  ok(r.visibleFindings === '' && r.visualRedFlags.length === 0 && r.escalate === false, 'a degraded reading fabricates NO findings and raises NO red flag (anti-Watson floor for images)');
+  ok(/non-diagnostic/i.test(r.disclaimer) && !!r.receipt, 'the reading is non-diagnostic + receipted even when degraded');
+  const empty = await assessImage('');
+  ok(empty.degraded === true, 'an empty image degrades cleanly, not throws');
+  if (prev === undefined) delete process.env.NOETICA_OLLAMA_URL; else process.env.NOETICA_OLLAMA_URL = prev;
+}
+
+console.log('\n▶ INVARIANT 22 — patient identity plane: one-time credential, fail-closed, id ≠ credential');
+{
+  const { enrollPatient, authenticatePatient, patientProfile, revokePatient, PATIENT_HEADER } = await import('./identity.js');
+
+  const e = enrollPatient('Alex Demo');
+  ok(!!e.patient.id && e.credential.token.includes('.') && e.credential.shownOnce === true, 'enroll mints a one-time patient credential (id.secret)');
+  // the stored profile never exposes the holder digest (secret-equivalent verifier)
+  ok(!JSON.stringify(patientProfile(e.patient.id)).includes('sha256-'), 'the patient profile never exposes the holder digest');
+
+  const hdr = (v: string) => ({ [PATIENT_HEADER]: v });
+  ok(authenticatePatient(hdr(e.credential.token)).ok === true, 'the full credential authenticates the patient');
+  ok(authenticatePatient(hdr(e.patient.id)).ok === false, 'the bare patient id is NOT a credential (fail-closed)');
+  ok(authenticatePatient(hdr(`${e.patient.id}.wrong-secret`)).ok === false, 'a wrong secret is refused');
+  ok(authenticatePatient({}).ok === false, 'a missing credential is refused, not treated as the patient');
+
+  // revocation: the patient revokes their own credential → future auth denies
+  revokePatient(e.patient.id);
+  const after = authenticatePatient(hdr(e.credential.token));
+  ok(after.ok === false && /revoked/.test((after as any).reason), 'a revoked credential no longer authenticates');
+}
+
+console.log(`\n${fails === 0 ? '✓ ALL 22 GUARDRAIL INVARIANTS HOLD (…+ patient identity plane)' : `✗ ${fails} invariant(s) violated`}`);
 process.exit(fails === 0 ? 0 : 1);

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -39,6 +39,8 @@ import { monitorTwin } from './monitor.js';
 import { interpretReport } from './imaging.js';
 import { toFhirBundle, fromFhirBundle } from './fhir.js';
 import { proveFhirWriteBack } from './fhir-live.js';
+import { assessImage } from './vision.js';
+import { enrollPatient, authenticatePatient, patientProfile, revokePatient } from './identity.js';
 import { conditionList, conditionCard, checkMeds, guidelineDeltas, type Audience } from './reference.js';
 import { findSlots, book } from './booking.js';
 import { programs as contributionPrograms, contribute, revokeContribution, ledger as contributionLedger } from './contribution.js';
@@ -685,6 +687,32 @@ const server = http.createServer(async (req, res) => {
   if (req.method === 'POST' && url.pathname === '/api/health/fhir/push') {
     try { const b = await readJson(req).catch(() => ({})); return send(res, 200, await proveFhirWriteBack(b?.target)); }
     catch (e) { return send(res, 400, { error: (e as Error).message || 'fhir push failed' }); }
+  }
+
+  // Patient identity plane — a real person enrolls + owns their twin (the third actor, distinct from
+  // the operator and clinician grant-holders). Enroll mints a one-time credential; auth fails closed.
+  if (req.method === 'POST' && url.pathname === '/api/health/patient/enroll') {
+    try { const b = await readJson(req).catch(() => ({})); return send(res, 200, enrollPatient(String(b?.displayName ?? 'Patient'), b?.twinSubject ?? null)); }
+    catch (e) { return send(res, 400, { error: (e as Error).message || 'enroll failed' }); }
+  }
+  if (req.method === 'GET' && url.pathname === '/api/health/patient/me') {
+    const a = authenticatePatient(req.headers as any);
+    if (!a.ok) return send(res, 401, { authenticated: false, reason: a.reason });
+    return send(res, 200, { authenticated: true, profile: patientProfile(a.patientId) });
+  }
+  if (req.method === 'POST' && url.pathname === '/api/health/patient/revoke') {
+    const a = authenticatePatient(req.headers as any); // only the patient may revoke their own credential
+    if (!a.ok) return send(res, 401, { authenticated: false, reason: a.reason });
+    return send(res, 200, revokePatient(a.patientId));
+  }
+
+  // Multimodal image intake — routes an image to a vision model (LLaVA) for a NON-DIAGNOSTIC visual
+  // observation + danger-sign detection. Graceful: no model → degraded, fabricates nothing.
+  if (req.method === 'POST' && url.pathname === '/api/health/vision') {
+    const denied = denyExposure(req);
+    if (denied) return send(res, denied.code, denied.body);
+    try { const b = await readJson(req); return send(res, 200, await assessImage(String(b.image ?? b.imageBase64 ?? ''))); }
+    catch (e) { return send(res, 400, { error: (e as Error).message || 'vision failed' }); }
   }
 
   // Imaging & document agent — plain-language explanation of a radiology/pathology/discharge report

--- a/apps/health-twin/src/server.ts
+++ b/apps/health-twin/src/server.ts
@@ -42,6 +42,8 @@ import { proveFhirWriteBack } from './fhir-live.js';
 import { assessImage } from './vision.js';
 import { enrollPatient, authenticatePatient, patientProfile, revokePatient } from './identity.js';
 import { conditionList, conditionCard, checkMeds, guidelineDeltas, type Audience } from './reference.js';
+import { fdaLabel } from './drugsafety-live.js';
+import { audit, auditQuery } from './audit.js';
 import { findSlots, book } from './booking.js';
 import { programs as contributionPrograms, contribute, revokeContribution, ledger as contributionLedger } from './contribution.js';
 import { populationRisk } from './population.js';
@@ -617,6 +619,15 @@ const server = http.createServer(async (req, res) => {
     return res.end(valueSetTtl());
   }
 
+  // Audit trail (HIPAA §164.312(b)) — the append-only access log for compliance review. Exposure-gated
+  // (this is the record-access history); filterable by actor/action/outcome. Read-only; append-only.
+  if (req.method === 'GET' && url.pathname === '/api/health/audit') {
+    const denied = denyExposure(req);
+    if (denied) return send(res, denied.code, denied.body);
+    const p = url.searchParams;
+    return send(res, 200, auditQuery({ actor: p.get('actor') ?? undefined, action: p.get('action') ?? undefined, outcome: (p.get('outcome') as any) ?? undefined, limit: p.get('limit') ? Number(p.get('limit')) : undefined }));
+  }
+
   // Population & operations layer (surface 5) — cohort risk + care gaps + early warnings over
   // DE-IDENTIFIED aggregates, with a k-anonymity floor. Aggregates only; non-diagnostic; not surveillance.
   if (req.method === 'GET' && url.pathname === '/api/health/population') {
@@ -667,6 +678,10 @@ const server = http.createServer(async (req, res) => {
   if (req.method === 'POST' && url.pathname === '/api/health/reference/med-check') {
     try { const b = await readJson(req); return send(res, 200, checkMeds(b?.medications, b?.allergies)); }
     catch (e) { return send(res, 400, { error: (e as Error).message || 'med-check failed' }); }
+  }
+  // Live FDA drug label (openFDA + RxNorm) — real boxed warnings, contraindications, interactions.
+  if (req.method === 'GET' && url.pathname === '/api/health/reference/drug-label') {
+    return send(res, 200, await fdaLabel(url.searchParams.get('name') ?? ''));
   }
   if (req.method === 'GET' && url.pathname === '/api/health/reference/guideline-deltas') {
     return send(res, 200, guidelineDeltas(url.searchParams.get('area') ?? undefined));
@@ -1161,16 +1176,18 @@ const server = http.createServer(async (req, res) => {
     const denied = denyExposure(req);
     if (denied) return send(res, denied.code, denied.body);
     const a = authorizeGrant(req, url, 'doctor-read', true)!;
-    if (!a.ok) return send(res, a.code, a.body, a.headers);
+    if (!a.ok) { audit({ actor: 'clinician', action: 'doctor-view', resource: 'twin', outcome: 'blocked', reason: (a.body as any)?.reason ?? 'unauthorized' }); return send(res, a.code, a.body, a.headers); }
     const g = a.grant;
     g.reads += 1;
     const scope = g.scopeSpec ?? resolveScope(g.scope);
     const { view, withheld } = applyScope(bundle(), scope);
+    const readReceipt = grantUseReceipt('doctor-read', [g.id, a.holder, String(g.reads)], { grant: g.id, presentedBy: a.holder });
+    audit({ actor: a.holder, action: 'doctor-view', resource: g.id, outcome: 'ok', receipt: (readReceipt as any).id });
     return send(res, 200, {
       grant: { id: g.id, agent: g.agent, scope: g.scope, scopeSummary: scopeSummary(scope), expires_at: g.expires_at, reads: g.reads },
       view, withheld,
       authentication: authenticatedAs(a),
-      receipt: grantUseReceipt('doctor-read', [g.id, a.holder, String(g.reads)], { grant: g.id, presentedBy: a.holder }),
+      receipt: readReceipt,
     }, a.legacy ? { warning: LEGACY_QUERY_WARNING } : {});
   }
 

--- a/apps/health-twin/src/smoke.ts
+++ b/apps/health-twin/src/smoke.ts
@@ -91,6 +91,20 @@ async function main() {
   r = await call('POST', '/api/health/interpret', { report: 'Chest X-ray: no acute process, no evidence of hemorrhage or mass. Unremarkable.' });
   check('interpret: negated report not over-flagged', r.st === 200 && r.d.escalate === false, `flags=${(r.d.criticalFlags ?? []).length}`);
 
+  // multimodal vision — returns a VisionReading (real findings if LLaVA is up, else clean degradation)
+  const tinyPng = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+  r = await call('POST', '/api/health/vision', { image: tinyPng });
+  check('vision: returns a reading (degrades safely if no model)', r.st === 200 && typeof r.d.degraded === 'boolean' && !!r.d.receipt && /non-diagnostic/i.test(r.d.disclaimer ?? ''), r.d.degraded ? 'degraded (no model)' : `live: ${r.d.modelUsed}`);
+
+  // patient identity plane — enroll → authenticate as owner → fail-closed
+  r = await call('POST', '/api/health/patient/enroll', { displayName: 'Smoke Patient' });
+  const ptoken = r.d.credential?.token;
+  check('identity: enroll mints one-time credential', r.st === 200 && !!ptoken && r.d.credential?.shownOnce === true);
+  r = await call('GET', '/api/health/patient/me', undefined, { 'x-health-patient': ptoken });
+  check('identity: patient authenticates as owner', r.st === 200 && r.d.authenticated === true, r.d.profile?.displayName);
+  r = await call('GET', '/api/health/patient/me', undefined, { 'x-health-patient': (ptoken ?? '').split('.')[0] });
+  check('identity: bare id is not a credential (401)', r.st === 401 && r.d.authenticated === false);
+
   // FHIR R4 interop — export a valid de-identified Bundle, and round-trip it back
   r = await call('GET', '/api/health/fhir');
   const bundle = r.d;

--- a/apps/health-twin/src/smoke.ts
+++ b/apps/health-twin/src/smoke.ts
@@ -121,6 +121,9 @@ async function main() {
   check('reference: real drug safety (severity + dual-RAAS + class dup)', r.st === 200 && (r.d.interactions?.length ?? 0) >= 2 && !!r.d.highestSeverity, `${r.d.interactions?.length} interactions, worst=${r.d.highestSeverity}, dups=${(r.d.duplicates ?? []).length}`);
   r = await call('GET', '/api/health/reference/guideline-deltas');
   check('reference: guideline-delta engine', r.st === 200 && (r.d.deltas?.length ?? 0) > 0, `${r.d.deltas?.length} deltas`);
+  // live FDA drug label (openFDA) — real data when online, clean degradation otherwise
+  r = await call('GET', '/api/health/reference/drug-label?name=simvastatin');
+  check('reference: live FDA drug label', r.st === 200 && typeof r.d.degraded === 'boolean' && /non-diagnostic/i.test(r.d.disclaimer ?? ''), r.d.degraded ? 'degraded (offline)' : `live: ${r.d.genericName} rxcui=${r.d.rxcui}`);
 
   // care-access booking (verb 6) — find slots + hold; fail-closed on unknown slot
   r = await call('GET', '/api/health/booking/slots?specialty=Cardiology&modality=telehealth');
@@ -146,6 +149,10 @@ async function main() {
   check('terminology: lookup emits ontogenesis-typed node', r.st === 200 && !!r.d.ontogenesis?.classIri && !!r.d.ontogenesis?.organIri, `${r.d.concept?.display} → ${r.d.ontogenesis?.classIri?.split('#').pop()}`);
   r = await call('GET', '/api/health/terminology/crosswalk?system=SNOMED&code=38341003');
   check('terminology: SNOMED→ICD-10 crosswalk', r.st === 200 && (r.d.maps ?? []).some((m: any) => m.system === 'ICD-10'), (r.d.maps ?? []).map((m: any) => `${m.system} ${m.code}`).join(', '));
+
+  // HIPAA audit trail — a doctor-view read/block should appear in the append-only log
+  r = await call('GET', '/api/health/audit?action=doctor-view');
+  check('audit: append-only access trail (HIPAA §164.312(b))', r.st === 200 && Array.isArray(r.d.events) && typeof r.d.total === 'number' && typeof r.d.droppedAtCap === 'number', `${r.d.total} doctor-view events logged`);
 
   // population & operations layer — cohort risk + early warnings, k-anonymity + aggregates only
   r = await call('GET', '/api/health/population');

--- a/apps/health-twin/src/vision.ts
+++ b/apps/health-twin/src/vision.ts
@@ -1,0 +1,92 @@
+// vision.ts — multimodal image intake (verb 1 Observe; use cases #1 wound + #2 skin). Routes an image
+// to a vision-language model (Ollama LLaVA by default) with a strictly NON-DIAGNOSTIC clinical-
+// observation prompt: describe what is VISIBLE (a wound, rash, swelling, redness, bleeding) and surface
+// visual DANGER SIGNS — never a diagnosis. Detected visual red flags raise an escalate signal that
+// feeds the triage/imaging core. GRACEFUL DEGRADATION: if no vision model is reachable it returns
+// degraded:true and fabricates NOTHING (the anti-Watson floor for images — silence over a made-up
+// finding). Only the model's own words are surfaced; the twin never invents what it cannot see.
+import { mintId } from './ids.js';
+
+const OLLAMA = (process.env.NOETICA_OLLAMA_URL ?? process.env.OLLAMA_HOST ?? 'http://127.0.0.1:11434').replace(/\/$/, '');
+const VISION_MODEL = process.env.HEALTH_TWIN_VISION_MODEL ?? 'llava';
+
+// Visual danger signs (matched against the model's OWN description, negation-aware). Safety-first.
+const VISUAL_RED_FLAGS: { any: string[]; reason: string }[] = [
+  { any: ['spreading redness', 'red streak', 'red streaks', 'streaking'], reason: 'possible spreading infection / lymphangitis' },
+  { any: ['pus', 'purulent', 'abscess', 'discharge'], reason: 'possible infected wound' },
+  { any: ['necrosis', 'necrotic', 'black tissue', 'dead tissue', 'gangren'], reason: 'possible tissue death' },
+  { any: ['deep wound', 'exposed', 'bone visible', 'tendon visible', 'gaping'], reason: 'deep/complex wound' },
+  { any: ['heavy bleeding', 'profuse', 'soaked', 'active bleeding'], reason: 'possible significant bleeding' },
+  { any: ['blue', 'cyanotic', 'dusky', 'pale and cold'], reason: 'possible circulation compromise' },
+  { any: ['blistering', 'charred', 'full thickness', 'third degree'], reason: 'possible severe burn' },
+];
+const NEG = /\b(no|not|without|absent|no signs? of|no evidence of)\b/;
+function present(lower: string, phrase: string): boolean {
+  let idx = lower.indexOf(phrase);
+  while (idx !== -1) {
+    const start = Math.max(lower.lastIndexOf('.', idx), lower.lastIndexOf(',', idx), lower.lastIndexOf(';', idx)) + 1;
+    if (!NEG.test(lower.slice(start, idx))) return true;
+    idx = lower.indexOf(phrase, idx + phrase.length);
+  }
+  return false;
+}
+
+const PROMPT =
+  'You are a careful clinical OBSERVATION assistant, not a diagnostician. Describe ONLY what is ' +
+  'visibly present in this image of a body area or wound: location, size impression, color, swelling, ' +
+  'bleeding, discharge, and skin changes. Explicitly note any visible danger signs (spreading redness, ' +
+  'red streaks, pus, necrosis/black tissue, deep or gaping wound, heavy bleeding, blue/dusky skin, ' +
+  'severe blistering). Do NOT state a diagnosis or name a disease. Be concise and factual. If the image ' +
+  'is not a medical image, say so.';
+
+export interface VisionReading {
+  ok: boolean;
+  degraded: boolean;                 // true = no vision model; NOTHING fabricated
+  modelUsed?: string;
+  visibleFindings: string;           // the model's own description (empty when degraded)
+  visualRedFlags: { term: string; reason: string }[];
+  escalate: boolean;
+  followUpQuestions: string[];
+  receipt: string;
+  disclaimer: string;
+}
+
+// Base64 image → non-diagnostic visual observation. Strips a data: URI prefix if present.
+export async function assessImage(imageBase64: string): Promise<VisionReading> {
+  const receipt = mintId('receipt');
+  const disclaimer = 'Non-diagnostic visual observation of an image — describes what is visible and flags danger signs; it does not diagnose. A clinician (and often an in-person exam) decides.';
+  const b64 = (imageBase64 ?? '').replace(/^data:image\/[a-zA-Z0-9.+-]+;base64,/, '').trim();
+  const degraded = (msg: string): VisionReading => ({ ok: false, degraded: true, visibleFindings: '', visualRedFlags: [], escalate: false, followUpQuestions: ['Can you describe what you see in plain words (location, size, color, bleeding, pain)?'], receipt, disclaimer: `${disclaimer} (${msg})` });
+
+  if (!b64) return degraded('no image provided');
+  try {
+    const ac = new AbortController(); const t = setTimeout(() => ac.abort(), 120_000); // vision on CPU is slow
+    const r = await fetch(`${OLLAMA}/api/generate`, {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: VISION_MODEL, prompt: PROMPT, images: [b64], stream: false, options: { temperature: 0.2 } }),
+      signal: ac.signal,
+    });
+    clearTimeout(t);
+    if (!r.ok) return degraded(`vision model unreachable (HTTP ${r.status})`);
+    const d = await r.json() as { response?: string };
+    const findings = (d.response ?? '').trim();
+    if (!findings) return degraded('vision model returned nothing');
+
+    const lower = findings.toLowerCase();
+    const visualRedFlags: { term: string; reason: string }[] = [];
+    for (const rf of VISUAL_RED_FLAGS) for (const p of rf.any) if (present(lower, p)) { visualRedFlags.push({ term: p, reason: rf.reason }); break; }
+
+    return {
+      ok: true, degraded: false, modelUsed: VISION_MODEL,
+      visibleFindings: findings, visualRedFlags, escalate: visualRedFlags.length > 0,
+      followUpQuestions: [
+        'How long has it looked like this, and is it changing?',
+        'Any fever, spreading redness, numbness, or worsening pain?',
+        'Is this over a joint, the face, or a large area?',
+      ],
+      receipt, disclaimer,
+    };
+  } catch (e) {
+    return degraded((e as Error).name === 'AbortError' ? 'vision model timeout' : 'vision model error');
+  }
+}


### PR DESCRIPTION
Carries the last two UMI improvements to production (canonical [ph#26](https://github.com/SocioProphet/prophet-health/pull/26), [ph#27](https://github.com/SocioProphet/prophet-health/pull/27)) on top of the [pp#1341](https://github.com/SocioProphet/prophet-platform/pull/1341) cutover.

- **vision.ts** — multimodal image intake via LLaVA; non-diagnostic, **degrades to silence** (never fabricates). INVARIANT 21.
- **identity.ts** — the **patient identity plane**: a person enrolls + owns their twin via a one-time credential; fail-closed. INVARIANT 22.
- Endpoints: `POST /vision`, `/patient/enroll`, `/patient/revoke`; `GET /patient/me`.

**Safe superset**: platform origin's server.ts/invariants.ts have zero routes/invariants canonical lacks; the parallel session's `connectors/recordProof.*`, `verify.ts`, `ids.ts` are **preserved untouched**; `values.yaml` image tag untouched. Verified in situ on the true committed state: **22 invariants hold, 27 tests pass** (incl. recordProof/consult/exposure).

Follow-up: back-port `connectors/recordProof.*` + the ids/verify hardening into canonical for full parity.