### PR TITLE
fix(compute-gateway): mask every result shape, not just nodes

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/masking.py
+++ b/apps/compute-gateway/src/compute_gateway/masking.py
@@ -157,13 +157,43 @@ def _decision(policy: dict[str, Any], project: str, actor: str, verdict: str,
     }
 
 
+_MAX_WALK_DEPTH = 6
+
+
 def _iter_records(output: ComputeOutput) -> list[dict[str, Any]]:
+    """Every dict anywhere in the payload is a candidate record.
+
+    This used to read `data["nodes"]` and nothing else, which meant a result shaped as
+    `rows` / `table` / `edges` was returned UNMASKED while the policy reported itself
+    active — and `rows` is a shape this estate actually emits, so it was a live hole, not a
+    theoretical one. An allowlist of container keys just moves the hole to the next shape
+    somebody adds.
+
+    Walking every nested dict is safe because _mask_record only rewrites keys that appear
+    in the policy's mask_fields: a dict with no configured field is returned untouched. So
+    the failure mode of over-walking is "nothing happens", while the failure mode of
+    under-walking is "personal data is served". Fail toward the former.
+    """
     if not output.data:
         return []
-    nodes = output.data.get("nodes")
-    if isinstance(nodes, list):
-        return [n for n in nodes if isinstance(n, dict)]
-    return []
+    seen: list[dict[str, Any]] = []
+    stack: list[tuple[Any, int]] = [(output.data, 0)]
+    while stack:
+        node, depth = stack.pop()
+        if depth > _MAX_WALK_DEPTH:
+            continue
+        if isinstance(node, dict):
+            seen.append(node)
+            for v in node.values():
+                if isinstance(v, (dict, list)):
+                    stack.append((v, depth + 1))
+        elif isinstance(node, list):
+            for v in node:
+                if isinstance(v, (dict, list)):
+                    stack.append((v, depth + 1))
+    # output.data itself is a container, not a record — masking its top level would rewrite
+    # envelope keys that happen to collide with a field name.
+    return seen[1:] if seen and seen[0] is output.data else seen
 
 
 def apply(outputs: list[ComputeOutput], *, kind: str, project: str, actor: str,

--- a/apps/compute-gateway/tests/test_masking_policy_values.py
+++ b/apps/compute-gateway/tests/test_masking_policy_values.py
@@ -99,17 +99,48 @@ def test_non_read_kinds_are_untouched():
     assert "notebook" not in masking.READ_KINDS
 
 
-def test_masking_coverage_boundary_is_nodes_only():
-    """KNOWN LIMIT, asserted so it cannot be mistaken for coverage.
+def test_every_result_shape_is_masked_not_just_nodes():
+    """The gap this closes was live in production.
 
-    masking._iter_records reads `data["nodes"]` and returns [] for anything else, so a result
-    shaped as rows / table / edges is returned UNMASKED even with this policy active. That is
-    the current boundary of the moat, not a claim about it. Widening it means changing
-    _iter_records, which is a larger change than turning the policy on; this test exists so
-    the next person reads the boundary from a failing assertion rather than from an incident.
+    The PDP previously walked `data["nodes"]` only, so a result shaped as rows / table /
+    edges came back UNMASKED while the policy reported itself active. `rows` is a shape this
+    estate actually emits, so it was a hole in the moat, not a hypothetical one.
     """
-    rows = [ComputeOutput(type="table", data={"rows": [{"email": "ada@example.com"}]})]
-    out = masking.apply(rows, kind="graph-query", project="default",
-                        actor="analyst", entitlement=None)
-    assert out[0].data["rows"][0]["email"] == "ada@example.com", \
-        "row-shaped outputs are now masked — good; update this test and the PR note"
+    shapes = {
+        "nodes": [ComputeOutput(type="graph", data={"nodes": [{"email": "ada@example.com"}]})],
+        "rows": [ComputeOutput(type="table", data={"rows": [{"email": "ada@example.com"}]})],
+        "edges": [ComputeOutput(type="graph", data={"edges": [{"email": "ada@example.com"}]})],
+        "records": [ComputeOutput(type="result", data={"records": [{"email": "ada@example.com"}]})],
+    }
+    for name, outs in shapes.items():
+        got = masking.apply(outs, kind="graph-query", project="default",
+                            actor="analyst", entitlement=None)
+        payload = json.dumps(got[0].data)
+        assert "ada@example.com" not in payload, f"{name}-shaped output leaked cleartext email"
+
+
+def test_nested_payloads_are_reached():
+    """An allowlist of container keys moves the hole to the next nesting level. The walker
+    is depth-bounded but shape-agnostic, so a record nested under an envelope is still
+    masked."""
+    out = masking.apply(
+        [ComputeOutput(type="result", data={"result": {"page": {"items": [
+            {"email": "ada@example.com"}]}}})],
+        kind="graph-query", project="default", actor="analyst", entitlement=None)
+    assert "ada@example.com" not in json.dumps(out[0].data)
+
+
+def test_over_walking_is_harmless():
+    """The walker visits every dict, which is only safe because _mask_record rewrites ONLY
+    keys named in the policy. A payload with no configured field must come back byte-identical
+    — otherwise widening coverage would corrupt unrelated envelopes."""
+    original = {"nodes": [{"city": "Cambridge", "count": 3}], "meta": {"page": 1}}
+    out = masking.apply([ComputeOutput(type="graph", data=json.loads(json.dumps(original)))],
+                        kind="graph-query", project="default", actor="analyst", entitlement=None)
+    assert out[0].data == original, "masking altered a payload containing no configured field"
+
+
+def test_non_read_kinds_still_untouched():
+    """The PDP governs reads. Widening the walker must not widen the KINDS it governs."""
+    assert "notebook" not in masking.READ_KINDS
+    assert masking.READ_KINDS == frozenset({"graph-query", "graph-stats"})


### PR DESCRIPTION
> **Closes a live hole.** Masking went on in #1387. `_iter_records` walked `data["nodes"]` and nothing else, so **rows / table / edges shaped results were returned UNMASKED** while the decision output reported the policy active.

`rows` is a shape this estate actually emits — both hellgraph-service and compute-gateway produce it. So personal data was being served in cleartext on those paths with masking nominally enforced.

I pinned that limit with a test instead of fixing it when the policy landed. Wrong call for something already enforcing in production.

## The fix

The walker is now **shape-agnostic and depth-bounded** — every nested dict is a candidate record. An allowlist of container keys only moves the hole to the next shape someone adds.

This is safe because `_mask_record` rewrites **only** keys named in `mask_fields`. A dict with no configured field comes back untouched. So:

- over-walking → nothing happens
- under-walking → personal data is served

Fail toward the former. `output.data` itself is excluded: it's the envelope, not a record, and masking its top level would rewrite container keys that collide with a field name.

## Tests

| Test | Asserts |
|---|---|
| `test_every_result_shape_is_masked_not_just_nodes` | nodes / rows / edges / records all leak nothing |
| `test_nested_payloads_are_reached` | a record under `result.page.items` is still masked |
| `test_over_walking_is_harmless` | a payload with no configured field returns **byte-identical** |
| `test_non_read_kinds_still_untouched` | widening the walker didn't widen the governed kinds |

252 tests pass.