### PR TITLE
feat(lattice-studio): surface updated_at freshness on catalog + lineage

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -1335,7 +1335,8 @@ async def catalog(project: str = "default",
         out.append({"id": n.get("id"), "name": p.get("name") or p.get("title") or n.get("id"),
                     "labels": [l for l in (n.get("labels") or []) if l != coll],
                     "connector": p.get("connector"), "source": p.get("source"),
-                    "epistemic_mode": p.get("epistemic_mode", "observed"), "governed": True, "columns": cols})
+                    "epistemic_mode": p.get("epistemic_mode", "observed"), "governed": True, "columns": cols,
+                    "updated_at": p.get("updated_at")})
     return {"project": project, "datasets": out, "count": len(out),
             "beat": "datasets are proof-carrying graph nodes — provenance + epistemic status are native, not a bolt-on catalog",
             "degraded": err}
@@ -1386,7 +1387,8 @@ async def lineage(project: str = "default", target: str = "", depth: int = 4,
         p = (n.get("properties") if n else {}) or {}
         out_nodes.append({"id": nid, "type": _node_type(n, coll) if n else "External",
                           "label": p.get("name") or p.get("title") or nid,
-                          "epistemic_mode": p.get("epistemic_mode")})
+                          "epistemic_mode": p.get("epistemic_mode"),
+                          "updated_at": p.get("updated_at")})
     return {"project": project, "target": target, "nodes": out_nodes, "edges": out_edges,
             "stats": {"nodes": len(out_nodes), "edges": len(out_edges)},
             "beat": "one proof-carrying lineage graph spanning data, pipelines, runs and models — every hop verifiable",

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -928,7 +928,8 @@ def test_catalog_lists_governed_datasets(monkeypatch):
             return ({"nodes": [
                 {"id": "proj-teamx:ingest:1", "labels": ["proj-teamx", "Person", "Ingested"],
                  "properties": {"name": "row1", "id_col": "1", "age": "40", "connector": "csv",
-                                "epistemic_mode": "observed", "source": "connector:csv:abc", "extractor": "x"}},
+                                "epistemic_mode": "observed", "source": "connector:csv:abc", "extractor": "x",
+                                "updated_at": "2026-08-01T00:00:00Z"}},
                 {"id": "proj-teamx:ent:foo", "labels": ["proj-teamx", "Entity"], "properties": {"name": "foo"}},
             ], "edgeList": []}, None)
         return (None, "x")
@@ -939,6 +940,9 @@ def test_catalog_lists_governed_datasets(monkeypatch):
     ds = b["datasets"][0]
     assert ds["connector"] == "csv" and ds["governed"] and ds["epistemic_mode"] == "observed"
     assert set(ds["columns"]) == {"id_col", "age"}           # provenance keys filtered out
+    # freshness: "how fresh is it" (the canonical lineage query this catalog must answer)
+    # must be a real surfaced field, not silently dropped as just a reserved-key exclusion.
+    assert ds["updated_at"] == "2026-08-01T00:00:00Z"
 
 
 def test_lineage_walks_the_flow_graph(monkeypatch):
@@ -947,7 +951,7 @@ def test_lineage_walks_the_flow_graph(monkeypatch):
     async def fake_req(client, method, url, json=None):
         if "subgraph" in url:
             return ({"nodes": [
-                {"id": "ds", "labels": ["proj-teamx", "Dataset"], "properties": {"name": "tidy", "epistemic_mode": "observed"}},
+                {"id": "ds", "labels": ["proj-teamx", "Dataset"], "properties": {"name": "tidy", "epistemic_mode": "observed", "updated_at": "2026-07-30T00:00:00Z"}},
                 {"id": "run", "labels": ["proj-teamx", "Run", "Experiment"], "properties": {"name": "fit"}},
                 {"id": "model", "labels": ["proj-teamx", "Model"], "properties": {"name": "clf", "epistemic_mode": "attested"}},
                 {"id": "unrelated", "labels": ["proj-teamx", "Entity"], "properties": {"name": "x"}},
@@ -965,6 +969,9 @@ def test_lineage_walks_the_flow_graph(monkeypatch):
     labels = {(e["from"], e["to"], e["label"]) for e in b["edges"]}
     assert ("model", "run", "produced_by") in labels and ("run", "ds", "feeds") in labels
     assert next(n for n in b["nodes"] if n["id"] == "model")["type"] == "Model"
+    # freshness travels with the lineage walk too — "where is X available from and
+    # how fresh is it" is one query, not two separate lookups.
+    assert next(n for n in b["nodes"] if n["id"] == "ds")["updated_at"] == "2026-07-30T00:00:00Z"
 
 
 def test_model_register_promote_and_list(monkeypatch):


### PR DESCRIPTION
## Summary
- \`/api/studio/catalog\` and \`/api/studio/lineage\` both already carry \`updated_at\` on their underlying graph nodes, but neither returned it — the canonical lineage query ("where is data asset X available from and how fresh is it") was only half-answerable via the API.
- Surfaces \`updated_at\` on both endpoints' node projections.

## Test plan
- [x] Extended existing fixtures in both \`test_catalog_lists_governed_datasets\` and \`test_lineage_walks_the_flow_graph\` to assert freshness is returned, not just present internally
- [x] \`pytest tests/test_server.py -k "catalog or lineage"\` — 2/2 pass