### PR TITLE
tools: reusable job-receipt helper (P2.10)

### DIFF
--- a/tools/job_receipt.py
+++ b/tools/job_receipt.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""A one-line honesty convention for scheduled jobs: write a receipt when you finish.
+
+The backup nightly exited 0 for days while every copy silently failed, because launchd only saw
+the process's last `echo`, not whether the work happened. The fix generalizes: a job writes a
+RECEIPT at completion — `{"job", "ts", "rc"}` — and something watches those receipts for
+staleness (a job that stopped running) or a non-zero `rc` (a job that ran and failed). The
+deploy-health alerter's `--receipts` mode already consumes exactly this shape, so adopting this
+helper wires any job into that watch for free.
+
+  # at the end of a Python job:
+  from job_receipt import write_receipt
+  write_receipt("nightly-backup", rc, directory="~/.local/state/receipts")
+
+  # or from a shell job:
+  job_receipt.py write nightly-backup "$rc" --dir ~/.local/state/receipts
+
+`verify_receipts()` is the reader (a thin, importable form of the alerter's check) so a job can
+also self-assert its peers are fresh.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+
+def write_receipt(job: str, rc: int, *, directory: str | Path = "~/.local/state/receipts",
+                  ts: float | None = None) -> Path:
+    """Write ``{job, ts, rc}`` to ``<directory>/<job>.json``. Returns the path.
+
+    Call it with the REAL exit code of the work — the whole point is that the receipt reflects
+    what happened, not that the script reached its last line.
+    """
+    d = Path(directory).expanduser()
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / f"{job}.json"
+    path.write_text(json.dumps({"job": job, "ts": ts if ts is not None else time.time(),
+                                "rc": int(rc)}) + "\n")
+    return path
+
+
+def verify_receipts(directory: str | Path, *, max_age_s: int, now: float | None = None,
+                    expect: list[str] | None = None) -> list[str]:
+    """Return a list of problems (empty = all fresh + rc 0). Mirrors the alerter's semantics.
+
+    A missing expected receipt, a stale one, or a non-zero rc is a problem — the three ways a
+    scheduled job silently lets you down.
+    """
+    d = Path(directory).expanduser()
+    now = time.time() if now is None else now
+    problems: list[str] = []
+    found: dict[str, dict] = {}
+    if d.is_dir():
+        for p in sorted(d.glob("*.json")):
+            try:
+                data = json.loads(p.read_text())
+                found[str(data.get("job") or p.stem)] = data
+            except (json.JSONDecodeError, OSError):
+                problems.append(f"{p.name}: unreadable receipt")
+    for name in (expect or []):
+        if name not in found:
+            problems.append(f"{name}: missing (job wrote no receipt — did it run?)")
+    for name, data in sorted(found.items()):
+        ts = data.get("ts")
+        if not isinstance(ts, (int, float)):
+            problems.append(f"{name}: no/invalid ts")
+        elif now - ts > max_age_s:
+            problems.append(f"{name}: stale ({int(now - ts)}s > {max_age_s}s)")
+        rc = data.get("rc")
+        if rc is None:
+            problems.append(f"{name}: no rc recorded")
+        elif int(rc) != 0:
+            problems.append(f"{name}: rc={rc}")
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Write or verify job receipts.")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    w = sub.add_parser("write", help="write a receipt")
+    w.add_argument("job")
+    w.add_argument("rc", type=int)
+    w.add_argument("--dir", default="~/.local/state/receipts")
+    v = sub.add_parser("verify", help="verify receipts are fresh + rc 0")
+    v.add_argument("--dir", default="~/.local/state/receipts")
+    v.add_argument("--max-age", type=int, default=93600, help="max age seconds (default 26h)")
+    v.add_argument("--expect", action="append", default=[])
+    args = ap.parse_args(argv)
+
+    if args.cmd == "write":
+        p = write_receipt(args.job, args.rc, directory=args.dir)
+        print(f"wrote {p}")
+        return 0
+    problems = verify_receipts(args.dir, max_age_s=args.max_age, expect=args.expect)
+    if problems:
+        print(f"FAIL: {len(problems)} receipt problem(s):")
+        for p in problems:
+            print(f"  {p}")
+        return 1
+    print("OK: all job receipts fresh and rc 0")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_job_receipt.py
+++ b/tools/tests/test_job_receipt.py
@@ -1,0 +1,51 @@
+"""The receipt helper exists to catch the three silent ways a scheduled job fails you:
+it stopped running (stale), it ran and failed (rc!=0), or it never ran (missing). Each is pinned."""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+import job_receipt as jr  # noqa: E402
+
+
+def test_roundtrip_fresh_success_is_clean(tmp_path):
+    jr.write_receipt("backup", 0, directory=tmp_path)
+    assert jr.verify_receipts(tmp_path, max_age_s=3600) == []
+
+
+def test_stale_receipt_flagged(tmp_path):
+    jr.write_receipt("backup", 0, directory=tmp_path, ts=time.time() - 99999)
+    out = jr.verify_receipts(tmp_path, max_age_s=3600)
+    assert any("stale" in p for p in out)
+
+
+def test_failed_receipt_flagged(tmp_path):
+    jr.write_receipt("backup", 2, directory=tmp_path)
+    assert any("rc=2" in p for p in jr.verify_receipts(tmp_path, max_age_s=3600))
+
+
+def test_missing_expected_receipt_flagged(tmp_path):
+    out = jr.verify_receipts(tmp_path, max_age_s=3600, expect=["nightly-backup"])
+    assert any("missing" in p for p in out)
+
+
+def test_unreadable_receipt_flagged(tmp_path):
+    (tmp_path / "junk.json").write_text("{not json")
+    assert any("unreadable" in p for p in jr.verify_receipts(tmp_path, max_age_s=3600))
+
+
+def test_written_shape_matches_alerter_receipts_contract(tmp_path):
+    import json
+    p = jr.write_receipt("x", 0, directory=tmp_path)
+    d = json.loads(p.read_text())
+    assert set(d) == {"job", "ts", "rc"} and d["job"] == "x" and d["rc"] == 0
+
+
+def test_cli_write_then_verify(tmp_path):
+    assert jr.main(["write", "job-a", "0", "--dir", str(tmp_path)]) == 0
+    assert jr.main(["verify", "--dir", str(tmp_path), "--max-age", "3600"]) == 0
+    jr.write_receipt("job-b", 1, directory=tmp_path)
+    assert jr.main(["verify", "--dir", str(tmp_path), "--max-age", "3600"]) == 1


### PR DESCRIPTION
P2.10 of the [SOTA backlog](https://claude.ai/code/artifact/3af54950-e6b3-41b0-a816-341062bd216f) — generalizes the backup-honesty fix into a reusable convention.

The backup exited 0 for days while every copy failed because launchd only saw the last `echo`, not the work. The fix generalizes: a job writes a **receipt** `{job, ts, rc}` at completion, and something watches those for **staleness** (stopped running), **non-zero rc** (ran and failed), or **absence** (never ran).

[`tools/job_receipt.py`](tools/job_receipt.py): `write`/`verify` CLI + importable `write_receipt`/`verify_receipts`. The receipt shape is **exactly** what the deploy-health alerter’s `--receipts` mode already consumes — so adopting this helper wires any job into that watch for free. 7 tests pin the round-trip and all three failure modes. (Local demonstration: the nightly backup adopts it, so a silently-failing backup is caught again — the original motivating case.)