### PR TITLE
deploy-health: emit self-heal beacons — detection drives remediation (P1.5, producer side)

### DIFF
--- a/infra/k8s/deploy-health-alerter/base/deploy_health_alert.py
+++ b/infra/k8s/deploy-health-alerter/base/deploy_health_alert.py
@@ -528,9 +528,15 @@ def main(argv: list[str] | None = None) -> int:
     if args.emit_beacons and report["findings"]:
         d = Path(args.emit_beacons).expanduser()
         d.mkdir(parents=True, exist_ok=True)
+
+        def _safe(s: str) -> str:
+            # keep the filename inside DIR: no '/', '..', or odd chars can steer the write path.
+            # k8s names are already DNS-safe, but a finding name is data — sanitize defensively.
+            return "".join(c if (c.isalnum() or c in "._-") else "_" for c in str(s))[:120] or "x"
+
         for i, f in enumerate(report["findings"]):
             b = beacon_of(f)
-            (d / f"{b['kind_class']}-{b['system']}-{i}.json").write_text(json.dumps(b) + "\n")
+            (d / f"{_safe(b['kind_class'])}-{_safe(b['system'])}-{i}.json").write_text(json.dumps(b) + "\n")
         print(f"  emitted {len(report['findings'])} self-heal beacon(s) to {d}")
     return code
 

--- a/infra/k8s/deploy-health-alerter/base/deploy_health_alert.py
+++ b/infra/k8s/deploy-health-alerter/base/deploy_health_alert.py
@@ -296,6 +296,49 @@ def _utc() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+# ── self-heal bridge: turn findings into beacons the sociosphere responder consumes ──
+# The reasoned self-heal responder (sociosphere automation/responder.py) decides on "beacons"
+# keyed by kind_class → its law_by_kind → an action (auto_fix / canary_fix / propose_pr / …).
+# This maps each deploy-health finding to a kind_class so detection can DRIVE remediation, not
+# just alert. The sociosphere side must add these classes to law_by_kind + register executors
+# (see the P1.5 integration issue) — until then the responder fail-closes them to `refuse`.
+def _beacon_kind_class(finding: dict) -> str:
+    reason = finding.get("reason", "")
+    if finding.get("kind") == "pod":
+        if "CreateContainerConfigError" in reason or "CreateContainerError" in reason:
+            return "missing_config"           # e.g. the arcticdb-gateway missing-secret class
+        if "ImagePull" in reason or "ErrImage" in reason or "InvalidImageName" in reason:
+            return "image_pull_failure"
+        if "CrashLoopBackOff" in reason or "restarts=" in reason:
+            return "crashloop"
+        return "pod_stuck"
+    if finding.get("kind") == "argocd-app":
+        if "health=Degraded" in reason:
+            return "app_degraded"
+        if "health=Missing" in reason:
+            return "app_missing"
+        if "health=Unknown" in reason:
+            return "app_unknown"
+        if "sync=OutOfSync" in reason:
+            return "sync_failure"
+        if "held-without-reason" in reason:
+            return "unaccountable_hold"
+    if finding.get("kind") == "job-receipt":
+        return "job_receipt_stale"
+    return "unknown"
+
+
+def beacon_of(finding: dict) -> dict:
+    """A responder beacon for one finding: kind_class (routes the Law) + system + evidence."""
+    return {
+        "kind_class": _beacon_kind_class(finding),
+        "system": finding.get("name", "?"),
+        "detail": finding.get("reason", ""),
+        "source": "deploy-health-alerter",
+        "ts": time.time(),
+    }
+
+
 def run(args: argparse.Namespace) -> tuple[int, dict]:
     """Return (exit_code, report). Pure-ish: all I/O is behind collect_*/load_*."""
     findings: list[dict] = []
@@ -467,6 +510,9 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--allow-blind", action="store_true",
                    help="do NOT fail when a scan observes nothing (default: fail-closed)")
     p.add_argument("--json", action="store_true", help="emit the report as JSON")
+    p.add_argument("--emit-beacons", metavar="DIR",
+                   help="also write each finding as a self-heal beacon (kind_class + system) to "
+                        "DIR, for the sociosphere responder to decide on (detection → remediation)")
     p.add_argument("--self-test", action="store_true",
                    help="run the classifier discrimination checks and exit")
     args = p.parse_args(argv)
@@ -479,6 +525,13 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(report, indent=2))
     else:
         _print_human(report)
+    if args.emit_beacons and report["findings"]:
+        d = Path(args.emit_beacons).expanduser()
+        d.mkdir(parents=True, exist_ok=True)
+        for i, f in enumerate(report["findings"]):
+            b = beacon_of(f)
+            (d / f"{b['kind_class']}-{b['system']}-{i}.json").write_text(json.dumps(b) + "\n")
+        print(f"  emitted {len(report['findings'])} self-heal beacon(s) to {d}")
     return code
 
 

