### PR TITLE
feat(mesh): hyper-feed-manifest.v0 — the node-symmetric federation primitive

### DIFF
--- a/contracts/crystal-atlas/schemas/hyper-feed-manifest.v0.schema.json
+++ b/contracts/crystal-atlas/schemas/hyper-feed-manifest.v0.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "hyper-feed-manifest.v0",
+  "description": "What a node publishes so peers federate WITHOUT trusting it or shipping raw data. Each entry carries a compact semantic-hash `code` (cross-node nearest-neighbour by Hamming distance), a content `digest` (content-addressed fetch verification), and an `attestation_ref` (provenance, verified via the twin or an mcp-a2a AttestationBundle — referenced, not embedded). Operational-set scoped: a peer matches only within an op_set it is entitled to.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["manifest_id", "node_id", "tenant_id", "created_at", "entries"],
+  "properties": {
+    "manifest_id": { "type": "string", "minLength": 3 },
+    "node_id": { "type": "string", "minLength": 1 },
+    "tenant_id": { "type": "string", "minLength": 1 },
+    "created_at": { "type": "string" },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["ref_id", "op_set", "code", "digest"],
+        "properties": {
+          "ref_id": { "type": "string", "minLength": 1, "description": "a graph node/hyperedge id this node holds" },
+          "op_set": { "type": "string", "minLength": 1 },
+          "code": { "type": "string", "pattern": "^[0-9a-f]+$", "description": "hex semantic-hash code; Hamming distance approximates semantic distance" },
+          "digest": { "type": "string", "minLength": 1, "description": "content digest for content-addressed fetch (e.g. sha256:...)" },
+          "attestation_ref": { "type": "string", "description": "reference to the provenance attestation (mcp-a2a AttestationBundle id / twin receipt)" }
+        }
+      }
+    },
+    "signature": { "type": "string", "description": "detached signature over the manifest by the publishing node's key" }
+  }
+}

--- a/tools/hyper_feed/__init__.py
+++ b/tools/hyper_feed/__init__.py
@@ -1,0 +1,1 @@
+"""Hyper Feed — the node-symmetric mesh federation primitive. See `manifest`."""

