### PR TITLE
feat(mount-intent): directional defaults — isolation by construction from day one

### DIFF
--- a/.github/workflows/mount-intent.yml
+++ b/.github/workflows/mount-intent.yml
@@ -5,13 +5,15 @@ on:
     paths:
       - 'libs/python/mount-intent/**'
       - 'tools/validate_mount_intent_egress.py'
-      - 'infra/k8s/edge-twin-sync/**'
+      - 'tools/validate_mount_intent_workload.py'
+      - 'infra/k8s/**'
       - '.github/workflows/mount-intent.yml'
   pull_request:
     paths:
       - 'libs/python/mount-intent/**'
       - 'tools/validate_mount_intent_egress.py'
-      - 'infra/k8s/edge-twin-sync/**'
+      - 'tools/validate_mount_intent_workload.py'
+      - 'infra/k8s/**'
       - '.github/workflows/mount-intent.yml'
 
 jobs:
@@ -30,3 +32,5 @@ jobs:
         run: cd libs/python/mount-intent && pytest -q
       - name: Enforce mount-intent egress policy on edge→twin sync
         run: python tools/validate_mount_intent_egress.py
+      - name: Enforce directional invariants on workloads (single egress + pinned verity)
+        run: python tools/validate_mount_intent_workload.py

--- a/infra/k8s/edge-twin-sync/base/sync-cronjob.yaml
+++ b/infra/k8s/edge-twin-sync/base/sync-cronjob.yaml
@@ -26,6 +26,10 @@ metadata:
     # egress-allowed (mount_intent.may_egress); tools/validate_mount_intent_egress.py fails
     # the build otherwise. The HellGraph store is canonical_data (the source of truth).
     mount-intent.socioprophet.io/egress: canonical_data
+    # Per-mount intents (directional invariant): `store` is the single egress chokepoint
+    # (canonical_data); `rclone-config` is an ingress secret. At most one egress mount per
+    # workload — tools/validate_mount_intent_workload.py fails the build otherwise.
+    mount-intent.socioprophet.io/mounts: store=canonical_data,rclone-config=secrets
 spec:
   schedule: "*/30 * * * *"   # PRIMARY sync (federation not yet wired — see header). Drop to daily ONLY after the twin is verified replicating live.
   concurrencyPolicy: Forbid

--- a/libs/python/mount-intent/README.md
+++ b/libs/python/mount-intent/README.md
@@ -57,3 +57,31 @@ hold**.
 declare `mount-intent.socioprophet.io/egress: <intent>[,...]`, and every declared intent must be
 egress-allowed. Adding `derived_index` or `secrets` to a sync job — or omitting the annotation —
 fails CI. Runs in `mount-intent.yml`.
+
+## Directional defaults (isolation by construction)
+
+Intent encodes *lifecycle* and *sensitivity*; it now also encodes **direction** and resolves
+to the **secure form by default**. Four invariants stick from day one:
+
+- **Direction axis** — every intent is `ingress` (ro input), `egress` (the one durable write
+  channel that survives the pod), or `none` (node-local). `canonical_data` is the *only* egress
+  intent. **At most one egress mount per workload** (`WorkloadDeclaration` /
+  `check_single_egress` / `validate_mount_intent_workload.py`) — one chokepoint, one place for
+  egress attestation.
+- **Verified-immutable corpus** — `curated_corpus` defaults to a `type=image` backend
+  (squashfs/erofs + **dm-verity**), and a `MountDeclaration` for it **must pin a
+  `verity_root_hash`**. Corpus integrity becomes a signature check, not a `readOnly: true`
+  trust assertion another view can bypass.
+- **Construction-enforced tenancy** — `canonical_data` binds the tenant in the mount *source*
+  (`tenant_scoped_source(store, tenant, path)` → `store:<tenant>:/path`), unforgeable from
+  inside the guest — not a path prefix or an admission rule a bad manifest can get wrong.
+- **`intent × link_availability × durability → backend`** — an egress mount over a *reliable*
+  link is **reference-mounted** (one object, no copy, no divergence, no reconciliation); over an
+  *intermittent* link it is forced into copy+snapshot+reconcile — the only case that needs the
+  conflict-resolution machinery. `resolve(intent, runtime, link)` returns `sync_semantics` and
+  `requires_conflict_resolution` accordingly.
+
+Workload manifests declare intents with
+`mount-intent.socioprophet.io/mounts: <vol>=<intent>,...` and pin verity with
+`mount-intent.socioprophet.io/verity.<vol>: <64-hex>`; both CI validators fail the build on a
+violation.

