### PR TITLE
fix(dashboard-bff): vendor third_party/open_ep_framework into the image (makes /v1/risk serve)

### DIFF
--- a/apps/dashboard-bff/Dockerfile
+++ b/apps/dashboard-bff/Dockerfile
@@ -3,12 +3,18 @@
 # those producers read files from SEVERAL sibling trees at REQUEST time. Every path
 # below was found by running the container and hitting each /v1 route the SPA calls,
 # not by reading imports — the failures only show up at request time:
-#   apps/dashboard-bff        main.py + its data/ (vdt, gyg)
-#   tools                     the 7 emit_* producers (stdlib-only)
+#   apps/dashboard-bff             main.py + its data/ (vdt, gyg, risk_ep fixture)
+#   tools                         the emit_* producers
+#   third_party/open_ep_framework the vendored Omnirisk/EP spine — emit_risk_ep_facts.py
+#                                 does sys.path.insert(ROOT/third_party) then imports it
+#                                 (pure stdlib, no pip deps); /v1/risk/portfolio-facts needs it
 #   apps/hellgraph-service/seeds   gyg-supply-chain-causal.json (/v1/valuation/causal)
-#   schemas/eval              metric-*.schema.json (/v1/intelligence-superiority validates)
-# Missing any one = a 200 on /health and a 500 on the route that needs it — the
+#   schemas/eval                  metric-*.schema.json (/v1/intelligence-superiority validates)
+# Missing any one = a 200 on /health and a 500/503 on the route that needs it — the
 # estate's signature "healthy-looking, broken" shape. Copy exactly these, no more.
+# (emit_risk_ep_facts.py is NOT stdlib-only — it dogfoods third_party/open_ep_framework;
+# omitting that tree is what put dashboard-bff in CrashLoopBackOff before #1369 made the
+# import failure degrade to a per-endpoint 503 instead of a whole-service crash.)
 FROM python:3.11-slim
 
 RUN useradd -u 10001 -m -s /usr/sbin/nologin app
@@ -19,6 +25,7 @@ RUN pip install --no-cache-dir -r apps/dashboard-bff/requirements.txt
 
 COPY apps/dashboard-bff ./apps/dashboard-bff
 COPY tools ./tools
+COPY third_party/open_ep_framework ./third_party/open_ep_framework
 COPY apps/hellgraph-service/seeds ./apps/hellgraph-service/seeds
 COPY schemas/eval ./schemas/eval
 


### PR DESCRIPTION
## Follow-up to #1369
#1369 stopped the crashloop by degrading a failed producer to a per-endpoint 503. This makes **/v1/risk/portfolio-facts actually serve**.

## Root cause
`tools/emit_risk_ep_facts.py` dogfoods the vendored Omnirisk/EP spine — `sys.path.insert(ROOT/'third_party')` then `from open_ep_framework import …`. The image `COPY`ied `tools/` but **not** `third_party/`, so the import failed (`ModuleNotFoundError`) in the prod image though it works locally. The Dockerfile even asserted the producers were "stdlib-only" — stale since `emit_risk_ep_facts` was added.

## Fix
`open_ep_framework` is **pure stdlib** (50 files, no pip deps), so one line:
```
COPY third_party/open_ep_framework ./third_party/open_ep_framework
```
placing it at `/app/third_party/open_ep_framework`, matching the runtime path (`_ROOT/'third_party'`, `_ROOT=/app`). Comment corrected to record the tree + why.

## Verified (docker daemon unavailable here → exact mirrored image layout)
Replicated the 5 `COPY` trees into a temp `/app` and booted the real app:
- **with** the tree → `/v1/risk/portfolio-facts` **200**, `/health` `degraded_producers: []`
- **without** it → the exact incident: **503** + `degraded_producers: ['emit_risk_ep_facts']`

So the `COPY` is precisely the fix. The image build (`images.yml`) exercises it end to end on merge.

**Durable guard:** `/health` now reports `degraded_producers` (from #1369) — the deploy-health alerter can flag a non-empty set as the runtime signal that a producer's tree is missing from an image, catching this whole class without a brittle build-time check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)