### PR TITLE
fix(compute-gateway): raise memory limit — gateway OOMKilling on boot (INCIDENT)

### DIFF
--- a/deploy/values/compute-gateway.yaml
+++ b/deploy/values/compute-gateway.yaml
@@ -46,5 +46,14 @@ secretEnv:
 # seconds of rollout downtime — deliberate; the object-store backend lifts this later.
 autoscaling: { enabled: false }
 replicaCount: 1
+# The gateway hydrates its durable receipt/blob store (/data, 2Gi PVC — thousands of
+# blobs + the hash-chained receipt log) into memory on boot, on top of the hellgraph
+# and embedding libraries. The shared chart default (512Mi) is too tight: the pod was
+# OOMKilled ~9s into startup, before it could serve or even log — 31 restarts, the whole
+# gateway (compute, config-plane, governance receipts) down. Raise the limit for THIS
+# service only (not the chart default, which every service inherits).
+resources:
+  requests: { cpu: 100m, memory: 384Mi }
+  limits:   { cpu: "1",  memory: 1Gi }
 strategy: { type: RollingUpdate, rollingUpdate: { maxSurge: 0, maxUnavailable: 1 } }
 persistence: { enabled: true, storageClass: dynamic-rwo, size: 2Gi, mountPath: /data }


### PR DESCRIPTION
## Incident
**compute-gateway is down.** The pod is `READY=false` with **31 restarts**, CrashLoopBackOff — **OOMKilled** (exit 137) ~9 seconds into startup, before it serves a request or emits a log. So the Service has **zero endpoints** and `/v1/config`, `/v1/compute`, and the governance-receipt spine all return nothing (HTTP 000).

Found while live-probing `/v1/config` for the `sovereign-config-plane` register promotion — the promotion is blocked by this.

## Root cause
The gateway hydrates its durable receipt/blob store (`/data`, a 2Gi PVC now holding thousands of blobs + the hash-chained receipt log) into memory on boot, on top of the hellgraph + embedding libraries — and it inherits the **shared chart default of 512Mi**, with no override in its own values. Too tight for that boot footprint.

## Fix
Raise the limit to **1Gi** (request 384Mi) for **this service only** — not the chart default that every service inherits. `helm template` confirms the deployment now renders `memory: 1Gi`.

Immediate mitigation. **Follow-up** (filed separately): make boot hydration lazy/bounded so the footprint doesn't grow unbounded with the store — otherwise the same OOM returns as the store keeps growing.