### PR TITLE
fix(dashboard-bff): resilient producer loading — one bad import no longer crashloops the service

### DIFF
--- a/apps/dashboard-bff/main.py
+++ b/apps/dashboard-bff/main.py
@@ -36,19 +36,59 @@ def _load_module(path: Path, name: str):
     return module
 
 
+# One broken producer must not crashloop the whole BFF. contracts.py is REQUIRED (fail closed
+# if it can't load — the response models are core to every endpoint); the tool producers below
+# are each used by ONE endpoint, so a producer that fails to import degrades only its endpoint
+# (a loud 503 naming the import error) and every other endpoint keeps serving. Failures are
+# surfaced in the startup log, never swallowed — the arcticdb/compute-gateway silent-down lesson:
+# a service that dies whole because one optional dependency is missing is a fragility, not safety.
+_FAILED_PRODUCERS: dict[str, str] = {}
+
+
+class _FailedProducer:
+    """Stands in for a producer module that failed to import. Any attribute access — an
+    endpoint reaching for `.emit()` — raises a 503 naming the producer and the underlying
+    error, so the endpoint fails honestly while the service stays up."""
+
+    def __init__(self, name: str, error: BaseException) -> None:
+        self._name = name
+        self._error = f'{type(error).__name__}: {error}'
+
+    def __getattr__(self, _attr: str):
+        raise HTTPException(status_code=503,
+                            detail=f"producer '{self._name}' unavailable: {self._error}")
+
+
+def _try_load(rel_tool: str, name: str):
+    """Load a per-endpoint producer resiliently — the module on success, else a
+    _FailedProducer sentinel (recorded in _FAILED_PRODUCERS) so boot never fails."""
+    try:
+        return _load_module(ROOT / 'tools' / rel_tool, name)
+    except Exception as e:  # noqa: BLE001 — a producer can fail for any import-time reason
+        _FAILED_PRODUCERS[name] = f'{type(e).__name__}: {e}'
+        return _FailedProducer(name, e)
+
+
+# REQUIRED: the response models every endpoint declares. If this can't load, fail closed.
 _contracts = _load_module(Path(__file__).with_name('contracts.py'), 'dashboard_bff_contracts')
 OverviewResponse = _contracts.OverviewResponse
-_producer = _load_module(ROOT / 'tools' / 'emit_intelligence_superiority_metrics.py', 'emit_metrics')
-_vdt_producer = _load_module(ROOT / 'tools' / 'emit_vdt_metrics.py', 'emit_vdt_metrics')
-_gyg_causal_producer = _load_module(ROOT / 'tools' / 'emit_gyg_causal.py', 'emit_gyg_causal')
-_gyg_locations_producer = _load_module(ROOT / 'tools' / 'emit_gyg_locations.py', 'emit_gyg_locations')
-_company_financials = _load_module(ROOT / 'tools' / 'emit_company_financials.py', 'emit_company_financials')
-_studio = _load_module(ROOT / 'tools' / 'emit_studio_valuation.py', 'emit_studio_valuation')
-_governance_test = _load_module(ROOT / 'tools' / 'emit_governance_test.py', 'emit_governance_test')
-_risk_ep = _load_module(ROOT / 'tools' / 'emit_risk_ep_facts.py', 'emit_risk_ep_facts')
 RiskEpFactsResponse = _contracts.RiskEpFactsResponse
-_board_producer = _load_module(ROOT / 'tools' / 'emit_intelligence_superiority_board.py', 'emit_is_board')
-_board_validator = _load_module(ROOT / 'tools' / 'validate_intelligence_superiority_board.py', 'is_board_validator')
+
+# Per-endpoint producers — resilient: one bad import degrades its endpoint, not the service.
+_producer = _try_load('emit_intelligence_superiority_metrics.py', 'emit_metrics')
+_vdt_producer = _try_load('emit_vdt_metrics.py', 'emit_vdt_metrics')
+_gyg_causal_producer = _try_load('emit_gyg_causal.py', 'emit_gyg_causal')
+_gyg_locations_producer = _try_load('emit_gyg_locations.py', 'emit_gyg_locations')
+_company_financials = _try_load('emit_company_financials.py', 'emit_company_financials')
+_studio = _try_load('emit_studio_valuation.py', 'emit_studio_valuation')
+_governance_test = _try_load('emit_governance_test.py', 'emit_governance_test')
+_risk_ep = _try_load('emit_risk_ep_facts.py', 'emit_risk_ep_facts')
+_board_producer = _try_load('emit_intelligence_superiority_board.py', 'emit_is_board')
+_board_validator = _try_load('validate_intelligence_superiority_board.py', 'is_board_validator')
+
+if _FAILED_PRODUCERS:
+    print(f'[dashboard-bff] WARN {len(_FAILED_PRODUCERS)} producer(s) failed to import and will '
+          f'503 on their endpoints; the rest serve: {_FAILED_PRODUCERS}', file=sys.stderr, flush=True)
 
 _SLUG_RE = re.compile(r'[^a-z0-9]+')
 
