### PR TITLE
feat(ie-engine): lexicon-based Big-Five (OCEAN) personality scorer

### DIFF
--- a/apps/ie-engine/src/ie_engine/server.py
+++ b/apps/ie-engine/src/ie_engine/server.py
@@ -7,9 +7,11 @@ so extraction feeds the same knowledge graph every other surface reads.
 
 Endpoints:
   GET  /healthz
-  POST /extract   { text }  → entities, relations, claims, topics, sentiment
-  POST /vectorize { texts[] } → lexical hashing vectors + pairwise cosine similarity
-  POST /to-graph  { text }  → extract, then upsert nodes/edges into hellgraph-service (:8090)
+  POST /extract     { text }  → entities, relations, claims, topics, sentiment
+  POST /vectorize   { texts[] } → lexical hashing vectors + pairwise cosine similarity
+  POST /to-graph    { text }  → extract, then upsert nodes/edges into hellgraph-service (:8090)
+  POST /personality { text }  → lexicon-based Big-Five (OCEAN) trait scores — see _personality()
+                                 docstring for the honesty/validity disclaimer this endpoint carries.
 """
 from __future__ import annotations
 import math, os, re
@@ -35,6 +37,83 @@ HEDGES = {"expect", "expected", "likely", "may", "might", "could", "should", "es
           "propose", "proposed", "reportedly", "seem", "suggest"}
 POS = {"gain", "growth", "improve", "improved", "strong", "success", "benefit", "up", "rise", "align", "support", "approve"}
 NEG = {"loss", "decline", "risk", "weak", "fail", "concern", "down", "fall", "penalty", "breach", "dispute", "cost", "costs"}
+
+# ---------------------------------------------------------------------------------------------
+# Big-Five (OCEAN) lexicon — a HAND-BUILT, hand-curated word-count heuristic, same category of
+# approach as POS/NEG above (plain English word sets, not a trained model). This is NOT a
+# reproduction of LIWC or any other licensed/proprietary lexicon: no LIWC category files, word
+# lists, or weights were consulted or copied. It is our own vocabulary, chosen using the same
+# published, non-proprietary finding that decades of psycholinguistics research keeps landing on
+# (Pennebaker & King 1999 "Linguistic styles"; Yarkoni 2010; Schwartz et al. 2013 "Personality,
+# gender, and age in the language of social media") — namely *which semantic direction* each
+# Big-Five trait skews language in. We use that published direction-of-association only; the
+# specific words below, and the scoring formula, are ours.
+#
+# Each trait has a HIGH set (words that push the trait up when present) and a LOW set (words
+# that push it down) — mirroring how POS/NEG work for sentiment above, generalized to five
+# bipolar axes instead of one.
+OCEAN_LEXICON: dict[str, dict[str, set[str]]] = {
+    # Openness to Experience: high = curiosity, imagination, ideas, art, novelty-seeking;
+    # low = preference for the familiar, concrete, routine, conventional.
+    "openness": {
+        "high": {"imagine", "curious", "curiosity", "explore", "art", "artistic", "creative", "creativity",
+                  "idea", "ideas", "philosophy", "novel", "abstract", "wonder", "aesthetic", "insight",
+                  "imagination", "discover", "invent", "inventive", "theory", "possibility", "unconventional",
+                  "diverse", "original", "experiment", "imaginative", "innovate", "innovative", "curiously",
+                  "wander", "dream", "dreamy", "unusual", "beauty", "profound", "metaphor", "poetry"},
+        "low": {"routine", "familiar", "conventional", "traditional", "practical", "concrete", "ordinary",
+                 "predictable", "literal", "simple", "plain", "boring", "usual", "habit", "custom"},
+    },
+    # Conscientiousness: high = order, planning, discipline, achievement, duty;
+    # low = disorganization, carelessness, impulsivity, procrastination.
+    "conscientiousness": {
+        "high": {"plan", "planned", "organize", "organized", "schedule", "scheduled", "deadline",
+                  "responsible", "duty", "disciplined", "discipline", "thorough", "efficient", "goal",
+                  "goals", "achieve", "achievement", "complete", "completed", "punctual", "systematic",
+                  "detail", "detailed", "diligent", "careful", "prepare", "prepared", "task", "checklist",
+                  "procedure", "routine", "reliable", "orderly", "meticulous", "committed", "persevere"},
+        "low": {"disorganized", "careless", "impulsive", "procrastinate", "procrastinated", "sloppy",
+                 "messy", "forgetful", "lazy", "late", "unreliable", "reckless", "haphazard", "chaotic",
+                 "distracted", "neglect", "neglected", "unprepared"},
+    },
+    # Extraversion: high = sociability, assertiveness, activity, positive excitement;
+    # low = reserve, solitude, quiet, withdrawal.
+    "extraversion": {
+        "high": {"party", "friends", "social", "excited", "excitement", "fun", "outgoing", "energetic",
+                  "talk", "talkative", "crowd", "adventure", "laugh", "laughed", "enthusiastic", "team",
+                  "celebrate", "spontaneous", "bold", "confident", "loud", "gregarious", "chat", "chatty",
+                  "gathering", "socialize", "assertive", "lively", "cheerful"},
+        "low": {"alone", "quiet", "reserved", "shy", "solitude", "solitary", "withdrawn", "introvert",
+                 "silent", "isolated", "timid", "reticent", "loner", "hesitant", "subdued", "unnoticed"},
+    },
+    # Agreeableness: high = warmth, cooperation, empathy, trust, politeness;
+    # low = antagonism, suspicion, coldness, hostility.
+    "agreeableness": {
+        "high": {"kind", "help", "helped", "helpful", "care", "caring", "please", "thank", "thanks",
+                  "trust", "friendly", "cooperate", "cooperative", "gentle", "generous", "compassion",
+                  "compassionate", "warm", "polite", "considerate", "supportive", "forgive", "forgiving",
+                  "share", "shared", "gratitude", "sympathy", "sympathetic", "agree", "kindness", "empathy",
+                  "understanding", "gracious"},
+        "low": {"rude", "selfish", "hostile", "hostility", "cruel", "cold", "suspicious", "distrust",
+                 "argue", "argued", "argument", "stubborn", "insult", "insulted", "contempt", "spiteful",
+                 "ruthless", "manipulative", "callous", "harsh"},
+    },
+    # Neuroticism: high = anxiety, worry, negative emotion, emotional instability;
+    # low = calm, emotional stability, security.
+    "neuroticism": {
+        "high": {"worry", "worried", "anxious", "anxiety", "afraid", "stress", "stressed", "nervous",
+                  "upset", "sad", "angry", "anger", "fear", "afraid", "panic", "insecure", "depressed",
+                  "overwhelmed", "hurt", "frustrated", "frustration", "guilty", "lonely", "doubt", "tense",
+                  "unstable", "dread", "miserable", "irritable", "restless"},
+        "low": {"calm", "secure", "relaxed", "stable", "confident", "content", "peaceful", "steady",
+                 "composed", "serene", "unworried", "grounded", "reassured", "settled"},
+    },
+}
+# Density-difference saturation cap: at (high_count - low_count) / alpha_tokens == this value,
+# the score saturates to 0.0 or 1.0. 0.12 is a deliberately conservative constant chosen because
+# even lexicon-dense text rarely exceeds ~10-15% single-category word density; it is NOT fit to
+# any labeled data (none exists for this task — see _personality() docstring).
+TRAIT_SATURATION_CAP = 0.12
 
 class TextReq(BaseModel):
     text: str
@@ -95,6 +174,62 @@ def _extract(text: str) -> dict[str, Any]:
             "counts": {"entities": len(seen), "relations": len(rel_out), "claims": len(claims), "tokens": len(doc)},
             "provenance": {"model": "spaCy en_core_web_sm", "extractor": "ie-engine", "real": True}}
 
+def _personality(text: str) -> dict[str, Any]:
+    """Lexicon-based Big-Five (OCEAN) scorer — a coarse heuristic, NOT a validated psychometric
+    instrument, and NOT comparable to IBM Watson Personality Insights or any clinically-validated
+    tool. There is no labeled personality ground-truth data anywhere in this estate, so this is
+    deliberately NOT a trained/supervised classifier (that would require labels we don't have and
+    can't honestly claim). Instead it is the same category of technique as the sentiment scorer
+    above: per-trait word-count density over a hand-built, hand-curated lexicon (see
+    OCEAN_LEXICON), normalized by text length. This is the standard "LIWC-style" lexicon-counting
+    approach used as an academic baseline in psycholinguistics research — a real, working,
+    honestly-labeled heuristic, not an approximation of a trained model.
+
+    Scale: each trait score is 0.0-1.0.
+      - 0.5 = the midpoint — no net lexical signal was detected either way (this is NOT the
+        same thing as "average trait level"; it just means the text didn't contain enough
+        high/low marker words to move the needle).
+      - Values above/below 0.5 indicate the direction and (saturating) strength of lexical
+        signal toward the high or low pole of the trait, capped at 0.0/1.0 once the marker-word
+        density difference reaches TRAIT_SATURATION_CAP.
+    Confidence is explicitly weak for short text: `tokens_considered` is returned per-trait so a
+    caller can see how little (or how much) evidence the score is based on.
+    """
+    doc = NLP(text)
+    lemmas = [w.lemma_.lower() for w in doc if w.is_alpha]
+    n_tokens = len(lemmas)
+    traits: dict[str, Any] = {}
+    for trait, sets in OCEAN_LEXICON.items():
+        high_hits = [w for w in lemmas if w in sets["high"]]
+        low_hits = [w for w in lemmas if w in sets["low"]]
+        raw = (len(high_hits) - len(low_hits)) / max(n_tokens, 1)
+        score = 0.5 + (raw / (2 * TRAIT_SATURATION_CAP))
+        score = max(0.0, min(1.0, score))
+        traits[trait] = {
+            "score": round(score, 3),
+            "high_matches": sorted(set(high_hits)),
+            "low_matches": sorted(set(low_hits)),
+            "tokens_considered": n_tokens,
+        }
+    return {
+        "traits": traits,
+        "scale": "0.0-1.0 per trait; 0.5 = no lexical signal (neutral midpoint, not a measured "
+                 "average); values move toward 0.0 (low-pole marker words) or 1.0 (high-pole "
+                 "marker words), saturating once marker-word density exceeds "
+                 f"{TRAIT_SATURATION_CAP:.0%} of tokens.",
+        "disclaimer": "HEURISTIC ONLY. This is a hand-built lexicon word-count baseline (same "
+                      "technique family as the POS/NEG sentiment lexicon in this service), not a "
+                      "trained model and not a validated psychometric instrument. It has NOT been "
+                      "validated against any ground-truth personality labels (none exist in this "
+                      "estate) and must not be treated as clinically or psychometrically accurate, "
+                      "or as comparable to IBM Watson Personality Insights or similar commercial "
+                      "products. Scores on short text are especially unreliable — see "
+                      "tokens_considered per trait.",
+        "counts": {"tokens": len(doc), "alpha_tokens": n_tokens},
+        "provenance": {"model": "hand-built OCEAN lexicon (word-count heuristic)",
+                        "extractor": "ie-engine", "real": True, "validated": False},
+    }
+
 def _span(tok) -> str:
     # widen a token to its noun-phrase span when possible
     for c in tok.doc.noun_chunks:
@@ -121,6 +256,13 @@ def healthz() -> dict[str, Any]:
 @app.post("/extract")
 def extract(req: TextReq) -> dict[str, Any]:
     return _extract(req.text)
+
+@app.post("/personality")
+def personality(req: TextReq) -> dict[str, Any]:
+    """Lexicon-based Big-Five (OCEAN) trait scoring. See _personality() docstring for the full
+    honesty/validity disclaimer — this is a heuristic word-count baseline, not a validated
+    psychometric instrument, and not comparable to any commercial personality-scoring product."""
+    return _personality(req.text)
 
 @app.post("/glossary")
 def glossary(req: TextReq) -> dict[str, Any]:

--- a/apps/ie-engine/tests/test_personality.py
+++ b/apps/ie-engine/tests/test_personality.py
@@ -1,0 +1,118 @@
+"""Tests for the lexicon-based Big-Five (OCEAN) personality scorer in ie_engine.server.
+
+IMPORTANT — what these tests do and do not prove:
+These tests assert that feeding text stereotypically dense in a trait's marker words moves that
+trait's score in the expected direction (and, where relevant, that opposite-pole text moves it the
+other way). That proves the lexicon look-up and scoring arithmetic behave as designed. It does
+NOT and CANNOT prove psychometric validity — there is no labeled ground-truth personality dataset
+anywhere in this estate to validate against, and this scorer was never trained or fit to one. This
+is a hand-built word-count heuristic (the same category of technique as the POS/NEG sentiment
+lexicon already in ie_engine/server.py), being tested for internal consistency only.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from fastapi.testclient import TestClient
+
+from ie_engine.server import OCEAN_LEXICON, _personality, app
+
+client = TestClient(app)
+
+OPENNESS_HIGH_TEXT = (
+    "I love to imagine new worlds and explore unconventional ideas. Art, philosophy, and abstract "
+    "theory fill me with curiosity — I am always eager to discover something novel and inventive."
+)
+CONSCIENTIOUSNESS_HIGH_TEXT = (
+    "I always plan my schedule carefully and organize every task with a detailed checklist. I am "
+    "disciplined, punctual, and thorough, and I complete every goal I set with diligent, systematic "
+    "preparation."
+)
+EXTRAVERSION_HIGH_TEXT = (
+    "I love a loud party with a big crowd of friends. I am outgoing, energetic, and talkative, "
+    "always laughing and chatting at social gatherings — I thrive on excitement with my team."
+)
+EXTRAVERSION_LOW_TEXT = (
+    "I prefer to be alone in quiet solitude. I am reserved, shy, and withdrawn, and I stay silent "
+    "and isolated rather than join a gathering."
+)
+AGREEABLENESS_HIGH_TEXT = (
+    "I try to be kind and helpful to everyone. I care about others, share what I have, and feel "
+    "compassion and gratitude — I am gentle, polite, and always ready to forgive and cooperate."
+)
+NEUROTICISM_HIGH_TEXT = (
+    "I feel so anxious and worried all the time. I am nervous, afraid, and overwhelmed by stress, "
+    "and I often feel sad, lonely, and tense with a sense of dread I cannot shake."
+)
+NEUTRAL_TEXT = "The quarterly report was filed on Tuesday and sent to the regional office."
+
+
+def test_healthz_still_ok():
+    r = client.get("/healthz")
+    assert r.status_code == 200 and r.json()["ok"] is True
+
+
+def test_personality_response_shape_and_disclaimer():
+    r = client.post("/personality", json={"text": OPENNESS_HIGH_TEXT})
+    assert r.status_code == 200
+    body = r.json()
+    assert set(body["traits"].keys()) == set(OCEAN_LEXICON.keys())
+    for trait, data in body["traits"].items():
+        assert 0.0 <= data["score"] <= 1.0
+        assert "high_matches" in data and "low_matches" in data and "tokens_considered" in data
+    # The honesty framing is not optional — assert it is actually present, in strong terms.
+    assert "HEURISTIC" in body["disclaimer"]
+    assert "not a trained model" in body["disclaimer"]
+    assert "not a validated psychometric instrument" in body["disclaimer"]
+    assert body["provenance"]["validated"] is False
+    assert "0.5" in body["scale"]
+
+
+def test_openness_high_text_scores_above_neutral():
+    out = _personality(OPENNESS_HIGH_TEXT)
+    assert out["traits"]["openness"]["score"] > 0.5
+    assert len(out["traits"]["openness"]["high_matches"]) >= 3
+
+
+def test_conscientiousness_high_text_scores_above_neutral():
+    out = _personality(CONSCIENTIOUSNESS_HIGH_TEXT)
+    assert out["traits"]["conscientiousness"]["score"] > 0.5
+    assert len(out["traits"]["conscientiousness"]["high_matches"]) >= 3
+
+
+def test_extraversion_direction_flips_between_high_and_low_text():
+    high = _personality(EXTRAVERSION_HIGH_TEXT)["traits"]["extraversion"]["score"]
+    low = _personality(EXTRAVERSION_LOW_TEXT)["traits"]["extraversion"]["score"]
+    assert high > 0.5
+    assert low < 0.5
+    assert high > low
+
+
+def test_agreeableness_high_text_scores_above_neutral():
+    out = _personality(AGREEABLENESS_HIGH_TEXT)
+    assert out["traits"]["agreeableness"]["score"] > 0.5
+    assert len(out["traits"]["agreeableness"]["high_matches"]) >= 3
+
+
+def test_neuroticism_high_text_scores_above_neutral():
+    out = _personality(NEUROTICISM_HIGH_TEXT)
+    assert out["traits"]["neuroticism"]["score"] > 0.5
+    assert len(out["traits"]["neuroticism"]["high_matches"]) >= 3
+
+
+def test_neutral_text_with_no_marker_words_stays_at_midpoint_for_most_traits():
+    out = _personality(NEUTRAL_TEXT)
+    # Business-report text carries essentially no OCEAN marker words for most traits, so those
+    # traits should sit at (or very near) the 0.5 neutral midpoint — not be pushed to an extreme.
+    near_neutral = [t for t, d in out["traits"].items() if abs(d["score"] - 0.5) < 0.05]
+    assert len(near_neutral) >= 4
+
+
+def test_score_saturates_within_bounds_on_extreme_repetition():
+    # Pathological input (the same high-marker word repeated) must still clamp to [0, 1], never
+    # overshoot — this checks the saturation cap logic, not any claim about real text.
+    out = _personality("curious " * 50)
+    assert out["traits"]["openness"]["score"] == 1.0


