### PR TITLE
feat(delivery): SLO-gated canary — the observability keystone's payload

### DIFF
--- a/.github/workflows/progressive-delivery.yml
+++ b/.github/workflows/progressive-delivery.yml
@@ -1,0 +1,42 @@
+name: progressive-delivery
+
+# The observability keystone's payload: SLO-gated canary. This gate proves the canary
+# AnalysisTemplate queries REAL recording rules (defined in the observability PrometheusRules)
+# and can actually fail — a canary gate over a phantom metric silently passes every bad deploy.
+on:
+  push:
+    paths:
+      - 'infra/k8s/progressive-delivery/**'
+      - 'infra/k8s/observability/**'
+      - 'tools/validate_analysis_metrics.py'
+      - 'tools/test_validate_analysis_metrics.py'
+      - '.github/workflows/progressive-delivery.yml'
+  pull_request:
+    paths:
+      - 'infra/k8s/progressive-delivery/**'
+      - 'infra/k8s/observability/**'
+      - 'tools/validate_analysis_metrics.py'
+      - 'tools/test_validate_analysis_metrics.py'
+      - '.github/workflows/progressive-delivery.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  slo-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pyyaml pytest
+      - name: Canary gate queries real, fail-capable SLO metrics
+        run: python3 tools/validate_analysis_metrics.py
+      - name: Validator unit tests
+        run: python3 -m pytest tools/test_validate_analysis_metrics.py -q
+      - name: Kustomize build (manifests are well-formed)
+        run: |
+          curl -sfL https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh | bash || true
+          ./kustomize build infra/k8s/progressive-delivery/base >/dev/null && echo "kustomize build OK" \
+            || kubectl kustomize infra/k8s/progressive-delivery/base >/dev/null && echo "kubectl kustomize OK"

--- a/infra/k8s/progressive-delivery/README.md
+++ b/infra/k8s/progressive-delivery/README.md
@@ -1,0 +1,24 @@
+# Progressive delivery — SLO-gated canary (the observability keystone's payload)
+
+Wires **Argo Rollouts** to the SLOs the observability stack already publishes, so a canary is
+promoted only if it holds the error-ratio and p99-latency budgets — and aborts automatically
+if it doesn't. This is the keystone that unblocks the three net-new delivery boxes (canary,
+chaos verification, metric-driven autoscale): each needs real metrics gating real promotions.
+
+## What's here
+- `analysistemplate-slo-gate.yaml` — queries `job:request_error_ratio:rate5m` and
+  `job:request_latency_p99:5m` (from `observability/base/prometheusrule-slos.yaml`, where they
+  are labelled *"the canary gate metric"*). Fail-closed: a single breach aborts.
+- `rollout-reference.yaml` — a canary strategy that runs the gate at each weight step. Copy the
+  shape per service, point `service-job` at that service's Prometheus `job` label.
+
+## The anti-theater gate
+`tools/validate_analysis_metrics.py` (CI: `progressive-delivery.yml`) fails the build if a
+canary AnalysisTemplate queries a recording rule that **isn't defined** (a phantom metric returns
+no data → Argo never fails it → every bad deploy silently promotes) or declares **no failure
+condition** (a gate that can't fail is not a gate).
+
+## Prerequisites
+The `argo-rollouts` controller and the observability stack (kube-prometheus-stack + the SLO
+recording rules) must be installed. The Prometheus address in the template targets
+`kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090`.

--- a/infra/k8s/progressive-delivery/base/analysistemplate-slo-gate.yaml
+++ b/infra/k8s/progressive-delivery/base/analysistemplate-slo-gate.yaml
@@ -1,0 +1,41 @@
+# Argo Rollouts SLO gate — the progressive-delivery keystone.
+#
+# Gates canary promotion on the SAME recording rules the SLOs already publish
+# (job:request_error_ratio:rate5m, job:request_latency_p99:5m — see
+# observability/base/prometheusrule-slos.yaml, where they are literally labelled
+# "the canary gate metric"). A canary that raises the 5xx ratio or p99 latency
+# aborts automatically instead of being promoted. tools/validate_analysis_metrics.py
+# fails CI if this template ever queries a metric that isn't a real recording rule
+# (a gate that queries a phantom metric silently passes — that is theater).
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: slo-canary-gate
+  namespace: observability
+spec:
+  args:
+    - name: service-job          # the Prometheus `job` label of the service under canary
+  metrics:
+    - name: error-ratio
+      # Sample five times, one minute apart; a single breach aborts (fail-closed).
+      interval: 1m
+      count: 5
+      failureLimit: 1
+      successCondition: "result[0] < 0.05"     # < 5% 5xx, the HighErrorRatio SLO threshold
+      failureCondition: "result[0] >= 0.05"
+      provider:
+        prometheus:
+          address: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
+          query: |
+            job:request_error_ratio:rate5m{job="{{args.service-job}}"}
+    - name: latency-p99
+      interval: 1m
+      count: 5
+      failureLimit: 1
+      successCondition: "result[0] < 0.75"     # p99 < 750ms (the recording rule is in seconds)
+      failureCondition: "result[0] >= 0.75"
+      provider:
+        prometheus:
+          address: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
+          query: |
+            job:request_latency_p99:5m{job="{{args.service-job}}"}

--- a/infra/k8s/progressive-delivery/base/kustomization.yaml
+++ b/infra/k8s/progressive-delivery/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Progressive delivery: SLO-gated canary. Requires the argo-rollouts controller and the
+# observability stack (kube-prometheus-stack + the SLO recording rules) already installed.
+resources:
+  - analysistemplate-slo-gate.yaml
+  - rollout-reference.yaml

--- a/infra/k8s/progressive-delivery/base/rollout-reference.yaml
+++ b/infra/k8s/progressive-delivery/base/rollout-reference.yaml
@@ -1,0 +1,41 @@
+# Reference Rollout showing the SLO gate wired into a canary strategy. A service adopts
+# progressive delivery by switching its Deployment to this Rollout shape and pointing
+# `templateName` at slo-canary-gate with its own Prometheus `job` label. Promotion pauses
+# for the analysis at each weight step; a breached SLO auto-aborts and rolls back.
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: hellgraph-api            # reference service; copy this shape per workload
+  namespace: observability
+spec:
+  replicas: 3
+  selector:
+    matchLabels: { app.kubernetes.io/name: hellgraph-api }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/name: hellgraph-api }
+    spec:
+      containers:
+        - name: hellgraph-api
+          image: hellgraph-api:latest   # digest-pinned by the GitOps promotion in practice
+          ports: [{ containerPort: 8080 }]
+  strategy:
+    canary:
+      steps:
+        - setWeight: 20
+        - pause: { duration: 2m }
+        - analysis:
+            templates:
+              - templateName: slo-canary-gate
+            args:
+              - name: service-job
+                value: hellgraph-api
+        - setWeight: 50
+        - pause: { duration: 2m }
+        - analysis:
+            templates:
+              - templateName: slo-canary-gate
+            args:
+              - name: service-job
+                value: hellgraph-api
+        # reaching 100% only happens if every analysis passed

