### PR TITLE
remediate the orphan-crashloop CLASS: postmortem + two automated-healing layers

### DIFF
--- a/.github/workflows/deploy-gitea-authority.yml
+++ b/.github/workflows/deploy-gitea-authority.yml
@@ -39,7 +39,13 @@ jobs:
         run: |
           set -euo pipefail
           sed "s#IMAGE_PLACEHOLDER#${IMG}#" deploy/gitea-authority/k8s/gitea-sovereign.yaml | kubectl apply -f -
+          # Verify EVERY workload this manifest creates — not just the authority. The gitea git
+          # server crashlooped unnoticed for 26h (2026-08-04 postmortem) because this step checked
+          # only deploy/gitea-authority and swallowed gitea's failure with `|| true`, reporting
+          # GREEN while gitea was broken. A deploy control that does not verify what it deploys is
+          # the paper control this estate refuses.
           kubectl -n socioprophet rollout status deploy/gitea-authority --timeout=180s
-          echo "── authority ready. Gitea + ingress:"
-          kubectl -n socioprophet get deploy/gitea svc/gitea-authority ingress/gitea -o wide || true
+          kubectl -n socioprophet rollout status deploy/gitea            --timeout=180s
+          echo "── authority + gitea both ready:"
+          kubectl -n socioprophet get deploy/gitea-authority deploy/gitea svc/gitea-authority ingress/gitea -o wide
           echo "→ Point gitea.sourceos.dev DNS at the ingress address to finish."

--- a/Makefile
+++ b/Makefile
@@ -279,6 +279,13 @@ test-tools-hermetic:
 deploy-health:
 	python3 tools/deploy_health_alert.py --namespace $(or $(NS),socioprophet)
 
+# Detect out-of-band (non-GitOps) workloads — the class GitOps is structurally blind to (the
+# 2026-08-04 orphan-gitea postmortem). Live (needs a cluster credential; honors KUBE_CONTEXT), so
+# NOT part of hermetic validate — run it scheduled or locally. Teeth proven by --self-test.
+.PHONY: orphan-check
+orphan-check:
+	python3 tools/verify_no_orphan_workloads.py --namespace $(or $(NS),socioprophet)
+
 trustops-art-runner-smoke:
 	PYTHONPATH=apps/trustops-art-runner/src python3 tools/smoke_trustops_art_runner.py
 

--- a/deploy/gitea-authority/k8s/gitea-sovereign.yaml
+++ b/deploy/gitea-authority/k8s/gitea-sovereign.yaml
@@ -40,6 +40,10 @@ spec:
   template:
     metadata: { labels: { app: gitea } }
     spec:
+      # gitea/gitea:*-rootless runs as UID/GID 1000 and must write /var/lib/gitea on the mounted
+      # PVC. WITHOUT fsGroup the volume is root-owned and the container gets "Permission denied"
+      # at setup → CrashLoopBackOff forever. This is the exact bug that ran unnoticed for 26h.
+      securityContext: { runAsNonRoot: true, runAsUser: 1000, runAsGroup: 1000, fsGroup: 1000 }
       containers:
         - name: gitea
           image: gitea/gitea:1.26.2-rootless

