### PR TITLE
fix(health-twin): align boot-smoke to the server's exposure gate on /doctor-view (unblocks all PRs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,11 +246,13 @@ jobs:
           # BOTH → the read goes through, receipted. This is the path that serves a real chart.
           curl -fsS -H "authorization: Bearer $HEALTH_TWIN_TOKEN" -H "x-health-grant: $TOKEN" \
             -X POST localhost:8098/api/health/agent-read -H 'content-type: application/json' -d '{}' | grep -q '"presentedBy":"sha256-'
-          # /doctor-view is not exposure-gated in this mirror (prophet-health is ahead there), so the
-          # holder credential alone is what stands between a caller and the chart. Assert exactly that
-          # rather than an exposure refusal this code does not make.
+          # /doctor-view IS exposure-gated in this mirror (denyExposure runs first): like /agent-read
+          # it needs BOTH the deployment credential AND the holder. No creds — or the holder alone —
+          # are refused; the two together serve the chart, receipted. (The smoke previously assumed
+          # holder-alone, which this server has never done here; aligned to the actual gate.)
           test "$(curl -s -o /dev/null -w '%{http_code}' localhost:8098/api/health/doctor-view)" = 401
-          curl -fsS -H "x-health-grant: $TOKEN" localhost:8098/api/health/doctor-view | grep -q '"presentedBy":"sha256-'
+          test "$(curl -s -o /dev/null -w '%{http_code}' -H "x-health-grant: $TOKEN" localhost:8098/api/health/doctor-view)" = 401
+          curl -fsS -H "authorization: Bearer $HEALTH_TWIN_TOKEN" -H "x-health-grant: $TOKEN" localhost:8098/api/health/doctor-view | grep -q '"presentedBy":"sha256-'
           # An authenticated deployment allows NO browser origin unless one is named. The cockpit
           # reaches this service same-origin through the nginx /svc/health proxy and never needs one;
           # a deployment that does need one says so, rather than inheriting a wildcard by default.


### PR DESCRIPTION
## Root cause (reproduced locally, not guessed)
The `health-twin` boot-smoke's "both membranes" step asserted **/doctor-view is holder-only** (`curl -fsS -H x-health-grant: $TOKEN … | grep presentedBy`, expecting 200). But the server **exposure-gates** /doctor-view — `denyExposure` runs first (server.ts:1176), so on an `authenticated` deployment it needs the **deployment credential AND the holder**, exactly like /agent-read. Holder-alone → 401, so the `-fsS` curl 401'd and the job exited 1. That check is **required and red on every PR**, blocking #1392 and #1397 estate-wide (issue #1398).

Local reproduction (`tsx src/server.ts`, the step's exact env):
```
doctor-view no-creds           → 401
doctor-view holder-only        → 401   (exposure-gated)
doctor-view deployment+holder  → 200   "presentedBy":"sha256-…
```

## Fix
Align the **test** to the server's actual, **stricter** gate: /doctor-view requires both creds; assert holder-alone is refused (401) and both-together serves the chart. **The medical control is untouched** — only the stale smoke expectation changed (loosening the server would have been the wrong, dangerous direction).

Closes the estate-wide red → unblocks #1392 (+ #1397). Workflow change → for your review, not auto-merged.