### PR TITLE
feat(matrix): !qes arm — query Architecture Reference Manual from Matrix

### DIFF
--- a/apps/matrix-qes-operator/app/commands.py
+++ b/apps/matrix-qes-operator/app/commands.py
@@ -25,3 +25,11 @@ def parse_command(*, actor: str, room_id: str, thread_id: str | None, body: str)
         room_id=room_id,
         thread_id=thread_id,
     )
+
+
+def is_dispatch_verb(verb: str) -> bool:
+    """Return True if *verb* is handled by the shell dispatch layer."""
+    # Import here to avoid a circular dependency at module load time.
+    from .dispatch import DISPATCH_VERBS  # noqa: PLC0415
+
+    return verb in DISPATCH_VERBS

--- a/apps/matrix-qes-operator/app/dispatch.py
+++ b/apps/matrix-qes-operator/app/dispatch.py
@@ -21,7 +21,7 @@ from .commands import OperatorCommand
 # ---------------------------------------------------------------------------
 
 DISPATCH_VERBS: frozenset[str] = frozenset(
-    {"cloudshell", "ctx", "csh", "doc", "git", "k3s", "mesh", "note", "noe", "runbook", "tunnel", "wormhole"}
+    {"arm", "cloudshell", "ctx", "csh", "doc", "git", "k3s", "mesh", "note", "noe", "runbook", "tunnel", "wormhole"}
 )
 
 _MAX_BODY = 4_000
@@ -548,11 +548,82 @@ def _handle_ctx(args: list[str]) -> DispatchResult:  # noqa: ARG001
         return DispatchResult(body=_error(str(exc)), ok=False)
 
 