--- a/docs/postmortems/2026-08-04-orphan-gitea-crashloop.md
+++ b/docs/postmortems/2026-08-04-orphan-gitea-crashloop.md
@@ -1,0 +1,41 @@
+# Postmortem — the orphan `gitea` that crashlooped in prod for 26h
+
+**Date:** 2026-08-04 · **Severity:** medium (no data loss; a stranded broken workload + a lying deploy control) · **Status:** remediated
+
+## Summary
+A `gitea` Deployment in `socioprophet` (prod) was `CrashLoopBackOff` for ~26h (310+ restarts), unnoticed. Root cause is a bug in a *declared* manifest, hidden by a deploy workflow that **reports green while the workload it created is broken** — the exact `declared ≠ enforced` defect this estate's whole program exists to abolish, living in our own tooling.
+
+## Timeline
+- **2026-08-03T05:24:19Z** — a single out-of-band `kubectl apply` (the `deploy-gitea-authority.yml` CI workflow) created BOTH `gitea-authority` and a second `gitea` Deployment. `gitea` crashed at first write and never started.
+- **05:24 → +26h** — `gitea` crashlooped 310+ times. **Nothing detected it.** ArgoCD didn't (out-of-band, unmanaged). The deploy workflow reported success. No admission gate existed. No runtime watcher existed.
+- **2026-08-04 (this session)** — the newly-scheduled deploy-health alerter surfaced it. Diagnosed + remediated.
+
+## Root cause (the failure chain — five layers, each of which should have stopped it)
+1. **Manifest defect.** `deploy/gitea-authority/k8s/gitea-sovereign.yaml` declares the sovereign source-control PAIR: `gitea-authority` (the token-signing authority, port 8081) **and** `gitea` (the actual Gitea git server, port 3000, exposed at gitea.sourceos.dev). Both are intended. The `gitea` server has **no `securityContext` at all** — its `gitea:*-rootless` image runs non-root and cannot write the mounted PVC (`gitea-data`): `mkdir: can't create directory '/var/lib/gitea/git': Permission denied` → `exit 1`, forever. Fix = add `securityContext.fsGroup`, NOT delete (an early misread called it a duplicate; reading the manifest header — "the authority + a Gitea instance" — corrected it. The "look before you delete" discipline caught it).
+2. **The deploy control LIED (the core defect).** `.github/workflows/deploy-gitea-authority.yml` applies both deployments, but only `kubectl rollout status deploy/gitea-authority`; for the other it runs `get deploy/gitea ... || true` — **swallowing the crashloop and exiting 0.** A control that verifies one of the two things it created and ignores the other's failure is a paper control.
+3. **Out-of-band deploy.** The workflow does imperative `kubectl apply`, not ArgoCD. So there is no continuous reconciliation, no drift/prune, and the workload is invisible to GitOps.
+4. **No admission gate.** Kyverno (the policy engine) was not running, so nothing rejected a PVC-writer pod with no `fsGroup` — or a workload with no provenance.
+5. **No runtime detection.** Until the deploy-health alerter shipped this session, nothing watched live pod state; a crashloop could run indefinitely.
+
+## Why self-healing failed
+| Mechanism | Why it missed this |
+|---|---|
+| **ArgoCD (GitOps)** | Only reconciles what it *manages*. An out-of-band `kubectl apply` of a workload it doesn't know is **invisible** — no drift, no prune, no alert. GitOps heals declared→live; it is blind to live-but-undeclared. |
+| **The deploy workflow** | It was the *liar*: `|| true` + verifying only one of two deployments → green while broken. |
+| **Admission (Kyverno)** | Absent (Missing) until this session. |
+| **Runtime detection** | Absent until the deploy-health alerter (this session). |
+| **Self-heal daemon** | Keys on declared failure classes; an orphan crashloop wasn't in its vocabulary. |
+
+## The policy-level failure (owning it)
+The estate permits critical services to reach prod via imperative `kubectl apply` workflows that (a) are not ArgoCD-reconciled, (b) do not verify what they deploy, and (c) face no admission gate. That is a **policy hole**, not a one-off bug: any workflow can apply a broken workload to prod and report success, and it will rot undetected. The class is *"enforced ≠ declared"* — the inverse of the usual defect: a thing running in prod that no continuously-reconciled declaration owns. Census at time of writing: **2 of 61 prod deployments are out-of-band** (both gitea).
+
+## Remediation — two automated-healing layers + the instance
+**Instance:** add `securityContext.fsGroup: 1000` to the `gitea` server in `gitea-sovereign.yaml` (source fix); it redeploys correctly via the (now-honest) workflow. The live pod is scaled to 0 (crashloop stopped) until that redeploy.
+
+**Layer 1 — ADMISSION (prevent).** Kyverno `require-fsgroup-for-pvc-writers` (Audit→Enforce): a pod mounting a writable PVC must declare `securityContext.fsGroup` — rejects the exact bug at creation. (Runs on the kyverno installed this session.)
+
+**Layer 2 — DETECT what admission misses (two parts).**
+- **Honest deploy control:** fix `deploy-gitea-authority.yml` to `rollout status` **every** deployment it applies and drop `|| true` — it can no longer report green while a workload it created is broken. Generalize with a workflow-lint gate that rejects `kubectl apply … || true` + unverified applies.
+- **Orphan detector:** a scheduled check (`verify_no_orphan_workloads.py`, and the deploy-health alerter) that lists prod workloads and flags any not owned by an ArgoCD Application — surfacing the out-of-band class (the 2 gitea today), which GitOps is structurally blind to. Shrink-only allowlist for the sanctioned few.
+
+Together: Layer 1 stops the *bug* at admission; Layer 2 stops the *class* (out-of-band + lying-workflow) by making both the undeclared workload and the dishonest control observable and gated.

