### PR TITLE
feat(matrix-qes-operator): shell dispatch + magic-wormhole capability

### DIFF
--- a/apps/matrix-qes-operator/app/commands.py
+++ b/apps/matrix-qes-operator/app/commands.py
@@ -25,3 +25,11 @@ def parse_command(*, actor: str, room_id: str, thread_id: str | None, body: str)
         room_id=room_id,
         thread_id=thread_id,
     )
+
+
+def is_dispatch_verb(verb: str) -> bool:
+    """Return True if *verb* is handled by the shell dispatch layer."""
+    # Import here to avoid a circular dependency at module load time.
+    from .dispatch import DISPATCH_VERBS  # noqa: PLC0415
+
+    return verb in DISPATCH_VERBS

--- a/apps/matrix-qes-operator/app/dispatch.py
+++ b/apps/matrix-qes-operator/app/dispatch.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+"""Shell command dispatcher for the Matrix QES operator.
+
+Handles non-incident ``!qes`` verbs by running local subprocesses and
+returning room-safe formatted output (max 4000 chars, truncated with ``…``).
+"""
+
+import subprocess
+from dataclasses import dataclass
+
+from . import wormhole
+from .commands import OperatorCommand
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+DISPATCH_VERBS: frozenset[str] = frozenset(
+    {"cloudshell", "k3s", "runbook", "noe", "wormhole"}
+)
+
+_MAX_BODY = 4_000
+_TRUNCATION_SUFFIX = "\n…[truncated]"
+_SUBPROCESS_PATH = "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin"
+_SUBPROCESS_ENV = {"PATH": _SUBPROCESS_PATH}
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class DispatchResult:
+    body: str  # room-safe reply text (≤ 4000 chars)
+    ok: bool
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _truncate(text: str) -> str:
+    if len(text) <= _MAX_BODY:
+        return text
+    cut = _MAX_BODY - len(_TRUNCATION_SUFFIX)
+    return text[:cut] + _TRUNCATION_SUFFIX
+
+
+def _run(cmd: list[str], timeout: int = 30) -> tuple[bool, str]:
+    """Run *cmd* and return ``(success, combined_output)``."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=_SUBPROCESS_ENV,
+        )
+        combined = result.stdout + (("\n" + result.stderr) if result.stderr.strip() else "")
+        return result.returncode == 0, combined.strip()
+    except subprocess.TimeoutExpired:
+        return False, f"Command timed out after {timeout}s."
+    except FileNotFoundError:
+        return False, f"Binary not found: {cmd[0]!r}. Check PATH ({_SUBPROCESS_PATH})."
+    except Exception as exc:  # noqa: BLE001
+        return False, f"Unexpected error running {cmd[0]!r}: {exc}"
+
+
+def _code_block(text: str) -> str:
+    return f"```\n{text}\n```"
+
+
+def _error(text: str) -> str:
+    return f"⚠ {text}"
+
+
+# ---------------------------------------------------------------------------
+# Verb handlers
+# ---------------------------------------------------------------------------
+
+
+def _handle_cloudshell(args: list[str]) -> DispatchResult:
+    sub = args[0] if args else "status"
+    if sub != "status":
+        return DispatchResult(body=_error(f"Unknown cloudshell sub-verb: {sub!r}. Try: status"), ok=False)
+    ok, out = _run(["turtle-ssh-tunnel", "status"])
+    body = _truncate(out if ok else _error(out))
+    return DispatchResult(body=body, ok=ok)
+
+
+def _handle_k3s(args: list[str]) -> DispatchResult:
+    if not args:
+        return DispatchResult(body=_error("Usage: !qes k3s <kubectl args…>"), ok=False)
+    cmd = ["kubectl"] + list(args)
+    # Embed the kubeconfig via environment
+    env = dict(_SUBPROCESS_ENV)
+    env["KUBECONFIG"] = "~/.kube/config-k3s-twin"
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        combined = result.stdout + (("\n" + result.stderr) if result.stderr.strip() else "")
+        out = combined.strip()
+        ok = result.returncode == 0
+    except subprocess.TimeoutExpired:
+        return DispatchResult(body=_error("kubectl timed out after 30s."), ok=False)
+    except FileNotFoundError:
+        return DispatchResult(body=_error("kubectl binary not found. Check PATH."), ok=False)
+    except Exception as exc:  # noqa: BLE001
+        return DispatchResult(body=_error(str(exc)), ok=False)
+
+    formatted = _code_block(_truncate(out)) if out else _code_block("(no output)")
+    # Wrap error prefix outside the code block for readability.
+    if not ok:
+        formatted = _error("kubectl returned non-zero exit code.\n") + formatted
+    return DispatchResult(body=_truncate(formatted), ok=ok)
+
+
+def _handle_runbook(args: list[str]) -> DispatchResult:
+    sub = args[0] if args else "list"
+
+    if sub == "list":
+        cmd = ["turtle-runbook", "list"]
+    elif sub == "search":
+        if len(args) < 2:
+            return DispatchResult(body=_error("Usage: !qes runbook search <query>"), ok=False)
+        cmd = ["turtle-runbook", "search"] + args[1:]
+    elif sub == "show":
+        if len(args) < 2:
+            return DispatchResult(body=_error("Usage: !qes runbook show <name>"), ok=False)
+        cmd = ["turtle-runbook", "show"] + args[1:]
+    else:
+        return DispatchResult(
+            body=_error(f"Unknown runbook sub-verb: {sub!r}. Try: list, search <q>, show <name>"),
+            ok=False,
+        )
+
+    ok, out = _run(cmd)
+    body = _truncate(out if ok else _error(out))
+    return DispatchResult(body=body, ok=ok)
+
+
+def _handle_noe(args: list[str]) -> DispatchResult:
+    query = " ".join(args)
+    if not query:
+        return DispatchResult(body=_error("Usage: !qes noe <query>"), ok=False)
+    ok, out = _run(["turtle-noetica-stream", query], timeout=30)
+    body = _truncate(out if ok else _error(out))
+    return DispatchResult(body=body, ok=ok)
+
+
+def _handle_wormhole(args: list[str]) -> DispatchResult:
+    sub = args[0] if args else ""
+
+    if sub == "send":
+        file_arg = args[1] if len(args) > 1 else None
+        try:
+            if file_arg:
+                code = wormhole.send_file(file_arg)
+                body = f"Wormhole transfer code: `{code}`\nRecipient runs: `wormhole receive {code}`"
+            else:
+                # Send placeholder text; document usage.
+                code = wormhole.send_text("(placeholder — pipe your content in a follow-up)")
+                body = (
+                    f"Wormhole transfer code: `{code}`\n"
+                    "No file specified — a placeholder text was sent.\n"
+                    "To send a file: `!qes wormhole send <path>`\n"
+                    "Recipient runs: `wormhole receive {code}`"
+                )
+        except RuntimeError as exc:
+            return DispatchResult(body=_error(str(exc)), ok=False)
+        return DispatchResult(body=body, ok=True)
+
+    elif sub == "recv":
+        if len(args) < 2:
+            return DispatchResult(body=_error("Usage: !qes wormhole recv <code>"), ok=False)
+        code = args[1]
+        try:
+            path = wormhole.receive(code, timeout=120)
+            body = f"Received. Saved to: `{path}`"
+        except RuntimeError as exc:
+            return DispatchResult(body=_error(str(exc)), ok=False)
+        return DispatchResult(body=body, ok=True)
+
+    else:
+        return DispatchResult(
+            body=_error(f"Unknown wormhole sub-verb: {sub!r}. Try: send [file], recv <code>"),
+            ok=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+_HANDLERS = {
+    "cloudshell": _handle_cloudshell,
+    "k3s": _handle_k3s,
+    "runbook": _handle_runbook,
+    "noe": _handle_noe,
+    "wormhole": _handle_wormhole,
+}
+
+
+def execute(command: OperatorCommand) -> DispatchResult:
+    """Dispatch *command* to the appropriate shell handler.
+
+    Returns a :class:`DispatchResult` with a room-safe reply body (≤ 4000 chars).
+    """
+    handler = _HANDLERS.get(command.verb)
+    if handler is None:
+        return DispatchResult(
+            body=_error(f"No dispatch handler for verb: {command.verb!r}"),
+            ok=False,
+        )
+    return handler(command.args)

--- a/apps/matrix-qes-operator/app/main.py
+++ b/apps/matrix-qes-operator/app/main.py
@@ -6,7 +6,8 @@ from uuid import uuid4
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
-from .commands import parse_command
+from . import dispatch
+from .commands import is_dispatch_verb, parse_command
 from .state_machine import IncidentThreadState, apply_transition, transition_map
 from .store import SQLiteThreadStateStore
 
@@ -57,6 +58,62 @@ def parse(req: ParseCommandRequest) -> dict[str, Any]:
             "actor": command.actor,
             "room_id": command.room_id,
             "thread_id": command.thread_id,
+        },
+    }
+
+
+@app.post("/v1/matrix-qes/commands/execute")
+def execute(req: ApplyCommandRequest) -> dict[str, Any]:
+    try:
+        command = parse_command(
+            actor=req.actor,
+            room_id=req.room_id,
+            thread_id=req.thread_id,
+            body=req.body,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    if is_dispatch_verb(command.verb):
+        result = dispatch.execute(command)
+        return {
+            "service": "matrix-qes-operator",
+            "reply": result.body,
+            "ok": result.ok,
+            "verb": command.verb,
+            "actor": command.actor,
+            "room_id": command.room_id,
+            "thread_id": command.thread_id,
+        }
+
+    # Fall through to incident state-machine logic (same as /apply).
+    current_record = store.get(room_id=req.room_id, thread_id=req.thread_id)
+    current_state = current_record.state if current_record is not None else IncidentThreadState.TRIAGE
+    try:
+        new_state = apply_transition(current_state, command.verb)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    persisted = store.upsert(
+        room_id=req.room_id,
+        thread_id=req.thread_id,
+        state=new_state,
+        last_action=command.verb,
+    )
+    return {
+        "service": "matrix-qes-operator",
+        "action_id": str(uuid4()),
+        "previous_state": current_state.value,
+        "current_state": new_state.value,
+        "room_id": persisted.room_id,
+        "thread_id": persisted.thread_id,
+        "incident_key": persisted.incident_key,
+        "last_action": persisted.last_action,
+        "updated_at": persisted.updated_at,
+        "command": {
+            "verb": command.verb,
+            "args": command.args,
+            "actor": command.actor,
         },
     }
 

--- a/apps/matrix-qes-operator/app/wormhole.py
+++ b/apps/matrix-qes-operator/app/wormhole.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+"""Wormhole helpers — thin wrappers around the magic-wormhole CLI.
+
+The ``wormhole`` binary (or ``wormhole-william``) must be installed on the
+host.  These functions locate the binary at call-time and return a clear error
+message when it is absent so the caller can relay that to the Matrix room.
+"""
+
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+_FALLBACK_BINARY = "/usr/local/bin/wormhole-william"
+_CODE_RE = re.compile(r"(\d+-[a-z]+-[a-z]+)")
+
+# Ensure common binary install locations are reachable.
+_SUBPROCESS_ENV_PATH = "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin"
+
+
+def _wormhole_bin() -> str | None:
+    """Return the path to the wormhole binary, or None if unavailable."""
+    found = shutil.which("wormhole", path=_SUBPROCESS_ENV_PATH)
+    if found:
+        return found
+    p = Path(_FALLBACK_BINARY)
+    if p.exists() and p.is_file():
+        return str(p)
+    return None
+
+
+def _missing_binary_error() -> str:
+    return (
+        "wormhole binary not found. "
+        "Install magic-wormhole (`pip install magic-wormhole`) or wormhole-william, "
+        "then ensure it is on PATH."
+    )
+
+
+def _extract_code(output: str) -> str:
+    """Extract the wormhole transfer code from subprocess output."""
+    m = _CODE_RE.search(output)
+    if m:
+        return m.group(1)
+    return output.strip()
+
+
+def send_text(text: str, timeout: int = 30) -> str:
+    """Send *text* via ``wormhole send --text -``.
+
+    Returns the wormhole transfer code string (e.g. ``3-guitar-tango``) so the
+    operator can post it into the Matrix thread.  Raises ``RuntimeError`` when
+    the binary is missing or the command fails.
+    """
+    binary = _wormhole_bin()
+    if binary is None:
+        raise RuntimeError(_missing_binary_error())
+
+    result = subprocess.run(
+        [binary, "send", "--text", text],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={"PATH": _SUBPROCESS_ENV_PATH},
+    )
+    combined = result.stdout + result.stderr
+    if result.returncode != 0:
+        raise RuntimeError(f"wormhole send failed: {combined.strip()}")
+    return _extract_code(combined)
+
+
+def send_file(path: str, timeout: int = 60) -> str:
+    """Send *path* via ``wormhole send <path>``.
+
+    Returns the wormhole transfer code string.  Raises ``RuntimeError`` on
+    failure.
+    """
+    binary = _wormhole_bin()
+    if binary is None:
+        raise RuntimeError(_missing_binary_error())
+
+    result = subprocess.run(
+        [binary, "send", path],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={"PATH": _SUBPROCESS_ENV_PATH},
+    )
+    combined = result.stdout + result.stderr
+    if result.returncode != 0:
+        raise RuntimeError(f"wormhole send failed: {combined.strip()}")
+    return _extract_code(combined)
+
+
+def receive(code: str, dest_dir: str | None = None, timeout: int = 120) -> str:
+    """Receive via ``wormhole receive --accept-file <code>``.
+
+    Files land in *dest_dir* (a new temp directory if not given).  Returns the
+    path to the received file/directory, or a status message on timeout.
+    Raises ``RuntimeError`` when the binary is missing.
+    """
+    binary = _wormhole_bin()
+    if binary is None:
+        raise RuntimeError(_missing_binary_error())
+
+    if dest_dir is None:
+        dest_dir = tempfile.mkdtemp(prefix="wormhole-recv-")
+
+    result = subprocess.run(
+        [binary, "receive", "--accept-file", code],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=dest_dir,
+        env={"PATH": _SUBPROCESS_ENV_PATH},
+    )
+    combined = result.stdout + result.stderr
+    if result.returncode != 0:
+        raise RuntimeError(f"wormhole receive failed: {combined.strip()}")
+
+    # Try to identify the saved filename from output.
+    for line in combined.splitlines():
+        if "Received file written to" in line or "saved to" in line.lower():
+            parts = line.split()
+            if parts:
+                candidate = Path(dest_dir) / parts[-1].strip("'\"")
+                if candidate.exists():
+                    return str(candidate)
+
+    return dest_dir

--- a/apps/matrix-qes-operator/requirements.txt
+++ b/apps/matrix-qes-operator/requirements.txt
@@ -2,3 +2,7 @@ fastapi==0.115.0
 uvicorn==0.30.6
 httpx==0.27.2
 pydantic==2.9.2
+
+# External binary dependencies (not Python packages — install separately on the host):
+#   magic-wormhole  → `pip install magic-wormhole`  or  wormhole-william binary at /usr/local/bin/wormhole-william
+#   turtle-ssh-tunnel, turtle-runbook, turtle-noetica-stream, kubectl  → sovereign tooling / PATH

--- a/apps/matrix-qes-operator/tests/test_dispatch.py
+++ b/apps/matrix-qes-operator/tests/test_dispatch.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from app.commands import OperatorCommand, is_dispatch_verb  # noqa: E402
+from app.dispatch import DispatchResult, execute  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cmd(verb: str, *args: str) -> OperatorCommand:
+    return OperatorCommand(
+        verb=verb,
+        args=list(args),
+        actor="@ops:example.org",
+        room_id="!room:example.org",
+        thread_id="$thread1",
+    )
+
+
+def _fake_run_ok(stdout: str = "ok output", stderr: str = "") -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr=stderr)
+
+
+def _fake_run_fail(stdout: str = "", stderr: str = "error text") -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout=stdout, stderr=stderr)
+
+
+# ---------------------------------------------------------------------------
+# is_dispatch_verb
+# ---------------------------------------------------------------------------
+
+
+def test_is_dispatch_verb_true() -> None:
+    for verb in ("cloudshell", "k3s", "runbook", "noe", "wormhole"):
+        assert is_dispatch_verb(verb), f"Expected {verb!r} to be a dispatch verb"
+
+
+def test_is_dispatch_verb_false() -> None:
+    for verb in ("ack", "investigate", "resolve", "close", "reopen"):
+        assert not is_dispatch_verb(verb), f"Expected {verb!r} NOT to be a dispatch verb"
+
+
+# ---------------------------------------------------------------------------
+# cloudshell verb
+# ---------------------------------------------------------------------------
+
+
+def test_cloudshell_status_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("tunnel is UP"),
+    )
+    result = execute(_cmd("cloudshell", "status"))
+    assert isinstance(result, DispatchResult)
+    assert result.ok
+    assert "tunnel is UP" in result.body
+
+
+def test_cloudshell_status_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No sub-verb defaults to 'status'."""
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("tunnel is DOWN"),
+    )
+    result = execute(_cmd("cloudshell"))
+    assert result.ok
+
+
+def test_cloudshell_unknown_subverb() -> None:
+    result = execute(_cmd("cloudshell", "restart"))
+    assert not result.ok
+    assert "Unknown cloudshell sub-verb" in result.body
+    assert "⚠" in result.body
+
+
+# ---------------------------------------------------------------------------
+# k3s verb
+# ---------------------------------------------------------------------------
+
+
+def test_k3s_wraps_output_in_code_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("NAME   READY\nnode1  True"),
+    )
+    result = execute(_cmd("k3s", "get", "nodes"))
+    assert isinstance(result, DispatchResult)
+    assert result.ok
+    # Output must be fenced.
+    assert result.body.startswith("```")
+    assert "node1" in result.body
+
+
+def test_k3s_error_prefixed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_fail(stderr="connection refused"),
+    )
+    result = execute(_cmd("k3s", "get", "pods"))
+    assert not result.ok
+    assert "⚠" in result.body
+
+
+def test_k3s_no_args() -> None:
+    result = execute(_cmd("k3s"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+# ---------------------------------------------------------------------------
+# runbook verb
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("runbook-a\nrunbook-b"),
+    )
+    result = execute(_cmd("runbook", "list"))
+    assert result.ok
+    assert "runbook-a" in result.body
+
+
+def test_runbook_search(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("found: db-restart"),
+    )
+    result = execute(_cmd("runbook", "search", "database"))
+    assert result.ok
+    assert "db-restart" in result.body
+
+
+def test_runbook_show(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("# DB Restart Runbook\nStep 1…"),
+    )
+    result = execute(_cmd("runbook", "show", "db-restart"))
+    assert result.ok
+
+
+def test_runbook_unknown_sub() -> None:
+    result = execute(_cmd("runbook", "delete"))
+    assert not result.ok
+    assert "Unknown runbook sub-verb" in result.body
+
+
+def test_runbook_search_missing_query() -> None:
+    result = execute(_cmd("runbook", "search"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+# ---------------------------------------------------------------------------
+# noe verb
+# ---------------------------------------------------------------------------
+
+
+def test_noe_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("Noetica response: the answer is 42"),
+    )
+    result = execute(_cmd("noe", "what", "is", "the", "answer"))
+    assert result.ok
+    assert "42" in result.body
+
+
+def test_noe_no_query() -> None:
+    result = execute(_cmd("noe"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+# ---------------------------------------------------------------------------
+# wormhole verb — binary missing
+# ---------------------------------------------------------------------------
+
+
+def test_wormhole_send_binary_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When neither wormhole binary is present the result is ok=False with install hint."""
+    monkeypatch.setattr("app.wormhole.shutil.which", lambda *a, **kw: None)
+    monkeypatch.setattr("app.wormhole.Path.exists", lambda self: False)
+
+    result = execute(_cmd("wormhole", "send", "/tmp/file.txt"))
+    assert not result.ok
+    assert "magic-wormhole" in result.body or "wormhole" in result.body.lower()
+
+
+def test_wormhole_recv_binary_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("app.wormhole.shutil.which", lambda *a, **kw: None)
+    monkeypatch.setattr("app.wormhole.Path.exists", lambda self: False)
+
+    result = execute(_cmd("wormhole", "recv", "3-guitar-tango"))
+    assert not result.ok
+    assert "magic-wormhole" in result.body or "wormhole" in result.body.lower()
+
+
+def test_wormhole_send_returns_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the binary is present and succeeds, the code is in the reply."""
+    monkeypatch.setattr("app.wormhole.shutil.which", lambda *a, **kw: "/usr/local/bin/wormhole")
+    monkeypatch.setattr(
+        "app.wormhole.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("Sending file…\nwormhole receive 7-guitar-tango\n"),
+    )
+
+    result = execute(_cmd("wormhole", "send", "/tmp/report.pdf"))
+    assert result.ok
+    assert "7-guitar-tango" in result.body
+
+
+def test_wormhole_recv_missing_code() -> None:
+    result = execute(_cmd("wormhole", "recv"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+def test_wormhole_unknown_sub() -> None:
+    result = execute(_cmd("wormhole", "list"))
+    assert not result.ok
+    assert "Unknown wormhole sub-verb" in result.body
+
+
+# ---------------------------------------------------------------------------
+# Output truncation
+# ---------------------------------------------------------------------------
+
+
+def test_output_truncated(monkeypatch: pytest.MonkeyPatch) -> None:
+    long_output = "x" * 10_000
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok(long_output),
+    )
+    result = execute(_cmd("cloudshell", "status"))
+    assert len(result.body) <= 4_000
+    assert result.body.endswith("…[truncated]")
+
+
+# ---------------------------------------------------------------------------
+# Unknown verb
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_dispatch_verb() -> None:
+    result = execute(_cmd("bogus"))
+    assert not result.ok
+    assert "bogus" in result.body

--- a/apps/matrix-qes-operator/tests/test_http_main.py
+++ b/apps/matrix-qes-operator/tests/test_http_main.py
@@ -82,3 +82,59 @@ def test_invalid_transition(monkeypatch, tmp_path: Path) -> None:
         },
     )
     assert resp.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# /execute endpoint — dispatch verbs
+# ---------------------------------------------------------------------------
+
+
+def test_execute_runbook_verb(monkeypatch) -> None:
+    """POST /execute with a dispatch verb (runbook) calls the shell handler."""
+    import subprocess
+
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="runbook-alpha\nrunbook-beta", stderr=""
+        ),
+    )
+
+    resp = client.post(
+        "/v1/matrix-qes/commands/execute",
+        json={
+            "actor": "@ops:example.org",
+            "room_id": "!incident:example.org",
+            "thread_id": "$thread3",
+            "body": "!qes runbook list",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["verb"] == "runbook"
+    assert "runbook-alpha" in body["reply"]
+    # Dispatch replies must not have state-machine fields.
+    assert "current_state" not in body
+
+
+def test_execute_incident_verb_ack(monkeypatch, tmp_path: Path) -> None:
+    """POST /execute with an incident verb (ack) falls through to the state machine."""
+    monkeypatch.setenv("SOCIOPROFIT_STATE_HOME", str(tmp_path))
+    main.store = main.SQLiteThreadStateStore()
+
+    resp = client.post(
+        "/v1/matrix-qes/commands/execute",
+        json={
+            "actor": "@ops:example.org",
+            "room_id": "!incident:example.org",
+            "thread_id": "$thread4",
+            "body": "!qes ack",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["previous_state"] == "triage"
+    assert body["current_state"] == "acknowledged"
+    # State-machine response must not have dispatch-only fields.
+    assert "reply" not in body


### PR DESCRIPTION
## Summary

- Adds `app/dispatch.py` — a `DispatchResult`-returning executor for non-incident `!qes` verbs: `cloudshell`, `k3s`, `runbook`, `noe`, and `wormhole`. Output is room-safe (≤ 4000 chars, truncated with `…[truncated]`); kubectl output is fenced in code blocks; errors carry a `⚠` prefix.
- Adds `app/wormhole.py` — `send_text()`, `send_file()`, and `receive()` helpers that locate the `wormhole` binary (falling back to `wormhole-william`) and return a clear install hint when neither is present.
- Extends `app/commands.py` with `is_dispatch_verb(verb: str) -> bool` backed by `DISPATCH_VERBS`.
- Adds `POST /v1/matrix-qes/commands/execute` to `app/main.py` — unified endpoint that routes dispatch verbs to the shell layer and incident verbs to the state machine.
- Documents external binary dependencies (`magic-wormhole`, `kubectl`, `turtle-*`) in `requirements.txt` comments; no new Python packages required.

## Supported verbs

| Verb | What it runs |
|---|---|
| `cloudshell status` | `turtle-ssh-tunnel status` |
| `k3s <args>` | `kubectl <args>` with `KUBECONFIG=~/.kube/config-k3s-twin` |
| `runbook list\|search\|show` | `turtle-runbook <sub> [args]` |
| `noe <query>` | `turtle-noetica-stream <query>` (30 s timeout) |
| `wormhole send [file]` | `wormhole send <file>` or text placeholder; returns transfer code |
| `wormhole recv <code>` | `wormhole receive --accept-file <code>`; returns saved path |

## Test plan

- [x] `tests/test_dispatch.py` — 22 new tests covering every verb, error paths, binary-missing fallback, output truncation, and unknown verb routing; all subprocess calls mocked with `monkeypatch`
- [x] `tests/test_http_main.py` — 2 new endpoint tests: `runbook` dispatch via `/execute` and `ack` incident fallback via `/execute`
- [x] All 31 tests pass locally (`pytest tests/ -v`)

Authored by @mdheller