### PR TITLE
[prepped] kyverno: reconcile Enforce→Audit for the audit-first rollout (P1.6)

### DIFF
--- a/infra/policy/cloudshell-fog/kyverno/require-image-digest.yaml
+++ b/infra/policy/cloudshell-fog/kyverno/require-image-digest.yaml
@@ -10,7 +10,11 @@ metadata:
     policies.kyverno.io/description: >-
       Require container images to use immutable digests rather than mutable tags.
 spec:
-  validationFailureAction: Enforce
+  # Audit-first (was Enforce). Syncing this at Enforce would immediately reject every Pod whose
+  # image is a mutable tag — estate-wide, including the sha-<commit> tag pins — an outage. The
+  # documented rollout (deploy/argocd/kyverno.yaml, ROLLOUT.md) is Audit → observe → Enforce.
+  # Flip back to Enforce in the final rollout step once Audit logs are clean. Tracked: #1344.
+  validationFailureAction: Audit
   background: true
   rules:
     - name: require-image-checksum

--- a/infra/policy/cloudshell-fog/kyverno/runtime-baseline.yaml
+++ b/infra/policy/cloudshell-fog/kyverno/runtime-baseline.yaml
@@ -10,7 +10,9 @@ metadata:
     policies.kyverno.io/description: >-
       Apply conservative runtime hardening to cloudshell-managed session pods.
 spec:
-  validationFailureAction: Enforce
+  # Audit-first (was Enforce) — see require-image-digest.yaml. Syncing at Enforce could reject
+  # existing Pods that violate the baseline, estate-wide. Audit → observe → Enforce (#1344).
+  validationFailureAction: Audit
   background: true
   rules:
     - name: require-hardened-managed-session-pods


### PR DESCRIPTION
P1.6 prep — **draft, your decision to merge + start the rollout.**

Removes the outage trap flagged in #1344: the rollout runbook promises audit-first/non-blocking, but `require-image-digest` and `runtime-baseline` shipped `validationFailureAction: Enforce`. Syncing as-is would **reject every tag-based Pod estate-wide** (including the `sha-` tag pins). This flips both to **Audit** for the initial rollout.

**Merging this changes nothing live** — kyverno is still HELD/unsynced (`deploy/argocd/kyverno.yaml` has no `automated` sync). It makes the *subsequent* operator sync safe. It is **step 1** of the tracked audit-first sequence in #1344:
1. ← *this PR* (Enforce→Audit) + vendor the chart (#1343 / #1351 ratchet)
2. sync the controller (policy-less → non-disruptive)
3. sync policies in Audit → observe admission logs
4. flip Audit→Enforce one policy at a time
5. remove the `deploy-health-hold` annotation

Left as a **draft** so nothing rolls until you say go.