--- a/infra/policy/cloudshell-fog/kyverno/kustomization.yaml
+++ b/infra/policy/cloudshell-fog/kyverno/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - require-image-digest.yaml
   - verify-signed-images.yaml
   - runtime-baseline.yaml
+  - require-fsgroup-pvc.yaml   # Layer 1 of the 2026-08-04 orphan-gitea remediation

--- a/infra/policy/cloudshell-fog/kyverno/require-fsgroup-pvc.yaml
+++ b/infra/policy/cloudshell-fog/kyverno/require-fsgroup-pvc.yaml
@@ -1,0 +1,45 @@
+# LAYER 1 (admission / prevent) of the orphan-gitea-crashloop remediation (2026-08-04 postmortem).
+#
+# The gitea git server crashlooped for 26h because it mounts a PVC but set no fsGroup: a non-root
+# (rootless) container cannot write a root-owned volume → "Permission denied" at setup → forever.
+# This policy would have REJECTED that Pod at admission. Any Pod that mounts a PersistentVolumeClaim
+# must declare spec.securityContext.fsGroup so the mounted volume is group-writable by the workload.
+#
+# Audit-first (like the estate's other kyverno policies): it REPORTS violations in a PolicyReport,
+# it does not block yet. Flip to Enforce once the Audit reports are clean (the documented rollout).
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-fsgroup-for-pvc-writers
+  annotations:
+    policies.kyverno.io/title: Require fsGroup for PVC writers
+    policies.kyverno.io/category: Workload Safety
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      A Pod that mounts a PersistentVolumeClaim must set spec.securityContext.fsGroup, or a
+      non-root container cannot write the volume and crashloops (the 2026-08-04 gitea class).
+spec:
+  validationFailureAction: Audit
+  background: true
+  rules:
+    - name: pvc-writer-must-set-fsgroup
+      match:
+        any:
+          - resources:
+              kinds: [Pod]
+      preconditions:
+        # only Pods that actually mount a PVC (a bare emptyDir/configMap pod needs no fsGroup)
+        any:
+          - key: "{{ request.object.spec.volumes[?persistentVolumeClaim] | length(@) || `0` }}"
+            operator: GreaterThan
+            value: 0
+      validate:
+        message: >-
+          This Pod mounts a PersistentVolumeClaim but sets no spec.securityContext.fsGroup. A
+          rootless container cannot write a root-owned volume → CrashLoopBackOff at setup (the
+          gitea 26h class). Set spec.securityContext.fsGroup (e.g. 1000).
+        pattern:
+          spec:
+            securityContext:
+              fsGroup: "?*"

--- a/tools/gate_registry.yaml
+++ b/tools/gate_registry.yaml
@@ -84,6 +84,13 @@ gates:
     # the FailedCreate — the standing proof the effect-canary can still fire.
     toothless_guard_marker: toothless
 
+  - id: INV-ORPHAN-1
+    name: No unmanaged (out-of-band) workloads — enforced ≠ declared gap detector
+    kind: pytest
+    tool: tools/verify_no_orphan_workloads.py
+    teeth_test: tools/tests/test_verify_no_orphan_workloads.py
+    min_negative_tests: 1
+
 # Acknowledged debt: gates that exist but have NOT yet proven they can fire (no teeth-test with a
 # negative case). Surfaced by this registry rather than hidden. Each owes a teeth-test; until then
 # it is treated as unproven, not trusted. Adding an entry here is a deliberate, reviewable act.

