### PR TITLE
fix(alert-delivery): close 4 Copilot findings left open after #1112 merged

### DIFF
--- a/infra/k8s/alert-delivery/base/prometheusrule-delivery.yaml
+++ b/infra/k8s/alert-delivery/base/prometheusrule-delivery.yaml
@@ -56,8 +56,18 @@ spec:
             runbook: infra/k8s/alert-delivery/README.md
 
         # The sink process being gone is itself an alert, not an absence.
+        #
+        # job="alert-sink" matches today because the Service (service.yaml) and the
+        # ServiceMonitor (servicemonitor.yaml) both happen to be named "alert-sink" --
+        # Prometheus Operator derives the `up` series' job label from the Service name,
+        # not the ServiceMonitor's, and no jobLabel override is set here. Scoping to
+        # namespace="observability" as well removes any ambiguity if another "alert-sink"
+        # job ever exists in a different namespace, rather than relying on name
+        # uniqueness holding cluster-wide by convention alone.
         - alert: AlertSinkDown
-          expr: up{job="alert-sink"} == 0 or absent(up{job="alert-sink"})
+          expr: |
+            up{job="alert-sink", namespace="observability"} == 0
+            or absent(up{job="alert-sink", namespace="observability"})
           for: 5m
           labels: { severity: critical, namespace: observability }
           annotations:

--- a/infra/k8s/alert-delivery/base/sink.py
+++ b/infra/k8s/alert-delivery/base/sink.py
@@ -77,6 +77,18 @@ _recent: collections.deque = collections.deque(maxlen=RING_MAX)
 _started = time.time()
 _last_notification = 0.0
 
+# Dedicated lock for the receipt sequence counter -- distinct from _lock (counters/
+# ring) and _emit_lock (stdout) so incrementing it can never contend with either.
+_seq_lock = threading.Lock()
+_receipt_seq = 0
+
+
+def next_seq() -> int:
+    global _receipt_seq
+    with _seq_lock:
+        _receipt_seq += 1
+        return _receipt_seq
+
 
 def utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
@@ -108,9 +120,17 @@ def emit(obj: dict) -> None:
 def receipt(action: str, status: str, subject_ref: str, body: dict, **extra) -> dict:
     """An EvidenceReceipt.v0.1. Fields and enum values come from the contract."""
     h = digest(body)
+    # `hash` (below) is the pure content digest -- intentionally identical for two
+    # occurrences of the same body. receipt_id must NOT be: the Watchdog heartbeat
+    # fires with an identical body every repeat_interval, and if receipt_id collided
+    # too, any downstream consumer that treats receipt_id as an idempotency/dedup key
+    # would silently collapse repeated heartbeats into "already seen" -- exactly the
+    # silent-delivery-failure class this sink exists to make loud. The sequence
+    # number makes every emission unique regardless of body content.
+    seq = next_seq()
     r = {
         "version": VERSION,
-        "receipt_id": "evr-%s-%s" % (action, h[:32]),
+        "receipt_id": "evr-%s-%s-%06d" % (action, h[:32], seq),
         "created_at": utc_now(),
         "service_ref": SERVICE_REF,
         "action": action,
@@ -186,6 +206,10 @@ def handle_notification(payload: dict) -> dict:
 
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
+    # HTTP/1.1 keep-alive means a request thread otherwise blocks indefinitely waiting
+    # for the next request on an idle (or misbehaving) client connection. Bound it so
+    # ThreadingHTTPServer can't accumulate permanently-parked threads.
+    timeout = 30
 
     def log_message(self, fmt, *args):  # noqa: A003 - stdlib hook
         # Access logs go through the same structured stream as everything else.
@@ -237,6 +261,13 @@ class Handler(BaseHTTPRequestHandler):
                     {"content_length": length, "limit": MAX_BODY},
                 )
             )
+            # Under HTTP/1.1 keep-alive, the client's declared Content-Length bytes are
+            # still sitting unread on the socket. Reading `length` bytes just to discard
+            # them would let an attacker force this process to drain an arbitrarily large
+            # declared body -- the same amplification risk the size cap exists to avoid.
+            # Close the connection instead of trying to keep it alive: the next request
+            # a reused socket would otherwise (mis)parse is exactly those unread bytes.
+            self.close_connection = True
             return self._send(413, {"error": "body too large", "limit": MAX_BODY})
 
         raw = self.rfile.read(length) if length else b""