+
+# ---------------------------------------------------------------------------
+# ARM verb handler
+# ---------------------------------------------------------------------------
+
+
+def _arm_bin() -> str:
+    """Locate the turtle-arm-generate binary."""
+    import shutil as _shutil
+
+    found = _shutil.which("turtle-arm-generate")
+    if found:
+        return found
+    candidate = Path.home() / ".local" / "share" / "sourceos" / "bin" / "turtle-arm-generate"
+    if candidate.exists():
+        return str(candidate)
+    return "turtle-arm-generate"
+
+
+def _handle_arm(args: list[str]) -> DispatchResult:
+    """Handle ``!qes arm`` sub-verbs: generate, show, search, status."""
+    import re as _re
+
+    sub = args[0] if args else "status"
+    bin_path = _arm_bin()
+
+    if sub == "generate":
+        ok, out = _run(["python3", bin_path, "generate"], timeout=60)
+        if ok:
+            m = _re.search(r"\((\d+) ADRs", out)
+            count = m.group(1) if m else "?"
+            body = f"ARM generated ({count} ADRs)"
+        else:
+            body = _error(out)
+        return DispatchResult(body=body, ok=ok)
+
+    elif sub == "show":
+        rest = args[1:]
+        cmd = ["python3", bin_path, "show"]
+        if rest:
+            cmd += ["--section", " ".join(rest)]
+        ok, out = _run(cmd, timeout=15)
+        body = _truncate(out[:3500] if ok else _error(out))
+        return DispatchResult(body=body, ok=ok)
+
+    elif sub == "search":
+        query_parts = args[1:]
+        if not query_parts:
+            return DispatchResult(body=_error("Usage: !qes arm search <query>"), ok=False)
+        query = " ".join(query_parts)
+        ok, out = _run(["python3", bin_path, "search", query], timeout=15)
+        body = _truncate(out[:3000] if ok else _error(out))
+        return DispatchResult(body=body, ok=ok)
+
+    elif sub == "status":
+        ok, out = _run(["python3", bin_path, "status"], timeout=10)
+        clean = _re.sub(r"\x1b\[[0-9;]*m", "", out)
+        body = _truncate(clean if ok else _error(clean))
+        return DispatchResult(body=body, ok=ok)
+
+    else:
+        return DispatchResult(
+            body=_error(
+                f"Unknown arm sub-verb: {sub!r}. "
+                "Try: generate, show [section], search <query>, status"
+            ),
+            ok=False,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
 _HANDLERS = {
+    "arm": _handle_arm,
     "cloudshell": _handle_cloudshell,
     "ctx": _handle_ctx,
     "csh": _handle_csh,

--- a/apps/matrix-qes-operator/app/dispatch.py
+++ b/apps/matrix-qes-operator/app/dispatch.py
@@ -1,0 +1,583 @@
+from __future__ import annotations
+
+"""Shell command dispatcher for the Matrix QES operator.
+
+Handles non-incident ``!qes`` verbs by running local subprocesses and
+returning room-safe formatted output (max 4000 chars, truncated with ``…``).
+"""
+
+import datetime
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import wormhole
+from .commands import OperatorCommand
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+DISPATCH_VERBS: frozenset[str] = frozenset(
+    {"cloudshell", "ctx", "csh", "doc", "git", "k3s", "mesh", "note", "noe", "runbook", "tunnel", "wormhole"}
+)
+
+_MAX_BODY = 4_000
+_TRUNCATION_SUFFIX = "\n…[truncated]"
+_SUBPROCESS_PATH = "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin"
+_SUBPROCESS_ENV = {"PATH": _SUBPROCESS_PATH}
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class DispatchResult:
+    body: str  # room-safe reply text (≤ 4000 chars)
+    ok: bool
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _truncate(text: str) -> str:
+    if len(text) <= _MAX_BODY:
+        return text
+    cut = _MAX_BODY - len(_TRUNCATION_SUFFIX)
+    return text[:cut] + _TRUNCATION_SUFFIX
+
+
+def _run(cmd: list[str], timeout: int = 30, cwd: str | None = None) -> tuple[bool, str]:
+    """Run *cmd* and return ``(success, combined_output)``."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=_SUBPROCESS_ENV,
+            cwd=cwd,
+        )
+        combined = result.stdout + (("\n" + result.stderr) if result.stderr.strip() else "")
+        return result.returncode == 0, combined.strip()
+    except subprocess.TimeoutExpired:
+        return False, f"Command timed out after {timeout}s."
+    except FileNotFoundError:
+        return False, f"Binary not found: {cmd[0]!r}. Check PATH ({_SUBPROCESS_PATH})."
+    except Exception as exc:  # noqa: BLE001
+        return False, f"Unexpected error running {cmd[0]!r}: {exc}"
+
+
+def _code_block(text: str) -> str:
+    return f"```\n{text}\n```"
+
+
+def _error(text: str) -> str:
+    return f"⚠ {text}"
+
+
+# ---------------------------------------------------------------------------
+# Path helpers (extracted so tests can monkeypatch them)
+# ---------------------------------------------------------------------------
+
+
+def _mesh_jsonl_path() -> Path:
+    return Path.home() / ".local" / "state" / "sourceos" / "memory-mesh" / "context.jsonl"
+
+
+def _ctx_json_path() -> Path:
+    return Path.home() / ".local" / "state" / "sourceos" / "memory-mesh" / "active.json"
+
+
+def _notes_dir() -> Path:
+    return Path.home() / "notes"
+
+
+def _git_root() -> str:
+    val = os.environ.get("SOURCEOS_GIT_ROOT")
+    if val:
+        return val
+    candidate = Path.home() / "dev"
+    return str(candidate)
+
+
+# ---------------------------------------------------------------------------
+# Verb handlers — original set
+# ---------------------------------------------------------------------------
+
+
+def _handle_cloudshell(args: list[str]) -> DispatchResult:
+    sub = args[0] if args else "status"
+    if sub != "status":
+        return DispatchResult(body=_error(f"Unknown cloudshell sub-verb: {sub!r}. Try: status"), ok=False)
+    ok, out = _run(["turtle-ssh-tunnel", "status"])
+    body = _truncate(out if ok else _error(out))
+    return DispatchResult(body=body, ok=ok)
+
+
+def _handle_k3s(args: list[str]) -> DispatchResult:
+    if not args:
+        return DispatchResult(body=_error("Usage: !qes k3s <kubectl args…>"), ok=False)
+    cmd = ["kubectl"] + list(args)
+    env = dict(_SUBPROCESS_ENV)
+    env["KUBECONFIG"] = "~/.kube/config-k3s-twin"
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        combined = result.stdout + (("\n" + result.stderr) if result.stderr.strip() else "")
+        out = combined.strip()
+        ok = result.returncode == 0
+    except subprocess.TimeoutExpired:
+        return DispatchResult(body=_error("kubectl timed out after 30s."), ok=False)
+    except FileNotFoundError:
+        return DispatchResult(body=_error("kubectl binary not found. Check PATH."), ok=False)
+    except Exception as exc:  # noqa: BLE001
+        return DispatchResult(body=_error(str(exc)), ok=False)
+
+    formatted = _code_block(_truncate(out)) if out else _code_block("(no output)")
+    if not ok:
+        formatted = _error("kubectl returned non-zero exit code.\n") + formatted
+    return DispatchResult(body=_truncate(formatted), ok=ok)
+
+
+def _handle_runbook(args: list[str]) -> DispatchResult:
+    sub = args[0] if args else "list"
+
+    if sub == "list":
+        cmd = ["turtle-runbook", "list"]
+    elif sub == "search":
+        if len(args) < 2:
+            return DispatchResult(body=_error("Usage: !qes runbook search <query>"), ok=False)
+        cmd = ["turtle-runbook", "search"] + args[1:]
+    elif sub == "show":
+        if len(args) < 2:
+            return DispatchResult(body=_error("Usage: !qes runbook show <name>"), ok=False)
+        cmd = ["turtle-runbook", "show"] + args[1:]
+    else:
+        return DispatchResult(
+            body=_error(f"Unknown runbook sub-verb: {sub!r}. Try: list, search <q>, show <name>"),
+            ok=False,
+        )
+
+    ok, out = _run(cmd)
+    body = _truncate(out if ok else _error(out))
+    return DispatchResult(body=body, ok=ok)
+
+
+def _handle_noe(args: list[str]) -> DispatchResult:
+    query = " ".join(args)
+    if not query:
+        return DispatchResult(body=_error("Usage: !qes noe <query>"), ok=False)
+    ok, out = _run(["turtle-noetica-stream", query], timeout=30)
+    body = _truncate(out if ok else _error(out))
+    return DispatchResult(body=body, ok=ok)
+
+
+def _handle_wormhole(args: list[str]) -> DispatchResult:
+    sub = args[0] if args else ""
+
+    if sub == "send":
+        file_arg = args[1] if len(args) > 1 else None
+        try:
+            if file_arg:
+                code = wormhole.send_file(file_arg)
+                body = f"Wormhole transfer code: `{code}`\nRecipient runs: `wormhole receive {code}`"
+            else:
+                code = wormhole.send_text("(placeholder — pipe your content in a follow-up)")
+                body = (
+                    f"Wormhole transfer code: `{code}`\n"
+                    "No file specified — a placeholder text was sent.\n"
+                    "To send a file: `!qes wormhole send <path>`\n"
+                    f"Recipient runs: `wormhole receive {code}`"
+                )
+        except RuntimeError as exc:
+            return DispatchResult(body=_error(str(exc)), ok=False)
+        return DispatchResult(body=body, ok=True)
+
+    elif sub == "recv":
+        if len(args) < 2:
+            return DispatchResult(body=_error("Usage: !qes wormhole recv <code>"), ok=False)
+        code = args[1]
+        try:
+            path = wormhole.receive(code, timeout=120)
+            body = f"Received. Saved to: `{path}`"
+        except RuntimeError as exc:
+            return DispatchResult(body=_error(str(exc)), ok=False)
+        return DispatchResult(body=body, ok=True)
+
+    elif sub == "pipe":
+        text_parts = args[1:]
+        if not text_parts:
+            return DispatchResult(body=_error("Usage: !qes wormhole pipe <text…>"), ok=False)
+        text = " ".join(text_parts)
+        try:
+            code = wormhole.send_text(text, timeout=30)
+            body = f"Wormhole transfer code: `{code}`\nRecipient runs: `wormhole receive {code}`"
+        except RuntimeError as exc:
+            return DispatchResult(body=_error(str(exc)), ok=False)
+        return DispatchResult(body=body, ok=True)
+
+    else:
+        return DispatchResult(
+            body=_error(f"Unknown wormhole sub-verb: {sub!r}. Try: send [file], recv <code>, pipe <text…>"),
+            ok=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Verb handlers — new set
+# ---------------------------------------------------------------------------
+
+
+def _handle_git(args: list[str]) -> DispatchResult:
+    sub = args[0] if args else ""
+
+    cwd = _git_root()
+
+    if sub == "log":
+        try:
+            n = int(args[1]) if len(args) > 1 else 10
+        except ValueError:
+            n = 10
+        ok, out = _run(["git", "log", "--oneline", f"-n{n}"], cwd=cwd)
+        body = _truncate(out or "(empty log)")
+        return DispatchResult(body=body, ok=ok)
+
+    elif sub == "diff":
+        ref = args[1] if len(args) > 1 else "HEAD~1..HEAD"
+        ok, out = _run(["git", "diff", ref], cwd=cwd)
+        if out:
+            body = _truncate(f"```diff\n{out}\n```")
+        else:
+            body = "(no diff)"
+        return DispatchResult(body=body, ok=ok)
+
+    elif sub == "status":
+        ok, out = _run(["git", "status", "--short"], cwd=cwd)
+        body = _truncate(out or "(clean)")
+        return DispatchResult(body=body, ok=ok)
+
+    else:
+        return DispatchResult(
+            body=_error(f"Unknown git sub-verb: {sub!r}. Try: log [n], diff [ref], status"),
+            ok=False,
+        )
+
+
+def _handle_mesh(args: list[str]) -> DispatchResult:
+    try:
+        n = int(args[0]) if args else 20
+    except ValueError:
+        n = 20
+
+    path = _mesh_jsonl_path()
+    if not path.exists():
+        return DispatchResult(body="⚠ mesh JSONL not found.", ok=False)
+
+    try:
+        lines = path.read_text().splitlines()
+        lines = lines[-n:]
+        formatted: list[str] = []
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+                ts = str(record.get("ts", ""))[:16]
+                rtype = record.get("type", "?")
+                title = record.get("title", "")
+                formatted.append(f"{ts} {rtype}: {title}")
+            except (json.JSONDecodeError, KeyError):
+                formatted.append(line[:80])
+        body = "\n".join(formatted) or "(empty)"
+        return DispatchResult(body=_truncate(body), ok=True)
+    except Exception as exc:  # noqa: BLE001
+        return DispatchResult(body=_error(str(exc)), ok=False)
+
+
+def _handle_note(args: list[str]) -> DispatchResult:
+    sub = args[0] if args else "list"
+    notes = _notes_dir()
+
+    if sub == "list":
+        try:
+            files = sorted(notes.glob("*.md"), key=lambda p: p.stat().st_mtime, reverse=True)
+            if not files:
+                return DispatchResult(body="(no notes found)", ok=True)
+            lines: list[str] = []
+            for f in files:
+                mtime = datetime.datetime.fromtimestamp(f.stat().st_mtime).strftime("%Y-%m-%d %H:%M")
+                lines.append(f"{f.name}  {mtime}")
+            return DispatchResult(body=_truncate("\n".join(lines)), ok=True)
+        except Exception as exc:  # noqa: BLE001
+            return DispatchResult(body=_error(str(exc)), ok=False)
+
+    elif sub == "show":
+        if len(args) < 2:
+            return DispatchResult(body=_error("Usage: !qes note show <slug>"), ok=False)
+        slug = args[1]
+        candidates = [notes / slug, notes / f"{slug}.md"]
+        for candidate in candidates:
+            if candidate.exists():
+                try:
+                    content = candidate.read_text()
+                    return DispatchResult(body=content[:3000], ok=True)
+                except Exception as exc:  # noqa: BLE001
+                    return DispatchResult(body=_error(str(exc)), ok=False)
+        return DispatchResult(body=_error(f"Note not found: {slug!r}"), ok=False)
+
+    else:
+        return DispatchResult(
+            body=_error(f"Unknown note sub-verb: {sub!r}. Try: list, show <slug>"),
+            ok=False,
+        )
+
+
+def _handle_csh(args: list[str]) -> DispatchResult:
+    if not args:
+        return DispatchResult(body=_error("Usage: !qes csh <cmd…>"), ok=False)
+    cmd = ["turtle-ssh-tunnel", "exec"] + list(args)
+    ok, out = _run(cmd)
+    if not ok and "Binary not found" in out:
+        return DispatchResult(body="⚠ turtle-ssh-tunnel not found — cloudshell not configured", ok=False)
+    body = _truncate(out if ok else _error(out))
+    return DispatchResult(body=body, ok=ok)
+
+
+def _handle_tunnel(args: list[str]) -> DispatchResult:
+    sub = args[0] if args else "status"
+
+    if sub == "status":
+        ok, out = _run(["turtle-ssh-tunnel", "status"])
+        body = _truncate(out if ok else _error(out))
+        return DispatchResult(body=body, ok=ok)
+
+    elif sub == "start":
+        ok, out = _run(["turtle-ssh-tunnel", "tunnel", "start"])
+        body = _truncate(out if ok else _error(out))
+        return DispatchResult(body=body, ok=ok)
+
+    else:
+        return DispatchResult(
+            body=_error(f"Unknown tunnel sub-verb: {sub!r}. Try: status, start"),
+            ok=False,
+        )
+
+
+def _doc_feedback_bin() -> str:
+    """Locate the turtle-doc-feedback binary."""
+    import shutil as _shutil
+    found = _shutil.which("turtle-doc-feedback")
+    if found:
+        return found
+    candidate = Path.home() / ".local" / "share" / "sourceos" / "bin" / "turtle-doc-feedback"
+    if candidate.exists():
+        return str(candidate)
+    return "turtle-doc-feedback"
+
+
+def _handle_doc(args: list[str]) -> DispatchResult:
+    """Handle ``!qes doc`` sub-verbs: feedback, list, faq, distill."""
+    sub = args[0] if args else ""
+
+    if sub == "feedback":
+        # !qes doc feedback <doc_ref> <sentiment> [<comment>]
+        rest = args[1:]
+        if len(rest) < 2:
+            return DispatchResult(
+                body=_error("Usage: !qes doc feedback <doc_ref> <sentiment> [<comment>]"),
+                ok=False,
+            )
+        cmd = ["python3", _doc_feedback_bin(), "submit"] + list(rest)
+        ok, out = _run(cmd, timeout=15)
+        return DispatchResult(body=_truncate(out if ok else _error(out)), ok=ok)
+
+    elif sub == "list":
+        rest = args[1:]
+        cmd = ["python3", _doc_feedback_bin(), "list"] + list(rest)
+        ok, out = _run(cmd, timeout=10)
+        return DispatchResult(body=_truncate(out if ok else _error(out)), ok=ok)
+
+    elif sub == "faq":
+        rest = args[1:]
+        cmd = ["python3", _doc_feedback_bin(), "faq"] + list(rest)
+        ok, out = _run(cmd, timeout=10)
+        return DispatchResult(body=_truncate(out if ok else _error(out)), ok=ok)
+
+    elif sub == "distill":
+        # Distillation calls Noetica — fire async and confirm immediately
+        rest = args[1:]
+        cmd = ["python3", _doc_feedback_bin(), "distill"] + list(rest)
+        try:
+            subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                env=_SUBPROCESS_ENV,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return DispatchResult(body=_error(f"Could not launch distill: {exc}"), ok=False)
+        label = f" for {rest[0]!r}" if rest else ""
+        return DispatchResult(
+            body=f"⏳ Distilling{label}… (runs in background; use `!qes doc faq` when done)",
+            ok=True,
+        )
+
+    else:
+        return DispatchResult(
+            body=_error(
+                f"Unknown doc sub-verb: {sub!r}. "
+                "Try: feedback <ref> <sentiment> [comment], list [ref], faq [ref], distill [ref]"
+            ),
+            ok=False,
+        )
+
+
+def _transcript_pending_path() -> Path:
+    return Path.home() / ".local" / "state" / "sourceos" / "transcript-claims" / "pending.jsonl"
+
+
+def _transcript_bin() -> str:
+    """Locate the turtle-transcript-extract binary."""
+    import shutil as _shutil
+    found = _shutil.which("turtle-transcript-extract")
+    if found:
+        return found
+    candidate = Path.home() / ".local" / "share" / "sourceos" / "bin" / "turtle-transcript-extract"
+    if candidate.exists():
+        return str(candidate)
+    return "turtle-transcript-extract"
+
+
+def _handle_transcript(args: list[str]) -> DispatchResult:
+    """Handle ``!qes transcript`` sub-verbs: extract, list, commit."""
+    sub = args[0] if args else ""
+
+    if sub == "extract":
+        # !qes transcript extract [--since <hours>]
+        since_args = args[1:]
+        since_h = 24
+        i = 0
+        while i < len(since_args):
+            if since_args[i] == "--since" and i + 1 < len(since_args):
+                try:
+                    since_h = int(since_args[i + 1])
+                except ValueError:
+                    pass
+                i += 2
+            else:
+                i += 1
+        cmd = ["python3", _transcript_bin(), "extract", "--since", str(since_h)]
+        try:
+            subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                env=_SUBPROCESS_ENV,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return DispatchResult(body=_error(f"Could not launch extract: {exc}"), ok=False)
+        return DispatchResult(
+            body=f"⏳ Extracting last {since_h}h… (runs in background; use `!qes transcript list` when done)",
+            ok=True,
+        )
+
+    elif sub == "list":
+        pending_path = _transcript_pending_path()
+        if not pending_path.exists():
+            return DispatchResult(body="(no pending claims)", ok=True)
+        try:
+            lines = [ln.strip() for ln in pending_path.read_text().splitlines() if ln.strip()]
+        except Exception as exc:  # noqa: BLE001
+            return DispatchResult(body=_error(str(exc)), ok=False)
+        if not lines:
+            return DispatchResult(body="(no pending claims)", ok=True)
+        records = lines[-10:]
+        rows: list[str] = []
+        import json as _json
+        for line in records:
+            try:
+                r = _json.loads(line)
+                claim_id = r.get("id", "?")
+                extracted_at = r.get("extracted_at", "?")[:16]
+                preview = r.get("claim", "")[:60].replace("\n", " ")
+                rows.append(f"{claim_id}  {extracted_at}  {preview}…")
+            except Exception:
+                rows.append(line[:80])
+        total = len(lines)
+        header = f"Pending claims ({total} total, showing last {len(records)}):"
+        body = header + "\n" + "\n".join(rows)
+        return DispatchResult(body=_truncate(body), ok=True)
+
+    elif sub == "commit":
+        cmd = ["python3", _transcript_bin(), "commit"]
+        ok, out = _run(cmd, timeout=30)
+        return DispatchResult(body=_truncate(out if ok else _error(out)), ok=ok)
+
+    else:
+        return DispatchResult(
+            body=_error(
+                f"Unknown transcript sub-verb: {sub!r}. "
+                "Try: extract [--since <hours>], list, commit"
+            ),
+            ok=False,
+        )
+
+
+def _handle_ctx(args: list[str]) -> DispatchResult:  # noqa: ARG001
+    path = _ctx_json_path()
+    if not path.exists():
+        return DispatchResult(body="⚠ No active context.", ok=False)
+    try:
+        data = json.loads(path.read_text())
+        lines: list[str] = [f"{k}: {v}" for k, v in data.items()]
+        return DispatchResult(body=_truncate("\n".join(lines)), ok=True)
+    except Exception as exc:  # noqa: BLE001
+        return DispatchResult(body=_error(str(exc)), ok=False)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+_HANDLERS = {
+    "cloudshell": _handle_cloudshell,
+    "ctx": _handle_ctx,
+    "csh": _handle_csh,
+    "doc": _handle_doc,
+    "git": _handle_git,
+    "k3s": _handle_k3s,
+    "mesh": _handle_mesh,
+    "note": _handle_note,
+    "noe": _handle_noe,
+    "runbook": _handle_runbook,
+    "transcript": _handle_transcript,
+    "tunnel": _handle_tunnel,
+    "wormhole": _handle_wormhole,
+}
+
+
+def execute(command: OperatorCommand) -> DispatchResult:
+    """Dispatch *command* to the appropriate shell handler.
+
+    Returns a :class:`DispatchResult` with a room-safe reply body (≤ 4000 chars).
+    """
+    handler = _HANDLERS.get(command.verb)
+    if handler is None:
+        return DispatchResult(
+            body=_error(f"No dispatch handler for verb: {command.verb!r}"),
+            ok=False,
+        )
+    return handler(command.args)

--- a/apps/matrix-qes-operator/app/wormhole.py
+++ b/apps/matrix-qes-operator/app/wormhole.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+"""Wormhole helpers — thin wrappers around the magic-wormhole CLI.
+
+The ``wormhole`` binary (or ``wormhole-william``) must be installed on the
+host.  These functions locate the binary at call-time and return a clear error
+message when it is absent so the caller can relay that to the Matrix room.
+"""
+
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+_FALLBACK_BINARY = "/usr/local/bin/wormhole-william"
+_CODE_RE = re.compile(r"(\d+-[a-z]+-[a-z]+)")
+
+# Ensure common binary install locations are reachable.
+_SUBPROCESS_ENV_PATH = "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin"
+
+
+def _wormhole_bin() -> str | None:
+    """Return the path to the wormhole binary, or None if unavailable."""
+    found = shutil.which("wormhole", path=_SUBPROCESS_ENV_PATH)
+    if found:
+        return found
+    p = Path(_FALLBACK_BINARY)
+    if p.exists() and p.is_file():
+        return str(p)
+    return None
+
+
+def _missing_binary_error() -> str:
+    return (
+        "wormhole binary not found. "
+        "Install magic-wormhole (`pip install magic-wormhole`) or wormhole-william, "
+        "then ensure it is on PATH."
+    )
+
+
+def _extract_code(output: str) -> str:
+    """Extract the wormhole transfer code from subprocess output."""
+    m = _CODE_RE.search(output)
+    if m:
+        return m.group(1)
+    return output.strip()
+
+
+def send_text(text: str, timeout: int = 30) -> str:
+    """Send *text* via ``wormhole send --text -``.
+
+    Returns the wormhole transfer code string (e.g. ``3-guitar-tango``) so the
+    operator can post it into the Matrix thread.  Raises ``RuntimeError`` when
+    the binary is missing or the command fails.
+    """
+    binary = _wormhole_bin()
+    if binary is None:
+        raise RuntimeError(_missing_binary_error())
+
+    result = subprocess.run(
+        [binary, "send", "--text", text],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={"PATH": _SUBPROCESS_ENV_PATH},
+    )
+    combined = result.stdout + result.stderr
+    if result.returncode != 0:
+        raise RuntimeError(f"wormhole send failed: {combined.strip()}")
+    return _extract_code(combined)
+
+
+def send_file(path: str, timeout: int = 60) -> str:
+    """Send *path* via ``wormhole send <path>``.
+
+    Returns the wormhole transfer code string.  Raises ``RuntimeError`` on
+    failure.
+    """
+    binary = _wormhole_bin()
+    if binary is None:
+        raise RuntimeError(_missing_binary_error())
+
+    result = subprocess.run(
+        [binary, "send", path],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={"PATH": _SUBPROCESS_ENV_PATH},
+    )
+    combined = result.stdout + result.stderr
+    if result.returncode != 0:
+        raise RuntimeError(f"wormhole send failed: {combined.strip()}")
+    return _extract_code(combined)
+
+
+def receive(code: str, dest_dir: str | None = None, timeout: int = 120) -> str:
+    """Receive via ``wormhole receive --accept-file <code>``.
+
+    Files land in *dest_dir* (a new temp directory if not given).  Returns the
+    path to the received file/directory, or a status message on timeout.
+    Raises ``RuntimeError`` when the binary is missing.
+    """
+    binary = _wormhole_bin()
+    if binary is None:
+        raise RuntimeError(_missing_binary_error())
+
+    if dest_dir is None:
+        dest_dir = tempfile.mkdtemp(prefix="wormhole-recv-")
+
+    result = subprocess.run(
+        [binary, "receive", "--accept-file", code],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=dest_dir,
+        env={"PATH": _SUBPROCESS_ENV_PATH},
+    )
+    combined = result.stdout + result.stderr
+    if result.returncode != 0:
+        raise RuntimeError(f"wormhole receive failed: {combined.strip()}")
+
+    # Try to identify the saved filename from output.
+    for line in combined.splitlines():
+        if "Received file written to" in line or "saved to" in line.lower():
+            parts = line.split()
+            if parts:
+                candidate = Path(dest_dir) / parts[-1].strip("'\"")
+                if candidate.exists():
+                    return str(candidate)
+
+    return dest_dir

--- a/apps/matrix-qes-operator/tests/test_dispatch.py
+++ b/apps/matrix-qes-operator/tests/test_dispatch.py
@@ -1,0 +1,638 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from app.commands import OperatorCommand, is_dispatch_verb  # noqa: E402
+from app.dispatch import DispatchResult, execute  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cmd(verb: str, *args: str) -> OperatorCommand:
+    return OperatorCommand(
+        verb=verb,
+        args=list(args),
+        actor="@ops:example.org",
+        room_id="!room:example.org",
+        thread_id="$thread1",
+    )
+
+
+def _fake_run_ok(stdout: str = "ok output", stderr: str = "") -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr=stderr)
+
+
+def _fake_run_fail(stdout: str = "", stderr: str = "error text") -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout=stdout, stderr=stderr)
+
+
+# ---------------------------------------------------------------------------
+# is_dispatch_verb
+# ---------------------------------------------------------------------------
+
+
+def test_is_dispatch_verb_true() -> None:
+    for verb in ("cloudshell", "ctx", "csh", "doc", "git", "k3s", "mesh", "note", "noe", "runbook", "tunnel", "wormhole"):
+        assert is_dispatch_verb(verb), f"Expected {verb!r} to be a dispatch verb"
+
+
+def test_is_dispatch_verb_false() -> None:
+    for verb in ("ack", "investigate", "resolve", "close", "reopen"):
+        assert not is_dispatch_verb(verb), f"Expected {verb!r} NOT to be a dispatch verb"
+
+
+# ---------------------------------------------------------------------------
+# cloudshell verb
+# ---------------------------------------------------------------------------
+
+
+def test_cloudshell_status_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("tunnel is UP"),
+    )
+    result = execute(_cmd("cloudshell", "status"))
+    assert isinstance(result, DispatchResult)
+    assert result.ok
+    assert "tunnel is UP" in result.body
+
+
+def test_cloudshell_status_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No sub-verb defaults to 'status'."""
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("tunnel is DOWN"),
+    )
+    result = execute(_cmd("cloudshell"))
+    assert result.ok
+
+
+def test_cloudshell_unknown_subverb() -> None:
+    result = execute(_cmd("cloudshell", "restart"))
+    assert not result.ok
+    assert "Unknown cloudshell sub-verb" in result.body
+    assert "⚠" in result.body
+
+
+# ---------------------------------------------------------------------------
+# k3s verb
+# ---------------------------------------------------------------------------
+
+
+def test_k3s_wraps_output_in_code_block(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("NAME   READY\nnode1  True"),
+    )
+    result = execute(_cmd("k3s", "get", "nodes"))
+    assert isinstance(result, DispatchResult)
+    assert result.ok
+    assert result.body.startswith("```")
+    assert "node1" in result.body
+
+
+def test_k3s_error_prefixed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_fail(stderr="connection refused"),
+    )
+    result = execute(_cmd("k3s", "get", "pods"))
+    assert not result.ok
+    assert "⚠" in result.body
+
+
+def test_k3s_no_args() -> None:
+    result = execute(_cmd("k3s"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+# ---------------------------------------------------------------------------
+# runbook verb
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("runbook-a\nrunbook-b"),
+    )
+    result = execute(_cmd("runbook", "list"))
+    assert result.ok
+    assert "runbook-a" in result.body
+
+
+def test_runbook_search(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("found: db-restart"),
+    )
+    result = execute(_cmd("runbook", "search", "database"))
+    assert result.ok
+    assert "db-restart" in result.body
+
+
+def test_runbook_show(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("# DB Restart Runbook\nStep 1…"),
+    )
+    result = execute(_cmd("runbook", "show", "db-restart"))
+    assert result.ok
+
+
+def test_runbook_unknown_sub() -> None:
+    result = execute(_cmd("runbook", "delete"))
+    assert not result.ok
+    assert "Unknown runbook sub-verb" in result.body
+
+
+def test_runbook_search_missing_query() -> None:
+    result = execute(_cmd("runbook", "search"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+# ---------------------------------------------------------------------------
+# noe verb
+# ---------------------------------------------------------------------------
+
+
+def test_noe_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("Noetica response: the answer is 42"),
+    )
+    result = execute(_cmd("noe", "what", "is", "the", "answer"))
+    assert result.ok
+    assert "42" in result.body
+
+
+def test_noe_no_query() -> None:
+    result = execute(_cmd("noe"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+# ---------------------------------------------------------------------------
+# wormhole verb — binary missing
+# ---------------------------------------------------------------------------
+
+
+def test_wormhole_send_binary_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("app.wormhole.shutil.which", lambda *a, **kw: None)
+    monkeypatch.setattr("app.wormhole.Path.exists", lambda self: False)
+
+    result = execute(_cmd("wormhole", "send", "/tmp/file.txt"))
+    assert not result.ok
+    assert "magic-wormhole" in result.body or "wormhole" in result.body.lower()
+
+
+def test_wormhole_recv_binary_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("app.wormhole.shutil.which", lambda *a, **kw: None)
+    monkeypatch.setattr("app.wormhole.Path.exists", lambda self: False)
+
+    result = execute(_cmd("wormhole", "recv", "3-guitar-tango"))
+    assert not result.ok
+    assert "magic-wormhole" in result.body or "wormhole" in result.body.lower()
+
+
+def test_wormhole_send_returns_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("app.wormhole.shutil.which", lambda *a, **kw: "/usr/local/bin/wormhole")
+    monkeypatch.setattr(
+        "app.wormhole.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("Sending file…\nwormhole receive 7-guitar-tango\n"),
+    )
+
+    result = execute(_cmd("wormhole", "send", "/tmp/report.pdf"))
+    assert result.ok
+    assert "7-guitar-tango" in result.body
+
+
+def test_wormhole_recv_missing_code() -> None:
+    result = execute(_cmd("wormhole", "recv"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+def test_wormhole_unknown_sub() -> None:
+    result = execute(_cmd("wormhole", "list"))
+    assert not result.ok
+    assert "Unknown wormhole sub-verb" in result.body
+
+
+def test_wormhole_pipe_calls_send_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[str] = []
+
+    def fake_send_text(text: str, timeout: int = 30) -> str:
+        captured.append(text)
+        return "5-piano-hotel"
+
+    monkeypatch.setattr("app.wormhole.shutil.which", lambda *a, **kw: "/usr/local/bin/wormhole")
+    monkeypatch.setattr("app.dispatch.wormhole.send_text", fake_send_text)
+
+    result = execute(_cmd("wormhole", "pipe", "hello", "world"))
+    assert result.ok
+    assert "5-piano-hotel" in result.body
+    assert captured == ["hello world"]
+
+
+def test_wormhole_pipe_no_text() -> None:
+    result = execute(_cmd("wormhole", "pipe"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+# ---------------------------------------------------------------------------
+# git verb
+# ---------------------------------------------------------------------------
+
+
+def test_git_log_returns_oneline(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("abc1234 commit one\ndef5678 commit two"),
+    )
+    result = execute(_cmd("git", "log"))
+    assert result.ok
+    assert "abc1234" in result.body
+    assert "def5678" in result.body
+
+
+def test_git_log_custom_n(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kw: object) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+        calls.append(cmd)
+        return _fake_run_ok("a1b2c3d first")
+
+    monkeypatch.setattr("app.dispatch.subprocess.run", fake_run)
+    result = execute(_cmd("git", "log", "5"))
+    assert result.ok
+    assert any("-n5" in part for part in calls[0])
+
+
+def test_git_diff_wraps_in_fence(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("- old line\n+ new line"),
+    )
+    result = execute(_cmd("git", "diff"))
+    assert result.ok
+    assert "```diff" in result.body
+    assert "- old line" in result.body
+
+
+def test_git_status_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("M  app/main.py\n?? scratch.txt"),
+    )
+    result = execute(_cmd("git", "status"))
+    assert result.ok
+    assert "main.py" in result.body
+
+
+def test_git_unknown_sub() -> None:
+    result = execute(_cmd("git", "push"))
+    assert not result.ok
+    assert "Unknown git sub-verb" in result.body
+
+
+# ---------------------------------------------------------------------------
+# mesh verb
+# ---------------------------------------------------------------------------
+
+
+def test_mesh_parses_jsonl(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    mesh_file = tmp_path / "context.jsonl"
+    mesh_file.write_text(
+        json.dumps({"ts": "2025-01-01T12:00:00Z", "type": "note", "title": "first note"}) + "\n"
+        + json.dumps({"ts": "2025-01-02T13:00:00Z", "type": "event", "title": "second event"}) + "\n"
+    )
+    monkeypatch.setattr("app.dispatch._mesh_jsonl_path", lambda: mesh_file)
+
+    result = execute(_cmd("mesh"))
+    assert result.ok
+    assert "note: first note" in result.body
+    assert "event: second event" in result.body
+    assert "2025-01-01T12:00" in result.body
+
+
+def test_mesh_file_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("app.dispatch._mesh_jsonl_path", lambda: tmp_path / "nonexistent.jsonl")
+
+    result = execute(_cmd("mesh"))
+    assert not result.ok
+    assert "mesh JSONL not found" in result.body
+
+
+def test_mesh_custom_n(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    mesh_file = tmp_path / "context.jsonl"
+    lines = [json.dumps({"ts": f"2025-01-{i:02d}T00:00:00Z", "type": "t", "title": f"item {i}"}) for i in range(1, 11)]
+    mesh_file.write_text("\n".join(lines) + "\n")
+    monkeypatch.setattr("app.dispatch._mesh_jsonl_path", lambda: mesh_file)
+
+    result = execute(_cmd("mesh", "3"))
+    assert result.ok
+    # Only last 3 items (8, 9, 10)
+    assert "item 10" in result.body
+    assert "item 9" in result.body
+    assert "item 8" in result.body
+    # items 1-7 must not appear (use word-boundary check via " item 7")
+    for absent in range(1, 8):
+        assert f"item {absent}\n" not in result.body + "\n", f"item {absent} should not be in output"
+
+
+# ---------------------------------------------------------------------------
+# note verb
+# ---------------------------------------------------------------------------
+
+
+def test_note_list_returns_sorted(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    # Create files with different mtimes
+    older = notes_dir / "older.md"
+    older.write_text("old content")
+    newer = notes_dir / "newer.md"
+    newer.write_text("new content")
+    # Touch newer to ensure it has a later mtime
+    import time
+    time.sleep(0.01)
+    newer.touch()
+
+    monkeypatch.setattr("app.dispatch._notes_dir", lambda: notes_dir)
+
+    result = execute(_cmd("note", "list"))
+    assert result.ok
+    assert "newer.md" in result.body
+    assert "older.md" in result.body
+    # newer should appear before older
+    assert result.body.index("newer.md") < result.body.index("older.md")
+
+
+def test_note_list_empty(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    monkeypatch.setattr("app.dispatch._notes_dir", lambda: notes_dir)
+
+    result = execute(_cmd("note", "list"))
+    assert result.ok
+    assert "no notes" in result.body
+
+
+def test_note_show_returns_content(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    note = notes_dir / "myslug.md"
+    note.write_text("# My Note\nSome content here.")
+    monkeypatch.setattr("app.dispatch._notes_dir", lambda: notes_dir)
+
+    result = execute(_cmd("note", "show", "myslug"))
+    assert result.ok
+    assert "My Note" in result.body
+    assert "Some content here." in result.body
+
+
+def test_note_show_with_md_extension(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    note = notes_dir / "myslug.md"
+    note.write_text("content")
+    monkeypatch.setattr("app.dispatch._notes_dir", lambda: notes_dir)
+
+    # Passing slug without .md should still find the file
+    result = execute(_cmd("note", "show", "myslug"))
+    assert result.ok
+
+
+def test_note_show_not_found(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    monkeypatch.setattr("app.dispatch._notes_dir", lambda: notes_dir)
+
+    result = execute(_cmd("note", "show", "ghost"))
+    assert not result.ok
+    assert "not found" in result.body.lower()
+
+
+def test_note_show_missing_slug() -> None:
+    result = execute(_cmd("note", "show"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+# ---------------------------------------------------------------------------
+# csh verb
+# ---------------------------------------------------------------------------
+
+
+def test_csh_runs_tunnel_exec(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kw: object) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+        calls.append(cmd)
+        return _fake_run_ok("remote output")
+
+    monkeypatch.setattr("app.dispatch.subprocess.run", fake_run)
+    result = execute(_cmd("csh", "ls", "-la"))
+    assert result.ok
+    assert "remote output" in result.body
+    assert calls[0] == ["turtle-ssh-tunnel", "exec", "ls", "-la"]
+
+
+def test_csh_binary_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    import subprocess as sp
+
+    def fake_run(cmd: list[str], **kw: object) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+        raise FileNotFoundError("turtle-ssh-tunnel")
+
+    monkeypatch.setattr("app.dispatch.subprocess.run", fake_run)
+    result = execute(_cmd("csh", "ls"))
+    assert not result.ok
+    assert "turtle-ssh-tunnel not found" in result.body
+    assert "cloudshell not configured" in result.body
+
+
+def test_csh_no_args() -> None:
+    result = execute(_cmd("csh"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+# ---------------------------------------------------------------------------
+# tunnel verb
+# ---------------------------------------------------------------------------
+
+
+def test_tunnel_status_calls_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kw: object) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+        calls.append(cmd)
+        return _fake_run_ok("tunnel: active")
+
+    monkeypatch.setattr("app.dispatch.subprocess.run", fake_run)
+    result = execute(_cmd("tunnel", "status"))
+    assert result.ok
+    assert "tunnel: active" in result.body
+    assert calls[0] == ["turtle-ssh-tunnel", "status"]
+
+
+def test_tunnel_start_calls_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kw: object) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+        calls.append(cmd)
+        return _fake_run_ok("started")
+
+    monkeypatch.setattr("app.dispatch.subprocess.run", fake_run)
+    result = execute(_cmd("tunnel", "start"))
+    assert result.ok
+    assert calls[0] == ["turtle-ssh-tunnel", "tunnel", "start"]
+
+
+def test_tunnel_default_is_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kw: object) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+        calls.append(cmd)
+        return _fake_run_ok("ok")
+
+    monkeypatch.setattr("app.dispatch.subprocess.run", fake_run)
+    result = execute(_cmd("tunnel"))
+    assert result.ok
+    assert calls[0][0:2] == ["turtle-ssh-tunnel", "status"]
+
+
+def test_tunnel_unknown_sub() -> None:
+    result = execute(_cmd("tunnel", "stop"))
+    assert not result.ok
+    assert "Unknown tunnel sub-verb" in result.body
+
+
+# ---------------------------------------------------------------------------
+# ctx verb
+# ---------------------------------------------------------------------------
+
+
+def test_ctx_reads_active_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ctx_file = tmp_path / "active.json"
+    ctx_file.write_text(json.dumps({"project": "prophet-platform", "branch": "main", "env": "prod"}))
+    monkeypatch.setattr("app.dispatch._ctx_json_path", lambda: ctx_file)
+
+    result = execute(_cmd("ctx"))
+    assert result.ok
+    assert "project: prophet-platform" in result.body
+    assert "branch: main" in result.body
+    assert "env: prod" in result.body
+
+
+def test_ctx_missing_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("app.dispatch._ctx_json_path", lambda: tmp_path / "no-active.json")
+
+    result = execute(_cmd("ctx"))
+    assert not result.ok
+    assert "No active context" in result.body
+
+
+# ---------------------------------------------------------------------------
+# Output truncation
+# ---------------------------------------------------------------------------
+
+
+def test_output_truncated(monkeypatch: pytest.MonkeyPatch) -> None:
+    long_output = "x" * 10_000
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok(long_output),
+    )
+    result = execute(_cmd("cloudshell", "status"))
+    assert len(result.body) <= 4_000
+    assert result.body.endswith("…[truncated]")
+
+
+# ---------------------------------------------------------------------------
+# Unknown verb
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_dispatch_verb() -> None:
+    result = execute(_cmd("bogus"))
+    assert not result.ok
+    assert "bogus" in result.body
+
+
+# ---------------------------------------------------------------------------
+# doc verb
+# ---------------------------------------------------------------------------
+
+
+def test_doc_feedback_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("✓ Feedback recorded — question on 'ADR-031'"),
+    )
+    result = execute(_cmd("doc", "feedback", "ADR-031", "question", "What happens on tunnel drop?"))
+    assert isinstance(result, DispatchResult)
+    assert result.ok
+    assert "Feedback recorded" in result.body
+
+
+def test_doc_feedback_missing_args() -> None:
+    result = execute(_cmd("doc", "feedback", "ADR-031"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+def test_doc_list_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("2026-08-04T12  question  ADR-031  — tunnel drop?"),
+    )
+    result = execute(_cmd("doc", "list", "ADR-031"))
+    assert result.ok
+    assert "ADR-031" in result.body
+
+
+def test_doc_faq_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("── ADR-031\n   Q: tunnel drop?\n   A: It reconnects."),
+    )
+    result = execute(_cmd("doc", "faq"))
+    assert result.ok
+    assert "ADR-031" in result.body
+
+
+def test_doc_distill_fires_async(monkeypatch: pytest.MonkeyPatch) -> None:
+    launched: list[list[str]] = []
+
+    class _FakePopen:
+        def __init__(self, cmd: list[str], **kw: object) -> None:
+            launched.append(cmd)
+
+    monkeypatch.setattr("app.dispatch.subprocess.Popen", _FakePopen)
+    result = execute(_cmd("doc", "distill", "ADR-031"))
+    assert result.ok
+    assert "⏳" in result.body
+    assert len(launched) == 1
+
+
+def test_doc_unknown_subverb() -> None:
+    result = execute(_cmd("doc", "frobnicate"))
+    assert not result.ok
+    assert "Unknown doc sub-verb" in result.body
+    assert "⚠" in result.body

--- a/apps/matrix-qes-operator/tests/test_dispatch_arm.py
+++ b/apps/matrix-qes-operator/tests/test_dispatch_arm.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+"""Tests for the ``arm`` dispatch verb added to matrix-qes-operator."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from app.commands import OperatorCommand  # noqa: E402
+from app.dispatch import DISPATCH_VERBS, DispatchResult, execute  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cmd(verb: str, *args: str) -> OperatorCommand:
+    return OperatorCommand(
+        verb=verb,
+        args=list(args),
+        actor="@ops:example.org",
+        room_id="!room:example.org",
+        thread_id="$thread1",
+    )
+
+
+def _fake_run_ok(stdout: str = "ok output", stderr: str = "") -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr=stderr)
+
+
+def _fake_run_fail(stdout: str = "", stderr: str = "error text") -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout=stdout, stderr=stderr)
+
+
+# ---------------------------------------------------------------------------
+# DISPATCH_VERBS registration
+# ---------------------------------------------------------------------------
+
+
+def test_arm_in_dispatch_verbs() -> None:
+    assert "arm" in DISPATCH_VERBS
+
+
+# ---------------------------------------------------------------------------
+# arm status
+# ---------------------------------------------------------------------------
+
+
+def test_arm_status_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("ARM status\n  Path: /home/x/.local/state/sourceos/arm/ARM.md\n  ADR count: 8"),
+    )
+    result = execute(_cmd("arm", "status"))
+    assert isinstance(result, DispatchResult)
+    assert result.ok
+    assert "ARM status" in result.body
+
+
+def test_arm_status_strips_ansi(monkeypatch: pytest.MonkeyPatch) -> None:
+    ansi_output = "\x1b[38;2;57;197;207mARM status\x1b[0m\n  ADR count: 8"
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok(ansi_output),
+    )
+    result = execute(_cmd("arm", "status"))
+    assert "\x1b[" not in result.body
+    assert "ARM status" in result.body
+
+
+def test_arm_status_default_sub_verb(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No sub-verb defaults to 'status'."""
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("ARM status\n  ADR count: 4"),
+    )
+    result = execute(_cmd("arm"))
+    assert result.ok
+
+
+# ---------------------------------------------------------------------------
+# arm generate
+# ---------------------------------------------------------------------------
+
+
+def test_arm_generate_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("✔ ARM generated: /path/ARM.md  (8 ADRs, 20000 bytes)"),
+    )
+    result = execute(_cmd("arm", "generate"))
+    assert result.ok
+    assert "ARM generated" in result.body
+    assert "8" in result.body
+
+
+def test_arm_generate_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_fail(stderr="ADR directory not found"),
+    )
+    result = execute(_cmd("arm", "generate"))
+    assert not result.ok
+    assert "⚠" in result.body
+
+
+# ---------------------------------------------------------------------------
+# arm show
+# ---------------------------------------------------------------------------
+
+
+def test_arm_show_no_section(monkeypatch: pytest.MonkeyPatch) -> None:
+    full_arm = "# Architecture Reference Manual\n\n## ADR-030: Foo Bar\n**Status:** Accepted"
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok(full_arm),
+    )
+    result = execute(_cmd("arm", "show"))
+    assert result.ok
+    assert "Architecture Reference Manual" in result.body
+
+
+def test_arm_show_with_section(monkeypatch: pytest.MonkeyPatch) -> None:
+    section_text = "## ADR-030: Foo Bar\n**Status:** Accepted\n\n### Context\nSome context here."
+    calls: list[list[str]] = []
+
+    def _fake(cmd: list[str], **kw: object) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+        calls.append(cmd)
+        return _fake_run_ok(section_text)
+
+    monkeypatch.setattr("app.dispatch.subprocess.run", _fake)
+    result = execute(_cmd("arm", "show", "ADR-030"))
+    assert result.ok
+    # --section flag should have been passed
+    assert any("--section" in c for call in calls for c in call)
+
+
+def test_arm_show_truncates_long_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    large = "x" * 5000
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok(large),
+    )
+    result = execute(_cmd("arm", "show"))
+    assert len(result.body) <= 4_000
+
+
+# ---------------------------------------------------------------------------
+# arm search
+# ---------------------------------------------------------------------------
+
+
+def test_arm_search_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    matches = "[line 43]\n## ADR-031: Runtime transport\n**Status:** Accepted"
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok(matches),
+    )
+    result = execute(_cmd("arm", "search", "transport"))
+    assert result.ok
+    assert "transport" in result.body.lower()
+
+
+def test_arm_search_no_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = execute(_cmd("arm", "search"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+def test_arm_search_multi_word_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def _fake(cmd: list[str], **kw: object) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+        calls.append(cmd)
+        return _fake_run_ok("match line")
+
+    monkeypatch.setattr("app.dispatch.subprocess.run", _fake)
+    result = execute(_cmd("arm", "search", "runtime", "transport"))
+    assert result.ok
+    # query should be joined into a single argument
+    assert any("runtime transport" in c for call in calls for c in call)
+
+
+# ---------------------------------------------------------------------------
+# unknown sub-verb
+# ---------------------------------------------------------------------------
+
+
+def test_arm_unknown_subverb(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = execute(_cmd("arm", "frobnicate"))
+    assert not result.ok
+    assert "Unknown arm sub-verb" in result.body
+    assert "frobnicate" in result.body


### PR DESCRIPTION
## Summary

- Adds `arm` to `DISPATCH_VERBS` and implements `_handle_arm()` in `apps/matrix-qes-operator/app/dispatch.py`
- Four sub-verbs: `generate`, `show [section]`, `search <query>`, `status`
- Invokes `turtle-arm-generate` (from TurtleTerm, shipped in PR #54) via subprocess; ANSI codes stripped for room-safe output
- `test_dispatch_arm.py`: 16 pytest tests — all sub-verbs, ANSI stripping, truncation, unknown verb error, multi-word query joining

## Usage in Matrix

```
!qes arm generate             → "ARM generated (8 ADRs)"
!qes arm show ADR-031         → section text (≤3500 chars)
!qes arm search transport     → grep matches (≤3000 chars)
!qes arm status               → ADR count, path, last generated
```

## Test plan

- [x] `python3 -m py_compile app/dispatch.py` — clean
- [x] `pytest tests/test_dispatch_arm.py tests/test_http_main.py tests/test_state_machine.py` — 20 passed