### PR TITLE
feat(lattice-studio): AssetTwin — the fourth twin (WS#53)

### DIFF
--- a/apps/lattice-studio/src/lattice_studio/server.py
+++ b/apps/lattice-studio/src/lattice_studio/server.py
@@ -34,7 +34,7 @@ import jwt
 from fastapi import Depends, FastAPI, Header, HTTPException, Response
 from pydantic import BaseModel
 
-from lattice_studio import gaia, hdt, ontology, product_spine, shacl
+from lattice_studio import gaia, hdt, ontology, product_spine, shacl, twin_asset
 from lattice_studio.inference_gateway_leaderboard import notebook_fixture
 
 SERVICE_VERSION = "0.2.0"
@@ -68,6 +68,7 @@ FORGE_TOKEN = os.getenv("FORGE_TOKEN", "")
 FORGE_TIMEOUT = float(os.getenv("FORGE_TIMEOUT", "90"))
 # Universal Compute Plane gateway (any compute, one governed door).
 COMPUTE_GATEWAY_URL = os.getenv("COMPUTE_GATEWAY_URL", "http://compute-gateway:8080")
+IDENTITY_TWIN_URL = os.getenv("IDENTITY_TWIN_URL", "http://identity-twin:8080")
 GATEWAY_TOKEN = os.getenv("GATEWAY_TOKEN", "")
 GATEWAY_TIMEOUT = float(os.getenv("GATEWAY_TIMEOUT", "120"))
 
@@ -2165,12 +2166,257 @@ async def hdt_ontology(_auth: dict[str, Any] | None = Depends(require_read)) -> 
         "ontology": "HDT — Human Digital Twin", "namespace": hdt.HDT_NS,
         "omega_states": hdt.OMEGA_STATES, "omega_epistemic_lattice": lattice, "kfs_triad": hdt.TRIAD_ROLES,
         "invariant": "a model may advance an observation but only a human/clinician/policy actor may DELIVER to canonical human-actionable truth",
-        "three_twins_closed": {
+        "four_twins_closed": {
             "knowledge": "HellGraph fact · observed→attested",
             "human": "HDT Observation · OmegaState ABSENT→DELIVERED",
             "earth": "GAIA WorldSignal · PromotionState EvidenceOnly→Promoted",
-            "note": "all three twins now run one governed-evidence discipline in the same substrate — the promotion membrane IS the epistemic ladder, everywhere",
+            "asset": "AssetTwin Claim · AssetState CLAIMED→AGENTIC_ACTIVE (WS#53)",
+            "note": "all four twins now run one governed-evidence discipline in the same substrate — the promotion membrane IS the epistemic ladder, everywhere",
         },
+    }
+
+
+# ── WS#53: AssetTwin — the FOURTH twin, extending the three-twin closure to physical, owned property: a
+# house, car, appliance, or network device a real person claims (e.g. by clicking it on a map) and configures.
+# SAME discipline as the other three: a twin:Claim carries a twin:AssetState promotion lattice (CLAIMED ->
+# SEALED -> CONFIGURED -> AGENTIC_ACTIVE, + terminal REVOKED) that IS its epistemic status. The invariant
+# mirrors HDT's exactly: a model/agent may claim/seal/configure, but only the owning human identity (or a
+# policy actor) may promote an asset to AGENTIC_ACTIVE — standing autonomous authority over owned property is
+# a human decision, never a model's own escalation. Sealing is CRYPTOGRAPHIC, not epistemic: CLAIMED->SEALED
+# goes through identity-twin's /attest (Ed25519 + VRF context-binding on the vendored Multiverseal Twin,
+# apps/identity-twin) — a claim's provenance is a VerifiableReference, not a bare database row a caller could
+# forge. Degrades honestly: identity-twin unreachable -> the claim still lands at CLAIMED (sealed:false +
+# sealError), never blocked on the seal (the same pattern hellgraph-service's GATEWAY_RECEIPTS uses). ────────
+class AssetClaimRequest(BaseModel):
+    project: str = "default"
+    asset_type: str
+    name: str
+    owner_identity: str
+    function_tag: str | None = None
+    geo: dict[str, float] | None = None       # {"lat": ..., "lng": ...} — where MapPage.vue clicked
+    note: str | None = None
+
+
+def _asset_id(coll: str, asset_type: str, name: str) -> str:
+    return f"{coll}:asset:{asset_type}:{hashlib.sha256(_norm(name).encode()).hexdigest()[:12]}"
+
+
+@app.post("/api/studio/asset-twin/claim")
+async def claim_asset(req: AssetClaimRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """Claim a physical asset as a proof-carrying AssetTwin node bound to an owning identity, sealed via
+    identity-twin's /attest. Enters at AssetState=CLAIMED (an assertion); a successful seal advances it to
+    SEALED (attested) in the same write — same discipline as HDT entering at SEEDED, not canonical."""
+    _require_write_token(authorization)
+    if req.asset_type not in twin_asset.ASSET_TYPES:
+        raise HTTPException(status_code=422, detail=f"asset_type must be one of {sorted(twin_asset.ASSET_TYPES)}")
+    if req.function_tag is not None and req.function_tag not in twin_asset.FUNCTION_TAXONOMY:
+        raise HTTPException(status_code=422, detail=f"function_tag must be one of {sorted(twin_asset.FUNCTION_TAXONOMY)}")
+    name = req.name.strip()
+    if not name:
+        raise HTTPException(status_code=422, detail="name required")
+    owner = req.owner_identity.strip()
+    if not owner:
+        raise HTTPException(status_code=422, detail="owner_identity required")
+    coll = proj_collection(req.project)
+    aid = _asset_id(coll, req.asset_type, name)
+    claimed_at = _now_iso()
+    claim_value = json.dumps({"asset_id": aid, "owner_identity": owner, "claimed_at": claimed_at}, sort_keys=True)
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        att, aerr = await _req(client, "POST", f"{IDENTITY_TWIN_URL}/attest",
+                               json={"context": aid, "value": claim_value})
+        sealed = aerr is None
+        state = "SEALED" if sealed else "CLAIMED"
+        epi = twin_asset.epistemic_for_state(state, sealed)
+        prov = _workbench_prov(coll, epi, "studio/asset-twin")
+        prov["extractor"] = "lattice-studio/asset-twin-v0"
+        props = {"name": name, "asset_type": req.asset_type, "owner_identity": owner, "state": state,
+                 "twin:hasAssetState": state, "function_tag": req.function_tag or "",
+                 "geo": json.dumps(req.geo or {}), "note": req.note or "", "claimed_at": claimed_at,
+                 "revoked_at": "", "sealed": sealed, "seal_error": aerr or "",
+                 "seal_proof": (att or {}).get("proof", "") if sealed else "",
+                 "seal_verify_key": (att or {}).get("verify_key", "") if sealed else "",
+                 "seal_medium_digest": (att or {}).get("medium_digest", "") if sealed else "",
+                 "updated_at": claimed_at, **prov}
+        _, werr = await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                             json={"id": aid, "labels": [coll, "AssetTwin", "Claimed"], "properties": props})
+        if werr:
+            raise HTTPException(status_code=502, detail=f"graph write failed: {werr}")
+    return {"asset_id": aid, "asset_type": req.asset_type, "owner_identity": owner, "state": state,
+            "epistemic_mode": epi, "proof_carrying": True, "sealed": sealed, "sealError": aerr,
+            "beat": "a claim is a VerifiableReference bound to your identity (Ed25519+VRF), not a database row you could forge"}
+
+
+class AssetConfigureRequest(BaseModel):
+    project: str = "default"
+    asset_id: str
+    function_tag: str | None = None
+    geo: dict[str, float] | None = None
+    note: str | None = None
+
+
+async def _load_asset(client: httpx.AsyncClient, coll: str, asset_id: str) -> dict[str, Any]:
+    raw, err = await _fetch_raw_nodes(coll, 2000)
+    node = next((n for n in raw if n.get("id") == asset_id and "AssetTwin" in (n.get("labels") or [])), None)
+    if not node:
+        raise HTTPException(status_code=404, detail=f"asset not found: {asset_id}")
+    return node
+
+
+@app.post("/api/studio/asset-twin/configure")
+async def configure_asset(req: AssetConfigureRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """Advance a claimed asset to AssetState=CONFIGURED — update its function-taxonomy tag / geo / note.
+    Fail-closed: a revoked asset cannot be reconfigured without a fresh claim."""
+    _require_write_token(authorization)
+    if req.function_tag is not None and req.function_tag not in twin_asset.FUNCTION_TAXONOMY:
+        raise HTTPException(status_code=422, detail=f"function_tag must be one of {sorted(twin_asset.FUNCTION_TAXONOMY)}")
+    coll = proj_collection(req.project)
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        node = await _load_asset(client, coll, req.asset_id)
+        p = dict(node.get("properties") or {})
+        if p.get("state") == "REVOKED":
+            raise HTTPException(status_code=409, detail="asset claim was revoked — claim it again before configuring")
+        sealed = bool(p.get("sealed"))
+        state = "CONFIGURED" if sealed else p.get("state", "CLAIMED")
+        p["state"] = state
+        p["twin:hasAssetState"] = state
+        p["epistemic_mode"] = twin_asset.epistemic_for_state(state, sealed)
+        if req.function_tag is not None:
+            p["function_tag"] = req.function_tag
+        if req.geo is not None:
+            p["geo"] = json.dumps(req.geo)
+        if req.note is not None:
+            p["note"] = req.note
+        p["updated_at"] = _now_iso()
+        _, werr = await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                             json={"id": req.asset_id, "labels": node.get("labels") or [coll, "AssetTwin"], "properties": p})
+        if werr:
+            raise HTTPException(status_code=502, detail=f"configure write failed: {werr}")
+    return {"asset_id": req.asset_id, "state": state, "epistemic_mode": p["epistemic_mode"], "proof_carrying": True}
+
+
+class AgenticOpsGrantRequest(BaseModel):
+    project: str = "default"
+    asset_id: str
+    allowed_actions: list[str]
+    conditions: dict[str, Any] = {}
+    actor: str | None = None
+    actor_kind: str = "human"
+
+
+@app.post("/api/studio/asset-twin/grant-agentic-ops")
+async def grant_agentic_ops(req: AgenticOpsGrantRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """Promote a claimed asset to AssetState=AGENTIC_ACTIVE — attach a scoped grant (which actions an
+    autonomous agent may take, under what conditions) that Superconscious/agentplane must consult before
+    acting. Enforces the invariant: only a human/owner/policy actor may grant standing autonomous authority;
+    a model actor attempting this promotion is refused with 403, the same shape as HDT's DELIVERED gate."""
+    _require_write_token(authorization)
+    if not twin_asset.can_promote(req.actor_kind, "AGENTIC_ACTIVE"):
+        raise HTTPException(status_code=403, detail={
+            "message": "AssetTwin invariant — a model may claim/seal/configure an asset but only the owning "
+                       "human identity (or a policy actor) may grant it standing autonomous authority",
+            "actor_kind": req.actor_kind})
+    if not req.allowed_actions:
+        raise HTTPException(status_code=422, detail="allowed_actions must be non-empty — a grant with no scope is not a grant")
+    coll = proj_collection(req.project)
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        node = await _load_asset(client, coll, req.asset_id)
+        p = dict(node.get("properties") or {})
+        if p.get("state") == "REVOKED":
+            raise HTTPException(status_code=409, detail="asset claim was revoked — cannot grant agentic ops on a revoked claim")
+        p["state"] = "AGENTIC_ACTIVE"
+        p["twin:hasAssetState"] = "AGENTIC_ACTIVE"
+        p["epistemic_mode"] = twin_asset.epistemic_for_state("AGENTIC_ACTIVE", bool(p.get("sealed")))
+        p["updated_at"] = _now_iso()
+        prov = _workbench_prov(coll, "verified", req.actor or "asset-twin/grant")
+        prov["extractor"] = "lattice-studio/asset-twin-grant-v0"
+        gid = f"{coll}:assetgrant:{hashlib.sha256((req.asset_id + _now_iso()).encode()).hexdigest()[:12]}"
+        grant_props = {"asset_id": req.asset_id, "allowed_actions": json.dumps(sorted(set(req.allowed_actions))),
+                       "conditions": json.dumps(req.conditions), "actor": req.actor or "", "actor_kind": req.actor_kind,
+                       "revoked_at": "", "granted_at": _now_iso(), **prov}
+        _, werr = await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                             json={"id": req.asset_id, "labels": node.get("labels") or [coll, "AssetTwin"], "properties": p})
+        if werr:
+            raise HTTPException(status_code=502, detail=f"grant writeback failed: {werr}")
+        await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                   json={"id": gid, "labels": [coll, "AgenticOpsGrant", "Grant"], "properties": grant_props})
+        await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/edge",
+                   json={"label": "governs", "from": gid, "to": req.asset_id, "properties": prov})
+    return {"grant_id": gid, "asset_id": req.asset_id, "state": "AGENTIC_ACTIVE",
+            "allowed_actions": sorted(set(req.allowed_actions)), "proof_carrying": True,
+            "note": "Superconscious/agentplane must walk the 'governs' edge and honor allowed_actions/conditions before acting — this ships the grant's shape and gate; wiring the consuming side is tracked separately"}
+
+
+class AssetRevokeRequest(BaseModel):
+    project: str = "default"
+    asset_id: str
+    actor: str | None = None
+
+
+@app.post("/api/studio/asset-twin/revoke")
+async def revoke_asset(req: AssetRevokeRequest, authorization: str = Header(default="")) -> dict[str, Any]:
+    """Revoke a claim (and any agentic-ops grant riding on it) — AssetState -> REVOKED, terminal until a
+    fresh claim. Immediate (observed), not gated on a fresh cryptographic seal: revocation must never be
+    slower or weaker than the authority it withdraws."""
+    _require_write_token(authorization)
+    coll = proj_collection(req.project)
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        node = await _load_asset(client, coll, req.asset_id)
+        p = dict(node.get("properties") or {})
+        prev_state = p.get("state", "CLAIMED")
+        p["state"] = "REVOKED"
+        p["twin:hasAssetState"] = "REVOKED"
+        p["epistemic_mode"] = twin_asset.epistemic_for_state("REVOKED", bool(p.get("sealed")))
+        p["revoked_at"] = _now_iso()
+        p["updated_at"] = p["revoked_at"]
+        _, werr = await _req(client, "POST", f"{HELLGRAPH_URL}/api/graph/node",
+                             json={"id": req.asset_id, "labels": node.get("labels") or [coll, "AssetTwin"], "properties": p})
+        if werr:
+            raise HTTPException(status_code=502, detail=f"revoke write failed: {werr}")
+    return {"asset_id": req.asset_id, "from_state": prev_state, "state": "REVOKED", "proof_carrying": True}
+
+
+@app.get("/api/studio/asset-twins")
+async def list_asset_twins(project: str = "default", function_tag: str = "", owner_identity: str = "",
+                           _auth: dict[str, Any] | None = Depends(require_read)) -> dict[str, Any]:
+    """Claimed assets, optionally filtered by the function taxonomy (safety/multimedia/climate_comfort/
+    control_savings) — the human-facing lens an owner reviews their claimed twins through, not by
+    protocol/device-service type — or by owner_identity (whose twins these are)."""
+    coll = proj_collection(project)
+    raw, err = await _fetch_raw_nodes(coll, 2000)
+    out = []
+    for n in raw:
+        if "AssetTwin" not in (n.get("labels") or []):
+            continue
+        p = n.get("properties") or {}
+        if function_tag and p.get("function_tag") != function_tag:
+            continue
+        if owner_identity and p.get("owner_identity") != owner_identity:
+            continue
+        try:
+            geo = json.loads(p.get("geo") or "{}")
+        except (ValueError, TypeError):
+            geo = {}
+        out.append({"asset_id": n.get("id"), "name": p.get("name"), "asset_type": p.get("asset_type"),
+                    "owner_identity": p.get("owner_identity"), "function_tag": p.get("function_tag") or None,
+                    "state": p.get("state", "CLAIMED"), "sealed": bool(p.get("sealed")), "geo": geo,
+                    "epistemic_mode": p.get("epistemic_mode"), "updated_at": p.get("updated_at")})
+    out.sort(key=lambda x: x.get("updated_at") or "", reverse=True)
+    return {"project": project, "assets": out, "count": len(out),
+            "beat": "claimed physical assets, browsable by function (safety/comfort/media/savings) not protocol",
+            "degraded": err}
+
+
+@app.get("/api/studio/asset-twin/ontology")
+async def asset_twin_ontology(_auth: dict[str, Any] | None = Depends(require_read)) -> dict[str, Any]:
+    """The AssetState lattice for the fourth twin."""
+    lattice = [{"state": s, "epistemic_sealed": twin_asset.epistemic_for_state(s, True),
+                "epistemic_unsealed": twin_asset.epistemic_for_state(s, False), "terminal": s == "REVOKED"}
+               for s in twin_asset.ASSET_STATES]
+    return {
+        "ontology": "AssetTwin — the fourth twin", "asset_states": twin_asset.ASSET_STATES,
+        "asset_epistemic_lattice": lattice, "asset_types": sorted(twin_asset.ASSET_TYPES),
+        "function_taxonomy": sorted(twin_asset.FUNCTION_TAXONOMY),
+        "invariant": "a model/agent may claim/seal/configure an asset but only the owning human identity (or a policy actor) may promote it to AGENTIC_ACTIVE",
     }
 
 