### PR DESCRIPTION
## Summary
- Closes the psycholinguistic/personality-profiling capability gap (no Watson-Personality-Insights equivalent existed anywhere in the estate) with a from-scratch, no-licensing-dependency baseline.
- Adds `POST /personality` to `apps/ie-engine` — a lexicon-based Big-Five (OCEAN) scorer, same category of technique as the existing `POS`/`NEG` sentiment lexicon already in `server.py` (hand-built word sets, density-normalized counting, no proprietary/licensed lexicon consulted or copied).
- There is **no labeled personality ground-truth data** anywhere in this estate, so this is deliberately **not** a trained/supervised classifier — that would be dishonest given no ground truth exists. It is a coarse heuristic and says so explicitly in its own response payload (`disclaimer`, `provenance.validated: false`).
- Chose to extend `ie-engine` rather than stand up a new app: Big-Five scoring over free text is conceptually adjacent to the sentiment/tone extraction the service already does, reuses the same spaCy pipeline/tokenization, and keeps one less service to operate.

## Design
- `OCEAN_LEXICON`: per-trait `high`/`low` hand-curated word sets (own vocabulary — not reproduced from LIWC or any licensed source), chosen using the published, non-proprietary *direction of association* each trait has with language (Pennebaker & King 1999; Yarkoni 2010; Schwartz et al. 2013) — the specific words and scoring formula are original.
- Score = `(high_count − low_count) / alpha_tokens`, mapped to a 0.0–1.0 scale where 0.5 is the "no lexical signal" neutral midpoint, saturating to 0/1 once marker-word density exceeds a conservative 12% cap (`TRAIT_SATURATION_CAP`) — not fit to any labeled data.
- Response includes `high_matches`/`low_matches`/`tokens_considered` per trait for transparency, plus an explicit `disclaimer` string and `scale` explanation so no caller can mistake this for a validated instrument.

## Test plan
- [x] `apps/ie-engine/tests/test_personality.py` — new FastAPI `TestClient` test file (same pattern as `apps/lattice-studio/tests/test_server.py`). Docstring is explicit that these tests prove the lexicon/scoring logic is internally consistent, **not** psychometric validity (no ground truth exists to validate against).
- [x] Stereotypical high-marker text for each trait (Openness, Conscientiousness, Extraversion, Agreeableness, Neuroticism) asserted to score above the 0.5 neutral midpoint.
- [x] Extraversion additionally asserted to flip direction between high- and low-marker text.
- [x] Neutral business text asserted to stay near the 0.5 midpoint for most traits (no false-positive signal).
- [x] Saturation-cap clamping asserted on pathological repeated-word input.
- [x] Ran `python3 -m pytest apps/ie-engine/tests/test_personality.py -v` locally — **9/9 passed**.
- [x] Verified `/extract` still returns 200 (no regression to existing endpoints).
- No `.github/workflows/**` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)