### PR TITLE
feat(autonomy): validator-quorum Genesis Guard — high autonomy is not self-granted

### DIFF
--- a/.github/workflows/autonomy-quorum.yml
+++ b/.github/workflows/autonomy-quorum.yml
@@ -1,0 +1,33 @@
+name: autonomy-quorum
+
+# The Genesis Guard: high-autonomy admission requires a validator quorum (QuorumProof),
+# conforming to the authoritative shape. This gate proves the verifier is fail-closed.
+on:
+  push:
+    paths:
+      - 'tools/quorum.py'
+      - 'tools/test_quorum.py'
+      - 'tools/emit_autonomy_admission_receipt.py'
+      - '.github/workflows/autonomy-quorum.yml'
+  pull_request:
+    paths:
+      - 'tools/quorum.py'
+      - 'tools/test_quorum.py'
+      - 'tools/emit_autonomy_admission_receipt.py'
+      - '.github/workflows/autonomy-quorum.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  quorum:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install test deps
+        run: pip install pytest
+      - name: Verify quorum gate is fail-closed and threshold-correct
+        run: python3 -m pytest tools/test_quorum.py -q

--- a/tools/emit_autonomy_admission_receipt.py
+++ b/tools/emit_autonomy_admission_receipt.py
@@ -31,6 +31,8 @@ from validate_autonomy_admission_receipt import validate_receipt  # noqa: E402
 # (surface/action) is supplied. Absent that, we stay the legacy autonomy-only
 # gate and emit a v0.1 receipt.
 from capability_membrane import CapabilityRequest, resolve_capability  # noqa: E402
+# Genesis Guard: high autonomy is not self-granted — it requires a validator quorum.
+from quorum import quorum_gate  # noqa: E402
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_LADDER = ROOT / "contracts" / "prophet-mesh" / "ai-driven-development.ladder.json"
@@ -240,6 +242,11 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--membrane-decision", default="ALLOW", help="upstream membrane verdict")
     parser.add_argument("--scope", default="user_local", help="user_local | global_platform")
     parser.add_argument("--unowned", action="store_true", help="surface we do not own → observe-only")
+    # Genesis Guard: a grant at or above the floor requires a validator quorum (QuorumProof).
+    parser.add_argument("--quorum-proof", help="path to a QuorumProof JSON co-signing this admission")
+    parser.add_argument("--quorum-floor", default="L3", help="autonomy level at/above which a quorum is required")
+    parser.add_argument("--enforce-quorum", action="store_true",
+                        help="demote the grant below the floor when the quorum is unmet (default: advisory)")
     args = parser.parse_args(argv[1:])
 
     ladder = Ladder.load(Path(args.ladder))
@@ -294,6 +301,32 @@ def main(argv: list[str]) -> int:
             decision["granted_level"] = "L0"
             decision["decision"] = "deny"
             decision["reason"] = "; ".join(x for x in (decision.get("reason", ""), note) if x)
+
+    # Genesis Guard: a grant at or above --quorum-floor requires a validator quorum co-signing
+    # THIS admission. Advisory by default (records satisfied/unmet in the reason + a quorum://
+    # policy ref, never lowers the grant); --enforce-quorum demotes an unmet quorum below the
+    # floor. Conforms to the authoritative QuorumProof shape; binds the quorum to the operation.
+    floor_rank = max(_rank(args.quorum_floor), 0)
+    granted_rank = max(_rank(decision["granted_level"]), 0)
+    if granted_rank >= floor_rank:
+        proof = None
+        if args.quorum_proof:
+            proof = json.loads(Path(args.quorum_proof).read_text(encoding="utf-8"))
+        q_payload = {"subject_ref": subject_ref,
+                     "requested_level": decision["requested_level"],
+                     "surface": surface or ""}
+        q_hash = "sha256:" + hashlib.sha256(_canonical_bytes(q_payload)).hexdigest()
+        qg = quorum_gate(granted_rank, floor_rank=floor_rank, proof=proof,
+                         payload_hash=q_hash, enforce=args.enforce_quorum)
+        decision = dict(decision)
+        note = (f"validator quorum {'satisfied' if qg['quorum_ok'] else 'UNMET'} "
+                f"(floor {args.quorum_floor}): {qg['reason']}")
+        decision["reason"] = "; ".join(x for x in (decision.get("reason", ""), note) if x)
+        if qg.get("demoted"):
+            decision["granted_level"] = f"L{qg['granted_rank']}"
+            decision["decision"] = "demote"
+        if proof is not None:
+            policy_refs = list(dict.fromkeys(policy_refs + [f"quorum://{proof.get('rule', '?')}/{q_hash}"]))
 
     created_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     receipt_id = args.receipt_id or f"aar-{int(time.time())}"