--- a/libs/python/mount-intent/src/mount_intent/__init__.py
+++ b/libs/python/mount-intent/src/mount_intent/__init__.py
@@ -6,24 +6,34 @@
     may_egress(MountIntent.SECRETS)                       # -> False (never leaves the device)
 """
 from .intents import (
+    EGRESS_DIRECTION_INTENTS,
     EGRESSABLE_INTENTS,
+    Direction,
     IntentBinding,
     Layer,
+    LinkAvailability,
     MountIntent,
     Retention,
     Runtime,
     binding,
+    check_single_egress,
+    direction,
     may_cache,
     may_delete,
     may_egress,
     resolve,
+    tenant_scoped_source,
+    verified_immutable,
 )
 from .lifecycle import ArtifactState, can_transition, is_terminal, transition
-from .schema import MountDeclaration, PolicyDecision
+from .schema import MountDeclaration, PolicyDecision, WorkloadDeclaration
 
 __all__ = [
     "MountIntent", "Layer", "Retention", "Runtime", "IntentBinding",
+    "Direction", "LinkAvailability",
     "binding", "resolve", "may_egress", "may_cache", "may_delete", "EGRESSABLE_INTENTS",
+    "direction", "verified_immutable", "tenant_scoped_source",
+    "check_single_egress", "EGRESS_DIRECTION_INTENTS",
     "ArtifactState", "can_transition", "transition", "is_terminal",
-    "MountDeclaration", "PolicyDecision",
+    "MountDeclaration", "WorkloadDeclaration", "PolicyDecision",
 ]

--- a/libs/python/mount-intent/src/mount_intent/intents.py
+++ b/libs/python/mount-intent/src/mount_intent/intents.py
@@ -57,6 +57,30 @@ class Runtime(str, Enum):
     PODMAN = "podman"  # rootful on this Mac
 
 
+class Direction(str, Enum):
+    """Data-flow direction relative to the WORKLOAD — orthogonal to lifecycle/sensitivity.
+
+    A workload's security model is directional: read-only inputs come IN, exactly one durable
+    channel goes OUT (the only mount whose contents survive the pod and the one place egress
+    attestation lives), everything else is node-local. Encoding direction lets us enforce the
+    single-egress-chokepoint invariant by construction instead of hoping the manifest is right.
+    """
+
+    INGRESS = "ingress"              # read-only input the workload consumes
+    EGRESS = "egress"                # the durable write channel — survives the pod, attested
+    BIDIRECTIONAL = "bidirectional"  # both (discouraged: two attestation points)
+    NONE = "none"                    # node-local; never crosses the workload boundary durably
+
+
+class LinkAvailability(str, Enum):
+    """Whether the edge↔twin link is dependable. This — with durability — decides copy vs
+    reference semantics, and therefore whether the conflict-resolution machinery is even needed.
+    """
+
+    RELIABLE = "reliable"          # reference-mount the store: one object, no divergence
+    INTERMITTENT = "intermittent"  # must copy + snapshot + reconcile (CRF/ternary earns its keep)
+
+
 @dataclass(frozen=True)
 class IntentBinding:
     """The full, policy-bearing binding for one intent."""
@@ -64,13 +88,23 @@ class IntentBinding:
     intent: MountIntent
     layer: Layer
     retention: Retention
-    may_egress: bool   # may this data ever leave the device (e.g. sync to the cloud twin)?
+    direction: Direction  # workload-boundary flow — the single-egress-chokepoint axis
+    may_egress: bool   # may this data ever leave the DEVICE (e.g. sync to the cloud twin)?
     may_cache: bool    # may this be vendor-materialized (Layer 3 file handle)?
     read_only: bool
+    # verified_immutable: immutability is STRUCTURAL (squashfs/erofs, no write path in the kernel
+    # driver) and, in the sovereign form, CRYPTOGRAPHIC (dm-verity root hash pinned in the
+    # manifest) — categorically stronger than read_only, which is only a mount flag another view
+    # can bypass. Corpus that must be provably unmutated crawl-time→query-time requires this.
+    verified_immutable: bool = False
+    # tenancy_in_source: the tenant/session is bound in the mount SOURCE string (e.g.
+    # `store:<tenant>:/path`), unforgeable from inside the guest — construction-enforced isolation,
+    # not a path prefix or an admission rule a bad manifest can get wrong.
+    tenancy_in_source: bool = False
     # backend per runtime: (kind, options)
-    kubernetes: tuple[str, str]
-    docker: tuple[str, str]
-    podman: tuple[str, str]
+    kubernetes: tuple[str, str] = ("", "")
+    docker: tuple[str, str] = ("", "")
+    podman: tuple[str, str] = ("", "")
 
     def backend(self, runtime: Runtime) -> tuple[str, str]:
         return {
@@ -84,58 +118,67 @@ class IntentBinding:
 # Policy Engine still governs it); everything else is rebuildable, ephemeral, or sensitive and
 # MUST NOT leave the device. This is enforcement-by-construction, not documentation.
 _BINDINGS: dict[MountIntent, IntentBinding] = {
+    # canonical_data is the ONE durable write channel: direction=egress, tenant bound in the
+    # mount source (construction-enforced isolation). Link-aware backend (reference vs copy) is
+    # chosen by select_backend(); the static backend is the durable store fallback.
     MountIntent.CANONICAL_DATA: IntentBinding(
         MountIntent.CANONICAL_DATA, Layer.CANONICAL, Retention.DURABLE,
-        may_egress=True, may_cache=True, read_only=False,
+        direction=Direction.EGRESS, may_egress=True, may_cache=True, read_only=False,
+        tenancy_in_source=True,
         kubernetes=("persistentVolumeClaim", "topolvm/local/nfs"),
         docker=("volume", "local/driver"),
         podman=("volume", "local"),
     ),
+    # curated_corpus is a read-only INGRESS input, and its default is a verified-immutable image
+    # (squashfs/erofs + dm-verity, root hash pinned in the manifest) — provably unmutated
+    # crawl-time→query-time, which `readOnly: true` cannot guarantee. This wires the `type=image`
+    # backend to curated_corpus as T0.
     MountIntent.CURATED_CORPUS: IntentBinding(
         MountIntent.CURATED_CORPUS, Layer.CANONICAL, Retention.DURABLE,
-        may_egress=True, may_cache=True, read_only=True,
-        kubernetes=("persistentVolumeClaim", "topolvm/local/nfs"),
-        docker=("volume", "local/driver"),
-        podman=("volume", "local"),
+        direction=Direction.INGRESS, may_egress=True, may_cache=True, read_only=True,
+        verified_immutable=True,
+        kubernetes=("image", "verity-ro"),
+        docker=("image", "verity-ro"),
+        podman=("image", "squashfs+dm-verity,ro"),
     ),
     MountIntent.DERIVED_INDEX: IntentBinding(
         MountIntent.DERIVED_INDEX, Layer.DERIVED, Retention.REBUILDABLE,
-        may_egress=False, may_cache=False, read_only=False,
+        direction=Direction.NONE, may_egress=False, may_cache=False, read_only=False,
         kubernetes=("persistentVolumeClaim", "topolvm/local"),
         docker=("volume", "local"),
         podman=("volume", "local"),
     ),
     MountIntent.SCRATCH: IntentBinding(
         MountIntent.SCRATCH, Layer.EPHEMERAL, Retention.EPHEMERAL,
-        may_egress=False, may_cache=False, read_only=False,
+        direction=Direction.NONE, may_egress=False, may_cache=False, read_only=False,
         kubernetes=("emptyDir", ""),
         docker=("tmpfs", ""),
         podman=("tmpfs", ""),
     ),
     MountIntent.CACHE: IntentBinding(
         MountIntent.CACHE, Layer.VENDOR_CACHE, Retention.TTL,
-        may_egress=False, may_cache=True, read_only=False,
+        direction=Direction.NONE, may_egress=False, may_cache=True, read_only=False,
         kubernetes=("emptyDir", ""),
         docker=("tmpfs", ""),
         podman=("overlay", ":O"),
     ),
     MountIntent.SECRETS: IntentBinding(
         MountIntent.SECRETS, Layer.EPHEMERAL, Retention.EPHEMERAL,
-        may_egress=False, may_cache=False, read_only=True,
+        direction=Direction.INGRESS, may_egress=False, may_cache=False, read_only=True,
         kubernetes=("secret", "tmpfs-copy"),
         docker=("tmpfs", "secret"),
         podman=("secret", "mount/env"),
     ),
     MountIntent.CONFIG_RO: IntentBinding(
         MountIntent.CONFIG_RO, Layer.CONFIG, Retention.MANAGED_RO,
-        may_egress=False, may_cache=False, read_only=True,
+        direction=Direction.INGRESS, may_egress=False, may_cache=False, read_only=True,
         kubernetes=("configMap", "projected"),
         docker=("bind", "ro"),
         podman=("bind", "ro"),
     ),
     MountIntent.IPC_BRIDGE: IntentBinding(
         MountIntent.IPC_BRIDGE, Layer.NODE_LOCAL, Retention.EPHEMERAL,
-        may_egress=False, may_cache=False, read_only=False,
+        direction=Direction.NONE, may_egress=False, may_cache=False, read_only=False,
         kubernetes=("emptyDir", "socket"),
         docker=("npipe", "named-pipe"),
         podman=("bind", "socket"),
@@ -147,19 +190,71 @@ def binding(intent: MountIntent) -> IntentBinding:
     return _BINDINGS[intent]
 
 
-def resolve(intent: MountIntent, runtime: Runtime) -> dict:
-    """The backend mount spec + policy for an intent on a given runtime."""
+def resolve(intent: MountIntent, runtime: Runtime,
+            link: LinkAvailability = LinkAvailability.RELIABLE) -> dict:
+    """The backend mount spec + policy for an intent — the SECURE form by default.
+
+    The real signature is `intent × link_availability × durability → backend`: a durable
+    egress channel over a RELIABLE link is reference-mounted (one object, no copy, no
+    divergence, no conflict-resolution); over an INTERMITTENT link it is forced into
+    copy+snapshot+reconcile, which is the only case that needs the CRF/ternary machinery.
+    """
     b = binding(intent)
     kind, options = b.backend(runtime)
-    return {
+    sync = _sync_semantics(b, link)
+    out = {
         "intent": intent.value,
         "runtime": runtime.value,
         "layer": b.layer.value,
         "retention": b.retention.value,
+        "direction": b.direction.value,
         "backend": {"kind": kind, "options": options},
         "read_only": b.read_only,
+        "verified_immutable": b.verified_immutable,
+        "tenancy_in_source": b.tenancy_in_source,
+        "sync_semantics": sync["semantics"],
+        "requires_conflict_resolution": sync["requires_conflict_resolution"],
         "policy": {"may_egress": b.may_egress, "may_cache": b.may_cache},
     }
+    if b.verified_immutable:
+        # a verified-immutable mount is meaningless without its pinned root hash; the manifest
+        # MUST supply it (validators enforce presence). Signal the requirement here.
+        out["requires_verity_root_hash"] = True
+    return out
+
+
+def _sync_semantics(b: IntentBinding, link: LinkAvailability) -> dict:
+    """Copy vs reference, and whether conflict-resolution is needed — a function of the
+    (durability × link) product, not a property of the data."""
+    durable_boundary = b.direction in (Direction.EGRESS, Direction.BIDIRECTIONAL)
+    if not durable_boundary:
+        return {"semantics": "node_local", "requires_conflict_resolution": False}
+    if link is LinkAvailability.RELIABLE:
+        # reference-mount the store: no second copy, so no divergence, so no reconciliation.
+        return {"semantics": "reference", "requires_conflict_resolution": False}
+    # intermittent: copy + snapshot + reconcile — this is where SP-EVAL-CRF-001 earns its keep.
+    return {"semantics": "copy", "requires_conflict_resolution": True}
+
+
+def direction(intent: MountIntent) -> Direction:
+    return binding(intent).direction
+
+
+def verified_immutable(intent: MountIntent) -> bool:
+    return binding(intent).verified_immutable
+
+
+def tenant_scoped_source(store: str, tenant: str, path: str) -> str:
+    """Construct a tenant-bound mount source, e.g. `store:<tenant>:/path`.
+
+    Isolation is bound at mount time in the source string and is unforgeable from inside the
+    guest — construction-enforced, not a path prefix or an admission rule a bad manifest can
+    get wrong. Use for every canonical (egress) mount.
+    """
+    tenant = tenant.strip().strip(":")
+    if not tenant:
+        raise ValueError("tenant must be non-empty (tenancy is construction-enforced)")
+    return f"{store}:{tenant}:{path if path.startswith('/') else '/' + path}"
 
 
 # ── Policy gates (Layer 5: the Policy Engine gates egress / caching / deletion) ──────────────
@@ -180,3 +275,24 @@ def may_delete(intent: MountIntent) -> bool:
 
 
 EGRESSABLE_INTENTS: frozenset[MountIntent] = frozenset(i for i in MountIntent if may_egress(i))
+
+# Intents whose workload-boundary DIRECTION is egress — the durable-write chokepoint(s).
+EGRESS_DIRECTION_INTENTS: frozenset[MountIntent] = frozenset(
+    i for i in MountIntent if binding(i).direction in (Direction.EGRESS, Direction.BIDIRECTIONAL)
+)
+
+
+def check_single_egress(intents) -> list[str]:
+    """Enforce the single-egress-chokepoint invariant on a workload's set of mount intents.
+
+    At most one egress mount per workload — the only mount whose contents survive the pod, so
+    egress attestation and chain-of-custody have exactly one place to live. Returns a list of
+    violation strings (empty == ok). This is the workload-level counterpart to the per-device
+    may_egress policy.
+    """
+    egress = [i for i in intents if i in EGRESS_DIRECTION_INTENTS]
+    if len(egress) > 1:
+        names = ", ".join(sorted(i.value for i in egress))
+        return [f"workload declares {len(egress)} egress mounts ({names}); at most one is allowed "
+                f"— egress must have a single durable-write chokepoint"]
+    return []

--- a/libs/python/mount-intent/src/mount_intent/schema.py
+++ b/libs/python/mount-intent/src/mount_intent/schema.py
@@ -6,12 +6,23 @@ PolicyDecision (Layer 5: the Policy Engine records events to the append-only Aud
 """
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
-from typing import Literal
+from typing import Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
-from .intents import MountIntent, Runtime, binding, resolve
+from .intents import (
+    LinkAvailability,
+    MountIntent,
+    Runtime,
+    binding,
+    check_single_egress,
+    resolve,
+    verified_immutable,
+)
+
+_VERITY_ROOT_HASH = re.compile(r"^[0-9a-f]{64}$")  # dm-verity root hash (sha256), hex
 
 
 class MountDeclaration(BaseModel):