@@ -91,7 +131,12 @@ app.add_middleware(
 
 @app.get('/health')
 def health() -> dict:
-    return {'service': 'dashboard-bff', 'status': 'ok'}
+    # 'ok' = the service is up and serving. degraded_producers names any per-endpoint producer
+    # that failed to import (those endpoints 503) so the degradation is visible on the liveness
+    # surface instead of hidden until someone hits the endpoint. Liveness stays green: a degraded
+    # endpoint is not a dead service — that distinction is the whole point of this change.
+    return {'service': 'dashboard-bff', 'status': 'ok',
+            'degraded_producers': sorted(_FAILED_PRODUCERS)}
 
 @app.get('/v1/overview', response_model=OverviewResponse)
 def overview() -> object:

--- a/apps/dashboard-bff/test_resilient_producers.py
+++ b/apps/dashboard-bff/test_resilient_producers.py
@@ -1,0 +1,61 @@
+"""Boot resilience: one broken producer must not crashloop the whole dashboard-bff.
+
+The 2026-08-04 incident: dashboard-bff eagerly imported ~11 tools/emit_*.py producers at boot;
+emit_risk_ep_facts.py imports a vendored framework (open_ep_framework) absent from the prod
+image, so the WHOLE service crashlooped (120+ restarts) — every endpoint down because one
+endpoint's producer couldn't import. The fix degrades a failed producer to a loud per-endpoint
+503 and keeps the service up. These pin it both ways.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import main  # noqa: E402
+
+client = TestClient(main.app)
+
+
+def test_boots_and_health_reports_producer_status():
+    r = client.get('/health')
+    assert r.status_code == 200
+    body = r.json()
+    assert body['status'] == 'ok'
+    # degradation is VISIBLE on the liveness surface, not hidden until an endpoint is hit
+    assert isinstance(body['degraded_producers'], list)
+
+
+def test_overview_serves():
+    # proves the app booted and a non-producer endpoint serves
+    assert client.get('/v1/overview').status_code == 200
+
+
+def test_failed_producer_sentinel_raises_503_naming_the_error():
+    fp = main._FailedProducer('emit_risk_ep_facts', ImportError("No module named 'open_ep_framework'"))
+    with pytest.raises(HTTPException) as ei:
+        fp.emit()
+    assert ei.value.status_code == 503
+    assert 'emit_risk_ep_facts' in ei.value.detail
+    assert 'open_ep_framework' in ei.value.detail
+
+
+def test_try_load_missing_tool_degrades_instead_of_crashing():
+    main._FAILED_PRODUCERS.pop('ghost_producer', None)
+    mod = main._try_load('definitely_missing_tool_qux.py', 'ghost_producer')
+    assert isinstance(mod, main._FailedProducer)          # boot survives a missing producer
+    assert 'ghost_producer' in main._FAILED_PRODUCERS      # recorded → /health + startup log
+
+
+def test_incident_repro_missing_producer_503s_its_endpoint_others_stay_up(monkeypatch):
+    # Reproduce the exact incident: the risk-EP producer can't import in the prod image.
+    monkeypatch.setattr(main, '_risk_ep', main._FailedProducer(
+        'emit_risk_ep_facts', ImportError("No module named 'open_ep_framework'")))
+    # its endpoint fails LOUDLY, naming the missing dependency...
+    r = client.get('/v1/risk/portfolio-facts')
+    assert r.status_code == 503
+    assert 'open_ep_framework' in r.json()['detail']
+    # ...while an unrelated endpoint keeps serving — the service is degraded, NOT down.
+    assert client.get('/v1/overview').status_code == 200


### PR DESCRIPTION
## Incident
`dashboard-bff` has been in **CrashLoopBackOff (120+ restarts)** in `socioprophet`, surfaced the moment the deploy-health alerter (#1346) went live. Root cause: it eagerly `_load_module`s ~11 `tools/emit_*.py` producers at import, and `emit_risk_ep_facts.py` imports `open_ep_framework` — absent from the prod image — so the **whole service** died at boot. Every endpoint down because one endpoint's producer couldn't import.

## Fix (the pattern, not the instance)
- `contracts.py` stays **required** (fail closed — response models are core to every endpoint).
- Each tool producer now loads via `_try_load`; on failure it returns a `_FailedProducer` sentinel recorded in `_FAILED_PRODUCERS`.
- Any endpoint reaching for a failed producer gets a **loud 503** naming the import error; **every other endpoint keeps serving**.
- `/health` surfaces `degraded_producers`; a startup-log WARN lists them — never swallowed.

## Tests (5, incl. exact incident repro)
- boot + `/health` reports producer status; `/v1/overview` serves
- `_FailedProducer` raises 503 naming the producer + error
- `_try_load` of a missing tool degrades instead of crashing
- **incident repro**: `_risk_ep` missing → `/v1/risk/portfolio-facts` 503s with `open_ep_framework` in the detail, `/v1/overview` still 200

Same silent-down lesson as the compute-gateway OOM: a service that dies whole because one optional dependency is missing is a fragility, not safety.

**Follow-up:** this makes the bff boot; `/v1/risk/portfolio-facts` still needs `open_ep_framework` vendored into the image to actually serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)