--- a/tools/quorum.py
+++ b/tools/quorum.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Validator-quorum verification for autonomy admission — the canon's "Genesis Guard".
+
+The Source Canon requires that dangerous / high-autonomy actions are not self-granted: a
+QUORUM of independent validators (`min_validators: 3, threshold: 2/3`) must co-sign, and
+"every validator keeps its own truth" (each signature is an independent witness). Today the
+platform admits with a single membrane decision; this makes the quorum real.
+
+It CONFORMS to the authoritative QuorumProof shape
+(mcp-a2a-zero-trust :: schemas/canonical/quorum_proof.schema.json, vendored under
+apps/compute-gateway/.../schemas) — we verify that shape, we do not invent one:
+
+    { "rule": "2of3-human",
+      "validators": ["spiffe://validators/human1", ...],
+      "signed_payload_hash": "sha256:<64hex>",
+      "signatures": [ {"kind":"human","spiffe_id":"spiffe://validators/human1","sig":"..."} ] }
+
+`verify_quorum` is fail-closed: any missing field, a rule that doesn't parse, a signer not in
+the validator set, a duplicate signer, a payload-hash mismatch, or fewer than `threshold`
+signatures → NOT a valid quorum. `quorum_gate` is the Genesis Guard: an autonomy level at or
+above a floor requires a valid quorum, else the grant is demoted.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+
+_RULE = re.compile(r"^(\d+)of(\d+)-([a-z]+)$")           # e.g. "2of3-human"
+_PAYLOAD_HASH = re.compile(r"^sha256:[a-f0-9]{64}$")
+_SIG_MIN_LEN = 16
+
+
+@dataclass(frozen=True)
+class QuorumRule:
+    threshold: int
+    total: int
+    kind: str
+
+
+def parse_rule(rule: str) -> Optional[QuorumRule]:
+    """`MofN-kind` → QuorumRule, or None if malformed / non-sensical (M>N, M<1)."""
+    m = _RULE.match(rule or "")
+    if not m:
+        return None
+    threshold, total = int(m.group(1)), int(m.group(2))
+    if threshold < 1 or total < 1 or threshold > total:
+        return None
+    return QuorumRule(threshold, total, m.group(3))
+
+
+def verify_quorum(proof: dict, *, payload_hash: Optional[str] = None) -> tuple[bool, list[str]]:
+    """Fail-closed verification of a QuorumProof against the canonical shape + threshold.
+
+    If `payload_hash` is given, the proof must be over exactly that payload (binds the quorum
+    to the thing being admitted). Returns (ok, reasons); reasons is non-empty on failure.
+    """
+    reasons: list[str] = []
+    if not isinstance(proof, dict):
+        return False, ["quorum proof is not an object"]
+
+    # required shape
+    for field in ("rule", "validators", "signed_payload_hash", "signatures"):
+        if field not in proof:
+            reasons.append(f"missing required field '{field}'")
+    if reasons:
+        return False, reasons
+
+    rule = parse_rule(proof["rule"])
+    if rule is None:
+        return False, [f"rule '{proof['rule']}' does not parse as MofN-kind (M>=1, M<=N)"]
+
+    validators = proof["validators"]
+    if not isinstance(validators, list) or not validators:
+        return False, ["validators must be a non-empty list"]
+    validator_set = set(validators)
+    if len(validator_set) != len(validators):
+        reasons.append("validators list has duplicates")
+    if len(validator_set) < rule.total:
+        reasons.append(f"rule needs {rule.total} validators; only {len(validator_set)} listed")
+
+    phash = proof["signed_payload_hash"]
+    if not isinstance(phash, str) or not _PAYLOAD_HASH.match(phash):
+        reasons.append("signed_payload_hash must be 'sha256:<64hex>'")
+    elif payload_hash is not None and phash != payload_hash:
+        reasons.append("signed_payload_hash does not match the admitted payload (quorum unbound)")
+
+    sigs = proof["signatures"]
+    if not isinstance(sigs, list) or not sigs:
+        return False, reasons + ["signatures must be a non-empty list"]
+
+    seen: set[str] = set()
+    valid = 0
+    for i, s in enumerate(sigs):
+        if not isinstance(s, dict) or any(k not in s for k in ("kind", "spiffe_id", "sig")):
+            reasons.append(f"signature[{i}] missing kind/spiffe_id/sig")
+            continue
+        if s["kind"] != rule.kind:
+            reasons.append(f"signature[{i}] kind '{s['kind']}' != rule kind '{rule.kind}'")
+            continue
+        if s["spiffe_id"] not in validator_set:
+            reasons.append(f"signature[{i}] signer '{s['spiffe_id']}' is not a listed validator")
+            continue
+        if s["spiffe_id"] in seen:
+            reasons.append(f"signature[{i}] duplicate signer '{s['spiffe_id']}'")
+            continue
+        if not isinstance(s["sig"], str) or len(s["sig"]) < _SIG_MIN_LEN:
+            reasons.append(f"signature[{i}] sig too short / missing")
+            continue
+        seen.add(s["spiffe_id"])
+        valid += 1
+
+    if valid < rule.threshold:
+        reasons.append(f"{valid} valid distinct signature(s) < threshold {rule.threshold} "
+                       f"(rule {proof['rule']})")
+
+    ok = not reasons
+    return ok, reasons
+
+
+def compose_quorum_proof(rule: str, validators: Iterable[str], payload_hash: str,
+                         signatures: Iterable[dict]) -> dict:
+    """Assemble a QuorumProof dict (does not sign — callers supply signatures)."""
+    return {
+        "rule": rule,
+        "validators": list(validators),
+        "signed_payload_hash": payload_hash,
+        "signatures": list(signatures),
+    }
+
+
+def quorum_gate(granted_rank: int, *, floor_rank: int, proof: Optional[dict],
+                payload_hash: Optional[str] = None,
+                enforce: bool = False) -> dict[str, Any]:
+    """Genesis Guard: a grant at or above `floor_rank` requires a valid validator quorum.
+
+    Advisory by default (records the requirement + whether it was met, never lowers the grant),
+    so wiring this cannot break the current single-decision admission. With enforce=True an
+    unmet quorum DEMOTES the grant to just below the floor — high autonomy is never self-granted.
+    """
+    if granted_rank < floor_rank:
+        return {"quorum_required": False, "quorum_ok": True, "granted_rank": granted_rank,
+                "reason": f"L{granted_rank} below quorum floor L{floor_rank}"}
+    ok, reasons = (False, ["no quorum proof supplied"]) if proof is None \
+        else verify_quorum(proof, payload_hash=payload_hash)
+    result = {"quorum_required": True, "quorum_ok": ok, "granted_rank": granted_rank,
+              "floor_rank": floor_rank, "reason": "; ".join(reasons) or "quorum satisfied"}
+    if not ok and enforce:
+        result["granted_rank"] = floor_rank - 1
+        result["demoted"] = True
+    return result