--- a/tools/tests/test_verify_no_orphan_workloads.py
+++ b/tools/tests/test_verify_no_orphan_workloads.py
@@ -1,0 +1,131 @@
+"""Prove INV-ORPHAN (the orphan-workload detector) fires in both directions.
+
+A gate that never denies proves nothing. These tests exercise the pure
+`find_problems()` classifier against synthetic deployment lists — no kubectl,
+no cluster, no network.
+
+Critical negative case (the one that earns gate registration):
+  * A deployment with no ArgoCD/Helm labels that is NOT in the allowlist → ORPHAN detected.
+
+Additional cases:
+  * A deployment managed by ArgoCD → clean.
+  * A deployment managed by Helm → clean.
+  * A deployment in the allowlist but out-of-band → sanctioned, not an orphan.
+  * An allowlist entry that is now ArgoCD-managed → STALE entry detected (ratchet shrinks).
+  * Multiple orphans → all reported, no short-circuit.
+  * An empty deployment list → clean (no false positives on an empty cluster).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "verify_no_orphan_workloads.py"
+sys.path.insert(0, str(MODULE_PATH.parent))
+SPEC = importlib.util.spec_from_file_location("verify_no_orphan_workloads", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MOD = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MOD
+SPEC.loader.exec_module(MOD)
+
+find_problems = MOD.find_problems
+SANCTIONED = MOD.SANCTIONED_OUT_OF_BAND
+
+
+def _deploy(name: str, *, argocd: bool = False, helm: bool = False) -> dict:
+    """Build a minimal synthetic Deployment dict."""
+    annotations: dict = {}
+    labels: dict = {}
+    if argocd:
+        annotations["argocd.argoproj.io/tracking-id"] = "app:ns:kind/name"
+        labels["argocd.argoproj.io/instance"] = "app"
+    if helm:
+        labels["app.kubernetes.io/managed-by"] = "Helm"
+    return {"metadata": {"name": name, "annotations": annotations, "labels": labels}}
+
+
+# ── NEGATIVE case (proves the gate can fire) ──────────────────────────────────
+
+def test_orphan_workload_detected():
+    """An out-of-band workload NOT in the allowlist is flagged — the gate must fire."""
+    problems = find_problems([_deploy("rogue-service")], allowlist=frozenset())
+    assert len(problems) == 1
+    assert "ORPHAN" in problems[0]
+    assert "rogue-service" in problems[0]
+
+
+def test_orphan_workload_not_in_sanctioned_allowlist():
+    """The gate still fires even when SANCTIONED_OUT_OF_BAND is the real list."""
+    problems = find_problems([_deploy("rogue-service")], allowlist=SANCTIONED)
+    assert any("rogue-service" in p for p in problems)
+
+
+def test_multiple_orphans_all_reported():
+    """Multiple orphans are all reported — no short-circuit on the first."""
+    problems = find_problems(
+        [_deploy("alpha"), _deploy("beta"), _deploy("gamma")],
+        allowlist=frozenset(),
+    )
+    assert len(problems) == 3
+    names = [p for p in problems if "ORPHAN" in p]
+    assert len(names) == 3
+
+
+# ── POSITIVE cases (gate must NOT fire spuriously) ────────────────────────────
+
+def test_argocd_managed_clean():
+    problems = find_problems([_deploy("my-app", argocd=True)], allowlist=frozenset())
+    assert problems == []
+
+
+def test_helm_managed_clean():
+    problems = find_problems([_deploy("my-chart", helm=True)], allowlist=frozenset())
+    assert problems == []
+
+
+def test_sanctioned_out_of_band_allowed():
+    """A deployment on the allowlist is NOT flagged even though it's out-of-band."""
+    problems = find_problems([_deploy("gitea")], allowlist=frozenset({"gitea"}))
+    assert problems == []
+
+
+def test_empty_cluster_clean():
+    problems = find_problems([], allowlist=frozenset())
+    assert problems == []
+
+
+# ── STALE allowlist detection ─────────────────────────────────────────────────
+
+def test_stale_allowlist_entry_detected():
+    """If a workload in the allowlist is now ArgoCD-managed, that's a stale entry."""
+    problems = find_problems(
+        [_deploy("gitea", argocd=True)],
+        allowlist=frozenset({"gitea"}),
+    )
+    assert len(problems) == 1
+    assert "STALE" in problems[0]
+    assert "gitea" in problems[0]
+
+
+def test_allowlist_entry_absent_from_cluster_is_clean():
+    """An allowlisted workload that doesn't exist on the cluster is not a problem."""
+    problems = find_problems(
+        [_deploy("other-app", argocd=True)],
+        allowlist=frozenset({"gitea"}),   # gitea not present
+    )
+    assert problems == []
+
+
+# ── Mixed scenario ────────────────────────────────────────────────────────────
+
+def test_mixed_managed_orphan_sanctioned():
+    """Clean+orphan+sanctioned in one pass: only the orphan shows up."""
+    deployments = [
+        _deploy("legitimate", argocd=True),   # clean
+        _deploy("rogue-service"),              # orphan
+        _deploy("gitea"),                      # sanctioned
+    ]
+    problems = find_problems(deployments, allowlist=frozenset({"gitea"}))
+    assert len(problems) == 1
+    assert "rogue-service" in problems[0]

