### PR TITLE
fix(ci): gate the ie-engine (and voice-substrate) app test suites

### DIFF
--- a/.github/workflows/validate-target-diagnostics.yml
+++ b/.github/workflows/validate-target-diagnostics.yml
@@ -229,6 +229,17 @@ jobs:
             working-directory: apps/device-service
             install: pip install -r requirements.txt -r requirements-test.txt
             test: PYTHONPATH=src pytest -q tests
+          # ie-engine (NLP/IE service). Gates the sentiment / tone / entity-level-sentiment
+          # lexicon heuristics, the variable-length input tiers, and the lexicon-based
+          # Big-Five (OCEAN) scorer — suites that landed in #1363/#1364 and until now
+          # protected nothing on merge. src/ie_engine/server.py calls spacy.load() at
+          # IMPORT time, so the en_core_web_sm download is part of install rather than an
+          # optional extra: without it every test in this leg fails at collection. Same
+          # model the Dockerfile bakes in, so CI and the runtime image agree.
+          - name: ie-engine
+            working-directory: apps/ie-engine
+            install: pip install -r requirements.txt -r requirements-test.txt && python -m spacy download en_core_web_sm
+            test: PYTHONPATH=src pytest -q tests
           - name: tools-tests
             working-directory: .
             install: pip install pytest pyyaml jsonschema


### PR DESCRIPTION
## ⚠️ This is a `.github/workflows/**` change — it requires human review before merge

Do not auto-merge. The change is confined to **one thing**: two… actually **one** new entry in the `app-test-diagnostics` matrix of `.github/workflows/validate-target-diagnostics.yml`. No `on:` triggers, no `permissions:` block, no token/secret configuration, no other job, and no other workflow file were touched. Full diff is 11 added lines (7 of them comment).

## What was ungated

`app-test-diagnostics` is an explicit **allow-list**. An app can carry a real, passing pytest suite and still be invisible to the required check, because the gate only runs what the matrix names.

| App | Suite | Status before this PR |
|---|---|---|
| `apps/ie-engine` | sentiment, tone/emotion, entity-level sentiment, variable-length input tiers, lexicon-based Big-Five (OCEAN) scorer — merged today in #1363 / #1364 | **Ungated.** 28 tests passing locally, protecting nothing on merge. |
| `apps/voice-substrate` | PII redaction, Luhn checks, spoken-digit runs, adapter-unavailability paths, redaction-precedes-emission ordering — PR #1383, branch `feat/voice-substrate` | **Ungated**, and not yet on `main`. See judgment call below. |

Until now the ie-engine suite could have been broken by any change and `diagnostics-gate` — the repository's only required check — would still have reported green.

## What this PR adds

```yaml
- name: ie-engine
  working-directory: apps/ie-engine
  install: pip install -r requirements.txt -r requirements-test.txt && python -m spacy download en_core_web_sm
  test: PYTHONPATH=src pytest -q tests
```

Shaped to match the existing `src/`-layout legs (`zone-router`, `semantic-bridge`, `compute-gateway`, `nugget-extractor`, `device-service`) — same `PYTHONPATH=src pytest -q tests`.

**On the model download.** `apps/ie-engine/requirements.txt` pins `spacy==3.8.2` and carries the model only as a comment (`# model: python -m spacy download en_core_web_sm`); pip cannot install it from that line. `src/ie_engine/server.py` calls `spacy.load("en_core_web_sm")` at **module import time**, so without the download this leg fails at *collection*, not at an assertion — a leg that is red for infrastructure reasons teaches nothing. `en_core_web_sm` is the same model `apps/ie-engine/Dockerfile` bakes in at build, so the CI environment and the shipped image agree rather than diverge.

## Judgment call: voice-substrate is NOT in this PR

The brief allowed adding it behind a skip-if-missing guard **only if the matrix already had a precedent for one**. It does not:

- Every existing leg's `working-directory` is a path that exists on `main`.
- The `Create virtualenv` step runs `working-directory: ${{ matrix.working-directory }}` **unconditionally**, before any test command — a leg pointing at a directory that isn't on `main` fails there, and no leg-level `if:` exists to prevent it. The only `if:` in the job is `matrix.name == 'node-app-suites'` for Node setup.
- The one general-purpose skip mechanism in this workflow (docs-only) is deliberately centralised in `tools/ci_docs_only.py` and `tools/ci_diagnostics_gate.py`, precisely so skip rules are testable rather than living as untested YAML expressions. `tools/ci_diagnostics_gate.py` is **fail-closed** and treats any skip it did not authorise as RED.

Inventing a new per-leg skip in the repo's only required check — to work around a directory that will exist in a few days — would weaken the gate to solve a scheduling problem. So: **ie-engine now; voice-substrate's entry belongs in #1383 itself**, landing atomically with the directory it points at. Verified against `origin/feat/voice-substrate`, this is the exact entry to add there (needs no model download, and `tests/conftest.py` already does the `sys.path` insert):

```yaml
- name: voice-substrate
  working-directory: apps/voice-substrate
  install: pip install -r requirements.txt -r requirements-test.txt
  test: PYTHONPATH=src pytest -q tests
```

If #1383 merges without it, that suite stays ungated and this problem recurs.

## Local proof that the install/test commands work

Run in a clean venv in an isolated worktree, exactly as the workflow does it (`python3 -m venv .venv` → `pip install --upgrade pip` → `${{ matrix.install }}` → `${{ matrix.test }}`).

**`apps/ie-engine`** — `pip install -r requirements.txt -r requirements-test.txt && python -m spacy download en_core_web_sm`, then `PYTHONPATH=src pytest -q tests`:

```
Successfully installed ... fastapi-0.115.0 httpx-0.27.2 pytest-8.4.2 spacy-3.8.2 ...
Successfully installed en-core-web-sm-3.8.0
✔ Download and installation successful
You can now load the package via spacy.load('en_core_web_sm')

............................                                             [100%]
28 passed, 1 warning in 1.59s
```

(The single warning is a `DeprecationWarning` from spaCy's own `cli/_util.py` about Click 9 — upstream, not ours.)

**`apps/voice-substrate`** (from `origin/feat/voice-substrate`, to prove the follow-up entry above is correct rather than guessed) — `pip install -r requirements.txt -r requirements-test.txt`, then `PYTHONPATH=src pytest -q tests`:

```
....................s................................................... [ 48%]
........................................................................ [ 96%]
......                                                                   [100%]
149 passed, 1 skipped in 0.59s
```

## Notes for the reviewer

- `tools/run_preflight.py` deliberately excludes `app-test-diagnostics` ("per-app venvs") from local preflight, so no preflight change is needed for a new leg.
- `tools/ci_diagnostics_gate.py` classifies **jobs**, not matrix legs; a new leg rolls up into the existing `app-test-diagnostics` job and needs no gate change.
- Local runs used Python 3.12; CI pins 3.11. `spacy==3.8.2` and `en_core_web_sm==3.8.0` both publish cp311 wheels, so the leg's first CI run is the real confirmation on 3.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)