### PR TITLE
feat(studio): catalog ops cockpit — readout/SLO/warrant surface (WO-3+WO-4)

### DIFF
--- a/apps/socioprophet-web/nginx.conf
+++ b/apps/socioprophet-web/nginx.conf
@@ -99,6 +99,10 @@ http {
         # gracefully (the surfaces are built to handle an unavailable verifier).
         location /svc/holmes/    { set $u holmes.socioprophet.svc.cluster.local;            rewrite ^/svc/holmes/(.*)$    /$1 break; proxy_pass http://$u:8091; proxy_http_version 1.1; proxy_set_header Host $host; }
         location /svc/synapse/   { set $u synapse-bridge.socioprophet.svc.cluster.local;    rewrite ^/svc/synapse/(.*)$   /$1 break; proxy_pass http://$u:8092; proxy_http_version 1.1; proxy_set_header Host $host; }
+        # catalog-gateway — the read/resolve/lineage + DCAT interop seam AND the catalog ops plane
+        # (readout KPIs + SLO verdict) over the Crystal Atlas catalog families. Deployed (ApplicationSet,
+        # tier=reference) on :8080. The Studio Catalog's ops dashboard degrades gracefully if it 502s.
+        location /svc/catalog/   { set $u catalog-gateway.socioprophet.svc.cluster.local;   rewrite ^/svc/catalog/(.*)$   /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
         # /api → dashboard-bff (valuation / GYG / chat / governance surfaces), prefix stripped.
         location /api/           { set $u dashboard-bff.socioprophet.svc.cluster.local;     rewrite ^/api/(.*)$           /$1 break; proxy_pass http://$u:8080; proxy_http_version 1.1; proxy_set_header Host $host; }
 

--- a/apps/socioprophet-web/src/__tests__/studioCatalogApi.test.ts
+++ b/apps/socioprophet-web/src/__tests__/studioCatalogApi.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { catalog, ApiError } from '../pages/studio/api';
+
+// The catalog ops cockpit (#1361) is only as trustworthy as the client under it: an id that
+// isn't encoded becomes a broken link or a path-injection into catalog-gateway, and a swallowed
+// error paints an empty "healthy" cockpit over a dead backend. These pin both.
+
+function fakeFetch(body: unknown, ok = true, status = 200) {
+  const text = typeof body === 'string' ? body : JSON.stringify(body);
+  return vi.spyOn(globalThis, 'fetch' as any).mockResolvedValue({
+    ok, status, text: async () => text,
+  } as any);
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('studio catalog api client', () => {
+  it('dcatUrl encodes the asset id (no unescaped slash/space/hash leaking into the path)', () => {
+    expect(catalog.dcatUrl('a b/c?d#e')).toBe(
+      '/svc/catalog/v1/catalog/asset/a%20b%2Fc%3Fd%23e.dcat.json',
+    );
+    // a plain id round-trips unchanged
+    expect(catalog.dcatUrl('dataset-42')).toBe(
+      '/svc/catalog/v1/catalog/asset/dataset-42.dcat.json',
+    );
+  });
+
+  it('resolve()/lineage() hit catalog-gateway with the id percent-encoded', async () => {
+    const spy = fakeFetch({ kind: 'dataset', entry: {} });
+    await catalog.resolve('dataset', 'ns/a b');
+    expect(spy).toHaveBeenLastCalledWith(
+      '/svc/catalog/v1/catalog/dataset/ns%2Fa%20b',
+      expect.anything(),
+    );
+    await catalog.lineage('asset', 'x/y');
+    expect(spy).toHaveBeenLastCalledWith(
+      '/svc/catalog/v1/catalog/asset/x%2Fy/lineage',
+      expect.anything(),
+    );
+  });
+
+  it('readout()/slo() hit the ops-plane endpoints and return the parsed body', async () => {
+    fakeFetch({ schema_version: 'v0', slo_id: 's1', verdict: 'ok', objectives: [] });
+    const slo = await catalog.slo();
+    expect((globalThis.fetch as any)).toHaveBeenLastCalledWith(
+      '/svc/catalog/v1/catalog/ops/slo',
+      expect.anything(),
+    );
+    expect(slo.verdict).toBe('ok');
+  });
+
+  it('surfaces a backend failure as ApiError — never a silent empty cockpit', async () => {
+    fakeFetch({ error: 'catalog-gateway unreachable' }, false, 503);
+    await expect(catalog.readout()).rejects.toBeInstanceOf(ApiError);
+    await expect(catalog.readout()).rejects.toMatchObject({ status: 503 });
+  });
+});

--- a/apps/socioprophet-web/src/pages/studio/StudioCatalog.vue
+++ b/apps/socioprophet-web/src/pages/studio/StudioCatalog.vue
@@ -9,6 +9,8 @@ import { loadCatalog, EPISTEMIC_COLORS, type Dataset } from '../../services/stud
 import Sparkline from '../../components/Sparkline.vue';
 import FactsheetDrawer from './FactsheetDrawer.vue';
 import { attestFacts } from './factsheetAttest';
+import StudioCatalogOps from './StudioCatalogOps.vue';
+import { catalog } from './api';
 
 const props = defineProps<{ project: string }>();
 
@@ -17,6 +19,13 @@ const loading = ref(true);
 const err = ref('');
 const facet = ref<string>('all');       // connector filter
 const sheet = ref<Dataset | null>(null); // dataset whose factsheet drawer is open
+
+// Warrant — the catalog-gateway's view of the open asset: its lineage + a DCAT export
+// link. Best-effort: resolved only for assets the gateway actually knows; absent (or the
+// service down) → the section is hidden. This is what a bolt-on catalog cannot show: the
+// row's interop document + upstream refs come from the same governed service, not a scrape.
+const warrant = ref<{ upstream: { ref: string; resolved: boolean; kind: string | null }[] } | null>(null);
+const warrantId = ref<string>('');
 
 async function load() {
   loading.value = true; err.value = '';
@@ -55,7 +64,16 @@ function demoSeries(id: string): number[] {
 function series(d: Dataset): number[] { return d.volume_trend?.length ? d.volume_trend : demoSeries(d.id); }
 function isLive(d: Dataset): boolean { return !!d.volume_trend?.length; }
 function last(s: number[]): number { return s[s.length - 1] ?? 0; }
-function openSheet(d: Dataset) { sheet.value = d; }
+function openSheet(d: Dataset) {
+  sheet.value = d;
+  // Best-effort warrant lookup against catalog-gateway. Silent on any failure (asset not
+  // in the gateway, or the service unreachable) — the factsheet still renders fully.
+  warrant.value = null; warrantId.value = '';
+  catalog.lineage('asset', d.id)
+    .then((r) => { warrant.value = { upstream: r.upstream }; warrantId.value = d.id; })
+    .catch(() => { /* not a gateway-resolvable asset — leave the warrant section hidden */ });
+}
+const dcatUrl = computed(() => (warrantId.value ? catalog.dcatUrl(warrantId.value) : ''));
 
 // Attested factsheet — a deterministic, recomputable summary built from the dataset's OWN facts
 // (not model-generated prose), with a content-id receipt = a hash of those facts. Honest "attested
@@ -69,6 +87,7 @@ function attest(d: Dataset): { summary: string; receipt: string; live: boolean }
 
 <template>
   <div class="cat">
+    <StudioCatalogOps />
     <div class="cbar">
       <div class="facets">
         <button class="facet" :class="{ on: facet === 'all' }" @click="facet = 'all'">All <i>{{ datasets.length }}</i></button>
@@ -129,6 +148,23 @@ function attest(d: Dataset): { summary: string; receipt: string; live: boolean }
           <p class="att-text">{{ attest(sheet).summary }}</p>
           <span class="att-note">Computed from the dataset's own facts — deterministic + recomputable (the receipt is a hash of those facts), not model-generated prose. {{ attest(sheet).live ? 'Ingest volume is live.' : 'Ingest volume is a demo series until the backend supplies volume_trend.' }}</span>
         </div>
+        <div v-if="warrant" class="fs-sec warrant">
+          <h4>Catalog warrant <span class="wk-chip" title="served by catalog-gateway (/svc/catalog)">▪ gateway</span></h4>
+          <div class="wr-row">
+            <span class="fk">DCAT / schema.org</span>
+            <a class="wr-export" :href="dcatUrl" target="_blank" rel="noopener" title="open the DCAT JSON-LD document">Export ld+json ↗</a>
+          </div>
+          <div class="wr-lineage">
+            <span class="fk">Lineage (upstream)</span>
+            <div v-if="warrant.upstream.length" class="wr-refs">
+              <span v-for="u in warrant.upstream" :key="u.ref" class="wr-ref" :class="{ unresolved: !u.resolved }" :title="u.resolved ? ('resolved · ' + u.kind) : 'declared but not yet in the catalog'">
+                <i class="wr-dot" />{{ u.ref }}<em v-if="u.kind">{{ u.kind }}</em>
+              </span>
+            </div>
+            <span v-else class="att-note">No upstream refs recorded.</span>
+          </div>
+          <span class="att-note">Lineage + interop document come from the same governed service that resolves the asset — not a scraped metastore. A bolt-on catalog cannot attest the row it lists.</span>
+        </div>
       </template>
     </FactsheetDrawer>
 
@@ -186,4 +222,18 @@ function attest(d: Dataset): { summary: string; receipt: string; live: boolean }
 .att-chip { font-family: var(--mono); font-size: 10px; color: var(--epi-attested); background: color-mix(in srgb, var(--epi-attested) 12%, transparent); border-radius: var(--r-1); padding: 1px 6px; letter-spacing: 0; text-transform: none; }
 .att-text { font-size: 13px; line-height: 1.55; color: var(--ink); margin: 0 0 8px; }
 .att-note { font-size: 11px; color: var(--muted); line-height: 1.5; }
+
+/* catalog warrant (lineage + DCAT export) — best-effort, gateway-served */
+.warrant { border: 1px solid var(--hairline); border-radius: var(--r-3); padding: var(--sp-3) var(--sp-4); background: var(--sunken); }
+.wk-chip { font-family: var(--mono); font-size: 10px; color: var(--accent-ink, var(--accent)); background: var(--accent-wash, transparent); border-radius: var(--r-1); padding: 1px 6px; letter-spacing: 0; text-transform: none; }
+.wr-row { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-2); margin-bottom: var(--sp-3); }
+.wr-export { font-size: 12px; color: var(--accent); text-decoration: none; border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--hairline)); border-radius: var(--r-2); padding: 3px 10px; }
+.wr-export:hover { background: var(--accent-wash, transparent); }
+.wr-lineage { display: flex; flex-direction: column; gap: 6px; margin-bottom: var(--sp-3); }
+.wr-refs { display: flex; flex-wrap: wrap; gap: 6px; }
+.wr-ref { display: inline-flex; align-items: center; gap: 5px; font-family: var(--mono); font-size: 11px; color: var(--ink-2); border: 1px solid var(--hairline); border-radius: var(--r-1); padding: 1px 7px; }
+.wr-ref em { font-style: normal; font-family: var(--ui); font-size: 9px; text-transform: uppercase; letter-spacing: .04em; color: var(--faint); }
+.wr-ref .wr-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--ok, #17864a); }
+.wr-ref.unresolved { border-style: dashed; color: var(--muted); }
+.wr-ref.unresolved .wr-dot { background: var(--faint); }
 </style>

--- a/apps/socioprophet-web/src/pages/studio/StudioCatalogOps.vue
+++ b/apps/socioprophet-web/src/pages/studio/StudioCatalogOps.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+// Catalog operations dashboard — the panel a data steward reads, and the thing WKC /
+// Collibra / Waterline / watsonx.governance show as a vendor chart WE back with a real
+// service. Every number here is a FOLD of crystallized operational events (catalog.*.v0)
+// served by catalog-gateway (/svc/catalog): the resolve hit-rate + DCAT coverage + cold
+// sources KPIs (the readout) and the Assay verdict over them (the SLO). Not a dashboard
+// bolted onto a metastore — the operational plane of a proof-carrying catalog.
+//
+// Best-effort + fail-soft: if catalog-gateway is unreachable the panel collapses to a
+// single muted line and the catalog table above it still works. It never blocks the page.
+import { ref, onMounted, computed } from 'vue';
+import { catalog, type CatalogReadout, type CatalogSlo, type SloVerdict } from './api';
+
+const readout = ref<CatalogReadout | null>(null);
+const slo = ref<CatalogSlo | null>(null);
+const loading = ref(true);
+const connected = ref(true);
+
+async function load() {
+  loading.value = true;
+  try {
+    const [r, s] = await Promise.all([catalog.readout(), catalog.slo()]);
+    readout.value = r; slo.value = s; connected.value = true;
+  } catch {
+    // catalog-gateway not reachable (dev without the service, or a 502 pre-deploy) —
+    // degrade to a quiet note rather than an error banner. The catalog still renders.
+    connected.value = false;
+  } finally { loading.value = false; }
+}
+onMounted(load);
+
+const pct = (v: number | null | undefined) => (v === null || v === undefined ? '—' : `${Math.round(v * 1000) / 10}%`);
+const VERDICT_LABEL: Record<SloVerdict, string> = { ok: 'OK', sad: 'SAD', bad: 'BAD', insufficient_data: 'n/a' };
+const verdict = computed<SloVerdict>(() => slo.value?.verdict ?? 'insufficient_data');
+</script>
+
+<template>
+  <section class="ops" aria-label="Catalog operations">
+    <div v-if="loading" class="ops-note">Loading catalog operations…</div>
+    <div v-else-if="!connected" class="ops-note muted">
+      Catalog operations plane not connected — <code>/svc/catalog</code> unreachable. KPIs appear once catalog-gateway is deployed.
+    </div>
+    <template v-else-if="readout">
+      <div class="ops-head">
+        <span class="ops-title">Catalog operations</span>
+        <span class="verdict" :class="'v-' + verdict" :title="'SLO verdict (Assay): ' + verdict">
+          <i class="dot" /> {{ VERDICT_LABEL[verdict] }}
+        </span>
+        <span class="ops-win" :title="'events folded into this readout'">{{ readout.window.events_scanned }} events</span>
+        <button class="ghost" @click="load" title="reload operations" aria-label="Reload operations">↻</button>
+      </div>
+
+      <div class="kpis">
+        <div class="kpi">
+          <span class="kv tnum">{{ pct(readout.resolve.hit_rate) }}</span>
+          <span class="kk">Resolve hit-rate</span>
+          <span class="kd">{{ readout.resolve.hits }}/{{ readout.resolve.total }} resolves</span>
+        </div>
+        <div class="kpi">
+          <span class="kv tnum">{{ pct(readout.dcat.coverage_of_resolved_assets) }}</span>
+          <span class="kk">DCAT coverage</span>
+          <span class="kd">{{ readout.dcat.distinct_assets }} asset{{ readout.dcat.distinct_assets === 1 ? '' : 's' }} exported</span>
+        </div>
+        <div class="kpi">
+          <span class="kv tnum">{{ readout.sources.cold.length }}</span>
+          <span class="kk">Cold sources</span>
+          <span class="kd">{{ readout.sources.read_in_window }}/{{ readout.sources.cataloged }} read</span>
+        </div>
+        <div class="kpi">
+          <span class="kv tnum">{{ readout.resolve.misses }}</span>
+          <span class="kk">Resolve misses</span>
+          <span class="kd">{{ readout.top_misses.length }} distinct absent</span>
+        </div>
+      </div>
+
+      <div class="ops-cols">
+        <div class="ops-list" v-if="readout.hot_entries.length">
+          <h5>Hot entries</h5>
+          <div v-for="h in readout.hot_entries.slice(0, 6)" :key="h.kind + '/' + h.entry_id" class="li">
+            <span class="lk">{{ h.kind }}</span><code class="lid">{{ h.entry_id }}</code><span class="ln tnum">{{ h.resolves }}</span>
+          </div>
+        </div>
+        <div class="ops-list" v-if="readout.top_misses.length">
+          <h5>Registration candidates <span class="hint" title="entries callers ask for that don't exist yet">?</span></h5>
+          <div v-for="m in readout.top_misses.slice(0, 6)" :key="m.kind + '/' + m.entry_id" class="li">
+            <span class="lk miss">{{ m.kind }}</span><code class="lid">{{ m.entry_id }}</code><span class="ln tnum">{{ m.misses }}</span>
+          </div>
+        </div>
+        <div class="ops-list" v-if="slo && slo.objectives.length">
+          <h5>SLO objectives</h5>
+          <div v-for="o in slo.objectives" :key="o.name" class="li">
+            <span class="obj-v" :class="'v-' + o.verdict"><i class="dot" /></span>
+            <span class="lk">{{ o.name.replace(/_/g, ' ') }}</span>
+            <span class="ln tnum" :title="'n=' + o.n + (o.note ? ' · ' + o.note : '')">{{ o.value === null ? '—' : (o.thresholds.direction === 'high' && o.value <= 1 ? pct(o.value) : o.value) }}</span>
+          </div>
+        </div>
+      </div>
+    </template>
+  </section>
+</template>
+
+<style scoped>
+.ops { border: 1px solid var(--hairline); border-radius: var(--r-3); padding: var(--sp-3) var(--sp-4); margin-bottom: var(--sp-4); background: var(--surface); font: 14px/1.5 var(--ui); color: var(--ink); }
+.ops-note { color: var(--muted); font-size: 12.5px; } .ops-note.muted code { font-family: var(--mono); font-size: 11px; color: var(--ink-2); }
+.ops-head { display: flex; align-items: center; gap: var(--sp-3); margin-bottom: var(--sp-3); flex-wrap: wrap; }
+.ops-title { font-size: 11px; text-transform: uppercase; letter-spacing: .07em; color: var(--faint); }
+.ops-win { font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; }
+.ghost { border: 1px solid var(--hairline-strong); background: var(--surface); color: var(--ink-2); border-radius: var(--r-2); width: 28px; height: 28px; cursor: pointer; margin-left: auto; }
+
+.verdict { display: inline-flex; align-items: center; gap: 6px; font-size: 11px; font-weight: 600; letter-spacing: .04em; border-radius: var(--pill); padding: 2px 10px; border: 1px solid var(--hairline-strong); }
+.verdict .dot, .obj-v .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--vc, var(--faint)); display: inline-block; }
+.v-ok { --vc: var(--ok, #17864a); color: var(--ok, #17864a); background: color-mix(in srgb, var(--ok, #17864a) 10%, transparent); border-color: color-mix(in srgb, var(--ok, #17864a) 30%, transparent); }
+.v-sad { --vc: var(--warn, #b7791f); color: var(--warn, #b7791f); background: color-mix(in srgb, var(--warn, #b7791f) 10%, transparent); border-color: color-mix(in srgb, var(--warn, #b7791f) 30%, transparent); }
+.v-bad { --vc: var(--fail, #c0392b); color: var(--fail, #c0392b); background: color-mix(in srgb, var(--fail, #c0392b) 10%, transparent); border-color: color-mix(in srgb, var(--fail, #c0392b) 30%, transparent); }
+.v-insufficient_data { --vc: var(--faint); color: var(--muted); }
+
+.kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: var(--sp-3); margin-bottom: var(--sp-3); }
+.kpi { border: 1px solid var(--hairline); border-radius: var(--r-2); padding: 8px 12px; background: var(--sunken); display: flex; flex-direction: column; gap: 1px; }
+.kv { font-size: 20px; font-weight: 650; color: var(--ink); line-height: 1.1; }
+.kk { font-size: 10.5px; text-transform: uppercase; letter-spacing: .05em; color: var(--faint); }
+.kd { font-size: 11px; color: var(--muted); }
+
+.ops-cols { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: var(--sp-4); }
+.ops-list h5 { margin: 0 0 var(--sp-2); font-size: 10.5px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); display: flex; align-items: center; gap: 6px; }
+.hint { font-size: 9px; color: var(--faint); border: 1px solid var(--hairline); border-radius: 50%; width: 13px; height: 13px; display: inline-flex; align-items: center; justify-content: center; cursor: help; }
+.li { display: flex; align-items: center; gap: 8px; padding: 2px 0; font-size: 12px; }
+.lk { font-size: 9.5px; text-transform: uppercase; letter-spacing: .04em; color: var(--faint); min-width: 46px; }
+.lk.miss { color: var(--fail, #c0392b); }
+.lid { font-family: var(--mono); font-size: 11px; color: var(--ink-2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
+.ln { margin-left: auto; color: var(--muted); font-size: 12px; }
+.obj-v { display: inline-flex; }
+</style>

--- a/apps/socioprophet-web/src/pages/studio/api.ts
+++ b/apps/socioprophet-web/src/pages/studio/api.ts
@@ -5,8 +5,8 @@
  * to the in-cluster service — so no CORS, no hard-coded hosts. Each service base is overridable at runtime
  * via window.__PROPHET_API__ for bespoke ingress topologies. Errors are surfaced, never swallowed.
  */
-type ApiMap = { hellgraph: string; reason: string; er: string; studio: string }
-const DEFAULTS: ApiMap = { hellgraph: '/svc/hellgraph', reason: '/svc/reason', er: '/svc/er', studio: '/svc/studio' }
+type ApiMap = { hellgraph: string; reason: string; er: string; studio: string; catalog: string }
+const DEFAULTS: ApiMap = { hellgraph: '/svc/hellgraph', reason: '/svc/reason', er: '/svc/er', studio: '/svc/studio', catalog: '/svc/catalog' }
 const CFG: ApiMap = { ...DEFAULTS, ...((globalThis as any).__PROPHET_API__ ?? {}) }
 
 export class ApiError extends Error {
@@ -56,6 +56,37 @@ export const reasoner = {
 // ── entity-resolution ────────────────────────────────────────────────────────────
 export const er = {
   resolve: (records: any[]) => call<any>(CFG.er, '/resolve', { method: 'POST', body: JSON.stringify({ records }) }),
+}
+
+// ── catalog-gateway ───────────────────────────────────────────────────────────────
+// The read/resolve/lineage + DCAT interop seam AND the operational plane (readout KPIs +
+// SLO verdict) over the Crystal Atlas catalog families. This is the sovereign catalog's
+// answer to WKC/Collibra/Waterline: every panel it feeds is backed by a real service, and
+// the ops KPIs are a fold of crystallized events (catalog.*.v0), not a vendor dashboard.
+export type CatalogReadout = {
+  schema_version: string; readout_id: string; generated_at: string
+  window: { events_scanned: number; first_event_at: string | null; last_event_at: string | null }
+  resolve: { total: number; hits: number; misses: number; hit_rate: number | null; by_kind: Record<string, { total: number; hits: number; misses: number }> }
+  hot_entries: { kind: string; entry_id: string; resolves: number }[]
+  top_misses: { kind: string; entry_id: string; misses: number }[]
+  dcat: { emissions: number; distinct_assets: number; coverage_of_resolved_assets: number | null }
+  sources: { cataloged: number; read_in_window: number; cold: string[] }
+}
+export type SloVerdict = 'ok' | 'sad' | 'bad' | 'insufficient_data'
+export type CatalogSlo = {
+  schema_version: string; slo_id: string; generated_at: string; verdict: SloVerdict; readout_ref: string | null
+  objectives: { name: string; verdict: SloVerdict; value: number | null; n: number; thresholds: { ok: number; sad: number; direction: 'high' | 'low' }; note: string }[]
+  window: { events_scanned: number; first_event_at: string | null; last_event_at: string | null }
+}
+export const catalog = {
+  readout: () => call<CatalogReadout>(CFG.catalog, '/v1/catalog/ops/readout'),
+  slo: () => call<CatalogSlo>(CFG.catalog, '/v1/catalog/ops/slo'),
+  resolve: (kind: string, id: string) => call<{ kind: string; entry: any }>(CFG.catalog, `/v1/catalog/${kind}/${encodeURIComponent(id)}`),
+  lineage: (kind: string, id: string) => call<{ node: string; kind: string; upstream: { ref: string; resolved: boolean; kind: string | null }[] }>(CFG.catalog, `/v1/catalog/${kind}/${encodeURIComponent(id)}/lineage`),
+  // DCAT/schema.org JSON-LD for an asset. Returns the parsed doc; the export button also
+  // links to the raw same-origin URL below so a steward can download the ld+json directly.
+  dcat: (id: string) => call<any>(CFG.catalog, `/v1/catalog/asset/${encodeURIComponent(id)}.dcat.json`),
+  dcatUrl: (id: string) => `${CFG.catalog}/v1/catalog/asset/${encodeURIComponent(id)}.dcat.json`,
 }
 
 export interface Health { name: string; ok: boolean; detail?: string }

--- a/apps/socioprophet-web/vite.config.ts
+++ b/apps/socioprophet-web/vite.config.ts
@@ -71,6 +71,12 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/svc\/synapse/, ''),
         },
+        // catalog-gateway — read/resolve/lineage + DCAT AND the catalog ops plane (readout + SLO).
+        '/svc/catalog': {
+          target: env.VITE_CATALOG_BASE || 'http://localhost:8096',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/svc\/catalog/, ''),
+        },
         // sherlock-engine — Tantivy (Rust, no-JVM) ontology-driven Discovery search.
         '/svc/sherlock': {
           target: env.VITE_SHERLOCK_BASE || 'http://localhost:8093',


### PR DESCRIPTION
## What
Surfaces the catalog **operational plane** (backend shipped in #1279 readout + #1280 SLO, both on main) inside the Studio Catalog. This is the surface WKC / Collibra / Waterline / watsonx.governance show as a vendor chart — backed here by a **real service** folding crystallized `catalog.*.v0` events, not a scraped metastore.

## WO-3 — the `/svc/catalog` seam (frontend-only, no bff fan-out)
- **`pages/studio/api.ts`** — a `catalog` client (`readout`, `slo`, `resolve`, `lineage`, `dcat`/`dcatUrl`) with `CatalogReadout` / `CatalogSlo` / `SloVerdict` types, on the same `/svc` convention as hellgraph/reason/er.
- **`nginx.conf` + `vite.config.ts`** — `/svc/catalog` → `catalog-gateway:8080` (prod resolver + dev proxy, `VITE_CATALOG_BASE` overridable). Peer routes untouched.

## WO-4 — the cockpit UI
- **`StudioCatalogOps.vue`** (new) — the ops dashboard:
  - the Assay **SLO verdict** chip (ok / sad / bad / n·a)
  - **KPI tiles**: resolve hit-rate, DCAT coverage, cold sources, misses
  - **Hot entries** + **Registration candidates** (top misses — entries callers ask for that don't exist yet) + per-objective SLO breakdown
  - **Fail-soft**: if `/svc/catalog` is unreachable it collapses to one muted line; the catalog table still renders.
- **`StudioCatalog.vue`** — mounts the ops panel; the factsheet drawer gains a best-effort **Catalog warrant** section: DCAT `ld+json` **export** + gateway-served **lineage**, shown only for assets the gateway actually resolves. The interop doc + upstream refs come from the *same governed service that lists the row* — a bolt-on catalog cannot attest what it lists.

## Verify
```
cd apps/socioprophet-web && npm run typecheck   # vue-tsc --noEmit → 0 errors
```
Rebased on current `main` (fb5fea31); diff is exactly 5 frontend files, none touched upstream since branch base (no clobber). Consumes endpoints already merged (#1279/#1280).

Completes the catalog mission's last mile: capture (#1213) → analysis (#1279) → verdict (#1280) → **cockpit** (this).