### PR TITLE
fix(ci): health-twin boot-smoke — doctor-view is exposure-gated in authenticated mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,11 +246,15 @@ jobs:
           # BOTH → the read goes through, receipted. This is the path that serves a real chart.
           curl -fsS -H "authorization: Bearer $HEALTH_TWIN_TOKEN" -H "x-health-grant: $TOKEN" \
             -X POST localhost:8098/api/health/agent-read -H 'content-type: application/json' -d '{}' | grep -q '"presentedBy":"sha256-'
-          # /doctor-view is not exposure-gated in this mirror (prophet-health is ahead there), so the
-          # holder credential alone is what stands between a caller and the chart. Assert exactly that
-          # rather than an exposure refusal this code does not make.
-          test "$(curl -s -o /dev/null -w '%{http_code}' localhost:8098/api/health/doctor-view)" = 401
-          curl -fsS -H "x-health-grant: $TOKEN" localhost:8098/api/health/doctor-view | grep -q '"presentedBy":"sha256-'
+          # /doctor-view IS exposure-gated in authenticated mode: #1341 (vendor-parity cutover) brought
+          # this mirror to parity with prophet-health by adding denyExposure() to the doctor-view
+          # handler. Reading a chart now needs BOTH the deployment credential AND the holder grant —
+          # exactly like /agent-read above. Neither membrane alone is enough. (Verified against the
+          # running server: grant-only → 401, both → 200.)
+          test "$(curl -s -o /dev/null -w '%{http_code}' localhost:8098/api/health/doctor-view)" = 401                              # neither → 401
+          test "$(curl -s -o /dev/null -w '%{http_code}' -H "x-health-grant: $TOKEN" localhost:8098/api/health/doctor-view)" = 401  # holder alone → 401 (the exposure membrane bites)
+          curl -fsS -H "authorization: Bearer $HEALTH_TWIN_TOKEN" -H "x-health-grant: $TOKEN" \
+            localhost:8098/api/health/doctor-view | grep -q '"presentedBy":"sha256-'                                                # both → the chart, receipted
           # An authenticated deployment allows NO browser origin unless one is named. The cockpit
           # reaches this service same-origin through the nginx /svc/health proxy and never needs one;
           # a deployment that does need one says so, rather than inheriting a wildcard by default.


### PR DESCRIPTION
## The failure (red on `main` since #1341)

The authenticated-mode boot smoke asserted `/doctor-view` returns the chart on the **holder grant alone** — no deployment credential — with a comment claiming doctor-view *"is not exposure-gated in this mirror."*

That stopped being true at **#1341 (vendor-parity cutover)**, which added `denyExposure()` to the doctor-view handler to reach parity with prophet-health. In `authenticated` mode the endpoint now needs **both** the deployment Bearer **and** the holder grant — exactly like `/agent-read`. #1341 didn't update this test, so `health-twin` has been red on `main` ever since (blocking every PR's advisory checks).

## Fix the test, never the server

A chart endpoint must not be weakened to make a test pass. So:
- Present **both** credentials for the success case.
- Add a **holder-alone → 401** assertion, so the exposure membrane is *proven to bite*.

## Verified against the running server

`npx tsx src/server.ts` with `HEALTH_TWIN_EXPOSURE=authenticated`:

```
neither  -> 401   (want 401)
holder   -> 401   (want 401)   ← exposure membrane
both     -> 200   (want 200)   ← "presentedBy":"sha256-..." present
```

⚠️ Touches `.github/workflows/ci.yml` — workflow change.