### PR TITLE
fix(canary): SLO gate fails closed on no data (unblocks all open PRs)

### DIFF
--- a/infra/k8s/progressive-delivery/base/analysistemplate-slo-gate.yaml
+++ b/infra/k8s/progressive-delivery/base/analysistemplate-slo-gate.yaml
@@ -21,8 +21,10 @@ spec:
       interval: 1m
       count: 5
       failureLimit: 1
-      successCondition: "result[0] < 0.05"     # < 5% 5xx, the HighErrorRatio SLO threshold
-      failureCondition: "result[0] >= 0.05"
+      # Fail-closed on no data: an empty series (service exports no such recording rule) must
+      # ABORT, never score healthy — Prometheus "no data" ≠ "healthy".
+      successCondition: "len(result) > 0 && result[0] < 0.05"     # exists AND < 5% 5xx (HighErrorRatio SLO)
+      failureCondition: "len(result) == 0 || result[0] >= 0.05"   # absent OR breaching → abort
       provider:
         prometheus:
           address: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
@@ -32,8 +34,8 @@ spec:
       interval: 1m
       count: 5
       failureLimit: 1
-      successCondition: "result[0] < 0.75"     # p99 < 750ms (the recording rule is in seconds)
-      failureCondition: "result[0] >= 0.75"
+      successCondition: "len(result) > 0 && result[0] < 0.75"     # exists AND p99 < 750ms (rule is in seconds)
+      failureCondition: "len(result) == 0 || result[0] >= 0.75"   # absent OR breaching → abort
       provider:
         prometheus:
           address: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090


### PR DESCRIPTION
## What

The `slo-canary-gate` AnalysisTemplate thresholded only on `result[0]`, so an **empty** Prometheus series (a service exporting no such recording rule) scored **Successful** — the canary promoted a release **nothing measured**. Prometheus "no data" ≠ "healthy". This is the estate's own `canary-slo-gate-check` firing on shipped config: **a control that could not fail.**

## Fix

Both metrics (`error-ratio`, `latency-p99`) now carry a data-presence guard:

```
successCondition: len(result) > 0 && result[0] < X    # exists AND within SLO
failureCondition: len(result) == 0 || result[0] >= X  # absent OR breaching → abort
```

## Why it matters now

`test_check_canary_slo_gate.py::test_shipped_repo_is_clean` fails on **every open PR** (it scans shipped config), so this single unrelated failure was **blocking #1390** (reconstruction contracts) and anything else in flight. Landing this turns them green.

## Verified

- `tools/tests/test_check_canary_slo_gate.py` — **14 passed**
- `tools/check_canary_slo_gate.py` — repo scans **clean** (`OK — every AnalysisTemplate metric fails closed on absent data`)