@@ -20,9 +31,59 @@ class MountDeclaration(BaseModel):
     name: str = Field(..., description="volume/mount name")
     intent: MountIntent
     mount_path: str = Field(..., description="container path")
+    link_availability: LinkAvailability = Field(
+        default=LinkAvailability.RELIABLE,
+        description="edge↔twin link reliability — decides reference vs copy for egress mounts",
+    )
+    verity_root_hash: Optional[str] = Field(
+        default=None,
+        description="dm-verity root hash (64-hex), pinned in the manifest — REQUIRED for "
+                    "verified-immutable intents (curated_corpus). Makes corpus integrity a "
+                    "signature check, not a trust assertion.",
+    )
+
+    @model_validator(mode="after")
+    def _verity_pinned_when_required(self) -> "MountDeclaration":
+        if verified_immutable(self.intent):
+            if not self.verity_root_hash:
+                raise ValueError(
+                    f"{self.intent.value} is verified-immutable and MUST pin a verity_root_hash "
+                    f"in the manifest (squashfs/erofs + dm-verity)"
+                )
+            if not _VERITY_ROOT_HASH.match(self.verity_root_hash):
+                raise ValueError("verity_root_hash must be a 64-char hex sha256 digest")
+        elif self.verity_root_hash:
+            raise ValueError(
+                f"{self.intent.value} is not verified-immutable — a verity_root_hash is meaningless"
+            )
+        return self
 
     def resolved(self, runtime: Runtime) -> dict:
-        return {"name": self.name, "mount_path": self.mount_path, **resolve(self.intent, runtime)}
+        return {
+            "name": self.name,
+            "mount_path": self.mount_path,
+            "verity_root_hash": self.verity_root_hash,
+            **resolve(self.intent, runtime, self.link_availability),
+        }
+
+
+class WorkloadDeclaration(BaseModel):
+    """A workload's full set of mounts. Enforces the single-egress-chokepoint invariant by
+    construction: at most one egress mount, and it must be named — the only mount whose
+    contents survive the pod, so egress attestation has exactly one home."""
+
+    name: str = Field(..., description="workload name")
+    mounts: list[MountDeclaration] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _single_egress(self) -> "WorkloadDeclaration":
+        violations = check_single_egress([m.intent for m in self.mounts])
+        if violations:
+            raise ValueError(f"{self.name}: " + "; ".join(violations))
+        return self
+
+    def resolved(self, runtime: Runtime) -> list[dict]:
+        return [m.resolved(runtime) for m in self.mounts]
 
 
 Gate = Literal["egress", "caching", "deletion"]

--- a/libs/python/mount-intent/tests/test_directional.py
+++ b/libs/python/mount-intent/tests/test_directional.py
@@ -1,0 +1,117 @@
+"""The directional + verified-immutable + link-aware defaults, enforced by construction."""
+import pytest
+
+from mount_intent import (
+    Direction,
+    LinkAvailability,
+    MountDeclaration,
+    MountIntent,
+    Runtime,
+    WorkloadDeclaration,
+    check_single_egress,
+    direction,
+    resolve,
+    tenant_scoped_source,
+    verified_immutable,
+)
+
+
+# ── direction axis ──────────────────────────────────────────────────────────────────────
+def test_canonical_is_the_only_egress_direction():
+    egress = {i for i in MountIntent if direction(i) in (Direction.EGRESS, Direction.BIDIRECTIONAL)}
+    assert egress == {MountIntent.CANONICAL_DATA}  # a single durable-write chokepoint
+
+
+@pytest.mark.parametrize("intent", [MountIntent.CURATED_CORPUS, MountIntent.CONFIG_RO, MountIntent.SECRETS])
+def test_read_only_inputs_are_ingress(intent):
+    assert direction(intent) == Direction.INGRESS
+
+
+@pytest.mark.parametrize("intent", [MountIntent.SCRATCH, MountIntent.CACHE, MountIntent.DERIVED_INDEX, MountIntent.IPC_BRIDGE])
+def test_node_local_intents_are_none(intent):
+    assert direction(intent) == Direction.NONE
+
+
+# ── single-egress-chokepoint invariant ──────────────────────────────────────────────────
+def test_one_egress_is_allowed():
+    assert check_single_egress([MountIntent.CANONICAL_DATA, MountIntent.CURATED_CORPUS,
+                                MountIntent.SCRATCH]) == []
+
+
+def test_two_egress_is_a_violation():
+    # only one intent is egress-direction, so a genuine 2-egress set needs it twice — the
+    # workload-level check counts declared egress mounts, which the WorkloadDeclaration builds.
+    v = check_single_egress([MountIntent.CANONICAL_DATA, MountIntent.CANONICAL_DATA])
+    assert v and "at most one" in v[0]
+
+
+def test_workload_rejects_two_egress_mounts():
+    with pytest.raises(ValueError, match="at most one"):
+        WorkloadDeclaration(name="w", mounts=[
+            MountDeclaration(name="a", intent=MountIntent.CANONICAL_DATA, mount_path="/a"),
+            MountDeclaration(name="b", intent=MountIntent.CANONICAL_DATA, mount_path="/b"),
+        ])
+
+
+def test_workload_accepts_one_egress_plus_ingress():
+    w = WorkloadDeclaration(name="w", mounts=[
+        MountDeclaration(name="out", intent=MountIntent.CANONICAL_DATA, mount_path="/out"),
+        MountDeclaration(name="corpus", intent=MountIntent.CURATED_CORPUS, mount_path="/corpus",
+                         verity_root_hash="a" * 64),
+        MountDeclaration(name="tmp", intent=MountIntent.SCRATCH, mount_path="/tmp"),
+    ])
+    assert len(w.mounts) == 3
+
+
+# ── verified-immutable corpus: verity root hash is mandatory ─────────────────────────────
+def test_curated_corpus_is_verified_immutable():
+    assert verified_immutable(MountIntent.CURATED_CORPUS) is True
+    r = resolve(MountIntent.CURATED_CORPUS, Runtime.PODMAN)
+    assert r["verified_immutable"] is True and r["requires_verity_root_hash"] is True
+    assert r["backend"]["kind"] == "image"  # the type=image / squashfs+dm-verity backend
+
+
+def test_curated_corpus_requires_pinned_verity_hash():
+    with pytest.raises(ValueError, match="verity_root_hash"):
+        MountDeclaration(name="c", intent=MountIntent.CURATED_CORPUS, mount_path="/c")
+    # a valid 64-hex hash is accepted
+    ok = MountDeclaration(name="c", intent=MountIntent.CURATED_CORPUS, mount_path="/c",
+                          verity_root_hash="f" * 64)
+    assert ok.resolved(Runtime.PODMAN)["verity_root_hash"] == "f" * 64
+
+
+def test_non_verified_intent_rejects_stray_verity_hash():
+    with pytest.raises(ValueError, match="meaningless"):
+        MountDeclaration(name="s", intent=MountIntent.SCRATCH, mount_path="/s",
+                         verity_root_hash="a" * 64)
+
+
+# ── link-aware sync semantics: reference vs copy ─────────────────────────────────────────
+def test_egress_over_reliable_link_is_reference_no_reconciliation():
+    r = resolve(MountIntent.CANONICAL_DATA, Runtime.KUBERNETES, LinkAvailability.RELIABLE)
+    assert r["sync_semantics"] == "reference"
+    assert r["requires_conflict_resolution"] is False
+
+
+def test_egress_over_intermittent_link_forces_copy_and_reconciliation():
+    r = resolve(MountIntent.CANONICAL_DATA, Runtime.KUBERNETES, LinkAvailability.INTERMITTENT)
+    assert r["sync_semantics"] == "copy"
+    assert r["requires_conflict_resolution"] is True  # SP-EVAL-CRF-001 only here
+
+
+def test_node_local_never_needs_reconciliation():
+    for intent in (MountIntent.DERIVED_INDEX, MountIntent.SCRATCH, MountIntent.CACHE):
+        r = resolve(intent, Runtime.PODMAN, LinkAvailability.INTERMITTENT)
+        assert r["sync_semantics"] == "node_local" and r["requires_conflict_resolution"] is False
+
+
+# ── construction-enforced tenancy ────────────────────────────────────────────────────────
+def test_canonical_binds_tenancy_in_source():
+    assert resolve(MountIntent.CANONICAL_DATA, Runtime.KUBERNETES)["tenancy_in_source"] is True
+
+
+def test_tenant_scoped_source_is_constructed():
+    assert tenant_scoped_source("rclone-filestore", "sess_013Sxj", "/mnt/out") \
+        == "rclone-filestore:sess_013Sxj:/mnt/out"
+    with pytest.raises(ValueError):
+        tenant_scoped_source("store", "  ", "/p")  # empty tenant is refused

