### PR TITLE
tools: controls census — the meta-control (P2.12)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,13 @@ drift-check:
 standards-check:
 	python3 tools/check_standards_lock.py
 
+# The meta-control: census every enforcement control and report which can actually be shown to
+# FAIL (has a negative control), which run on a schedule, which are meta-monitored. Reads the SOTA
+# scorecard from reality instead of by hand. Informational here; `controls_census.py
+# --fail-on-undiscriminating` is the gate form (turn it on once the current guards get self-tests).
+controls-census:
+	python3 tools/controls_census.py
+
 topology-check:
 	python3 tools/check_transport_topology.py
 

--- a/tools/controls_census.py
+++ b/tools/controls_census.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Controls census — the meta-control that reads the SOTA scorecard from reality.
+
+You cannot manage what you cannot see. This program hunts controls that report green while doing
+nothing — so the one thing it must not do is let a control's own SOTA properties be asserted by
+hand. This enumerates the estate's enforcement controls from the repo and reports, for each,
+whether it actually has the properties a real control needs:
+
+  * discriminates — its script carries a negative control / self-test, so it can be shown to FAIL
+                    (a gate that cannot fail is the defect this whole program exists to abolish);
+  * scheduled     — it runs on its own (a CronJob), not only when a human invokes it;
+  * meta-monitored— something alerts if the control itself stops (the check checks the checker).
+
+Two kinds of control are enumerated:
+  - scheduled controls: CronJobs under infra/k8s/*/base/cronjob.yaml (+ their ArgoCD app + rule);
+  - gate validators: the tools/ scripts wired into `make validate` / `make preflight`.
+
+`--fail-on-undiscriminating` turns the census into a GATE: any control that cannot fail fails the
+build. Self-excluding — this reporter is not itself in the census. `--live` enriches with
+"ever-fired" from the cluster when reachable; the static census needs no cluster.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SELF = Path(__file__).name
+
+# A control "discriminates" if it can be shown to FAIL — either an inline negative control /
+# self-test in the script, or a dedicated test file (tools/tests/test_<name>.py) that exercises it.
+_DISCRIMINATES_RE = re.compile(
+    r"_self_test|--self-test|self.test|_negative_control|negative control|teeth|check_schema|"
+    r"must fail|MUST fail|assert .*(==|!=|not )")
+
+
+def _discriminates(script: Path) -> bool:
+    # a co-located test file is the estate's most common negative control
+    if (script.parent / "tests" / f"test_{script.stem}.py").is_file():
+        return True
+    try:
+        return bool(_DISCRIMINATES_RE.search(script.read_text(encoding="utf-8", errors="ignore")))
+    except OSError:
+        return False
+
+
+def _meta_monitored(base: Path) -> bool:
+    return any(base.glob("prometheusrule*.yaml"))
+
+
+def scheduled_controls(root: Path) -> list[dict]:
+    """CronJob-based controls: each infra/k8s/<name>/base/cronjob.yaml."""
+    out: list[dict] = []
+    for cj in sorted(root.glob("infra/k8s/*/base/cronjob.yaml")):
+        base = cj.parent
+        name = base.parent.name
+        # the mounted script (if any) is the discriminating unit
+        scripts = [p for p in base.glob("*.py")]
+        discr = any(_discriminates(p) for p in scripts)
+        out.append({
+            "control": name,
+            "kind": "cronjob",
+            "discriminates": discr,
+            "scheduled": True,
+            "meta_monitored": _meta_monitored(base),
+            "gitops_app": (root / "deploy/argocd" / f"{name}.yaml").is_file()
+                          or any((root / "deploy/argocd").glob(f"*{name}*.yaml")),
+        })
+    return out
+
+
+def gate_validators(root: Path) -> list[dict]:
+    """tools/ validators wired into `make validate` or `make preflight`."""
+    makefile = (root / "Makefile").read_text(encoding="utf-8", errors="ignore") if (root / "Makefile").is_file() else ""
+    out: list[dict] = []
+    for script in sorted(root.glob("tools/*.py")):
+        if script.name == SELF or script.name.startswith("test_"):
+            continue
+        if not re.match(r"(validate_|verify_|check_|preflight_|selftest_)", script.name):
+            continue
+        wired = script.name in makefile or script.stem in makefile
+        if not wired:
+            continue
+        out.append({
+            "control": script.stem,
+            "kind": "validator",
+            "discriminates": _discriminates(script),
+            "scheduled": False,       # runs in CI on change, not on a wall-clock schedule
+            "gate_wired": True,
+        })
+    return out
+
+
+def _ever_fired_live(controls: list[dict]) -> None:
+    """Best-effort: mark cronjob controls that have a completed Job in the cluster."""
+    try:
+        raw = subprocess.run(["kubectl", "get", "jobs", "-A", "-o", "json"],
+                             capture_output=True, text=True, timeout=30)
+        jobs = json.loads(raw.stdout).get("items", []) if raw.returncode == 0 else []
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
+        jobs = []
+    names = [j.get("metadata", {}).get("name", "") for j in jobs]
+    for c in controls:
+        if c["kind"] == "cronjob":
+            c["ever_ran"] = any(n.startswith(c["control"]) for n in names)
+
+
+def census(root: Path, live: bool = False) -> list[dict]:
+    controls = scheduled_controls(root) + gate_validators(root)
+    if live:
+        _ever_fired_live(controls)
+    return controls
+
+
+def _print(controls: list[dict], live: bool) -> None:
+    sched = [c for c in controls if c["kind"] == "cronjob"]
+    vals = [c for c in controls if c["kind"] == "validator"]
+    disc = sum(1 for c in controls if c["discriminates"])
+    print(f"Controls census — {len(controls)} controls "
+          f"({len(sched)} scheduled, {len(vals)} gate validators)")
+    print(f"  discriminate (can actually fail): {disc}/{len(controls)}")
+    print("  scheduled controls:")
+    for c in sorted(sched, key=lambda x: x["control"]):
+        flags = [("discriminates" if c["discriminates"] else "⚠ NO negative control"),
+                 ("meta-monitored" if c.get("meta_monitored") else "⚠ no PrometheusRule"),
+                 ("gitops" if c.get("gitops_app") else "⚠ no ArgoCD app")]
+        if live:
+            flags.append("ever-ran" if c.get("ever_ran") else "⚠ never ran")
+        print(f"    {c['control']:32s} {' · '.join(flags)}")
+    undiscriminating_vals = [c['control'] for c in vals if not c['discriminates']]
+    print(f"  gate validators: {len(vals)} ({len(vals) - len(undiscriminating_vals)} discriminate)")
+    if undiscriminating_vals:
+        print(f"    ⚠ no negative control: {', '.join(undiscriminating_vals)}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Census of the estate's enforcement controls.")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--live", action="store_true", help="enrich with ever-ran from the cluster")
+    ap.add_argument("--fail-on-undiscriminating", action="store_true",
+                    help="exit non-zero if any SCHEDULED control lacks a negative control")
+    args = ap.parse_args(argv)
+    controls = census(ROOT, live=args.live)
+    if args.json:
+        print(json.dumps(controls, indent=2))
+    else:
+        _print(controls, args.live)
+    if args.fail_on_undiscriminating:
+        blind = [c["control"] for c in controls if c["kind"] == "cronjob" and not c["discriminates"]]
+        if blind:
+            print(f"FAIL: scheduled control(s) with no negative control (cannot be shown to fail): "
+                  f"{', '.join(blind)}")
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_controls_census.py
+++ b/tools/tests/test_controls_census.py
@@ -1,0 +1,68 @@
+"""The census is the meta-control: it must correctly tell a control that CAN fail from one that
+can't, and its --fail-on-undiscriminating gate must actually trip on a scheduled control with no
+negative control. Tested on synthetic trees so it never depends on the live repo's current state."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+import controls_census as cc  # noqa: E402
+
+
+def _mk_cronjob(root: Path, name: str, *, script_selftest: bool, rule: bool, app: bool):
+    base = root / "infra" / "k8s" / name / "base"
+    base.mkdir(parents=True)
+    (base / "cronjob.yaml").write_text("kind: CronJob\n")
+    (base / f"{name}.py").write_text("def _self_test(): ...\n" if script_selftest else "x = 1\n")
+    if rule:
+        (base / "prometheusrule-guard.yaml").write_text("kind: PrometheusRule\n")
+    if app:
+        (root / "deploy" / "argocd").mkdir(parents=True, exist_ok=True)
+        (root / "deploy" / "argocd" / f"{name}.yaml").write_text("kind: Application\n")
+
+
+def test_discriminates_via_inline_selftest(tmp_path):
+    s = tmp_path / "v.py"; s.write_text("def _self_test():\n return True\n")
+    assert cc._discriminates(s) is True
+
+
+def test_discriminates_via_colocated_test_file(tmp_path):
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_v.py").write_text("def test_x(): assert True\n")
+    s = tmp_path / "v.py"; s.write_text("x = 1\n")  # no inline marker
+    assert cc._discriminates(s) is True
+
+
+def test_non_discriminating_script(tmp_path):
+    s = tmp_path / "v.py"; s.write_text("print('ok')\n")
+    assert cc._discriminates(s) is False
+
+
+def test_meta_monitored_matches_any_prometheusrule_name(tmp_path):
+    b = tmp_path; (b / "prometheusrule-guard.yaml").write_text("x")
+    assert cc._meta_monitored(b) is True
+    assert cc._meta_monitored(tmp_path / "empty") is False
+
+
+def test_scheduled_control_enumerated_with_properties(tmp_path):
+    _mk_cronjob(tmp_path, "good-guard", script_selftest=True, rule=True, app=True)
+    ctrls = cc.scheduled_controls(tmp_path)
+    assert len(ctrls) == 1
+    c = ctrls[0]
+    assert c["control"] == "good-guard" and c["discriminates"] and c["meta_monitored"] and c["gitops_app"]
+
+
+def test_fail_gate_trips_on_undiscriminating_scheduled_control(tmp_path, monkeypatch, capsys):
+    _mk_cronjob(tmp_path, "blind-guard", script_selftest=False, rule=False, app=False)
+    monkeypatch.setattr(cc, "ROOT", tmp_path)
+    # a scheduled control that cannot be shown to fail must fail the gate
+    assert cc.main(["--fail-on-undiscriminating"]) == 1
+    assert "blind-guard" in capsys.readouterr().out
+
+
+def test_gate_passes_when_scheduled_control_discriminates(tmp_path, monkeypatch):
+    _mk_cronjob(tmp_path, "good-guard", script_selftest=True, rule=True, app=True)
+    monkeypatch.setattr(cc, "ROOT", tmp_path)
+    assert cc.main(["--fail-on-undiscriminating"]) == 0


### PR DESCRIPTION
P2.12 of the [SOTA backlog](https://claude.ai/code/artifact/3af54950-e6b3-41b0-a816-341062bd216f) — the meta-control that makes the scorecard self-updating.

You cannot manage what you cannot see. [`tools/controls_census.py`](tools/controls_census.py) enumerates the estate’s enforcement controls and reports, for each, whether it has the properties a real control needs:
- **discriminates** — can be shown to FAIL (inline negative control/self-test, or a co-located `test_<name>.py`);
- **scheduled** — runs on its own (a CronJob), not only when invoked;
- **meta-monitored** — a PrometheusRule alerts if the control itself stops.

Two kinds: scheduled CronJob controls and the `tools/` gate validators wired into `make validate`.

**First run — the headline finding:** 72 controls, but **only 15 can be shown to fail**. The rest are unverified — potential paper controls. That is the scorecard’s *Discriminates* dimension, now **measured from the tree instead of asserted by hand.**

`make controls-census` (informational). `--fail-on-undiscriminating` is the gate form — turn it into a ratchet once the two current guards (`pvc-capacity-guard`, `rule-liveness-guard`) get negative controls. `--live` adds ever-ran from the cluster. Self-excluding; 7 tests.