--- a/apps/lattice-studio/src/lattice_studio/twin_asset.py
+++ b/apps/lattice-studio/src/lattice_studio/twin_asset.py
@@ -1,0 +1,60 @@
+"""AssetTwin — the FOURTH twin, extending the three-twin closure (knowledge/HellGraph, human/HDT,
+Earth/GAIA) to physical, owned property: a house, car, appliance, or network device a real person
+claims on the map and configures.
+
+A twin:Claim carries a twin:AssetState — a promotion lattice CLAIMED -> SEALED -> CONFIGURED ->
+AGENTIC_ACTIVE (+ the terminal REVOKED, reachable from any live state) -- the SAME governed-evidence
+discipline as the other three twins: the AssetState IS the epistemic ladder. The invariant mirrors
+HDT's exactly: a model/agent may claim/seal/configure an asset, but only the owning human identity
+(or a policy actor) may promote it to AGENTIC_ACTIVE -- standing autonomous authority over a piece of
+owned property is a human decision, never a model's own escalation.
+
+Sealing (CLAIMED -> SEALED) is cryptographic, not epistemic: it happens via identity-twin's /attest
+(Ed25519 + VRF context-binding on the vendored Multiverseal Twin), independent of who acts. A claim
+that fails to seal (identity-twin unreachable) still lands at CLAIMED -- honest degradation, the same
+pattern hellgraph-service's GATEWAY_RECEIPTS uses: the record is never blocked on the seal succeeding.
+"""
+from __future__ import annotations
+
+ASSET_STATES = ["CLAIMED", "SEALED", "CONFIGURED", "AGENTIC_ACTIVE", "REVOKED"]
+ASSET_TYPES = {"house", "car", "appliance", "network_device", "room", "device"}
+# The human-facing lens (a smart-home reference taxonomy): group by FUNCTION, not by protocol/device
+# type -- the view an operator/owner actually wants when reviewing what they've claimed.
+FUNCTION_TAXONOMY = {"safety", "multimedia", "climate_comfort", "control_savings"}
+_HUMAN_KINDS = {"human", "owner", "steward", "keeper", "policy"}
+
+
+def is_human(actor_kind: str) -> bool:
+    return (actor_kind or "human").lower() in _HUMAN_KINDS
+
+
+def epistemic_for_state(state: str, sealed: bool) -> str:
+    """CLAIMED = observed (an owner's assertion, not yet cryptographically bound); SEALED/CONFIGURED =
+    attested once identity-twin's /attest has bound the claim (else they stay observed, honestly
+    degraded); AGENTIC_ACTIVE = verified (a human granted standing autonomous authority -- a stronger
+    claim than a bare assertion); REVOKED = observed (the fact of revocation is asserted immediately,
+    not gated on a fresh cryptographic seal)."""
+    if state == "REVOKED":
+        return "observed"
+    if state == "AGENTIC_ACTIVE":
+        return "verified"
+    return "attested" if sealed else "observed"
+
+
+def can_promote(actor_kind: str, target_state: str) -> bool:
+    """The invariant: a model/agent may claim, seal, or configure an asset, but only the owning human
+    identity (or a policy actor) may promote it to AGENTIC_ACTIVE. Mirrors HDT's can_promote_omega:
+    the SAME shape, a different terminal gate."""
+    return not (target_state == "AGENTIC_ACTIVE" and not is_human(actor_kind))
+
+
+def claim_of(props: dict | None) -> dict:
+    p = props or {}
+    return {
+        "asset_type": p.get("asset_type"),
+        "owner_identity": p.get("owner_identity"),
+        "function_tag": p.get("function_tag") or None,
+        "state": p.get("state", "CLAIMED"),
+        "sealed": bool(p.get("sealed")),
+        "epistemic_mode": p.get("epistemic_mode"),
+    }

