### PR TITLE
feat(deploy): install the argo-rollouts controller — the missing canary engine

### DIFF
--- a/deploy/argocd/argo-rollouts.yaml
+++ b/deploy/argocd/argo-rollouts.yaml
@@ -1,0 +1,71 @@
+# Argo Rollouts controller — the missing engine.
+#
+# The estate has a well-designed canary gate (infra/k8s/rollouts/base/analysistemplate-slo.yaml,
+# the cluster-scoped `slo-gate` that aborts on 5xx>=5% or p99>=1.5s) and Rollout resources that
+# reference it (search-orchestrator) — but NO CONTROLLER was ever installed, so none of it runs.
+# A canary with no controller is decorative: a bad image syncs straight to active with no
+# analysis and no abort. This installs the controller (foundation, before any Rollout) and
+# deploys the shared slo-gate, so progressive delivery is actually load-bearing.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo-rollouts
+  namespace: argocd
+  annotations:
+    # foundation: must be up BEFORE any Rollout syncs (Rollouts at wave 0+); after the telemetry
+    # substrate (kube-prometheus-stack, wave -3) the slo-gate analysis reads from.
+    argocd.argoproj.io/sync-wave: "-2"
+    socioprophet.io/tier: "foundation"
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argo-rollouts
+  source:
+    repoURL: https://argoproj.github.io/argo-helm
+    chart: argo-rollouts
+    targetRevision: 2.37.7        # pinned; rollouts controller ~1.7.2
+    helm:
+      releaseName: argo-rollouts
+      values: |
+        installCRDs: true
+        controller:
+          resources:
+            requests: { cpu: 100m, memory: 128Mi }
+            limits: { cpu: 500m, memory: 256Mi }
+        dashboard:
+          enabled: false          # CLI/API only; keep the footprint small
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true      # rollouts CRDs are large; SSA avoids the last-applied bloat
+---
+# Deploy the shared cluster-scoped SLO gate. Cluster-scoped so a Rollout in ANY namespace can
+# reference `templateName: slo-gate` (INV-DEP-9 — a namespaced template resolved for nothing and
+# made prod applies fail InvalidSpec). Synced AFTER the controller (its CRDs must exist first).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: rollouts-slo-gate
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    socioprophet.io/tier: "foundation"
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argo-rollouts
+  source:
+    repoURL: https://github.com/SocioProphet/prophet-platform.git
+    targetRevision: main
+    path: infra/k8s/rollouts/base
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Why: the canary/rollback loop is inert
Diagnosis (prompted by "gitops canaries and rollbacks aren't working"): the estate has a **well-designed** cluster-scoped `slo-gate` (aborts a canary on 5xx≥5% or p99≥1.5s) and Rollouts that reference it — but:
1. **No argo-rollouts controller was ever installed** → nothing executes the canary steps or the AnalysisTemplate.
2. **The appset never synced `infra/k8s/rollouts`** → even the `slo-gate` template isn't applied.
3. Only **3 Rollouts vs 55 plain Deployments** → ~1 service has a canary at all.
4. `deploy_health_alert.py` **alerts, it doesn't act**; Argo `selfHeal: true` **re-applies the bad git** (so the only valid rollback is a git-revert, which nothing automates).

Net: a bad image syncs straight to active with no analysis, no abort, no self-heal. This PR fixes the **root** (#1).

## What's here
Two ArgoCD Applications (mirroring the `kube-prometheus-stack` install convention):
- **`argo-rollouts`** — the controller, Helm-pinned `2.37.7`, `sync-wave: -2` (up before any Rollout, after the telemetry substrate the gate reads from), SSA for the large CRDs.
- **`rollouts-slo-gate`** — deploys the shared **cluster-scoped** `slo-gate` (`sync-wave: -1`), so a Rollout in any namespace resolves `templateName: slo-gate` (INV-DEP-9).

## Follow-ups (registered)
1. **Migrate the 55 plain Deployments → Rollouts** so 95% of the estate gets the gate, not one service.
2. **Auto-revert self-heal loop** — deploy-unhealthy → the reasoned responder (#563) opens a **git-revert PR** → so a bad merge that slips the canary *still* heals. This is the "if you fuck that up it should still self-heal" piece.
3. **Reconcile my #1375** `progressive-delivery/` — it duplicated this shared `slo-gate` (and namespaced, which INV-DEP-9 says resolves for nothing); consolidate onto the cluster-scoped one.

Touches prod deploy infra — flagged for human review; not auto-merging.