### PR TITLE
producer: wire the CPU throttle signal so CPU limits can reach PROVED (P2.9)

### DIFF
--- a/infra/k8s/resource-contract-producer/base/cronjob.yaml
+++ b/infra/k8s/resource-contract-producer/base/cronjob.yaml
@@ -44,6 +44,11 @@ spec:
                 - socioprophet
                 - --publish-url
                 - http://global-devsecops-intelligence.socioprophet.svc.cluster.local:8840/mesh/telemetry
+                # CPU throttle signal (container_cpu_cfs_throttled_periods_total) so CPU limits can
+                # reach PROVED, not just INCONCLUSIVE. Best-effort: if Prometheus is unreachable,
+                # CPU stays INCONCLUSIVE and emission still completes.
+                - --prometheus-url
+                - http://kube-prometheus-stack-prometheus.observability.svc:9090
               volumeMounts:
                 - name: producer
                   mountPath: /opt/producer/emit_resource_contracts.py

--- a/infra/k8s/resource-contract-producer/base/emit_resource_contracts.py
+++ b/infra/k8s/resource-contract-producer/base/emit_resource_contracts.py
@@ -52,6 +52,7 @@ import subprocess
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
@@ -225,6 +226,39 @@ def sample_peaks(ns: str, samples: int, interval: float) -> tuple[dict, int]:
     return peaks, taken
 
 
+def cpu_throttle_by_pod(prometheus_url: str, ns: str, window_s: float) -> dict[str, float] | None:
+    """Throttled CFS periods per pod over the window, from Prometheus (cAdvisor). None on failure.
+
+    This is the missing CPU enforcement signal: `container_cpu_cfs_throttled_periods_total` is the
+    number of scheduler periods in which the container was throttled because it hit its CPU limit.
+    The k8s API does not expose it, which is why CPU verdicts are INCONCLUSIVE without this — the
+    limit's teeth are simply unobserved. `increase(...[window])` > 0 means throttling FIRED.
+    None (query failed) is distinct from {} (queried, nothing throttled): the caller keeps CPU
+    INCONCLUSIVE on None, but can reach PROVED/VIOLATION on a real {} / positive result.
+    """
+    win = max(int(window_s), 60)
+    q = (f'sum by (pod) (increase(container_cpu_cfs_throttled_periods_total'
+         f'{{namespace="{ns}"}}[{win}s]))')
+    url = prometheus_url.rstrip("/") + "/api/v1/query?query=" + urllib.parse.quote(q)
+    try:
+        with urllib.request.urlopen(urllib.request.Request(url, headers={"Accept": "application/json"}),
+                                    timeout=15) as r:
+            data = json.load(r)
+    except (urllib.error.URLError, OSError, ValueError) as e:
+        sys.stderr.write(f"[producer] prometheus throttle query failed: {e}\n")
+        return None
+    if data.get("status") != "success":
+        return None
+    out: dict[str, float] = {}
+    for res in data.get("data", {}).get("result", []):
+        pod = (res.get("metric") or {}).get("pod", "")
+        try:
+            out[pod] = float((res.get("value") or [None, "0"])[1])
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--namespace", default="socioprophet")
@@ -234,6 +268,10 @@ def main() -> int:
     ap.add_argument("--publish-url", default="",
                     help="POST each contract as a resource_contract EventEnvelope to a mesh "
                          "ingest URL (best-effort; emission always completes regardless)")
+    ap.add_argument("--prometheus-url", default="",
+                    help="Prometheus base URL to read the CPU throttle signal "
+                         "(container_cpu_cfs_throttled_periods_total). Without it, CPU stays "
+                         "INCONCLUSIVE — the throttle counter is not on the k8s API.")
     args = ap.parse_args()
     ns = args.namespace
 
@@ -260,6 +298,15 @@ def main() -> int:
             if cs.get("lastState", {}).get("terminated", {}).get("reason") == "OOMKilled":
                 oom[owner(nm)] = oom.get(owner(nm), 0) + 1
 