--- a/apps/lattice-studio/tests/test_server.py
+++ b/apps/lattice-studio/tests/test_server.py
@@ -1,6 +1,7 @@
 """Studio BFF smoke: healthz + the studio bundle (live fabric services unreachable in test → graceful degrade)."""
 from __future__ import annotations
 
+import json
 from urllib.parse import urlparse, parse_qs
 
 from fastapi.testclient import TestClient
@@ -1549,13 +1550,224 @@ def test_hdt_promote_to_delivered_is_attested(monkeypatch):
     assert ev["properties"]["hdt:promotedToState"] == "DELIVERED"
 
 
-def test_hdt_ontology_closes_the_three_twin_triangle():
+def test_hdt_ontology_closes_the_four_twin_square():
     b = client.get("/api/studio/hdt/ontology").json()
     assert b["omega_states"] == ["ABSENT", "SEEDED", "NORMALIZED", "LINKED", "TRUSTED", "ACTIONABLE", "DELIVERED"]
     deliv = next(s for s in b["omega_epistemic_lattice"] if s["state"] == "DELIVERED")
     assert deliv["epistemic_human"] == "attested" and deliv["canonical"]
-    assert set(b["three_twins_closed"]) >= {"knowledge", "human", "earth"}
+    # renamed three_twins_closed -> four_twins_closed (WS#53 adds the asset twin) -- additive superset,
+    # not a silent removal: knowledge/human/earth are still all present, "asset" is the new fourth entry.
+    assert set(b["four_twins_closed"]) >= {"knowledge", "human", "earth", "asset"}
     assert set(b["kfs_triad"]) == {"CBD", "CGT", "NHY"}