--- a/infra/k8s/alert-delivery/tests/test_sink_receipt_uniqueness.py
+++ b/infra/k8s/alert-delivery/tests/test_sink_receipt_uniqueness.py
@@ -1,0 +1,63 @@
+"""receipt_id must be unique per emission, even for identical bodies.
+
+The Watchdog alert fires with an effectively identical body every repeat_interval --
+that is the whole point of it as a dead-man's switch. Pre-fix, receipt_id was derived
+only from a hash of the body, so every Watchdog heartbeat produced the SAME
+receipt_id. Anything downstream that treats receipt_id as an idempotency/dedup key
+would then silently collapse repeated heartbeats into "already seen" -- exactly the
+kind of silent delivery failure this sink exists to make loud. `hash` (the pure
+content digest) is deliberately left unchanged; only receipt_id must vary per call.
+
+Local-only (Actions are spend-capped). Requires: python3 (stdlib only).
+"""
+from __future__ import annotations
+
+import importlib.util
+import threading
+from pathlib import Path
+
+_SINK = Path(__file__).resolve().parents[1] / "base" / "sink.py"
+
+
+def _load_sink():
+    spec = importlib.util.spec_from_file_location("alert_sink_under_test_uniq", _SINK)
+    assert spec and spec.loader, f"cannot build an import spec for {_SINK}"
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_identical_body_gets_distinct_receipt_ids_same_hash():
+    sink = _load_sink()
+    body = {"alertname": "Watchdog", "severity": "none", "status": "firing"}
+
+    r1 = sink.receipt("alert-delivered", "accepted", "alert/-/Watchdog", body)
+    r2 = sink.receipt("alert-delivered", "accepted", "alert/-/Watchdog", body)
+
+    assert r1["hash"] == r2["hash"], "content hash must still reflect identical bodies"
+    assert r1["receipt_id"] != r2["receipt_id"], (
+        "receipt_id collided across two occurrences of the same body -- a downstream "
+        "consumer that dedupes by receipt_id would drop the second Watchdog heartbeat"
+    )
+
+
+def test_receipt_id_unique_under_concurrent_calls():
+    """next_seq() is called from many request threads at once in production; it must
+    never hand out the same sequence number twice."""
+    sink = _load_sink()
+    body = {"alertname": "Watchdog", "severity": "none", "status": "firing"}
+    n = 64
+    ids: list[str] = [None] * n  # type: ignore[list-item]
+    barrier = threading.Barrier(n)
+
+    def one(i: int) -> None:
+        barrier.wait()
+        ids[i] = sink.receipt("alert-delivered", "accepted", "alert/-/Watchdog", body)["receipt_id"]
+
+    threads = [threading.Thread(target=one, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(set(ids)) == n, f"expected {n} distinct receipt_ids, got {len(set(ids))} (sequence collision)"


### PR DESCRIPTION
## Context

#1112 ("Alertmanager's only receiver was named \"null\"") merged 2026-08-02. It had
10 Copilot review threads; the AlertmanagerConfig-wiring and emit()-concurrency
findings were fixed directly on the branch before merge, but the other 4 were never
addressed and the PR closed with them still open. This PR closes those 4.

## Findings and fixes

1. **receipt_id collided on identical bodies** (e.g. the Watchdog heartbeat, which
   fires with an effectively identical body every `repeat_interval` by design) —
   every heartbeat got the SAME `receipt_id`. A downstream consumer treating it as
   an idempotency key would silently drop repeats — exactly the silent-delivery-
   failure class this sink exists to make loud. Fixed with a thread-safe per-process
   sequence number folded into `receipt_id`; `hash` (the pure content digest) is
   unchanged. New test (`test_sink_receipt_uniqueness.py`) proven red on the old form,
   green on the fix, plus a 64-thread concurrency check on the counter itself.

2. **413 (oversize body) path never consumed the declared body**, but
   `protocol_version = "HTTP/1.1"` keeps the connection alive by default — the next
   request on a reused connection would misparse the unread bytes as its own request
   line. Draining the body instead would let an attacker force this process to read
   an arbitrarily large declared `Content-Length` just to reject it. Fixed by closing
   the connection (`self.close_connection = True`) rather than draining.

3. **No bound on keep-alive thread lifetime** — `ThreadingHTTPServer` + HTTP/1.1
   keep-alive means a request thread blocks indefinitely on an idle or misbehaving
   client connection. Added `Handler.timeout = 30`.

4. **`AlertSinkDown` doesn't scope `job="alert-sink"` to a namespace** — correct
   today only because the Service and ServiceMonitor happen to share the name
   `alert-sink` (Prometheus derives `job` from the Service, not the ServiceMonitor).
   Documented that coupling and added `namespace="observability"` to the selector.

## Verified

- `pytest infra/k8s/alert-delivery/tests/` — 3 passed (existing concurrency test +
  2 new).
- `kubectl kustomize infra/k8s/alert-delivery/base` renders the updated
  `AlertSinkDown` rule correctly.