--- a/tools/deploy_health_alert.py
+++ b/tools/deploy_health_alert.py
@@ -528,9 +528,15 @@ def main(argv: list[str] | None = None) -> int:
     if args.emit_beacons and report["findings"]:
         d = Path(args.emit_beacons).expanduser()
         d.mkdir(parents=True, exist_ok=True)
+
+        def _safe(s: str) -> str:
+            # keep the filename inside DIR: no '/', '..', or odd chars can steer the write path.
+            # k8s names are already DNS-safe, but a finding name is data — sanitize defensively.
+            return "".join(c if (c.isalnum() or c in "._-") else "_" for c in str(s))[:120] or "x"
+
         for i, f in enumerate(report["findings"]):
             b = beacon_of(f)
-            (d / f"{b['kind_class']}-{b['system']}-{i}.json").write_text(json.dumps(b) + "\n")
+            (d / f"{_safe(b['kind_class'])}-{_safe(b['system'])}-{i}.json").write_text(json.dumps(b) + "\n")
         print(f"  emitted {len(report['findings'])} self-heal beacon(s) to {d}")
     return code
 

--- a/tools/deploy_health_alert.py
+++ b/tools/deploy_health_alert.py
@@ -296,6 +296,49 @@ def _utc() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+# ── self-heal bridge: turn findings into beacons the sociosphere responder consumes ──
+# The reasoned self-heal responder (sociosphere automation/responder.py) decides on "beacons"
+# keyed by kind_class → its law_by_kind → an action (auto_fix / canary_fix / propose_pr / …).
+# This maps each deploy-health finding to a kind_class so detection can DRIVE remediation, not
+# just alert. The sociosphere side must add these classes to law_by_kind + register executors
+# (see the P1.5 integration issue) — until then the responder fail-closes them to `refuse`.
+def _beacon_kind_class(finding: dict) -> str:
+    reason = finding.get("reason", "")
+    if finding.get("kind") == "pod":
+        if "CreateContainerConfigError" in reason or "CreateContainerError" in reason:
+            return "missing_config"           # e.g. the arcticdb-gateway missing-secret class
+        if "ImagePull" in reason or "ErrImage" in reason or "InvalidImageName" in reason:
+            return "image_pull_failure"
+        if "CrashLoopBackOff" in reason or "restarts=" in reason:
+            return "crashloop"
+        return "pod_stuck"
+    if finding.get("kind") == "argocd-app":
+        if "health=Degraded" in reason:
+            return "app_degraded"
+        if "health=Missing" in reason:
+            return "app_missing"
+        if "health=Unknown" in reason:
+            return "app_unknown"
+        if "sync=OutOfSync" in reason:
+            return "sync_failure"
+        if "held-without-reason" in reason:
+            return "unaccountable_hold"
+    if finding.get("kind") == "job-receipt":
+        return "job_receipt_stale"
+    return "unknown"
+
+
+def beacon_of(finding: dict) -> dict:
+    """A responder beacon for one finding: kind_class (routes the Law) + system + evidence."""
+    return {
+        "kind_class": _beacon_kind_class(finding),
+        "system": finding.get("name", "?"),
+        "detail": finding.get("reason", ""),
+        "source": "deploy-health-alerter",
+        "ts": time.time(),
+    }
+
+
 def run(args: argparse.Namespace) -> tuple[int, dict]:
     """Return (exit_code, report). Pure-ish: all I/O is behind collect_*/load_*."""
     findings: list[dict] = []
@@ -467,6 +510,9 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--allow-blind", action="store_true",
                    help="do NOT fail when a scan observes nothing (default: fail-closed)")
     p.add_argument("--json", action="store_true", help="emit the report as JSON")
+    p.add_argument("--emit-beacons", metavar="DIR",
+                   help="also write each finding as a self-heal beacon (kind_class + system) to "
+                        "DIR, for the sociosphere responder to decide on (detection → remediation)")
     p.add_argument("--self-test", action="store_true",
                    help="run the classifier discrimination checks and exit")
     args = p.parse_args(argv)
@@ -479,6 +525,13 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(report, indent=2))
     else:
         _print_human(report)
+    if args.emit_beacons and report["findings"]:
+        d = Path(args.emit_beacons).expanduser()
+        d.mkdir(parents=True, exist_ok=True)
+        for i, f in enumerate(report["findings"]):
+            b = beacon_of(f)
+            (d / f"{b['kind_class']}-{b['system']}-{i}.json").write_text(json.dumps(b) + "\n")
+        print(f"  emitted {len(report['findings'])} self-heal beacon(s) to {d}")
     return code
 
 

--- a/tools/tests/test_deploy_health_alert.py
+++ b/tools/tests/test_deploy_health_alert.py
@@ -121,6 +121,42 @@ def test_app_hold_reason_helper():
     assert dha.app_hold_reason({}) is None
 
 
