### PR TITLE
feat(fips): sherlock-engine ring→aws-lc-rs — drop the non-FIPS TLS provider

### DIFF
--- a/apps/sherlock-engine/Cargo.lock
+++ b/apps/sherlock-engine/Cargo.lock
@@ -56,6 +56,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
 name = "cc"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +146,44 @@ name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
 
 [[package]]
 name = "crc32fast"
@@ -188,10 +255,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -275,6 +357,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +420,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +436,22 @@ name = "htmlescape"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -453,6 +563,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +657,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,7 +674,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -878,9 +1004,9 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -902,6 +1028,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -960,6 +1087,7 @@ dependencies = [
 name = "sherlock-engine"
 version = "0.1.0"
 dependencies = [
+ "rustls",
  "serde",
  "serde_json",
  "tantivy",
@@ -1285,20 +1413,34 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
+ "cookie_store",
  "flate2",
  "log",
- "once_cell",
+ "percent-encoding",
  "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
- "url",
- "webpki-roots 0.26.11",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -1320,6 +1462,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1484,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1396,15 +1550,6 @@ checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/apps/sherlock-engine/Cargo.toml
+++ b/apps/sherlock-engine/Cargo.toml
@@ -13,8 +13,12 @@ tantivy = "0.22"
 tiny_http = "0.12"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-# blocking HTTP client for the dense tier (embeddings + Qdrant) — light deps, fast compile
-ureq = { version = "2", features = ["json"] }
+# blocking HTTP client for the dense tier (embeddings + Qdrant). ureq 3's default `rustls` feature
+# bundles the non-FIPS `ring` provider, so we take `rustls-no-provider` and supply rustls's aws-lc-rs
+# provider (installed as the process default in main) — `ring` is dropped from the binary. The
+# CMVP-validated build is aws-lc-rs's `fips` feature (a heavy AWS-LC compile → done in CI), a follow-up.
+ureq = { version = "3", default-features = false, features = ["json", "gzip", "rustls-no-provider", "rustls-webpki-roots"] }
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "logging", "std", "tls12"] }
 
 [profile.release]
 opt-level = 2

--- a/apps/sherlock-engine/src/main.rs
+++ b/apps/sherlock-engine/src/main.rs
@@ -186,13 +186,17 @@ fn highlight(body: &str, query: &str) -> String {
 }
 
 fn embed(agent: &ureq::Agent, url: &str, model: &str, text: &str) -> Option<Vec<f32>> {
-    let resp = agent.post(url).send_json(json!({ "input": text, "model": model })).ok()?;
-    let v: serde_json::Value = resp.into_json().ok()?;
+    let mut resp = agent.post(url).send_json(json!({ "input": text, "model": model })).ok()?;
+    let v: serde_json::Value = resp.body_mut().read_json().ok()?;
     let arr = v.get("data")?.get(0)?.get("embedding")?.as_array()?;
     Some(arr.iter().filter_map(|x| x.as_f64().map(|f| f as f32)).collect())
 }
 
 fn main() {
+    // Install aws-lc-rs as the process-default rustls crypto provider (FIPS-capable; the non-FIPS
+    // `ring` provider is not compiled in). ureq's rustls-no-provider TLS uses this default.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     let mut sb = Schema::builder();
     let f_id = sb.add_text_field("id", STRING | STORED);
     let f_idx = sb.add_u64_field("idx", STORED | FAST);
@@ -220,9 +224,10 @@ fn main() {
     let qp = QueryParser::for_index(&index, vec![f_title, f_body]);
 
     // ── dense tier (optional): embed corpus → Qdrant (shared substrate) ─────────
-    let agent = ureq::AgentBuilder::new()
-        .timeout(Duration::from_secs(12))
-        .build();
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(12)))
+        .build()
+        .into();
     let emb_url = std::env::var("EMBEDDINGS_URL").unwrap_or_default();
     let emb_model = std::env::var("EMBEDDINGS_MODEL").unwrap_or_else(|_| "nomic-embed-text".into());
     let qdrant_url = std::env::var("QDRANT_URL").unwrap_or_default().trim_end_matches('/').to_string();
@@ -363,11 +368,11 @@ fn main() {
                 let mut dense_score: HashMap<usize, f32> = HashMap::new();
                 if dense {
                     if let Some(qv) = embed(&agent, &emb_url, &emb_model, q.trim()) {
-                        if let Ok(resp) = agent
+                        if let Ok(mut resp) = agent
                             .post(&format!("{}/collections/{}/points/search", qdrant_url, coll))
                             .send_json(json!({ "vector": qv, "limit": limit * 2, "with_payload": false }))
                         {
-                            if let Ok(jv) = resp.into_json::<serde_json::Value>() {
+                            if let Ok(jv) = resp.body_mut().read_json::<serde_json::Value>() {
                                 if let Some(res) = jv.get("result").and_then(|r| r.as_array()) {
                                     for item in res {
                                         if let Some(id) = item.get("id").and_then(|x| x.as_u64()) {


### PR DESCRIPTION
## FIPS Build-2 · Rust surface: sherlock-engine `ring`→`aws-lc-rs`

sherlock-engine's dense tier (embeddings + Qdrant HTTP) used `ureq`, which pulled **rustls with the non-FIPS `ring` provider** — the one in-repo `ring` dependency the Build-2 recon flagged.

### Change
- **ureq 2 → 3** — API port (3 call sites): `AgentBuilder`→`config_builder`/`timeout_global`, `into_json()`→`body_mut().read_json()`.
- **Provider swap** — ureq's default `rustls` feature bundles `ring`, so take `rustls-no-provider` + `rustls-webpki-roots`, add `rustls` with the **aws-lc-rs** provider, and install it as the process-default crypto provider at `main()` start. `ring` is **dropped from the binary**.

### Proof (local)
`cargo build` clean; `cargo tree` flips to:
```
aws-lc-rs v1.17.3
aws-lc-sys v0.43.0
rustls v0.23.42
```
— **no `ring`**.

### The CMVP step (follow-up, in CI)
The `aws-lc-rs` here is the standard build. The **CMVP-validated** module is aws-lc-rs's `fips` feature — a heavy AWS-LC compile that needs Go + cmake, so it belongs in CI, not a laptop. It's a one-line follow-up (`fips` feature) once this lands.

Completes the in-repo **Rust** half of FIPS Build-2 (the Go algorithm half was the tritrpcbridge HMAC-SHA256 suite, #1347).