--- a/libs/python/mount-intent/tests/test_workload_validator.py
+++ b/libs/python/mount-intent/tests/test_workload_validator.py
@@ -1,0 +1,49 @@
+"""The workload-manifest gate: single-egress chokepoint + pinned verity, fail-closed."""
+import importlib.util
+import pathlib
+import sys
+
+_REPO = pathlib.Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(_REPO / "libs" / "python" / "mount-intent" / "src"))
+_spec = importlib.util.spec_from_file_location(
+    "vw", _REPO / "tools" / "validate_mount_intent_workload.py")
+vw = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(vw)
+
+A_MOUNTS = "mount-intent.socioprophet.io/mounts"
+A_VERITY = "mount-intent.socioprophet.io/verity."
+
+
+def _doc(anns):
+    return {"kind": "Deployment", "metadata": {"name": "w", "annotations": anns}}
+
+
+def test_valid_workload_passes():
+    assert vw.validate_doc(_doc({
+        A_MOUNTS: "out=canonical_data,corpus=curated_corpus,tmp=scratch",
+        A_VERITY + "corpus": "a" * 64,
+    }), "f") == []
+
+
+def test_two_egress_rejected():
+    e = vw.validate_doc(_doc({A_MOUNTS: "a=canonical_data,b=canonical_data"}), "f")
+    assert any("at most one" in x for x in e)
+
+
+def test_unpinned_curated_corpus_rejected():
+    e = vw.validate_doc(_doc({A_MOUNTS: "c=curated_corpus"}), "f")
+    assert any("root hash" in x for x in e)
+
+
+def test_bad_verity_hash_rejected():
+    e = vw.validate_doc(_doc({A_MOUNTS: "c=curated_corpus", A_VERITY + "c": "nothex"}), "f")
+    assert any("64-hex" in x for x in e)
+
+
+def test_unknown_intent_rejected():
+    e = vw.validate_doc(_doc({A_MOUNTS: "x=bogus"}), "f")
+    assert any("unknown intent" in x for x in e)
+
+
+def test_unannotated_workload_skipped():
+    assert vw.validate_doc(_doc({}), "f") == []