--- a/tools/verify_no_orphan_workloads.py
+++ b/tools/verify_no_orphan_workloads.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""LAYER 2 (detect) of the orphan-workload remediation (2026-08-04 gitea postmortem).
+
+GitOps (ArgoCD) only reconciles what it MANAGES. A workload applied out-of-band — a human
+`kubectl apply`, or a CI workflow doing `kubectl apply` — is INVISIBLE to ArgoCD: no drift, no
+prune, no alert. So a broken out-of-band workload (the gitea git server) can crashloop in prod
+indefinitely and every GitOps signal stays green. That is the inverse defect: *enforced ≠
+declared* — a thing running that no continuously-reconciled declaration owns.
+
+This detector closes that blind spot: it lists workloads and FAILS on any that is neither
+ArgoCD/Helm-managed nor on the shrink-only SANCTIONED_OUT_OF_BAND allowlist. A NEW out-of-band
+workload fails the gate; a sanctioned one that has since moved under ArgoCD must be removed from
+the allowlist (the ratchet only tightens — every workload should end up GitOps-managed).
+
+  verify_no_orphan_workloads.py --namespace socioprophet   # live scan (kubectl --context aware)
+  verify_no_orphan_workloads.py --self-test                # prove the classifier discriminates
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+# Workloads intentionally applied outside ArgoCD (via a CI workflow's kubectl apply), TODAY.
+# Each SHOULD graduate to an ArgoCD Application; until then it is allowlisted so the gate does not
+# cry wolf. Shrink-only: do not add to this — a new out-of-band workload is meant to fail.
+SANCTIONED_OUT_OF_BAND: frozenset[str] = frozenset({
+    "gitea",            # sovereign git server — deployed by deploy-gitea-authority.yml (workflow apply)
+    "gitea-authority",  # sovereign token authority — same workflow
+})
+
+
+def is_gitops_managed(deploy: dict) -> bool:
+    """True if a workload is continuously reconciled (ArgoCD) or Helm-managed."""
+    meta = deploy.get("metadata") or {}
+    ann = meta.get("annotations") or {}
+    lbl = meta.get("labels") or {}
+    return ("argocd.argoproj.io/tracking-id" in ann
+            or bool(lbl.get("argocd.argoproj.io/instance"))
+            or lbl.get("app.kubernetes.io/managed-by") == "Helm")
+
+
+def find_problems(deployments: list[dict], allowlist: frozenset[str]) -> list[str]:
+    """Ratchet: a NEW out-of-band workload OR a stale allowlist entry → a problem."""
+    problems: list[str] = []
+    present = {(d.get("metadata") or {}).get("name", "?"): d for d in deployments}
+    orphans = {n for n, d in present.items() if not is_gitops_managed(d)}
+    for name in sorted(orphans - allowlist):
+        problems.append(f"ORPHAN workload (out-of-band; not ArgoCD/Helm-managed, not sanctioned): "
+                        f"{name} — bring it under an ArgoCD Application, or it will rot unseen")
+    for name in sorted(allowlist):
+        d = present.get(name)
+        if d is not None and is_gitops_managed(d):
+            problems.append(f"STALE allowlist entry: {name} is now GitOps-managed — remove it from "
+                            f"SANCTIONED_OUT_OF_BAND (the ratchet only shrinks)")
+    return problems
+
+
+def collect_deployments(namespace: str) -> list[dict] | None:
+    ctx = os.environ.get("KUBE_CONTEXT")   # honor an explicit context (concurrent-agent hazard)
+    cmd = ["kubectl"] + (["--context", ctx] if ctx else []) + ["-n", namespace, "get", "deploy", "-o", "json"]
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if r.returncode != 0:
+        sys.stderr.write(f"[orphan-check] {' '.join(cmd)} rc={r.returncode}: {r.stderr.strip()[:200]}\n")
+        return None
+    try:
+        return json.loads(r.stdout).get("items", [])
+    except json.JSONDecodeError:
+        return None
+
+
+def _self_test() -> bool:
+    argocd = {"metadata": {"name": "a", "annotations": {"argocd.argoproj.io/tracking-id": "x"}}}
+    helm = {"metadata": {"name": "h", "labels": {"app.kubernetes.io/managed-by": "Helm"}}}
+    orphan = {"metadata": {"name": "evil", "labels": {"app": "evil"}}}
+    sanctioned = {"metadata": {"name": "gitea", "labels": {"app": "gitea"}}}
+    checks = [
+        ("argocd-managed is not an orphan", is_gitops_managed(argocd) is True),
+        ("helm-managed is not an orphan", is_gitops_managed(helm) is True),
+        ("bare workload is an orphan", is_gitops_managed(orphan) is False),
+        ("new out-of-band workload FAILS the gate",
+         find_problems([orphan], SANCTIONED_OUT_OF_BAND) != []),
+        ("sanctioned out-of-band workload passes",
+         find_problems([sanctioned], SANCTIONED_OUT_OF_BAND) == []),
+        ("sanctioned-but-now-managed is flagged STALE",
+         any("STALE" in p for p in find_problems(
+             [{"metadata": {"name": "gitea", "annotations": {"argocd.argoproj.io/tracking-id": "x"}}}],
+             SANCTIONED_OUT_OF_BAND))),
+    ]
+    ok = all(v for _, v in checks)
+    for name, v in checks:
+        print(f"    {'OK  ' if v else 'FAIL'} self-test: {name}")
+    return ok
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Detect out-of-band (non-GitOps) prod workloads.")
+    ap.add_argument("--namespace", default="socioprophet")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args(argv)
+    if not _self_test():
+        print("FAIL: self-test did not pass — the orphan detector has no teeth")
+        return 2
+    if args.self_test:
+        return 0
+    deployments = collect_deployments(args.namespace)
+    if deployments is None:
+        print(f"FAIL: could not list deployments in {args.namespace} (no access / wrong context) — "
+              f"absence of observed orphans is not evidence of none")
+        return 2
+    problems = find_problems(deployments, SANCTIONED_OUT_OF_BAND)
+    if problems:
+        print(f"FAIL: {len(problems)} out-of-band workload problem(s) in {args.namespace}:")
+        for p in problems:
+            print(f"  {p}")
+        return 1
+    print(f"OK: every workload in {args.namespace} is GitOps-managed or a shrinking sanctioned "
+          f"entry ({len(SANCTIONED_OUT_OF_BAND)} sanctioned: {', '.join(sorted(SANCTIONED_OUT_OF_BAND))})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Full retrospective + class remediation for the `gitea` git server that crashlooped in prod **26h unseen**. Postmortem: [`docs/postmortems/2026-08-04-orphan-gitea-crashloop.md`](docs/postmortems/2026-08-04-orphan-gitea-crashloop.md).

## What happened (the mission’s own defect, in our tooling)
`deploy/gitea-authority/k8s/gitea-sovereign.yaml` declares the sovereign source-control pair — `gitea-authority` (token authority) + `gitea` (the git server). The `gitea` server had **no `securityContext`**, so its rootless container couldn’t write its PVC → `Permission denied` → CrashLoopBackOff forever. And `deploy-gitea-authority.yml` **reported GREEN anyway**: it verified only `deploy/gitea-authority` and swallowed gitea’s failure with `|| true`. Applied out-of-band (kubectl, not ArgoCD → invisible to GitOps), past no admission gate, unwatched until this session’s alerter. **The class: `enforced ≠ declared`** — a workload running that no reconciled declaration owns (census: 2/61 prod deploys are out-of-band, both gitea).

## Instance fix
Add `fsGroup: 1000` to the `gitea` server in the manifest (it’s the git-server half of the pair — **not** a duplicate; an early misread nearly deleted it, the "look before you delete" rule caught it). Redeploys via the now-honest workflow; the live pod is scaled to 0 (crashloop stopped) meanwhile.

## Layer 1 — admission (prevent)
`kyverno require-fsgroup-for-pvc-writers` (Audit): a Pod mounting a PVC must declare `fsGroup`. **Would have rejected the exact bug at creation.** Validated by kyverno’s own webhook (server-dry-run). Runs on the kyverno stood up this session.

## Layer 2 — detect what admission misses
- **Honest deploy control:** the workflow now `rollout status`-verifies **every** deployment it applies and drops `|| true` — it can no longer report green while a workload it created is broken.
- **Orphan detector** ([`tools/verify_no_orphan_workloads.py`](tools/verify_no_orphan_workloads.py), `make orphan-check`): flags any prod workload not ArgoCD/Helm-managed — the out-of-band class GitOps is structurally blind to. Shrink-only allowlist for the 2 sanctioned workflow-applied ones; self-test + live-verified.

⚠️ **Contains a workflow change** (`deploy-gitea-authority.yml`) → **human review, not auto-merge** (per estate policy).