### PR TITLE
fix(compute-gateway): a quorum of one, where the one is the requester, is not a quorum

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/grants.py
+++ b/apps/compute-gateway/src/compute_gateway/grants.py
@@ -68,6 +68,39 @@ def decide(kind: str, backend: str) -> dict[str, Any]:
     }
 
 
+def _check_quorum_independence(sigs: list[dict], actor: str, project: str) -> str | None:
+    """Independence checks the DECISION layer owns. Returns a refusal reason, or None.
+
+    Cryptographic signature verification is deliberately NOT here — it belongs to the authority
+    kernel behind the transport seam (see module docstring). But these two properties are decision
+    properties, not transport properties, and this module is where the decision is made:
+
+    1. **Distinct signers.** `len(sigs) >= need` counts signatures, not voices. The same principal
+       twice is one voice; an N-of-M rule satisfied by one repeated signer is not a quorum.
+    2. **No self-signing.** The actor requesting a HIGH-danger grant may not be the human who
+       approves it. A quorum of one in which the one is the requester is not a quorum — it is a
+       self-issued permission wearing a quorum's shape.
+
+    Rule (2) is the same property the estate enforces elsewhere: an attestor must be independent of
+    the subject, not merely distinct in name. Absence of a signer identity is refused rather than
+    skipped — an unidentified signer cannot be shown independent.
+    """
+    seen: set[str] = set()
+    requester = f"{ISSUER}/{project}/{actor}"
+    for s in sigs:
+        sid = (s or {}).get("spiffe_id")
+        if not sid:
+            return "a quorum signature carries no spiffe_id — an unidentified signer cannot be shown independent"
+        if sid in seen:
+            return f"duplicate quorum signer {sid!r} — the same principal twice is one voice, not a quorum"
+        seen.add(sid)
+        # the requester may not approve their own HIGH-danger grant
+        if sid == requester or sid.rstrip("/").endswith(f"/{project}/{actor}"):
+            return (f"quorum signer {sid!r} is the actor requesting the grant — a quorum of one in "
+                    "which the one is the requester is not a quorum")
+    return None
+
+
 def _quorum_proof(operation: str, signatures: list[dict]) -> dict[str, Any]:
     return {
         "rule": "1-of-N-human",
@@ -89,6 +122,13 @@ def request_grant(*, kind: str, backend: str, project: str, actor: str,
         _ledger_add("OP_GRANT_DENY", "-", reason="insufficient quorum", operation=f"{kind}:{backend}")
         return {"decision": decision, "grant": None, "quorum_required": need,
                 "reason": f"HIGH-danger operation requires {need} human quorum signature(s)"}
+    if need:
+        # Counting signatures is not counting voices. Refuse a quorum that is not independent.
+        bad = _check_quorum_independence(sigs, actor, project)
+        if bad:
+            _ledger_add("OP_GRANT_DENY", "-", reason="quorum not independent",
+                        operation=f"{kind}:{backend}", detail=bad)
+            return {"decision": decision, "grant": None, "quorum_required": need, "reason": bad}
 
     effect = _EFFECT.get(kind, "compute")
     gid = "grant-" + uuid.uuid4().hex

--- a/apps/compute-gateway/tests/test_grants.py
+++ b/apps/compute-gateway/tests/test_grants.py
@@ -67,3 +67,41 @@ def test_revoke_unknown_404_and_auth():
     assert client.post("/v1/grants/nope/revoke", headers=AUTH).status_code == 404
     assert client.post("/v1/grants", json={"kind": "graph-query"}).status_code == 401
     assert client.get("/v1/grants/ledger").status_code == 401
+
+
+# --- quorum independence: counting signatures is not counting voices -------------------------
+
+def test_the_requester_cannot_approve_their_own_high_danger_grant():
+    """The hole this closes: `len(sigs) >= need` accepted a signature from the actor themselves."""
+    r = grants.request_grant(
+        kind="notebook", backend="local", project="p", actor="alice", session=None,
+        quorum_signatures=[{"spiffe_id": f"{grants.ISSUER}/p/alice", "sig": "s" * 24}])
+    assert r["grant"] is None, "a self-signed quorum must not issue a HIGH-danger grant"
+    assert "is not a quorum" in r["reason"]
+
+
+def test_an_independent_human_still_satisfies_the_quorum():
+    r = grants.request_grant(
+        kind="notebook", backend="local", project="p", actor="alice", session=None,
+        quorum_signatures=[{"spiffe_id": "spiffe://ops/bob", "sig": "s" * 24}])
+    assert r["grant"] is not None
+    assert r["grant"]["quorum_proof"]["rule"] == "1-of-N-human"
+
+
+def test_the_same_signer_twice_is_one_voice():
+    """Guards the N-of-M case: required_quorum > 1 must not be satisfied by one repeated signer."""
+    reason = grants._check_quorum_independence(
+        [{"spiffe_id": "spiffe://ops/bob", "sig": "x"}, {"spiffe_id": "spiffe://ops/bob", "sig": "y"}],
+        actor="alice", project="p")
+    assert reason and "one voice" in reason
+
+
+def test_an_unidentified_signer_is_refused_not_skipped():
+    reason = grants._check_quorum_independence([{"sig": "x"}], actor="alice", project="p")
+    assert reason and "cannot be shown independent" in reason
+
+
+def test_two_distinct_humans_pass():
+    assert grants._check_quorum_independence(
+        [{"spiffe_id": "spiffe://ops/bob", "sig": "x"}, {"spiffe_id": "spiffe://ops/carol", "sig": "y"}],
+        actor="alice", project="p") is None


### PR DESCRIPTION
*Replaces #1419, which was branched from the wrong base and inadvertently carried two unrelated `feat/identity-twin-foundation` commits. This is the same fix, alone, on top of `main`: **2 files, +78**.*

## The hole

`request_grant` gated HIGH-danger (user-code) operations on `len(sigs) >= required_quorum`. That counts **signatures, not voices** — nothing checked who the signers were.

**The requester could approve their own grant.** Nothing compared a signature's `spiffe_id` to the `actor` requesting it, so `actor=alice` supplying a signature from `…/alice` satisfied the "human quorum" on the gateway's highest-danger path. A self-issued permission wearing a quorum's shape.

**The same principal twice counted twice.** `required_quorum` is 1 today so this is latent — but the rule is named `1-of-N-human` and the code is generic, so the first time N-of-M rises above 1 it would be satisfiable by one repeated signer.

## What I did *not* change

**Cryptographic signature verification.** The module docstring is explicit that the authority kernel behind the transport seam owns it, and the tests pass `"s" * 24` by design. That is a deliberate reference-implementation boundary and I'm not front-running it.

But **distinctness and non-self-signing are decision properties, not transport properties**, and this module is where the decision is made.

## The rule

An approver must be **independent of the subject**, not merely distinct in name. An unidentified signer is **refused, not skipped** — absence of a signer identity cannot be shown independent. Refusals append `OP_GRANT_DENY` to the ledger with the reason, so a rejected quorum is evidence rather than a silent no.

## Verification

9 tests pass (5 new), including the previously-open case: a self-signed HIGH-danger grant is refused, while an independent human still satisfies the quorum.