--- a/tools/validate_mount_intent_workload.py
+++ b/tools/validate_mount_intent_workload.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Enforce the directional mount-intent invariants on workload manifests.
+
+A workload declares its mounts' intents via the annotation
+`mount-intent.socioprophet.io/mounts: <vol>=<intent>[,<vol>=<intent>...]`, and pins the
+verity root hash for any verified-immutable mount via
+`mount-intent.socioprophet.io/verity.<vol>: <64-hex>`.
+
+This gate enforces, by construction, two invariants that keep isolation from drifting:
+
+  1. SINGLE EGRESS CHOKEPOINT — at most one egress-direction mount per workload (the only
+     mount whose contents survive the pod, so egress attestation has one home).
+  2. VERIFIED CORPUS IS PINNED — every curated_corpus (verified-immutable) mount must pin a
+     dm-verity root hash in the manifest, so corpus integrity is a signature check, not a
+     `readOnly: true` trust assertion.
+
+Fail-closed: an unknown intent, a bad verity hash, or a verified-immutable mount with no
+pinned hash is an error. Workloads that declare no mount-intent annotation are skipped (the
+egress-sync gate covers the device boundary separately).
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+import yaml
+
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "libs" / "python" / "mount-intent" / "src"))
+from mount_intent import MountIntent, check_single_egress, verified_immutable  # noqa: E402
+
+MOUNTS_ANN = "mount-intent.socioprophet.io/mounts"
+VERITY_PREFIX = "mount-intent.socioprophet.io/verity."
+SCAN_DIR = _ROOT / "infra" / "k8s"
+WORKLOAD_KINDS = {"Pod", "Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob", "ReplicaSet"}
+_HEX64 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _docs(path: pathlib.Path):
+    try:
+        return [d for d in yaml.safe_load_all(path.read_text()) if isinstance(d, dict)]
+    except yaml.YAMLError:
+        return []
+
+
+def validate_doc(doc: dict, where: str) -> list[str]:
+    meta = doc.get("metadata", {}) or {}
+    anns = meta.get("annotations", {}) or {}
+    raw = anns.get(MOUNTS_ANN)
+    if not raw:
+        return []  # not intent-annotated — device-egress gate covers it separately
+    name = meta.get("name", "<unnamed>")
+    errors: list[str] = []
+
+    pairs: list[tuple[str, MountIntent]] = []
+    for tok in [s.strip() for s in raw.split(",") if s.strip()]:
+        if "=" not in tok:
+            errors.append(f"{where}: {name} mount decl '{tok}' must be <vol>=<intent>")
+            continue
+        vol, intent_raw = (p.strip() for p in tok.split("=", 1))
+        try:
+            pairs.append((vol, MountIntent(intent_raw)))
+        except ValueError:
+            errors.append(f"{where}: {name} declares unknown intent '{intent_raw}' for '{vol}'")
+
+    # 1. single egress chokepoint
+    errors += [f"{where}: {name}: {v}" for v in check_single_egress([i for _, i in pairs])]
+
+    # 2. verified-immutable mounts must pin a valid verity root hash
+    for vol, intent in pairs:
+        if verified_immutable(intent):
+            h = anns.get(VERITY_PREFIX + vol)
+            if not h:
+                errors.append(f"{where}: {name}: '{vol}' is {intent.value} (verified-immutable) but "
+                              f"pins no `{VERITY_PREFIX}{vol}` root hash")
+            elif not _HEX64.match(h):
+                errors.append(f"{where}: {name}: `{VERITY_PREFIX}{vol}` must be a 64-hex sha256 digest")
+    return errors
+
+
+def main() -> int:
+    if not SCAN_DIR.exists():
+        print(f"no k8s dir at {SCAN_DIR} — nothing to validate")
+        return 0
+    errors: list[str] = []
+    checked = 0
+    for path in sorted(SCAN_DIR.rglob("*.yaml")):
+        for doc in _docs(path):
+            if doc.get("kind") not in WORKLOAD_KINDS:
+                continue
+            if not ((doc.get("metadata", {}) or {}).get("annotations", {}) or {}).get(MOUNTS_ANN):
+                continue
+            checked += 1
+            errors += validate_doc(doc, path.name)
+    if errors:
+        print("mount-intent workload invariants VIOLATED:")
+        for e in errors:
+            print("  ✗ " + e)
+        return 1
+    print(f"mount-intent workload invariants OK ({checked} intent-annotated workload(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Implements a sandbox-substrate analysis of the mount taxonomy and bakes its lessons in as **defaults**, so isolation sticks from day one instead of depending on per-manifest care. Reframes `intent → backend` into `intent × link_availability × durability → backend`.

## Four construction-enforced invariants (each with a fail-closed CI gate + tests)
1. **Direction axis** — every intent is `ingress` / `egress` / node-local. `canonical_data` is the *only* egress intent, and **at most one egress mount per workload** — a single durable-write chokepoint, one home for egress attestation. *(Was: `canonical_data` permitted PVC|Docker|Podman all rw = three attestation points.)*
2. **Verified-immutable corpus** — `curated_corpus` defaults to a `type=image` backend (squashfs/erofs + **dm-verity**) and *must pin a `verity_root_hash`*. Integrity becomes a signature check, not a `readOnly: true` assertion another view can bypass. Wires the `type=image` backend to `curated_corpus` as T0.
3. **Construction-enforced tenancy** — `canonical_data` binds the tenant in the mount *source* (`store:<tenant>:/path`), unforgeable from inside the guest.
4. **Link-aware sync** — egress over a *reliable* link is reference-mounted (no copy → no divergence → no reconciliation); over an *intermittent* link it's forced into copy+reconcile — the only case that needs the conflict-resolution machinery. `resolve()` returns `sync_semantics` + `requires_conflict_resolution`.

## Made active, not just available
- `resolve()`/`MountDeclaration` return the secure form by default.
- New `WorkloadDeclaration` + `tools/validate_mount_intent_workload.py` gate the single-egress + pinned-verity invariants in CI.
- Annotated the **real** edge→twin sync CronJob with the `mounts` annotation so the gate has a live subject today.
- **71 tests** pass.

_(Note: `wt-identity-twin` and `prophet-platform-household-twin` are git worktrees of THIS repo, not separate repos — this single PR to main is the source of truth; no mirror sync needed.)_

Touches a workflow — flagged for human review; not auto-merging.