+# ── self-heal beacons: findings → kind_class the responder decides on ─────────
+def test_beacon_kind_class_maps_each_finding_type():
+    cases = [
+        ({"kind": "pod", "reason": "svc:CreateContainerConfigError"}, "missing_config"),
+        ({"kind": "pod", "reason": "svc:CrashLoopBackOff"}, "crashloop"),
+        ({"kind": "pod", "reason": "svc:restarts=70"}, "crashloop"),
+        ({"kind": "pod", "reason": "svc:ImagePullBackOff"}, "image_pull_failure"),
+        ({"kind": "argocd-app", "reason": "health=Degraded"}, "app_degraded"),
+        ({"kind": "argocd-app", "reason": "health=Missing"}, "app_missing"),
+        ({"kind": "argocd-app", "reason": "sync=OutOfSync (sync failing)"}, "sync_failure"),
+        ({"kind": "job-receipt", "reason": "stale"}, "job_receipt_stale"),
+    ]
+    for finding, expected in cases:
+        assert dha._beacon_kind_class(finding) == expected
+
+
+def test_beacon_of_shape_matches_responder_contract():
+    b = dha.beacon_of({"kind": "pod", "name": "gitea-x", "reason": "gitea:CrashLoopBackOff"})
+    # the responder routes on kind_class + system (sociosphere automation/responder.py)
+    assert b["kind_class"] == "crashloop" and b["system"] == "gitea-x"
+    assert b["source"] == "deploy-health-alerter" and "ts" in b
+
+
+def test_emit_beacons_writes_one_file_per_finding(tmp_path, monkeypatch):
+    monkeypatch.setattr(dha, "collect_apps", lambda ns: [
+        {"metadata": {"name": "svc-x"}, "status": {"health": {"status": "Degraded"},
+                                                   "sync": {"status": "Synced"}}}])
+    monkeypatch.setattr(dha, "collect_pods", lambda ns: [])
+    dha.main(["--namespace", "x", "--no-pods", "--emit-beacons", str(tmp_path)])
+    import json
+    files = list(tmp_path.glob("*.json"))
+    assert len(files) == 1
+    b = json.loads(files[0].read_text())
+    assert b["kind_class"] == "app_degraded" and b["system"] == "svc-x"
+
+
 # ── pod classification ───────────────────────────────────────────────────────
 def test_running_pod_is_clean():
     pod = {"status": {"phase": "Running", "containerStatuses": [

--- a/tools/tests/test_deploy_health_alert.py
+++ b/tools/tests/test_deploy_health_alert.py
@@ -157,6 +157,22 @@ def test_emit_beacons_writes_one_file_per_finding(tmp_path, monkeypatch):
     assert b["kind_class"] == "app_degraded" and b["system"] == "svc-x"
 
 
+def test_emit_beacons_filename_is_path_safe(tmp_path, monkeypatch):
+    # adversarial: a finding name with path chars must not steer the write outside DIR
+    monkeypatch.setattr(dha, "collect_apps", lambda ns: [
+        {"metadata": {"name": "../../etc/evil"}, "status": {"health": {"status": "Degraded"},
+                                                            "sync": {"status": "Synced"}}}])
+    monkeypatch.setattr(dha, "collect_pods", lambda ns: [])
+    outdir = tmp_path / "beacons"
+    dha.main(["--namespace", "x", "--no-pods", "--emit-beacons", str(outdir)])
+    files = list(outdir.glob("*.json"))
+    assert len(files) == 1                       # written INSIDE outdir, not traversed out
+    assert files[0].parent == outdir             # the real safety property: it lands in the dir…
+    assert "/" not in files[0].name              # …because no path separator survives sanitization
+    import json
+    assert json.loads(files[0].read_text())["system"] == "../../etc/evil"  # content keeps the real name
+
+
 # ── pod classification ───────────────────────────────────────────────────────
 def test_running_pod_is_clean():
     pod = {"status": {"phase": "Running", "containerStatuses": [


### PR DESCRIPTION
P1.5 of the [SOTA backlog](https://claude.ai/code/artifact/3af54950-e6b3-41b0-a816-341062bd216f) — the **Acts** dimension, producer side (the daemon side is coordinated separately, see the linked issue).

Detection and remediation are still separate: `arcticdb-gateway` was healed by hand. The reasoned self-heal responder (`sociosphere automation/responder.py`) decides on **beacons** keyed by `kind_class` → `law_by_kind` → action (`auto_fix`/`canary_fix`/`propose_pr`/…). This adds the **producer side**: `--emit-beacons DIR` writes each finding as a beacon the responder can consume.

`kind_class` mapping: `missing_config` (the arcticdb missing-secret class), `crashloop`, `image_pull_failure`, `app_degraded`, `app_missing`, `sync_failure`, `job_receipt_stale`. **Additive** — new flag, default behavior unchanged. Mirror re-synced; **+4 tests (35 total)**; live it emitted real beacons matching the responder’s `{kind_class, system}` contract.

The **sociosphere side** (add these classes to `law_by_kind` + register executors — e.g. `missing_config → canary_fix` via provision-secrets mint, `crashloop → propose_pr` rollback-to-last-good) is the coordinated completing step, filed as an integration issue. Not edited here to avoid clobbering the active parallel work on `feat/canary-quarantine-executors`.