### PR TITLE
kyverno: failurePolicy: Ignore for Audit-phase policies (safe rollout)

### DIFF
--- a/infra/policy/cloudshell-fog/kyverno/require-image-digest.yaml
+++ b/infra/policy/cloudshell-fog/kyverno/require-image-digest.yaml
@@ -15,6 +15,9 @@ spec:
   # documented rollout (deploy/argocd/kyverno.yaml, ROLLOUT.md) is Audit → observe → Enforce.
   # Flip back to Enforce in the final rollout step once Audit logs are clean. Tracked: #1344.
   validationFailureAction: Audit
+  # Audit-phase: kyverno being unavailable must NOT block admissions (it is an observer, not a
+  # gate yet). Flip to Fail only when this policy goes Enforce, deliberately (#1344).
+  failurePolicy: Ignore
   background: true
   rules:
     - name: require-image-checksum

--- a/infra/policy/cloudshell-fog/kyverno/runtime-baseline.yaml
+++ b/infra/policy/cloudshell-fog/kyverno/runtime-baseline.yaml
@@ -13,6 +13,9 @@ spec:
   # Audit-first (was Enforce) — see require-image-digest.yaml. Syncing at Enforce could reject
   # existing Pods that violate the baseline, estate-wide. Audit → observe → Enforce (#1344).
   validationFailureAction: Audit
+  # Audit-phase: kyverno being unavailable must NOT block admissions (it is an observer, not a
+  # gate yet). Flip to Fail only when this policy goes Enforce, deliberately (#1344).
+  failurePolicy: Ignore
   background: true
   rules:
     - name: require-hardened-managed-session-pods

--- a/infra/policy/cloudshell-fog/kyverno/verify-signed-images.yaml
+++ b/infra/policy/cloudshell-fog/kyverno/verify-signed-images.yaml
@@ -16,6 +16,9 @@ spec:
   # follow-up PR once the Audit logs are clean (see ROLLOUT.md). The controller is installed
   # HELD via deploy/argocd/kyverno.yaml.
   validationFailureAction: Audit
+  # Audit-phase: kyverno being unavailable must NOT block admissions (it is an observer, not a
+  # gate yet). Flip to Fail only when this policy goes Enforce, deliberately (#1344).
+  failurePolicy: Ignore
   background: false
   webhookTimeoutSeconds: 30
   rules:


### PR DESCRIPTION
Surfaced by the live kyverno install: the Audit ClusterPolicies made kyverno's resource webhook `failurePolicy: Fail` — a blocking critical path for Pod admission if the controller is down. During Audit/observation that is backwards (the policy is an observer). Sets `failurePolicy: Ignore` on all three; flip to `Fail` only when going Enforce (#1344). Kyverno is HA so the window was low-risk; this closes it.