--- a/tools/hyper_feed/fetch.py
+++ b/tools/hyper_feed/fetch.py
@@ -1,0 +1,57 @@
+"""Node-to-node fetch — the pull half of Hyper Feed federation. Given a peer's manifest, a node
+discovers matches by Hamming (manifest.match), fetches the raw objects, and ADMITS each only if it
+verifies: the content content-addresses to the manifest's digest AND its provenance attestation
+verifies. Fail-closed — a tampered object, an unverifiable attestation, or a failed fetch is rejected,
+never admitted.
+
+This is "trust nothing, verify everything" across the mesh: raw data moves only after the code-level
+match, and only verified data is admitted. Fetcher + attestation verifier are injectable, so the whole
+protocol is testable without a live peer or the real twin.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List, Mapping, Optional
+
+from tools.hyper_feed.manifest import match, verify_digest
+
+Fetcher = Callable[[str], bytes]              # ref_id -> raw bytes (HTTP to the peer, or a mock)
+AttestationVerifier = Callable[[str], bool]   # attestation_ref -> ok? (twin verify / mcp-a2a check)
+
+
+@dataclass(frozen=True)
+class AdmitResult:
+    ref_id: str
+    admitted: bool
+    reason: str
+    content: Optional[bytes] = None
+
+
+def admit(entry: Mapping, content: bytes, *,
+          attestation_verifier: Optional[AttestationVerifier] = None) -> AdmitResult:
+    """Admit a fetched object iff its digest matches AND — when it carries an attestation_ref and a
+    verifier is supplied — its provenance verifies. Fail-closed."""
+    if not verify_digest(entry, content):
+        return AdmitResult(entry["ref_id"], False, "digest-mismatch")
+    att = entry.get("attestation_ref")
+    if att and attestation_verifier is not None and not attestation_verifier(att):
+        return AdmitResult(entry["ref_id"], False, "attestation-invalid")
+    return AdmitResult(entry["ref_id"], True, "ok", content)
+
+
+def federate(query_code: str, peer_manifest: Mapping, *, fetcher: Fetcher, max_hamming: int,
+             op_set: Optional[str] = None,
+             attestation_verifier: Optional[AttestationVerifier] = None) -> List[AdmitResult]:
+    """Discover (Hamming match) → fetch → admit (verify), nearest first. Only admitted results carry
+    content; a fetch failure is a rejection, not a crash."""
+    index = {e["ref_id"]: e for e in peer_manifest.get("entries", [])}
+    results: List[AdmitResult] = []
+    for ref_id, _ in match(query_code, peer_manifest, max_hamming=max_hamming, op_set=op_set):
+        entry = index[ref_id]
+        try:
+            content = fetcher(ref_id)
+        except Exception as exc:  # noqa: BLE001 — any fetch failure is a rejection
+            results.append(AdmitResult(ref_id, False, f"fetch-failed:{type(exc).__name__}"))
+            continue
+        results.append(admit(entry, content, attestation_verifier=attestation_verifier))
+    return results

--- a/tools/hyper_feed/manifest.py
+++ b/tools/hyper_feed/manifest.py
@@ -1,0 +1,64 @@
+"""Hyper Feed manifest — what a node publishes so peers federate WITHOUT trusting it or shipping raw
+data. Each entry carries a compact semantic-hash `code` (cheap cross-node nearest-neighbour by Hamming),
+a content `digest` (content-addressed fetch), and an `attestation_ref` (provenance verified via the twin
+or an mcp-a2a AttestationBundle — referenced, not re-invented). Operational-set scoped.
+
+A peer matches its query codes against a manifest by Hamming — no raw data moves, the codes alone
+answer "who has something like this" — then verifies a fetched object by digest and checks provenance
+by reference. Deterministic.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import List, Mapping, Optional, Sequence, Tuple
+
+__all__ = ["hamming_hex", "content_digest", "build_manifest", "match", "verify_digest"]
+
+
+def hamming_hex(a: str, b: str) -> int:
+    """Hamming distance between two equal-length hex-encoded codes (number of differing bits)."""
+    if len(a) != len(b):
+        raise ValueError("codes differ in length — incomparable")
+    return bin(int(a, 16) ^ int(b, 16)).count("1")
+
+
+def content_digest(content: bytes) -> str:
+    """A content-address used to verify a fetched object against the manifest."""
+    return "sha256:" + hashlib.sha256(content).hexdigest()
+
+
+def build_manifest(node_id: str, tenant_id: str, entries: Sequence[Mapping], *,
+                   manifest_id: Optional[str] = None, now: str = "") -> dict:
+    """Assemble a hyper-feed-manifest.v0 from a node's entries (each: ref_id, op_set, code, digest,
+    optionally attestation_ref)."""
+    return {
+        "manifest_id": manifest_id or f"hfm:{node_id}:{now}",
+        "node_id": node_id,
+        "tenant_id": tenant_id,
+        "created_at": now,
+        "entries": [dict(e) for e in entries],
+    }
+
+
+def match(query_code: str, manifest: Mapping, *, max_hamming: int,
+          op_set: Optional[str] = None) -> List[Tuple[str, int]]:
+    """A peer's query code → the manifest's (ref_id, hamming) within `max_hamming`, nearest first.
+    If `op_set` is given, only entries in that set are considered (isolation). A code of a different
+    length is incomparable and skipped, never a crash."""
+    out: List[Tuple[str, int]] = []
+    for e in manifest.get("entries", []):
+        if op_set is not None and e.get("op_set") != op_set:
+            continue
+        try:
+            d = hamming_hex(query_code, e["code"])
+        except ValueError:
+            continue
+        if d <= max_hamming:
+            out.append((e["ref_id"], d))
+    out.sort(key=lambda t: (t[1], t[0]))
+    return out
+
+
+def verify_digest(entry: Mapping, content: bytes) -> bool:
+    """A fetched object is trustworthy only if its content hashes to the manifest's digest."""
+    return entry.get("digest") == content_digest(content)

--- a/tools/tests/test_hyper_feed_fetch.py
+++ b/tools/tests/test_hyper_feed_fetch.py
@@ -1,0 +1,57 @@
+"""Theorems of node-to-node fetch (tools.hyper_feed.fetch) — the pull half of federation: discover
+by Hamming, fetch, and admit ONLY verified objects (digest + attestation). Fail-closed."""
+from __future__ import annotations
+
+from tools.hyper_feed import fetch as ff
+from tools.hyper_feed import manifest as hf
+
+
+def _entry(ref, code, content, op_set="discourse", att=None):
+    return {"ref_id": ref, "op_set": op_set, "code": code, "digest": hf.content_digest(content),
+            **({"attestation_ref": att} if att else {})}
+
+
+def test_admit_accepts_matching_content():
+    e = _entry("r1", "ff00", b"data")
+    r = ff.admit(e, b"data")
+    assert r.admitted and r.reason == "ok" and r.content == b"data"
+
+
+def test_admit_rejects_tampered_content():
+    e = _entry("r1", "ff00", b"data")
+    r = ff.admit(e, b"tampered")
+    assert not r.admitted and r.reason == "digest-mismatch" and r.content is None
+
+
+def test_admit_rejects_invalid_attestation():
+    e = _entry("r1", "ff00", b"data", att="att:bad")
+    r = ff.admit(e, b"data", attestation_verifier=lambda a: False)
+    assert not r.admitted and r.reason == "attestation-invalid"
+
+
+def test_federate_pulls_and_admits_only_verified():
+    m = hf.build_manifest("peer", "t1", [
+        _entry("r_near", "ff01", b"near-content", att="att:near"),
+        _entry("r_far", "0000", b"far-content"),
+    ], now="T")
+    store = {"r_near": b"near-content"}  # the peer serves this; digest matches
+    res = ff.federate("ff00", m, fetcher=lambda rid: store[rid], max_hamming=4,
+                      attestation_verifier=lambda a: True)
+    assert [(r.ref_id, r.admitted) for r in res] == [("r_near", True)]  # r_far excluded by Hamming
+    assert res[0].content == b"near-content"
+
+
+def test_federate_rejects_a_tampering_peer():
+    m = hf.build_manifest("peer", "t1", [_entry("r1", "ff00", b"honest")], now="T")
+    res = ff.federate("ff00", m, fetcher=lambda rid: b"SWAPPED", max_hamming=2)
+    assert res == [ff.AdmitResult("r1", False, "digest-mismatch")]  # the swap is caught
+
+
+def test_federate_treats_a_fetch_failure_as_rejection():
+    m = hf.build_manifest("peer", "t1", [_entry("r1", "ff00", b"x")], now="T")
+
+    def boom(_):
+        raise ConnectionError("peer down")
+
+    res = ff.federate("ff00", m, fetcher=boom, max_hamming=2)
+    assert not res[0].admitted and res[0].reason.startswith("fetch-failed")