+    # CPU throttle count per workload (CPU enforcement FIRED), from Prometheus if wired.
+    # throttle is None when unavailable (CPU stays INCONCLUSIVE) vs a dict when queried.
+    throttle_by_pod = cpu_throttle_by_pod(args.prometheus_url, ns, window_s) if args.prometheus_url else None
+    wl_throttle: dict[str, float] | None = None
+    if throttle_by_pod is not None:
+        wl_throttle = {}
+        for pod, cnt in throttle_by_pod.items():
+            wl_throttle[owner(pod)] = wl_throttle.get(owner(pod), 0.0) + cnt
+
     # aggregate pod peaks -> workload peaks
     wl_peak: dict[str, dict] = {}
     for pod, d in pod_peak.items():
@@ -283,8 +330,12 @@ def main() -> int:
             specs.append(("memory", "bytes", _mem_to_bytes(lim["memory"]), peak["mem"],
                           "terminate", oom.get(name, 0)))          # OOMKill = real fired signal
         if lim.get("cpu"):
+            # throttle FIRED signal from Prometheus if wired; None keeps CPU INCONCLUSIVE (the
+            # counter is not on the k8s API). A workload with a CPU limit but no throttle series
+            # yet has fired 0 (queried, none) → still a real, gate-eligible observation.
+            cpu_fired = None if wl_throttle is None else int(wl_throttle.get(name, 0))
             specs.append(("cpu", "millicores", _cpu_to_millicores(lim["cpu"]), peak["cpu"],
-                          "throttle", None))                       # throttle counter not collected
+                          "throttle", cpu_fired))
         if not specs:
             unbounded.append(name)
             continue

--- a/infra/k8s/resource-contract-producer/base/emit_resource_contracts.py
+++ b/infra/k8s/resource-contract-producer/base/emit_resource_contracts.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import ssl
 import subprocess