--- a/tools/test_validate_analysis_metrics.py
+++ b/tools/test_validate_analysis_metrics.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""The canary-gate validator catches theater: phantom metrics and can't-fail gates."""
+import importlib.util
+import pathlib
+
+import yaml
+
+_SPEC = importlib.util.spec_from_file_location(
+    "vam", pathlib.Path(__file__).resolve().parent / "validate_analysis_metrics.py")
+vam = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(vam)
+
+
+def _write(tmp_path, monkeypatch, template: dict, rules=("job:request_error_ratio:rate5m",)):
+    pd = tmp_path / "infra/k8s/progressive-delivery/base"
+    pd.mkdir(parents=True)
+    (pd / "t.yaml").write_text(yaml.safe_dump(template))
+    monkeypatch.setattr(vam, "PD_DIR", tmp_path / "infra/k8s/progressive-delivery")
+    monkeypatch.setattr(vam, "defined_recording_rules", lambda: set(rules))
+    return vam.validate()
+
+
+def _tmpl(metrics):
+    return {"apiVersion": "argoproj.io/v1alpha1", "kind": "AnalysisTemplate",
+            "metadata": {"name": "t"}, "spec": {"metrics": metrics}}
+
+
+def _metric(name, query, **extra):
+    return {"name": name, "provider": {"prometheus": {"query": query}}, **extra}
+
+
+def test_real_recording_rule_with_failure_condition_passes(tmp_path, monkeypatch):
+    errs = _write(tmp_path, monkeypatch, _tmpl([
+        _metric("err", 'job:request_error_ratio:rate5m{job="x"}', failureCondition="result[0] >= 0.05")]))
+    assert errs == []
+
+
+def test_phantom_recording_rule_is_caught(tmp_path, monkeypatch):
+    errs = _write(tmp_path, monkeypatch, _tmpl([
+        _metric("p", 'job:does_not_exist:rate5m{job="x"}', failureCondition="result[0] > 1")]))
+    assert any("phantom metric" in e for e in errs)
+
+
+def test_gate_with_no_failure_path_is_caught(tmp_path, monkeypatch):
+    errs = _write(tmp_path, monkeypatch, _tmpl([
+        _metric("nofail", 'job:request_error_ratio:rate5m{job="x"}')]))  # no failureCondition/Limit
+    assert any("never fail" in e for e in errs)
+
+
+def test_failure_limit_counts_as_a_failure_path(tmp_path, monkeypatch):
+    errs = _write(tmp_path, monkeypatch, _tmpl([
+        _metric("ok", 'job:request_error_ratio:rate5m{job="x"}', failureLimit=1)]))
+    assert errs == []
+
+
+def test_template_with_no_metrics_is_caught(tmp_path, monkeypatch):
+    errs = _write(tmp_path, monkeypatch, _tmpl([]))
+    assert any("no metrics" in e for e in errs)