--- a/tools/test_quorum.py
+++ b/tools/test_quorum.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Tests for the validator-quorum gate — fail-closed, schema-conformant, threshold-correct."""
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from quorum import compose_quorum_proof, parse_rule, quorum_gate, verify_quorum  # noqa: E402
+
+V = ["spiffe://validators/h1", "spiffe://validators/h2", "spiffe://validators/h3"]
+PH = "sha256:" + "a" * 64
+
+
+def _sig(vid, s="MEUCIQD" + "f" * 20):
+    return {"kind": "human", "spiffe_id": vid, "sig": s}
+
+
+def _proof(sigs, rule="2of3-human", validators=None, phash=PH):
+    return compose_quorum_proof(rule, validators or V, phash, sigs)
+
+
+# ── rule parsing ─────────────────────────────────────────────────────────────
+def test_parse_valid_rule():
+    r = parse_rule("2of3-human")
+    assert r and r.threshold == 2 and r.total == 3 and r.kind == "human"
+
+
+def test_parse_rejects_threshold_gt_total():
+    assert parse_rule("4of3-human") is None
+
+
+def test_parse_rejects_malformed():
+    assert parse_rule("two-of-three") is None and parse_rule("") is None
+
+
+# ── verify_quorum: fail-closed ───────────────────────────────────────────────
+def test_valid_two_of_three_accepted():
+    ok, why = verify_quorum(_proof([_sig(V[0]), _sig(V[1])]), payload_hash=PH)
+    assert ok, why
+
+
+def test_below_threshold_rejected():
+    ok, _ = verify_quorum(_proof([_sig(V[0])]))
+    assert not ok
+
+
+def test_non_validator_signer_rejected():
+    ok, why = verify_quorum(_proof([_sig(V[0]), _sig("spiffe://validators/intruder")]))
+    assert not ok and any("not a listed" in x for x in why)
+
+
+def test_duplicate_signer_not_counted_twice():
+    ok, why = verify_quorum(_proof([_sig(V[0]), _sig(V[0])]))
+    assert not ok and any("duplicate" in x for x in why)
+
+
+def test_payload_hash_binding():
+    ok, why = verify_quorum(_proof([_sig(V[0]), _sig(V[1])]), payload_hash="sha256:" + "b" * 64)
+    assert not ok and any("does not match" in x for x in why)
+
+
+def test_bad_payload_hash_format_rejected():
+    ok, _ = verify_quorum(_proof([_sig(V[0]), _sig(V[1])], phash="not-a-hash"))
+    assert not ok
+
+
+def test_kind_mismatch_rejected():
+    sigs = [{"kind": "machine", "spiffe_id": V[0], "sig": "x" * 20},
+            {"kind": "machine", "spiffe_id": V[1], "sig": "x" * 20}]
+    ok, _ = verify_quorum(_proof(sigs))
+    assert not ok
+
+
+def test_missing_field_rejected():
+    ok, why = verify_quorum({"rule": "2of3-human", "validators": V, "signatures": [_sig(V[0])]})
+    assert not ok and any("signed_payload_hash" in x for x in why)
+
+
+def test_too_few_validators_for_rule_rejected():
+    ok, _ = verify_quorum(compose_quorum_proof("2of3-human", V[:2], PH, [_sig(V[0]), _sig(V[1])]))
+    assert not ok
+
+
+# ── Genesis Guard gate ───────────────────────────────────────────────────────
+def test_below_floor_needs_no_quorum():
+    g = quorum_gate(2, floor_rank=3, proof=None)
+    assert g["quorum_required"] is False and g["quorum_ok"]
+
+
+def test_at_floor_with_valid_quorum_admits():
+    g = quorum_gate(3, floor_rank=3, proof=_proof([_sig(V[0]), _sig(V[1])]), payload_hash=PH)
+    assert g["quorum_ok"] and g["granted_rank"] == 3
+
+
+def test_advisory_records_unmet_without_demote():
+    g = quorum_gate(3, floor_rank=3, proof=None, enforce=False)
+    assert g["quorum_required"] and not g["quorum_ok"] and g["granted_rank"] == 3
+
+
+def test_enforce_demotes_unmet_quorum():
+    g = quorum_gate(4, floor_rank=3, proof=None, enforce=True)
+    assert g.get("demoted") and g["granted_rank"] == 2
+
+
+if __name__ == "__main__":
+    import subprocess
+    raise SystemExit(subprocess.call(["python3", "-m", "pytest", "-q", __file__]))


### PR DESCRIPTION
## Summary
Establishes the **Source Canon's biggest declared-unenforced control** as truth: quorum / witness-mesh (*"min_validators 3, threshold 2/3; dangerous verbs blocked if quorum unsatisfied"*). Admission was a single membrane decision; a **high-autonomy grant now requires a QUORUM of independent validators to co-sign** — the canon's "Genesis Guard."

## Conform, don't invent
Verifies the **authoritative** `QuorumProof` shape (`mcp-a2a-zero-trust :: schemas/canonical/quorum_proof.schema.json`, vendored under `apps/compute-gateway`): `rule` (`MofN-kind`), `validators`, `signed_payload_hash`, `signatures[]`. We verify the canonical shape; we do not define one.

## What's here
- **`tools/quorum.py`** — `verify_quorum()` is **fail-closed**: rejects sub-threshold, non-validator signers, duplicate signers, **payload-hash mismatch** (binds the quorum to the admitted operation), kind mismatch, malformed rules. `quorum_gate()` is the Genesis Guard: a grant at/above a floor requires a valid quorum.
- **`emit_autonomy_admission_receipt.py`** — wired **advisory-by-default** (records satisfied/UNMET in the reason + a `quorum://<rule>/<hash>` policy ref, never lowers the grant → cannot break current admission); `--enforce-quorum` **demotes** an unmet quorum below the floor (proven L4→L2). Every receipt still self-validates against the `AutonomyAdmissionReceipt` contract.
- **`tools/test_quorum.py`** (16 tests) + **`autonomy-quorum.yml`** gate it.

## Proven end-to-end
- advisory, no quorum → L4 admitted, reason: *"validator quorum UNMET (floor L3)"*
- enforce, no quorum → **demoted L4→L2**
- valid 2-of-3 bound to the op → L4 admitted, `quorum://2of3-human/sha256:…` recorded

## Follow-ups
- Real validator signing (FIDO2/NitroKey) + witness-mesh replication ("every validator keeps its own truth").
- Require the quorum for the **OS-build admission** (extends socioprophet #557).

Touches a workflow — flagged for human review; not auto-merging.