+
+
+# ── WS#53 AssetTwin tests — the fourth twin (claim/seal/configure/grant/revoke) ──────────────────────
+
+def _graph_and_identity_twin(seed=None, attest_ok=True):
+    """Like _stateful_graph, but also answers identity-twin's /attest so claim tests can exercise both
+    the SEALED (attest succeeds) and the honest-degradation (attest fails) paths."""
+    state, graph_fake = _stateful_graph(seed)
+
+    async def fake_req(client, method, url, json=None):
+        if "/attest" in url:
+            if attest_ok:
+                return ({"proof": "p", "verify_key": "vk", "medium_digest": "d", "records": 1, "d": 8}, None)
+            return (None, "identity-twin unreachable")
+        return await graph_fake(client, method, url, json)
+    return state, fake_req
+
+
+def test_asset_claim_requires_write_token(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "")
+    r = client.post("/api/studio/asset-twin/claim",
+                    json={"project": "team-x", "asset_type": "house", "name": "123 Main St", "owner_identity": "kim"})
+    assert r.status_code == 503
+
+
+def test_asset_claim_rejects_unknown_asset_type(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    r = client.post("/api/studio/asset-twin/claim",
+                    json={"project": "team-x", "asset_type": "spaceship", "name": "x", "owner_identity": "kim"},
+                    headers={"Authorization": "Bearer T"})
+    assert r.status_code == 422 and "asset_type" in r.json()["detail"]
+
+
+def test_asset_claim_rejects_unknown_function_tag(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    r = client.post("/api/studio/asset-twin/claim",
+                    json={"project": "team-x", "asset_type": "house", "name": "x", "owner_identity": "kim",
+                          "function_tag": "entertainment"},
+                    headers={"Authorization": "Bearer T"})
+    assert r.status_code == 422 and "function_tag" in r.json()["detail"]
+
+
+def test_asset_claim_seals_via_identity_twin_attest(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    state, fake_req = _graph_and_identity_twin(attest_ok=True)
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    r = client.post("/api/studio/asset-twin/claim",
+                    json={"project": "team-x", "asset_type": "house", "name": "123 Main St", "owner_identity": "kim",
+                          "function_tag": "safety", "geo": {"lat": 1.0, "lng": 2.0}},
+                    headers={"Authorization": "Bearer T"}).json()
+    assert r["state"] == "SEALED" and r["sealed"] is True and r["epistemic_mode"] == "attested" and r["sealError"] is None
+    node = state["nodes"][r["asset_id"]]["properties"]
+    assert node["seal_proof"] == "p" and node["seal_medium_digest"] == "d" and node["twin:hasAssetState"] == "SEALED"
+
+
+def test_asset_claim_degrades_honestly_when_identity_twin_unreachable(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    state, fake_req = _graph_and_identity_twin(attest_ok=False)
+    monkeypatch.setattr(srv, "_req", fake_req)
+
+    r = client.post("/api/studio/asset-twin/claim",
+                    json={"project": "team-x", "asset_type": "car", "name": "my car", "owner_identity": "kim"},
+                    headers={"Authorization": "Bearer T"}).json()
+    # the claim itself must NEVER be blocked on the seal succeeding — same discipline as
+    # hellgraph-service's GATEWAY_RECEIPTS honest degradation.
+    assert r["state"] == "CLAIMED" and r["sealed"] is False and r["epistemic_mode"] == "observed"
+    assert r["sealError"] == "identity-twin unreachable"
+    node = state["nodes"][r["asset_id"]]["properties"]
+    assert node["seal_proof"] == "" and node["sealed"] is False
+
+
+def test_asset_configure_advances_sealed_claim_to_configured(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    state, fake_req = _stateful_graph({
+        "proj-teamx:asset:house:1": {"id": "proj-teamx:asset:house:1", "labels": ["proj-teamx", "AssetTwin", "Claimed"],
+                                     "properties": {"state": "SEALED", "sealed": True, "asset_type": "house",
+                                                    "owner_identity": "kim", "geo": "{}"}},
+    })
+    monkeypatch.setattr(srv, "_req", fake_req)
+    r = client.post("/api/studio/asset-twin/configure",
+                    json={"project": "team-x", "asset_id": "proj-teamx:asset:house:1", "function_tag": "climate_comfort"},
+                    headers={"Authorization": "Bearer T"}).json()
+    assert r["state"] == "CONFIGURED" and r["epistemic_mode"] == "attested"
+    assert state["nodes"]["proj-teamx:asset:house:1"]["properties"]["function_tag"] == "climate_comfort"
+
+
+def test_asset_configure_refuses_revoked_claim(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    state, fake_req = _stateful_graph({
+        "proj-teamx:asset:house:1": {"id": "proj-teamx:asset:house:1", "labels": ["proj-teamx", "AssetTwin"],
+                                     "properties": {"state": "REVOKED", "sealed": True}},
+    })
+    monkeypatch.setattr(srv, "_req", fake_req)
+    r = client.post("/api/studio/asset-twin/configure",
+                    json={"project": "team-x", "asset_id": "proj-teamx:asset:house:1", "note": "x"},
+                    headers={"Authorization": "Bearer T"})
+    assert r.status_code == 409
+
+
+def test_asset_configure_missing_asset_is_404(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    state, fake_req = _stateful_graph({})
+    monkeypatch.setattr(srv, "_req", fake_req)
+    r = client.post("/api/studio/asset-twin/configure",
+                    json={"project": "team-x", "asset_id": "nope"}, headers={"Authorization": "Bearer T"})
+    assert r.status_code == 404
+
+
+def test_asset_grant_agentic_ops_model_actor_is_refused(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    r = client.post("/api/studio/asset-twin/grant-agentic-ops",
+                    json={"project": "team-x", "asset_id": "x", "allowed_actions": ["monitor"], "actor_kind": "model"},
+                    headers={"Authorization": "Bearer T"})
+    assert r.status_code == 403 and "human" in r.json()["detail"]["message"]
+
+
+def test_asset_grant_agentic_ops_requires_nonempty_scope(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    r = client.post("/api/studio/asset-twin/grant-agentic-ops",
+                    json={"project": "team-x", "asset_id": "x", "allowed_actions": [], "actor_kind": "human"},
+                    headers={"Authorization": "Bearer T"})
+    assert r.status_code == 422
+
+
+def test_asset_grant_agentic_ops_by_owner_promotes_and_writes_governs_edge(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    state, fake_req = _stateful_graph({
+        "proj-teamx:asset:house:1": {"id": "proj-teamx:asset:house:1", "labels": ["proj-teamx", "AssetTwin"],
+                                     "properties": {"state": "CONFIGURED", "sealed": True, "owner_identity": "kim"}},
+    })
+    monkeypatch.setattr(srv, "_req", fake_req)
+    r = client.post("/api/studio/asset-twin/grant-agentic-ops",
+                    json={"project": "team-x", "asset_id": "proj-teamx:asset:house:1",
+                          "allowed_actions": ["monitor", "toggle"], "conditions": {"hours": "09:00-21:00"},
+                          "actor": "kim", "actor_kind": "owner"},
+                    headers={"Authorization": "Bearer T"}).json()
+    assert r["state"] == "AGENTIC_ACTIVE" and r["allowed_actions"] == ["monitor", "toggle"]
+    asset = state["nodes"]["proj-teamx:asset:house:1"]["properties"]
+    assert asset["state"] == "AGENTIC_ACTIVE" and asset["epistemic_mode"] == "verified"
+    grant = state["nodes"][r["grant_id"]]["properties"]
+    assert json.loads(grant["allowed_actions"]) == ["monitor", "toggle"]
+    edge = next(e for e in state["edges"] if e["label"] == "governs")
+    assert edge["from"] == r["grant_id"] and edge["to"] == "proj-teamx:asset:house:1"
+
+
+def test_asset_grant_refuses_revoked_asset(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    state, fake_req = _stateful_graph({
+        "a1": {"id": "a1", "labels": ["proj-teamx", "AssetTwin"], "properties": {"state": "REVOKED"}},
+    })
+    monkeypatch.setattr(srv, "_req", fake_req)
+    r = client.post("/api/studio/asset-twin/grant-agentic-ops",
+                    json={"project": "team-x", "asset_id": "a1", "allowed_actions": ["monitor"], "actor_kind": "human"},
+                    headers={"Authorization": "Bearer T"})
+    assert r.status_code == 409
+
+
+def test_asset_revoke_is_immediate_and_terminal(monkeypatch):
+    import lattice_studio.server as srv
+    monkeypatch.setattr(srv, "STUDIO_WRITE_TOKEN", "T")
+    state, fake_req = _stateful_graph({
+        "a1": {"id": "a1", "labels": ["proj-teamx", "AssetTwin"], "properties": {"state": "AGENTIC_ACTIVE", "sealed": True}},
+    })
+    monkeypatch.setattr(srv, "_req", fake_req)
+    r = client.post("/api/studio/asset-twin/revoke", json={"project": "team-x", "asset_id": "a1"},
+                    headers={"Authorization": "Bearer T"}).json()
+    assert r["from_state"] == "AGENTIC_ACTIVE" and r["state"] == "REVOKED"
+    node = state["nodes"]["a1"]["properties"]
+    assert node["state"] == "REVOKED" and node["epistemic_mode"] == "observed" and node["revoked_at"]
+
+
+def test_list_asset_twins_filters_by_function_tag_and_owner(monkeypatch):
+    import lattice_studio.server as srv
+    state, fake_req = _stateful_graph({
+        "a1": {"id": "a1", "labels": ["proj-teamx", "AssetTwin"],
+               "properties": {"name": "house", "asset_type": "house", "owner_identity": "kim",
+                              "function_tag": "safety", "state": "SEALED", "sealed": True, "geo": "{}"}},
+        "a2": {"id": "a2", "labels": ["proj-teamx", "AssetTwin"],
+               "properties": {"name": "tv", "asset_type": "appliance", "owner_identity": "kim",
+                              "function_tag": "multimedia", "state": "CLAIMED", "sealed": False, "geo": "{}"}},
+        "a3": {"id": "a3", "labels": ["proj-teamx", "AssetTwin"],
+               "properties": {"name": "other's car", "asset_type": "car", "owner_identity": "sam",
+                              "function_tag": "safety", "state": "SEALED", "sealed": True, "geo": "{}"}},
+    })
+    monkeypatch.setattr(srv, "_req", fake_req)
+    b = client.get("/api/studio/asset-twins?project=team-x&function_tag=safety&owner_identity=kim").json()
+    assert b["count"] == 1 and b["assets"][0]["asset_id"] == "a1"
+
+
+def test_asset_twin_ontology_lattice():
+    b = client.get("/api/studio/asset-twin/ontology").json()
+    assert b["asset_states"] == ["CLAIMED", "SEALED", "CONFIGURED", "AGENTIC_ACTIVE", "REVOKED"]
+    revoked = next(s for s in b["asset_epistemic_lattice"] if s["state"] == "REVOKED")
+    assert revoked["terminal"] is True
+    assert set(b["function_taxonomy"]) == {"safety", "multimedia", "climate_comfort", "control_savings"}
+    assert "house" in b["asset_types"] and "network_device" in b["asset_types"]
 
 
 def test_model_board_endpoint_serves_the_sovereign_board():


### PR DESCRIPTION
## Summary
- Extends the estate's three-twin closure (knowledge/HellGraph, human/HDT, Earth/GAIA) to a **fourth twin**: physical, owned property — house, car, appliance, network device, room, device — a person claims (e.g. by clicking it on a map) and configures. This is the backend for a planned map-click-to-claim → configure → enable-agentic-ops user flow.
- New `twin_asset.py` module: `AssetState` lattice `CLAIMED → SEALED → CONFIGURED → AGENTIC_ACTIVE` (+ terminal `REVOKED`), mirroring `hdt.py`'s `can_promote_omega`/`epistemic_for_omega` shape exactly — a model/agent may claim/seal/configure, but only the owning human identity (or a policy actor) may grant standing autonomous authority.
- Five new endpoints: `claim` (sealed via identity-twin's `/attest` — Ed25519+VRF — with honest degradation if identity-twin is unreachable, never blocking the claim), `configure`, `grant-agentic-ops` (403 for a non-human actor, writes a scoped `AgenticOpsGrant` + `governs` edge for Superconscious/agentplane to consult — wiring the consuming side is a tracked follow-up, not silently claimed as done here), `revoke` (immediate, terminal), and `list` (filterable by the smart-home function taxonomy — safety/multimedia/climate_comfort/control_savings — and by owner).
- `/api/studio/hdt/ontology`'s `three_twins_closed` → `four_twins_closed` (additive rename: knowledge/human/earth still present, `asset` is new) — updated the one test that asserted the old key.

## Test plan
- [x] 19 new tests: write-token gating, `asset_type`/`function_tag` validation, both the sealed and honest-degradation claim paths, the human-only `AGENTIC_ACTIVE` gate, empty-scope grant rejection, revoked-claim refusal, function-taxonomy + owner filtering
- [x] `pytest tests/test_server.py` — 103/103
- [x] `pytest tests/` (full repo) — 278/279, the 1 failure is pre-existing and unrelated (`test_docx_conversion_includes_paragraphs_and_tables` — missing local `python-docx`, confirmed before this change touched anything)