@@ -253,9 +254,14 @@ def cpu_throttle_by_pod(prometheus_url: str, ns: str, window_s: float) -> dict[s
     for res in data.get("data", {}).get("result", []):
         pod = (res.get("metric") or {}).get("pod", "")
         try:
-            out[pod] = float((res.get("value") or [None, "0"])[1])
+            val = float((res.get("value") or [None, "0"])[1])
         except (TypeError, ValueError):
             continue
+        # Prometheus returns NaN/Inf for absent or divide-by-zero series; int(NaN) would later
+        # raise and crash EMISSION, which must never happen for a best-effort signal. Drop them.
+        if not math.isfinite(val):
+            continue
+        out[pod] = val
     return out
 
 

--- a/tools/emit_resource_contracts.py
+++ b/tools/emit_resource_contracts.py
@@ -52,6 +52,7 @@ import subprocess
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
@@ -225,6 +226,39 @@ def sample_peaks(ns: str, samples: int, interval: float) -> tuple[dict, int]:
     return peaks, taken
 
 
+def cpu_throttle_by_pod(prometheus_url: str, ns: str, window_s: float) -> dict[str, float] | None:
+    """Throttled CFS periods per pod over the window, from Prometheus (cAdvisor). None on failure.
+
+    This is the missing CPU enforcement signal: `container_cpu_cfs_throttled_periods_total` is the
+    number of scheduler periods in which the container was throttled because it hit its CPU limit.
+    The k8s API does not expose it, which is why CPU verdicts are INCONCLUSIVE without this — the
+    limit's teeth are simply unobserved. `increase(...[window])` > 0 means throttling FIRED.
+    None (query failed) is distinct from {} (queried, nothing throttled): the caller keeps CPU
+    INCONCLUSIVE on None, but can reach PROVED/VIOLATION on a real {} / positive result.
+    """
+    win = max(int(window_s), 60)
+    q = (f'sum by (pod) (increase(container_cpu_cfs_throttled_periods_total'
+         f'{{namespace="{ns}"}}[{win}s]))')
+    url = prometheus_url.rstrip("/") + "/api/v1/query?query=" + urllib.parse.quote(q)
+    try:
+        with urllib.request.urlopen(urllib.request.Request(url, headers={"Accept": "application/json"}),
+                                    timeout=15) as r:
+            data = json.load(r)
+    except (urllib.error.URLError, OSError, ValueError) as e:
+        sys.stderr.write(f"[producer] prometheus throttle query failed: {e}\n")
+        return None
+    if data.get("status") != "success":
+        return None
+    out: dict[str, float] = {}
+    for res in data.get("data", {}).get("result", []):
+        pod = (res.get("metric") or {}).get("pod", "")
+        try:
+            out[pod] = float((res.get("value") or [None, "0"])[1])
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--namespace", default="socioprophet")
@@ -234,6 +268,10 @@ def main() -> int:
     ap.add_argument("--publish-url", default="",
                     help="POST each contract as a resource_contract EventEnvelope to a mesh "
                          "ingest URL (best-effort; emission always completes regardless)")
+    ap.add_argument("--prometheus-url", default="",
+                    help="Prometheus base URL to read the CPU throttle signal "
+                         "(container_cpu_cfs_throttled_periods_total). Without it, CPU stays "
+                         "INCONCLUSIVE — the throttle counter is not on the k8s API.")
     args = ap.parse_args()
     ns = args.namespace
 
@@ -260,6 +298,15 @@ def main() -> int:
             if cs.get("lastState", {}).get("terminated", {}).get("reason") == "OOMKilled":
                 oom[owner(nm)] = oom.get(owner(nm), 0) + 1
 
+    # CPU throttle count per workload (CPU enforcement FIRED), from Prometheus if wired.
+    # throttle is None when unavailable (CPU stays INCONCLUSIVE) vs a dict when queried.
+    throttle_by_pod = cpu_throttle_by_pod(args.prometheus_url, ns, window_s) if args.prometheus_url else None
+    wl_throttle: dict[str, float] | None = None
+    if throttle_by_pod is not None:
+        wl_throttle = {}
+        for pod, cnt in throttle_by_pod.items():
+            wl_throttle[owner(pod)] = wl_throttle.get(owner(pod), 0.0) + cnt
+
     # aggregate pod peaks -> workload peaks
     wl_peak: dict[str, dict] = {}
     for pod, d in pod_peak.items():
@@ -283,8 +330,12 @@ def main() -> int:
             specs.append(("memory", "bytes", _mem_to_bytes(lim["memory"]), peak["mem"],
                           "terminate", oom.get(name, 0)))          # OOMKill = real fired signal
         if lim.get("cpu"):
+            # throttle FIRED signal from Prometheus if wired; None keeps CPU INCONCLUSIVE (the
+            # counter is not on the k8s API). A workload with a CPU limit but no throttle series
+            # yet has fired 0 (queried, none) → still a real, gate-eligible observation.
+            cpu_fired = None if wl_throttle is None else int(wl_throttle.get(name, 0))
             specs.append(("cpu", "millicores", _cpu_to_millicores(lim["cpu"]), peak["cpu"],
-                          "throttle", None))                       # throttle counter not collected
+                          "throttle", cpu_fired))
         if not specs:
             unbounded.append(name)
             continue

--- a/tools/emit_resource_contracts.py
+++ b/tools/emit_resource_contracts.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import ssl
 import subprocess