--- a/tools/tests/test_hyper_feed_manifest.py
+++ b/tools/tests/test_hyper_feed_manifest.py
@@ -1,0 +1,58 @@
+"""Theorems of the Hyper Feed manifest (tools.hyper_feed.manifest) — node-symmetric federation:
+match by Hamming without moving raw data, verify by digest, op_set-scoped. Deterministic."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.hyper_feed import manifest as hf
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA = ROOT / "contracts/crystal-atlas/schemas/hyper-feed-manifest.v0.schema.json"
+
+
+def _entry(ref, code, op_set="discourse", content=b"x"):
+    return {"ref_id": ref, "op_set": op_set, "code": code, "digest": hf.content_digest(content),
+            "attestation_ref": f"att:{ref}"}
+
+
+def test_hamming_hex():
+    assert hf.hamming_hex("00", "00") == 0
+    assert hf.hamming_hex("00", "01") == 1
+    assert hf.hamming_hex("ff", "00") == 8
+    with pytest.raises(ValueError):
+        hf.hamming_hex("ff", "ffff")  # different length is incomparable
+
+
+def test_match_finds_near_codes_and_skips_far():
+    # THEOREM: a peer discovers "who has something like this" by Hamming on codes — no raw data moves.
+    m = hf.build_manifest("nodeA", "t1", [_entry("r_near", "ff01"), _entry("r_far", "0000")], now="T")
+    assert hf.match("ff00", m, max_hamming=4) == [("r_near", 1)]  # far one excluded
+
+
+def test_match_is_op_set_scoped():
+    # THEOREM: federation respects isolation — a peer only matches within an op_set it queries.
+    m = hf.build_manifest("nodeA", "t1", [
+        _entry("r_ok", "ff00", op_set="discourse"),
+        _entry("r_other", "ff00", op_set="finance"),
+    ], now="T")
+    assert hf.match("ff00", m, max_hamming=2, op_set="discourse") == [("r_ok", 0)]
+
+
+def test_digest_verifies_and_rejects_tamper():
+    # THEOREM: a fetched object is trusted only if it content-addresses to the manifest's digest.
+    e = _entry("r1", "ff00", content=b"hello")
+    assert hf.verify_digest(e, b"hello") is True
+    assert hf.verify_digest(e, b"HELLO") is False
+
+
+def test_manifest_validates_against_schema():
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA.read_text())
+    good = hf.build_manifest("nodeA", "t1", [_entry("r1", "ff00")], now="2026-08-04T00:00:00Z")
+    jsonschema.validate(good, schema)  # must not raise
+    bad = hf.build_manifest("nodeA", "t1", [{"ref_id": "r1", "op_set": "d", "code": "XYZ", "digest": "d"}], now="T")
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)  # code "XYZ" is not hex


### PR DESCRIPTION
## Hyper Feed manifest — the "any node" federation primitive

The sovereign↔cloud bridge is one edge of a **node-symmetric mesh** (cloud / edge / fog-K3s all full citizens). This is what a node **publishes** so peers federate — without trusting it and without shipping raw data.

Each manifest entry carries:
- a compact **semantic-hash `code`** → a peer finds "who has something like this" by **Hamming distance on the codes** (no raw data moves);
- a **content `digest`** → a fetched object is trusted only if it content-addresses to it;
- an **`attestation_ref`** → provenance verified via the twin / an mcp-a2a `AttestationBundle` (**referenced, not re-invented** — conform-don't-invent);
- an **`op_set`** → a peer matches only within a set it's entitled to (isolation survives federation).

`tools/hyper_feed`: `build_manifest` · `match` (Hamming, op_set-scoped) · `verify_digest`. New schema `hyper-feed-manifest.v0`.

### Why it composes
This is where the spine meets the mesh: the **codes** are the ⑤ semantic-hash (ProCybernetica #132); the **attestation_ref** is the twin's VRF receipt; the **ref_ids** are hellgraph nodes/hyperedges (#1400). A node runs the whole brain locally and federates only compact, verifiable state.

### Proof
`pytest tools/tests/test_hyper_feed_manifest.py` — **5 theorems**: Hamming, near-match/far-skip, op_set isolation, digest verify + tamper-reject, schema accepts-valid / rejects-non-hex-code.