### PR TITLE
feat(matrix-qes): consolidate all dispatch verbs — git/mesh/note/csh/tunnel/ctx/ticket/doc/transcript/arm

### DIFF
--- a/apps/matrix-qes-operator/app/dispatch.py
+++ b/apps/matrix-qes-operator/app/dispatch.py
@@ -6,8 +6,12 @@ Handles non-incident ``!qes`` verbs by running local subprocesses and
 returning room-safe formatted output (max 4000 chars, truncated with ``…``).
 """
 
+import datetime
+import json
+import os
 import subprocess
 from dataclasses import dataclass
+from pathlib import Path
 
 from . import wormhole
 from .commands import OperatorCommand
@@ -17,7 +21,11 @@ from .commands import OperatorCommand
 # ---------------------------------------------------------------------------
 
 DISPATCH_VERBS: frozenset[str] = frozenset(
-    {"cloudshell", "k3s", "runbook", "noe", "wormhole"}
+    {
+        "arm", "cloudshell", "ctx", "csh", "doc", "git",
+        "k3s", "mesh", "note", "noe", "runbook", "ticket",
+        "transcript", "tunnel", "wormhole",
+    }
 )
 
 _MAX_BODY = 4_000
@@ -49,7 +57,7 @@ def _truncate(text: str) -> str:
     return text[:cut] + _TRUNCATION_SUFFIX
 
 
-def _run(cmd: list[str], timeout: int = 30) -> tuple[bool, str]:
+def _run(cmd: list[str], timeout: int = 30, cwd: str | None = None) -> tuple[bool, str]:
     """Run *cmd* and return ``(success, combined_output)``."""
     try:
         result = subprocess.run(
@@ -58,6 +66,7 @@ def _run(cmd: list[str], timeout: int = 30) -> tuple[bool, str]:
             text=True,
             timeout=timeout,
             env=_SUBPROCESS_ENV,
+            cwd=cwd,
         )
         combined = result.stdout + (("\n" + result.stderr) if result.stderr.strip() else "")
         return result.returncode == 0, combined.strip()
@@ -78,6 +87,67 @@ def _error(text: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Path helpers (extracted so tests can monkeypatch them)
+# ---------------------------------------------------------------------------
+
+
+def _mesh_jsonl_path() -> Path:
+    return Path.home() / ".local" / "state" / "sourceos" / "memory-mesh" / "context.jsonl"
+
+
+def _ctx_json_path() -> Path:
+    return Path.home() / ".local" / "state" / "sourceos" / "memory-mesh" / "active.json"
+
+
+def _notes_dir() -> Path:
+    return Path.home() / "notes"
+
+
+def _git_root() -> str:
+    val = os.environ.get("SOURCEOS_GIT_ROOT")
+    if val:
+        return val
+    return str(Path.home() / "dev")
+
+
+def _doc_feedback_bin() -> str:
+    import shutil as _shutil
+    found = _shutil.which("turtle-doc-feedback")
+    if found:
+        return found
+    candidate = Path.home() / ".local" / "share" / "sourceos" / "bin" / "turtle-doc-feedback"
+    if candidate.exists():
+        return str(candidate)
+    return "turtle-doc-feedback"
+
+
+def _transcript_bin() -> str:
+    import shutil as _shutil
+    found = _shutil.which("turtle-transcript-extract")
+    if found:
+        return found
+    candidate = Path.home() / ".local" / "share" / "sourceos" / "bin" / "turtle-transcript-extract"
+    if candidate.exists():
+        return str(candidate)
+    return "turtle-transcript-extract"
+
+
+def _transcript_pending_path() -> Path:
+    return Path.home() / ".local" / "state" / "sourceos" / "transcript-claims" / "pending.jsonl"
+
+
+def _arm_bin() -> str:
+    import shutil as _shutil
+    found = _shutil.which("turtle-arm-generate")
+    if found:
+        return found
+    candidate = Path.home() / ".local" / "share" / "sourceos" / "bin" / "turtle-arm-generate"
+    if candidate.exists():
+        return str(candidate)
+    return "turtle-arm-generate"
+
+
+# ---------------------------------------------------------------------------
 # Verb handlers
 # ---------------------------------------------------------------------------
 
@@ -95,7 +165,6 @@ def _handle_k3s(args: list[str]) -> DispatchResult:
     if not args:
         return DispatchResult(body=_error("Usage: !qes k3s <kubectl args…>"), ok=False)
     cmd = ["kubectl"] + list(args)
-    # Embed the kubeconfig via environment
     env = dict(_SUBPROCESS_ENV)
     env["KUBECONFIG"] = "~/.kube/config-k3s-twin"
     try:
@@ -117,7 +186,6 @@ def _handle_k3s(args: list[str]) -> DispatchResult:
         return DispatchResult(body=_error(str(exc)), ok=False)
 
     formatted = _code_block(_truncate(out)) if out else _code_block("(no output)")
-    # Wrap error prefix outside the code block for readability.
     if not ok:
         formatted = _error("kubectl returned non-zero exit code.\n") + formatted
     return DispatchResult(body=_truncate(formatted), ok=ok)
@@ -166,7 +234,6 @@ def _handle_wormhole(args: list[str]) -> DispatchResult:
                 code = wormhole.send_file(file_arg)
                 body = f"Wormhole transfer code: `{code}`\nRecipient runs: `wormhole receive {code}`"
             else:
-                # Send placeholder text; document usage.
                 code = wormhole.send_text("(placeholder — pipe your content in a follow-up)")
                 body = (
                     f"Wormhole transfer code: `{code}`\n"
@@ -196,15 +263,363 @@ def _handle_wormhole(args: list[str]) -> DispatchResult:
         )
 
 
+def _handle_git(args: list[str]) -> DispatchResult:
+    sub = args[0] if args else ""
+    cwd = _git_root()
+
+    if sub == "log":
+        try:
+            n = int(args[1]) if len(args) > 1 else 10
+        except ValueError:
+            n = 10
+        ok, out = _run(["git", "log", "--oneline", f"-n{n}"], cwd=cwd)
+        return DispatchResult(body=_truncate(out or "(empty log)"), ok=ok)
+
+    elif sub == "diff":
+        ref = args[1] if len(args) > 1 else "HEAD~1..HEAD"
+        ok, out = _run(["git", "diff", ref], cwd=cwd)
+        body = _truncate(f"```diff\n{out}\n```") if out else "(no diff)"
+        return DispatchResult(body=body, ok=ok)
+
+    elif sub == "status":
+        ok, out = _run(["git", "status", "--short"], cwd=cwd)
+        return DispatchResult(body=_truncate(out or "(clean)"), ok=ok)
+
+    else:
+        return DispatchResult(
+            body=_error(f"Unknown git sub-verb: {sub!r}. Try: log [n], diff [ref], status"),
+            ok=False,
+        )
+
+
+def _handle_mesh(args: list[str]) -> DispatchResult:
+    try:
+        n = int(args[0]) if args else 20
+    except ValueError:
+        n = 20
+
+    path = _mesh_jsonl_path()
+    if not path.exists():
+        return DispatchResult(body="⚠ mesh JSONL not found.", ok=False)
+
+    try:
+        lines = path.read_text().splitlines()[-n:]
+        formatted: list[str] = []
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+                ts = str(record.get("ts", ""))[:16]
+                rtype = record.get("type", "?")
+                title = record.get("title", "")
+                formatted.append(f"{ts} {rtype}: {title}")
+            except (json.JSONDecodeError, KeyError):
+                formatted.append(line[:80])
+        return DispatchResult(body=_truncate("\n".join(formatted) or "(empty)"), ok=True)
+    except Exception as exc:  # noqa: BLE001
+        return DispatchResult(body=_error(str(exc)), ok=False)
+
+
+def _handle_note(args: list[str]) -> DispatchResult:
+    sub = args[0] if args else "list"
+    notes = _notes_dir()
+
+    if sub == "list":
+        try:
+            files = sorted(notes.glob("*.md"), key=lambda p: p.stat().st_mtime, reverse=True)
+            if not files:
+                return DispatchResult(body="(no notes found)", ok=True)
+            lines: list[str] = []
+            for f in files:
+                mtime = datetime.datetime.fromtimestamp(f.stat().st_mtime).strftime("%Y-%m-%d %H:%M")
+                lines.append(f"{f.name}  {mtime}")
+            return DispatchResult(body=_truncate("\n".join(lines)), ok=True)
+        except Exception as exc:  # noqa: BLE001
+            return DispatchResult(body=_error(str(exc)), ok=False)
+
+    elif sub == "show":
+        if len(args) < 2:
+            return DispatchResult(body=_error("Usage: !qes note show <slug>"), ok=False)
+        slug = args[1]
+        for candidate in [notes / slug, notes / f"{slug}.md"]:
+            if candidate.exists():
+                try:
+                    return DispatchResult(body=candidate.read_text()[:3000], ok=True)
+                except Exception as exc:  # noqa: BLE001
+                    return DispatchResult(body=_error(str(exc)), ok=False)
+        return DispatchResult(body=_error(f"Note not found: {slug!r}"), ok=False)
+
+    else:
+        return DispatchResult(
+            body=_error(f"Unknown note sub-verb: {sub!r}. Try: list, show <slug>"),
+            ok=False,
+        )
+
+
+def _handle_csh(args: list[str]) -> DispatchResult:
+    if not args:
+        return DispatchResult(body=_error("Usage: !qes csh <cmd…>"), ok=False)
+    ok, out = _run(["turtle-ssh-tunnel", "exec"] + list(args))
+    if not ok and "Binary not found" in out:
+        return DispatchResult(body="⚠ turtle-ssh-tunnel not found — cloudshell not configured", ok=False)
+    return DispatchResult(body=_truncate(out if ok else _error(out)), ok=ok)
+
+
+def _handle_tunnel(args: list[str]) -> DispatchResult:
+    sub = args[0] if args else "status"
+
+    if sub == "status":
+        ok, out = _run(["turtle-ssh-tunnel", "status"])
+        return DispatchResult(body=_truncate(out if ok else _error(out)), ok=ok)
+
+    elif sub == "start":
+        ok, out = _run(["turtle-ssh-tunnel", "tunnel", "start"])
+        return DispatchResult(body=_truncate(out if ok else _error(out)), ok=ok)
+
+    else:
+        return DispatchResult(
+            body=_error(f"Unknown tunnel sub-verb: {sub!r}. Try: status, start"),
+            ok=False,
+        )
+
+
+def _handle_ctx(args: list[str]) -> DispatchResult:  # noqa: ARG001
+    path = _ctx_json_path()
+    if not path.exists():
+        return DispatchResult(body="⚠ No active context.", ok=False)
+    try:
+        data = json.loads(path.read_text())
+        lines: list[str] = [f"{k}: {v}" for k, v in data.items()]
+        return DispatchResult(body=_truncate("\n".join(lines)), ok=True)
+    except Exception as exc:  # noqa: BLE001
+        return DispatchResult(body=_error(str(exc)), ok=False)
+
+
+def _handle_ticket(args: list[str]) -> DispatchResult:
+    sub = args[0] if args else "list"
+    rest = args[1:] if len(args) > 1 else []
+
+    if sub == "open":
+        if not rest:
+            return DispatchResult(body=_error("Usage: !qes ticket open <title>"), ok=False)
+        cmd = ["turtle-ticket", "open"] + rest
+    elif sub in ("list", "ls"):
+        cmd = ["turtle-ticket", "list", "--open"]
+    elif sub == "show":
+        if not rest:
+            return DispatchResult(body=_error("Usage: !qes ticket show <id>"), ok=False)
+        cmd = ["turtle-ticket", "show", rest[0]]
+    elif sub == "close":
+        if not rest:
+            return DispatchResult(body=_error("Usage: !qes ticket close <id>"), ok=False)
+        cmd = ["turtle-ticket", "close", rest[0]]
+    elif sub in ("comment", "note"):
+        if len(rest) < 2:
+            return DispatchResult(
+                body=_error("Usage: !qes ticket comment <id> <text>"), ok=False
+            )
+        cmd = ["turtle-ticket", "comment"] + rest
+    elif sub == "search":
+        if not rest:
+            return DispatchResult(body=_error("Usage: !qes ticket search <query>"), ok=False)
+        cmd = ["turtle-ticket", "search"] + rest
+    elif sub == "summary":
+        cmd = ["turtle-ticket", "summary"]
+    else:
+        return DispatchResult(
+            body=_error(
+                f"Unknown ticket sub-verb: {sub!r}. "
+                "Try: open <title>, list, show <id>, close <id>, "
+                "comment <id> <text>, search <query>, summary"
+            ),
+            ok=False,
+        )
+
+    ok, out = _run(cmd, timeout=15)
+    return DispatchResult(body=_truncate(out if ok else _error(out)), ok=ok)
+
+
+def _handle_doc(args: list[str]) -> DispatchResult:
+    sub = args[0] if args else ""
+
+    if sub == "feedback":
+        rest = args[1:]
+        if len(rest) < 2:
+            return DispatchResult(
+                body=_error("Usage: !qes doc feedback <doc_ref> <sentiment> [<comment>]"),
+                ok=False,
+            )
+        ok, out = _run(["python3", _doc_feedback_bin(), "submit"] + list(rest), timeout=15)
+        return DispatchResult(body=_truncate(out if ok else _error(out)), ok=ok)
+
+    elif sub == "list":
+        ok, out = _run(["python3", _doc_feedback_bin(), "list"] + args[1:], timeout=10)
+        return DispatchResult(body=_truncate(out if ok else _error(out)), ok=ok)
+
+    elif sub == "faq":
+        ok, out = _run(["python3", _doc_feedback_bin(), "faq"] + args[1:], timeout=10)
+        return DispatchResult(body=_truncate(out if ok else _error(out)), ok=ok)
+
+    elif sub == "distill":
+        rest = args[1:]
+        try:
+            subprocess.Popen(
+                ["python3", _doc_feedback_bin(), "distill"] + list(rest),
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                env=_SUBPROCESS_ENV,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return DispatchResult(body=_error(f"Could not launch distill: {exc}"), ok=False)
+        label = f" for {rest[0]!r}" if rest else ""
+        return DispatchResult(
+            body=f"⏳ Distilling{label}… (runs in background; use `!qes doc faq` when done)",
+            ok=True,
+        )
+
+    else:
+        return DispatchResult(
+            body=_error(
+                f"Unknown doc sub-verb: {sub!r}. "
+                "Try: feedback <ref> <sentiment> [comment], list [ref], faq [ref], distill [ref]"
+            ),
+            ok=False,
+        )
+
+
+def _handle_transcript(args: list[str]) -> DispatchResult:
+    sub = args[0] if args else ""
+
+    if sub == "extract":
+        since_h = 24
+        i = 1
+        while i < len(args):
+            if args[i] == "--since" and i + 1 < len(args):
+                try:
+                    since_h = int(args[i + 1])
+                except ValueError:
+                    pass
+                i += 2
+            else:
+                i += 1
+        try:
+            subprocess.Popen(
+                ["python3", _transcript_bin(), "extract", "--since", str(since_h)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                env=_SUBPROCESS_ENV,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return DispatchResult(body=_error(f"Could not launch extract: {exc}"), ok=False)
+        return DispatchResult(
+            body=f"⏳ Extracting last {since_h}h… (runs in background; use `!qes transcript list` when done)",
+            ok=True,
+        )
+
+    elif sub == "list":
+        pending_path = _transcript_pending_path()
+        if not pending_path.exists():
+            return DispatchResult(body="(no pending claims)", ok=True)
+        try:
+            lines = [ln.strip() for ln in pending_path.read_text().splitlines() if ln.strip()]
+        except Exception as exc:  # noqa: BLE001
+            return DispatchResult(body=_error(str(exc)), ok=False)
+        if not lines:
+            return DispatchResult(body="(no pending claims)", ok=True)
+        records = lines[-10:]
+        rows: list[str] = []
+        for line in records:
+            try:
+                r = json.loads(line)
+                claim_id = r.get("id", "?")
+                extracted_at = r.get("extracted_at", "?")[:16]
+                preview = r.get("claim", "")[:60].replace("\n", " ")
+                rows.append(f"{claim_id}  {extracted_at}  {preview}…")
+            except Exception:
+                rows.append(line[:80])
+        total = len(lines)
+        header = f"Pending claims ({total} total, showing last {len(records)}):"
+        return DispatchResult(body=_truncate(header + "\n" + "\n".join(rows)), ok=True)
+
+    elif sub == "commit":
+        ok, out = _run(["python3", _transcript_bin(), "commit"], timeout=30)
+        return DispatchResult(body=_truncate(out if ok else _error(out)), ok=ok)
+
+    else:
+        return DispatchResult(
+            body=_error(
+                f"Unknown transcript sub-verb: {sub!r}. "
+                "Try: extract [--since <hours>], list, commit"
+            ),
+            ok=False,
+        )
+
+
+def _handle_arm(args: list[str]) -> DispatchResult:
+    import re as _re
+
+    sub = args[0] if args else "status"
+    bin_path = _arm_bin()
+
+    if sub == "generate":
+        ok, out = _run(["python3", bin_path, "generate"], timeout=60)
+        if ok:
+            m = _re.search(r"\((\d+) ADRs", out)
+            count = m.group(1) if m else "?"
+            body = f"ARM generated ({count} ADRs)"
+        else:
+            body = _error(out)
+        return DispatchResult(body=body, ok=ok)
+
+    elif sub == "show":
+        cmd = ["python3", bin_path, "show"]
+        if args[1:]:
+            cmd += ["--section", " ".join(args[1:])]
+        ok, out = _run(cmd, timeout=15)
+        return DispatchResult(body=_truncate(out[:3500] if ok else _error(out)), ok=ok)
+
+    elif sub == "search":
+        if not args[1:]:
+            return DispatchResult(body=_error("Usage: !qes arm search <query>"), ok=False)
+        ok, out = _run(["python3", bin_path, "search", " ".join(args[1:])], timeout=15)
+        return DispatchResult(body=_truncate(out[:3000] if ok else _error(out)), ok=ok)
+
+    elif sub == "status":
+        ok, out = _run(["python3", bin_path, "status"], timeout=10)
+        clean = _re.sub(r"\x1b\[[0-9;]*m", "", out)
+        return DispatchResult(body=_truncate(clean if ok else _error(clean)), ok=ok)
+
+    else:
+        return DispatchResult(
+            body=_error(
+                f"Unknown arm sub-verb: {sub!r}. "
+                "Try: generate, show [section], search <query>, status"
+            ),
+            ok=False,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
 _HANDLERS = {
+    "arm": _handle_arm,
     "cloudshell": _handle_cloudshell,
+    "ctx": _handle_ctx,
+    "csh": _handle_csh,
+    "doc": _handle_doc,
+    "git": _handle_git,
     "k3s": _handle_k3s,
-    "runbook": _handle_runbook,
+    "mesh": _handle_mesh,
+    "note": _handle_note,
     "noe": _handle_noe,
+    "runbook": _handle_runbook,
+    "ticket": _handle_ticket,
+    "transcript": _handle_transcript,
+    "tunnel": _handle_tunnel,
     "wormhole": _handle_wormhole,
 }
 

--- a/apps/matrix-qes-operator/tests/test_dispatch.py
+++ b/apps/matrix-qes-operator/tests/test_dispatch.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -42,7 +43,11 @@ def _fake_run_fail(stdout: str = "", stderr: str = "error text") -> subprocess.C
 
 
 def test_is_dispatch_verb_true() -> None:
-    for verb in ("cloudshell", "k3s", "runbook", "noe", "wormhole"):
+    for verb in (
+        "arm", "cloudshell", "ctx", "csh", "doc", "git",
+        "k3s", "mesh", "note", "noe", "runbook", "ticket",
+        "transcript", "tunnel", "wormhole",
+    ):
         assert is_dispatch_verb(verb), f"Expected {verb!r} to be a dispatch verb"
 
 
@@ -232,6 +237,500 @@ def test_wormhole_unknown_sub() -> None:
     result = execute(_cmd("wormhole", "list"))
     assert not result.ok
     assert "Unknown wormhole sub-verb" in result.body
+
+
+# ---------------------------------------------------------------------------
+# git verb
+# ---------------------------------------------------------------------------
+
+
+def test_git_log_returns_oneline(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("abc1234 commit one\ndef5678 commit two"),
+    )
+    result = execute(_cmd("git", "log"))
+    assert result.ok
+    assert "abc1234" in result.body
+    assert "def5678" in result.body
+
+
+def test_git_log_custom_n(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kw: object) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+        calls.append(cmd)
+        return _fake_run_ok("a1b2c3d first")
+
+    monkeypatch.setattr("app.dispatch.subprocess.run", fake_run)
+    result = execute(_cmd("git", "log", "5"))
+    assert result.ok
+    assert any("-n5" in part for part in calls[0])
+
+
+def test_git_diff_wraps_in_fence(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("- old line\n+ new line"),
+    )
+    result = execute(_cmd("git", "diff"))
+    assert result.ok
+    assert "```diff" in result.body
+    assert "- old line" in result.body
+
+
+def test_git_status_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("M  app/main.py\n?? scratch.txt"),
+    )
+    result = execute(_cmd("git", "status"))
+    assert result.ok
+    assert "main.py" in result.body
+
+
+def test_git_unknown_sub() -> None:
+    result = execute(_cmd("git", "push"))
+    assert not result.ok
+    assert "Unknown git sub-verb" in result.body
+
+
+# ---------------------------------------------------------------------------
+# mesh verb
+# ---------------------------------------------------------------------------
+
+
+def test_mesh_parses_jsonl(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    mesh_file = tmp_path / "context.jsonl"
+    mesh_file.write_text(
+        json.dumps({"ts": "2025-01-01T12:00:00Z", "type": "note", "title": "first note"}) + "\n"
+        + json.dumps({"ts": "2025-01-02T13:00:00Z", "type": "event", "title": "second event"}) + "\n"
+    )
+    monkeypatch.setattr("app.dispatch._mesh_jsonl_path", lambda: mesh_file)
+    result = execute(_cmd("mesh"))
+    assert result.ok
+    assert "note: first note" in result.body
+    assert "event: second event" in result.body
+
+
+def test_mesh_file_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("app.dispatch._mesh_jsonl_path", lambda: tmp_path / "nonexistent.jsonl")
+    result = execute(_cmd("mesh"))
+    assert not result.ok
+    assert "mesh JSONL not found" in result.body
+
+
+def test_mesh_custom_n(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    mesh_file = tmp_path / "context.jsonl"
+    lines = [json.dumps({"ts": f"2025-01-{i:02d}T00:00:00Z", "type": "t", "title": f"item {i}"}) for i in range(1, 11)]
+    mesh_file.write_text("\n".join(lines) + "\n")
+    monkeypatch.setattr("app.dispatch._mesh_jsonl_path", lambda: mesh_file)
+    result = execute(_cmd("mesh", "3"))
+    assert result.ok
+    assert "item 10" in result.body
+    assert "item 9" in result.body
+    assert "item 8" in result.body
+
+
+# ---------------------------------------------------------------------------
+# note verb
+# ---------------------------------------------------------------------------
+
+
+def test_note_list_returns_sorted(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    older = notes_dir / "older.md"
+    older.write_text("old content")
+    import time
+    time.sleep(0.01)
+    newer = notes_dir / "newer.md"
+    newer.write_text("new content")
+    monkeypatch.setattr("app.dispatch._notes_dir", lambda: notes_dir)
+    result = execute(_cmd("note", "list"))
+    assert result.ok
+    assert "newer.md" in result.body
+    assert "older.md" in result.body
+    assert result.body.index("newer.md") < result.body.index("older.md")
+
+
+def test_note_list_empty(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    monkeypatch.setattr("app.dispatch._notes_dir", lambda: notes_dir)
+    result = execute(_cmd("note", "list"))
+    assert result.ok
+    assert "no notes" in result.body
+
+
+def test_note_show_returns_content(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    (notes_dir / "myslug.md").write_text("# My Note\nSome content here.")
+    monkeypatch.setattr("app.dispatch._notes_dir", lambda: notes_dir)
+    result = execute(_cmd("note", "show", "myslug"))
+    assert result.ok
+    assert "My Note" in result.body
+
+
+def test_note_show_not_found(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    monkeypatch.setattr("app.dispatch._notes_dir", lambda: notes_dir)
+    result = execute(_cmd("note", "show", "ghost"))
+    assert not result.ok
+    assert "not found" in result.body.lower()
+
+
+def test_note_show_missing_slug() -> None:
+    result = execute(_cmd("note", "show"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+# ---------------------------------------------------------------------------
+# csh verb
+# ---------------------------------------------------------------------------
+
+
+def test_csh_runs_tunnel_exec(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kw: object) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+        calls.append(cmd)
+        return _fake_run_ok("remote output")
+
+    monkeypatch.setattr("app.dispatch.subprocess.run", fake_run)
+    result = execute(_cmd("csh", "ls", "-la"))
+    assert result.ok
+    assert "remote output" in result.body
+    assert calls[0] == ["turtle-ssh-tunnel", "exec", "ls", "-la"]
+
+
+def test_csh_no_args() -> None:
+    result = execute(_cmd("csh"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+# ---------------------------------------------------------------------------
+# tunnel verb
+# ---------------------------------------------------------------------------
+
+
+def test_tunnel_status_calls_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kw: object) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+        calls.append(cmd)
+        return _fake_run_ok("tunnel: active")
+
+    monkeypatch.setattr("app.dispatch.subprocess.run", fake_run)
+    result = execute(_cmd("tunnel", "status"))
+    assert result.ok
+    assert calls[0] == ["turtle-ssh-tunnel", "status"]
+
+
+def test_tunnel_unknown_sub() -> None:
+    result = execute(_cmd("tunnel", "stop"))
+    assert not result.ok
+    assert "Unknown tunnel sub-verb" in result.body
+
+
+# ---------------------------------------------------------------------------
+# ctx verb
+# ---------------------------------------------------------------------------
+
+
+def test_ctx_reads_active_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    ctx_file = tmp_path / "active.json"
+    ctx_file.write_text(json.dumps({"project": "prophet-platform", "branch": "main"}))
+    monkeypatch.setattr("app.dispatch._ctx_json_path", lambda: ctx_file)
+    result = execute(_cmd("ctx"))
+    assert result.ok
+    assert "project: prophet-platform" in result.body
+
+
+def test_ctx_missing_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("app.dispatch._ctx_json_path", lambda: tmp_path / "no-active.json")
+    result = execute(_cmd("ctx"))
+    assert not result.ok
+    assert "No active context" in result.body
+
+
+# ---------------------------------------------------------------------------
+# ticket verb
+# ---------------------------------------------------------------------------
+
+
+def test_ticket_is_dispatch_verb() -> None:
+    assert is_dispatch_verb("ticket")
+
+
+def test_ticket_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("[abc12345] OPEN       p2   Test ticket"),
+    )
+    result = execute(_cmd("ticket", "list"))
+    assert result.ok
+
+
+def test_ticket_ls_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("app.dispatch.subprocess.run", lambda *a, **kw: _fake_run_ok("(no tickets)"))
+    result = execute(_cmd("ticket", "ls"))
+    assert result.ok
+
+
+def test_ticket_open_no_title() -> None:
+    result = execute(_cmd("ticket", "open"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+def test_ticket_open_with_title(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("✅ Ticket opened: [abc12345] Something broken"),
+    )
+    result = execute(_cmd("ticket", "open", "Something", "broken"))
+    assert result.ok
+
+
+def test_ticket_close_no_id() -> None:
+    result = execute(_cmd("ticket", "close"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+def test_ticket_comment_insufficient_args() -> None:
+    result = execute(_cmd("ticket", "comment", "abc12345"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+def test_ticket_note_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("app.dispatch.subprocess.run", lambda *a, **kw: _fake_run_ok("💬 Comment added"))
+    result = execute(_cmd("ticket", "note", "abc12345", "text"))
+    assert result.ok
+
+
+def test_ticket_search_no_query() -> None:
+    result = execute(_cmd("ticket", "search"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+def test_ticket_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("Total tickets: 3\nBy status:\n  open 2"),
+    )
+    result = execute(_cmd("ticket", "summary"))
+    assert result.ok
+
+
+def test_ticket_unknown_sub() -> None:
+    result = execute(_cmd("ticket", "invalidverb"))
+    assert not result.ok
+    assert "Unknown ticket sub-verb" in result.body
+
+
+# ---------------------------------------------------------------------------
+# doc verb
+# ---------------------------------------------------------------------------
+
+
+def test_doc_feedback_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("✓ Feedback recorded — question on 'ADR-031'"),
+    )
+    result = execute(_cmd("doc", "feedback", "ADR-031", "question", "What happens on tunnel drop?"))
+    assert result.ok
+    assert "Feedback recorded" in result.body
+
+
+def test_doc_feedback_missing_args() -> None:
+    result = execute(_cmd("doc", "feedback", "ADR-031"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+def test_doc_list_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("2026-08-04T12  question  ADR-031"),
+    )
+    result = execute(_cmd("doc", "list", "ADR-031"))
+    assert result.ok
+    assert "ADR-031" in result.body
+
+
+def test_doc_faq_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("── ADR-031\n   Q: tunnel drop?\n   A: It reconnects."),
+    )
+    result = execute(_cmd("doc", "faq"))
+    assert result.ok
+    assert "ADR-031" in result.body
+
+
+def test_doc_distill_fires_async(monkeypatch: pytest.MonkeyPatch) -> None:
+    launched: list[list[str]] = []
+
+    class _FakePopen:
+        def __init__(self, cmd: list[str], **kw: object) -> None:
+            launched.append(cmd)
+
+    monkeypatch.setattr("app.dispatch.subprocess.Popen", _FakePopen)
+    result = execute(_cmd("doc", "distill", "ADR-031"))
+    assert result.ok
+    assert "⏳" in result.body
+    assert len(launched) == 1
+
+
+def test_doc_unknown_subverb() -> None:
+    result = execute(_cmd("doc", "frobnicate"))
+    assert not result.ok
+    assert "Unknown doc sub-verb" in result.body
+
+
+# ---------------------------------------------------------------------------
+# transcript verb
+# ---------------------------------------------------------------------------
+
+
+def test_transcript_in_dispatch_verbs() -> None:
+    assert is_dispatch_verb("transcript")
+
+
+def test_transcript_extract_launches_background(monkeypatch: pytest.MonkeyPatch) -> None:
+    launched: list[list[str]] = []
+
+    class _FakePopen:
+        def __init__(self, cmd: list[str], **kw: object) -> None:
+            launched.append(cmd)
+
+    monkeypatch.setattr("app.dispatch.subprocess.Popen", _FakePopen)
+    result = execute(_cmd("transcript", "extract"))
+    assert result.ok
+    assert "Extracting" in result.body
+    assert "24h" in result.body
+    assert "extract" in launched[0]
+
+
+def test_transcript_extract_custom_since(monkeypatch: pytest.MonkeyPatch) -> None:
+    launched: list[list[str]] = []
+
+    class _FakePopen:
+        def __init__(self, cmd: list[str], **kw: object) -> None:
+            launched.append(cmd)
+
+    monkeypatch.setattr("app.dispatch.subprocess.Popen", _FakePopen)
+    result = execute(_cmd("transcript", "extract", "--since", "48"))
+    assert result.ok
+    assert "48h" in result.body
+
+
+def test_transcript_list_no_pending(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("app.dispatch._transcript_pending_path", lambda: tmp_path / "nonexistent.jsonl")
+    result = execute(_cmd("transcript", "list"))
+    assert result.ok
+    assert "no pending" in result.body
+
+
+def test_transcript_list_shows_claims(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    pending = tmp_path / "pending.jsonl"
+    records = [
+        {"id": f"claim-{i:08x}", "extracted_at": "2026-08-04T12:00:00Z", "claim": f"Fact {i}: something"}
+        for i in range(1, 6)
+    ]
+    pending.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    monkeypatch.setattr("app.dispatch._transcript_pending_path", lambda: pending)
+    result = execute(_cmd("transcript", "list"))
+    assert result.ok
+    assert "5 total" in result.body
+
+
+def test_transcript_commit_runs_bin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("app.dispatch.subprocess.run", lambda *a, **kw: _fake_run_ok("5 claim(s) committed"))
+    result = execute(_cmd("transcript", "commit"))
+    assert result.ok
+    assert "committed" in result.body
+
+
+def test_transcript_unknown_subverb() -> None:
+    result = execute(_cmd("transcript", "delete"))
+    assert not result.ok
+    assert "Unknown transcript sub-verb" in result.body
+
+
+def test_transcript_no_subverb_returns_error() -> None:
+    result = execute(_cmd("transcript"))
+    assert not result.ok
+    assert "⚠" in result.body
+
+
+# ---------------------------------------------------------------------------
+# arm verb
+# ---------------------------------------------------------------------------
+
+
+def test_arm_in_dispatch_verbs() -> None:
+    assert is_dispatch_verb("arm")
+
+
+def test_arm_generate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("ARM generated (7 ADRs)"),
+    )
+    result = execute(_cmd("arm", "generate"))
+    assert result.ok
+    assert "7" in result.body
+
+
+def test_arm_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("ARM index: 7 ADRs; last updated: 2026-08-04"),
+    )
+    result = execute(_cmd("arm", "status"))
+    assert result.ok
+    assert "ADRs" in result.body
+
+
+def test_arm_search_no_query() -> None:
+    result = execute(_cmd("arm", "search"))
+    assert not result.ok
+    assert "Usage" in result.body
+
+
+def test_arm_search_with_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("ADR-031: wormhole — ACCEPTED"),
+    )
+    result = execute(_cmd("arm", "search", "wormhole"))
+    assert result.ok
+    assert "wormhole" in result.body
+
+
+def test_arm_show(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.dispatch.subprocess.run",
+        lambda *a, **kw: _fake_run_ok("# Architecture Reference Manual\n## Overview"),
+    )
+    result = execute(_cmd("arm", "show"))
+    assert result.ok
+
+
+def test_arm_unknown_sub() -> None:
+    result = execute(_cmd("arm", "delete"))
+    assert not result.ok
+    assert "Unknown arm sub-verb" in result.body
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Resolves the `add/add` conflict that blocked PRs #1409, #1411, #1412, #1413 (all added `dispatch.py` as a new file, which conflicted with #1406 that merged first). This PR applies all 10 new verbs cleanly on top of the already-merged base.

**New `!qes` verbs:**

| Verb | Sub-verbs |
|---|---|
| `git` | `log [n]`, `diff [ref]`, `status` |
| `mesh` | `[n]` — tail memory-mesh JSONL |
| `note` | `list`, `show <slug>` |
| `csh` | `<cmd…>` — remote exec via cloudshell bastion |
| `tunnel` | `status`, `start` |
| `ctx` | post `active.json` context to room |
| `ticket` | `open`, `list`, `show`, `close`, `comment`/`note`, `search`, `summary` |
| `doc` | `feedback`, `list`, `faq`, `distill` |
| `transcript` | `extract [--since <h>]`, `list`, `commit` |
| `arm` | `generate`, `show [section]`, `search <q>`, `status` |

**Supersedes:** PRs #1409, #1411, #1412, #1413 (those can be closed once this merges).

## Test plan

- [ ] `pytest apps/matrix-qes-operator/tests/test_dispatch.py` — 73 tests, all pass
- [ ] `!qes git log` in Matrix → last 10 commits from `~/dev`
- [ ] `!qes doc feedback ADR-031 question What is the tunnel drop behavior?` → receipt filed
- [ ] `!qes ticket open k3s memory pressure` → ticket ID in threaded reply
- [ ] `!qes transcript extract` → async kick-off confirmed with ⏳
- [ ] `!qes arm status` → ADR count + last-updated date