@@ -253,9 +254,14 @@ def cpu_throttle_by_pod(prometheus_url: str, ns: str, window_s: float) -> dict[s
     for res in data.get("data", {}).get("result", []):
         pod = (res.get("metric") or {}).get("pod", "")
         try:
-            out[pod] = float((res.get("value") or [None, "0"])[1])
+            val = float((res.get("value") or [None, "0"])[1])
         except (TypeError, ValueError):
             continue
+        # Prometheus returns NaN/Inf for absent or divide-by-zero series; int(NaN) would later
+        # raise and crash EMISSION, which must never happen for a best-effort signal. Drop them.
+        if not math.isfinite(val):
+            continue
+        out[pod] = val
     return out
 
 

--- a/tools/tests/test_emit_resource_contracts.py
+++ b/tools/tests/test_emit_resource_contracts.py
@@ -73,6 +73,24 @@ def test_cpu_throttle_parses_prometheus_result(monkeypatch):
     assert out == {"api-abc-1": 7.0, "api-abc-2": 0.0}
 
 
+def test_cpu_throttle_drops_nonfinite_values(monkeypatch):
+    # adversarial: Prometheus returns NaN/Inf for an absent series; int(NaN) later would crash
+    # EMISSION. The parser must drop non-finite values, never propagate them.
+    import io, json as _j
+    canned = _j.dumps({"status": "success", "data": {"result": [
+        {"metric": {"pod": "p-nan"}, "value": [1, "NaN"]},
+        {"metric": {"pod": "p-inf"}, "value": [1, "+Inf"]},
+        {"metric": {"pod": "p-ok"}, "value": [1, "3"]}]}}).encode()
+
+    class _R(io.BytesIO):
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+    monkeypatch.setattr(erc.urllib.request, "urlopen", lambda *a, **k: _R(canned))
+    out = erc.cpu_throttle_by_pod("http://prom", "ns", 300)
+    assert out == {"p-ok": 3.0}                          # NaN/Inf dropped, no crash
+    assert all(v == v and v not in (float("inf"), float("-inf")) for v in out.values())
+
+
 def test_cpu_verdict_reaches_proved_when_throttle_fired():
     # with a real throttle count the CPU limit can be PROVED, not stuck INCONCLUSIVE
     assert erc.expected_verdict(peak=900, limit=1000, fired_count=7,

--- a/tools/tests/test_emit_resource_contracts.py
+++ b/tools/tests/test_emit_resource_contracts.py
@@ -53,6 +53,32 @@ def test_publish_is_best_effort_never_raises():
     assert ok == 0 and failed == 1
 
 
+# ── CPU throttle signal (makes CPU verdicts reachable beyond INCONCLUSIVE) ────
+def test_cpu_throttle_none_on_unreachable_prometheus():
+    # None (not {}) means "couldn't observe" → caller keeps CPU INCONCLUSIVE, never fakes PROVED
+    assert erc.cpu_throttle_by_pod("http://127.0.0.1:9/dead", "ns", 60) is None
+
+
+def test_cpu_throttle_parses_prometheus_result(monkeypatch):
+    import io, json as _j
+    canned = _j.dumps({"status": "success", "data": {"result": [
+        {"metric": {"pod": "api-abc-1"}, "value": [123, "7"]},
+        {"metric": {"pod": "api-abc-2"}, "value": [123, "0"]}]}}).encode()
+
+    class _Resp(io.BytesIO):
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+    monkeypatch.setattr(erc.urllib.request, "urlopen", lambda *a, **k: _Resp(canned))
+    out = erc.cpu_throttle_by_pod("http://prom", "ns", 300)
+    assert out == {"api-abc-1": 7.0, "api-abc-2": 0.0}
+
+
+def test_cpu_verdict_reaches_proved_when_throttle_fired():
+    # with a real throttle count the CPU limit can be PROVED, not stuck INCONCLUSIVE
+    assert erc.expected_verdict(peak=900, limit=1000, fired_count=7,
+                                gate_eligible=True, enforcement="throttle") == "PROVED"
+
+
 # ── the verdict algebra must discriminate all four branches ──────────────────────
 def test_gate_ineligible_is_inconclusive():
     # e.g. CPU: peak measured but the throttle signal (fired) is unknown → not gate-eligible


### PR DESCRIPTION
P2.9 of the [SOTA backlog](https://claude.ai/code/artifact/3af54950-e6b3-41b0-a816-341062bd216f) — the **Discriminates** dimension for CPU.

CPU verdicts were always `INCONCLUSIVE`: the throttle counter (cgroup `cpu.stat nr_throttled`) is not exposed by the k8s API, so a CPU limit’s teeth were simply *unobserved*. This reads `container_cpu_cfs_throttled_periods_total` from Prometheus (cAdvisor) — `increase(...[window]) > 0` per workload means throttling **fired**, so CPU can now reach **PROVED**/**VIOLATION**, not just `INCONCLUSIVE`.

- `cpu_throttle_by_pod()` returns **None on failure** (distinct from `{}` = queried, nothing throttled): None keeps CPU `INCONCLUSIVE` — it never fakes PROVED. A real count makes CPU gate-eligible.
- `--prometheus-url` is **best-effort** (like `--publish-url`): if Prometheus is down, CPU stays `INCONCLUSIVE` and emission still completes. The producer CronJob now passes the in-cluster Prometheus URL.
- Mirror re-synced (verify_cronjob_script_mirrors); **+3 tests** (unreachable→None, response parse, CPU→PROVED). No regression without the flag.

Completes the memory + CPU symmetry: the loop’s first memory PROVED came from the P0.3 negative control; CPU can now reach PROVED from real throttle data.