--- a/tools/validate_analysis_metrics.py
+++ b/tools/validate_analysis_metrics.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Prove the SLO canary gate queries REAL metrics and CAN fail.
+
+A canary AnalysisTemplate that queries a metric which doesn't exist returns no data →
+Argo treats it as inconclusive, never fails → the "gate" silently passes every bad deploy.
+That is theater. This validator makes it impossible:
+
+  1. Every recording-rule metric (`level:metric:op` form) referenced in an AnalysisTemplate
+     query MUST be defined as a `record:` in the observability PrometheusRules. A query over a
+     phantom recording rule fails the build.
+  2. Every metric in the template MUST declare a failureCondition or a failureLimit — a gate
+     with no way to fail is not a gate.
+
+Fail-closed: a malformed template, or an AnalysisTemplate with zero metrics, is an error.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+import yaml
+
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+PD_DIR = _ROOT / "infra" / "k8s" / "progressive-delivery"
+SLO_GLOB = "infra/k8s/observability/**/*.yaml"
+# recording-rule naming convention: level:metric:operations (Prometheus best practice)
+_RECORDING_RULE = re.compile(r"\b([a-zA-Z_][\w]*:[\w]+:[\w]+)\b")
+
+
+def _docs(path: pathlib.Path):
+    try:
+        return [d for d in yaml.safe_load_all(path.read_text()) if isinstance(d, dict)]
+    except yaml.YAMLError:
+        return []
+
+
+def defined_recording_rules() -> set[str]:
+    names: set[str] = set()
+    for path in _ROOT.glob(SLO_GLOB):
+        for doc in _docs(path):
+            if doc.get("kind") != "PrometheusRule":
+                continue
+            for group in (doc.get("spec", {}) or {}).get("groups", []) or []:
+                for rule in group.get("rules", []) or []:
+                    if rule.get("record"):
+                        names.add(rule["record"])
+    return names
+
+
+def validate() -> list[str]:
+    errors: list[str] = []
+    defined = defined_recording_rules()
+    templates = 0
+    if not PD_DIR.exists():
+        return ["no progressive-delivery dir — nothing to validate"]
+
+    for path in sorted(PD_DIR.rglob("*.yaml")):
+        for doc in _docs(path):
+            if doc.get("kind") != "AnalysisTemplate":
+                continue
+            templates += 1
+            name = doc.get("metadata", {}).get("name", "<unnamed>")
+            metrics = (doc.get("spec", {}) or {}).get("metrics", []) or []
+            if not metrics:
+                errors.append(f"{path.name}: AnalysisTemplate/{name} declares no metrics (nothing to gate on)")
+                continue
+            for m in metrics:
+                mname = m.get("name", "<metric>")
+                # 2. a gate must be able to fail
+                if not m.get("failureCondition") and m.get("failureLimit") is None:
+                    errors.append(f"{path.name}: {name}.{mname} has no failureCondition/failureLimit — "
+                                  f"it can never fail (theater)")
+                # 1. every recording-rule reference must be a real record:
+                query = (m.get("provider", {}) or {}).get("prometheus", {}).get("query", "") or ""
+                for ref in set(_RECORDING_RULE.findall(query)):
+                    if ref not in defined:
+                        errors.append(f"{path.name}: {name}.{mname} queries recording rule '{ref}' "
+                                      f"which is not defined in any PrometheusRule (phantom metric)")
+    if templates == 0:
+        errors.append("no AnalysisTemplate found under progressive-delivery (the gate is missing)")
+    return errors
+
+
+def main() -> int:
+    errors = validate()
+    if errors:
+        print("SLO canary-gate validation FAILED:")
+        for e in errors:
+            print("  ✗ " + e)
+        return 1
+    print(f"SLO canary gate OK — every query targets a defined recording rule and can fail "
+          f"(defined rules: {sorted(defined_recording_rules())})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Executes the **keystone** from the form-factor atlas: wire progressive delivery to the SLOs the observability stack already publishes. The estate runs the OTel collector + kube-prometheus-stack + SLO recording rules (`job:request_error_ratio:rate5m`, `job:request_latency_p99:5m` — literally commented *"the canary gate metric"*), but **nothing consumed them**. Progressive delivery was the one genuinely net-new box; this closes it.

## What's here
- **`analysistemplate-slo-gate.yaml`** — Argo Rollouts `AnalysisTemplate` gating promotion on error-ratio (<5%) and p99 (<750ms), **fail-closed** (one breach aborts). Queries the *existing* recording rules.
- **`rollout-reference.yaml`** — a canary strategy running the gate at each weight step; copy per service.
- **`tools/validate_analysis_metrics.py`** (+ 5 tests, `progressive-delivery.yml`) — the **anti-theater gate**: fails CI if a canary template queries a recording rule that isn't defined (a phantom metric returns no data → Argo never fails it → every bad deploy silently promotes) or declares no failure condition (a gate that can't fail is not a gate). Catches both, proven.

## Grounding correction
Observability is **far more wired** than the readiness chart implied — collector + Prometheus/Loki/Tempo exporters + SLO rules are all present. The real gap was this consumer. Unblocks the keystone's three dependents at once: canary (this), chaos (SLO metrics verify recovery), metric-driven autoscale.

Local: validator + 5 tests + `kustomize build` all green. Prereq: argo-rollouts controller + observability stack. Touches a workflow — flagged for human review; not auto-merging.