### PR TITLE
feat(hellgraph-service): enforce tenant/op_set isolation at the graph surface (W2 doors)

### DIFF
--- a/apps/hellgraph-service/src/auth.ts
+++ b/apps/hellgraph-service/src/auth.ts
@@ -154,7 +154,7 @@ export function authorize(state: AuthState, req: http.IncomingMessage, url: URL)
 /** Mint a graph-API token (tests + operator CLI). Same HMAC format as federation admit tokens. */
 export function mintGraphToken(
   secret: string,
-  principal: { id: string; scopes: GraphScope[]; tenant?: string; exp?: number },
+  principal: { id: string; scopes: GraphScope[]; tenant?: string; op_sets?: string[]; exp?: number },
 ): string {
   const verifier = HmacTokenVerifier.fromSecret(secret)
   return verifier.mint(principal as unknown as Parameters<HmacTokenVerifier['mint']>[0])

--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -50,6 +50,10 @@ import { describeResource, toTurtle, toJsonLd, toHtml, negotiate } from './resou
 import { askGraph, retrieveGrounding, retrieveGroundingAuto, synthesisEnabled, semanticEnabled } from './graphrag.js'
 import { pagerank, connectedComponents, bfs, sssp, cdlp, lcc, analyticsBackend, dataScope } from './analytics.js'
 import { initAuth, authorize, type AuthState } from './auth.js'
+import {
+  initTenant, tenantPrincipal, tenantScope, scopeForRead, assertWriteTenant, refuseUnscopable,
+  type TenantState,
+} from './tenant.js'
 import { assembleOrgans } from './organs.js'
 import { initMembrane, handleMembrane, membraneCheckNodeWrite, type MembraneState } from './membrane.js'
 import { sealToSpine, spineEnabled, unsealedReceipts } from './spine.js'
@@ -79,15 +83,16 @@ let federation: Federation | null = null
 // Wave 2 doors — governance init BEFORE the server exists. Fail-closed: AUTH_ENFORCE=on
 // without AUTH_HMAC_SECRET (or a drifted vendored contract) refuses startup rather than
 // serving an ungoverned surface; flags off announce themselves with one WARN each.
-function initGovernanceOrDie(): { auth: AuthState; membrane: MembraneState } {
+function initGovernanceOrDie(): { auth: AuthState; membrane: MembraneState; tenant: TenantState } {
   try {
-    return { auth: initAuth(), membrane: initMembrane() }
+    // initTenant throws if TENANT_ENFORCE=on without AUTH_ENFORCE=on (isolation needs a principal).
+    return { auth: initAuth(), membrane: initMembrane(), tenant: initTenant() }
   } catch (e) {
     console.error('[hellgraph-service] governance init FAILED (fail-closed):', e instanceof Error ? e.message : String(e))
     return process.exit(1)
   }
 }
-const { auth, membrane } = initGovernanceOrDie()
+const { auth, membrane, tenant } = initGovernanceOrDie()
 
 // Every route path this server actually handles (mirrors the header comment above),
 // used to shape the /metrics `http_route` label: hellgraph-service's routes carry no
@@ -124,6 +129,17 @@ function requestHandler(req: http.IncomingMessage, res: http.ServerResponse): vo
   // /api/membrane/* is reachable without a bearer token carrying the route's scope.
   const authDenied = authorize(auth, req, url)
   if (authDenied) return void json(res, authDenied.code, authDenied.body)
+
+  // Tenant/op_set isolation (tenant.ts): with TENANT_ENFORCE=on — (1) refuse endpoints that run in the
+  // fenced engine and can't be scoped here; (2) resolve the caller's read scope (deny a tokenless-tenant
+  // or an unentitled op_set); (3) expose `gv`, a view of the graph filtered to the caller's tenant/op_set
+  // that every read uses instead of `g`. Off ⇒ principal=null, gv===g — behaviour identical to today.
+  const unscopable = refuseUnscopable(tenant, url.pathname)
+  if (unscopable) return void json(res, unscopable.code, unscopable.body)
+  const principal = tenant.enforce ? tenantPrincipal(auth, req) : null
+  const readScope = scopeForRead(tenant, principal, url)
+  if (readScope && 'code' in readScope) return void json(res, readScope.code, readScope.body)
+  const gv = readScope ? tenantScope(g, readScope.tenant, readScope.opSet) : g
 
   // Membrane governance surface (membrane.ts): POST /api/membrane/decide. Same port.
   if (url.pathname.startsWith('/api/membrane/')) {
@@ -233,7 +249,7 @@ function requestHandler(req: http.IncomingMessage, res: http.ServerResponse): vo
   }
 
   if (req.method === 'GET' && url.pathname === '/api/graph/stats') {
-    return json(res, 200, { nodes: g.allNodes().length, edges: g.allEdges().length })
+    return json(res, 200, { nodes: gv.allNodes().length, edges: gv.allEdges().length })
   }
 
   // Log-tail surface — the materializer contract (Seal-the-Walls W1.1). HellGraph IS the platform
@@ -315,7 +331,7 @@ function requestHandler(req: http.IncomingMessage, res: http.ServerResponse): vo
     // scope=data (default) filters ontology nodes (KkoClass / KkoReferenceConcept) out of the analytics
     // projection so metrics rank DOMAIN data, not the type system. scope=all analyzes everything.
     const scope = url.searchParams.get('scope') ?? 'data'
-    const ga = scope === 'all' ? g : dataScope(g)
+    const ga = scope === 'all' ? gv : dataScope(gv)
     if (metric === 'components') return json(res, 200, { scope, ...connectedComponents(ga) })
     if (metric === 'pagerank') return json(res, 200, { metric, scope, ...pagerank(ga, limit) })
     try {
@@ -335,6 +351,9 @@ function requestHandler(req: http.IncomingMessage, res: http.ServerResponse): vo
       try {
         const { id, labels, properties } = JSON.parse(b) as { id: string; labels: string[]; properties?: Record<string, unknown> }
         if (!id || !Array.isArray(labels)) throw new Error('id and labels[] required')
+        // Tenant guard: no cross-tenant (or unlabeled) write when TENANT_ENFORCE=on.
+        const tw = assertWriteTenant(tenant, principal, properties)
+        if (tw) return json(res, tw.code, tw.body)
         // Membrane B-after-A gate (membrane.ts): an ExecutionReport write REQUIRES an
         // approved EffectDecision; EffectDecision nodes mint only via /api/membrane/decide.
         const gate = membraneCheckNodeWrite(membrane, g, { id, labels, properties })
@@ -350,6 +369,9 @@ function requestHandler(req: http.IncomingMessage, res: http.ServerResponse): vo
       try {
         const { label, from, to, properties } = JSON.parse(b) as { label: string; from: string; to: string; properties?: Record<string, unknown> }
         if (!label || !from || !to) throw new Error('label, from, to required')
+        // Tenant guard: no cross-tenant (or unlabeled) write when TENANT_ENFORCE=on.
+        const tw = assertWriteTenant(tenant, principal, properties)
+        if (tw) return json(res, tw.code, tw.body)
         g.addEdge(label, from, to, (properties ?? {}) as Record<string, never>)
         json(res, 200, { ok: true })
       } catch (e) { json(res, 400, { error: String(e) }) }
@@ -358,7 +380,7 @@ function requestHandler(req: http.IncomingMessage, res: http.ServerResponse): vo
 
   if (req.method === 'GET' && url.pathname === '/api/graph/query') {
     const label = url.searchParams.get('label') ?? ''
-    const nodes = g.allNodes().filter((n) => !label || n.labels.includes(label))
+    const nodes = gv.allNodes().filter((n) => !label || n.labels.includes(label))
     return json(res, 200, { count: nodes.length, nodes: nodes.slice(0, 200) })
   }
 
@@ -368,10 +390,10 @@ function requestHandler(req: http.IncomingMessage, res: http.ServerResponse): vo
   if (req.method === 'GET' && url.pathname === '/api/graph/subgraph') {
     const label = url.searchParams.get('label') ?? ''
     const limit = Math.min(Number(url.searchParams.get('limit') ?? 400), 2000)
-    const nodes = (label ? g.allNodes().filter((n) => n.labels.includes(label)) : g.allNodes()).slice(0, limit)
+    const nodes = (label ? gv.allNodes().filter((n) => n.labels.includes(label)) : gv.allNodes()).slice(0, limit)
     const ids = new Set(nodes.map((n) => n.id))
     // induced subgraph: keep an edge only when both endpoints are in the node set (no dangling)
-    const edges = g.allEdges().filter((e) => ids.has(e.from) && ids.has(e.to))
+    const edges = gv.allEdges().filter((e) => ids.has(e.from) && ids.has(e.to))
     return json(res, 200, { count: nodes.length, edges: edges.length, nodes, edgeList: edges })
   }
 
@@ -382,7 +404,7 @@ function requestHandler(req: http.IncomingMessage, res: http.ServerResponse): vo
     const view = url.searchParams.get('view') ?? 'all'
     const root = url.searchParams.get('root') ?? ''
     const limit = Math.min(Number(url.searchParams.get('limit') ?? 34), 500)
-    const allEdges = g.allEdges()
+    const allEdges = gv.allEdges()
     const deg = new Map<string, number>()
     for (const e of allEdges) { deg.set(e.from, (deg.get(e.from) ?? 0) + 1); deg.set(e.to, (deg.get(e.to) ?? 0) + 1) }
     const categorize = (labels: string[]): string => {
@@ -399,7 +421,7 @@ function requestHandler(req: http.IncomingMessage, res: http.ServerResponse): vo
       tech: ['code', 'tech'],
       people: ['people', 'person'],
     }
-    let pool = g.allNodes().map((n) => ({
+    let pool = gv.allNodes().map((n) => ({
       id: n.id,
       label: (n.properties?.['name'] as string) ?? (n.properties?.['label'] as string) ?? n.id,
       category: categorize(n.labels),
@@ -428,7 +450,7 @@ function requestHandler(req: http.IncomingMessage, res: http.ServerResponse): vo
   if (req.method === 'GET' && url.pathname === '/api/graph/resource') {
     const uri = url.searchParams.get('uri') ?? url.searchParams.get('iri') ?? ''
     if (!uri) return json(res, 400, { error: 'uri (or iri) query param required' })
-    const d = describeResource(g, uri)
+    const d = describeResource(gv, uri)
     const fmt = negotiate(req.headers['accept'])
     const code = d.found ? 200 : 404
     if (fmt === 'turtle') { res.writeHead(code, { 'content-type': 'text/turtle; charset=utf-8' }); return void res.end(toTurtle(d)) }
@@ -444,7 +466,7 @@ function requestHandler(req: http.IncomingMessage, res: http.ServerResponse): vo
     const q = url.searchParams.get('q') ?? ''
     if (!q) return json(res, 400, { error: 'q (question) required' })
     const hops = Math.min(Math.max(Number(url.searchParams.get('hops') ?? 1), 1), 4)
-    return void retrieveGroundingAuto(g, q, hops).then((grounding) =>
+    return void retrieveGroundingAuto(gv, q, hops).then((grounding) =>
       json(res, 200, { question: q, semanticEnabled: semanticEnabled(), ...grounding }))
   }
   if (req.method === 'POST' && url.pathname === '/api/graph/ask') {
@@ -452,7 +474,7 @@ function requestHandler(req: http.IncomingMessage, res: http.ServerResponse): vo
       try {
         const { question } = JSON.parse(b || '{}') as { question?: string }
         if (!question) throw new Error('question required')
-        json(res, 200, { synthesisEnabled: synthesisEnabled(), ...(await askGraph(g, question)) })
+        json(res, 200, { synthesisEnabled: synthesisEnabled(), ...(await askGraph(gv, question)) })
       } catch (e) { json(res, 400, { error: String(e) }) }
     })
   }

--- a/apps/hellgraph-service/src/spine.test.ts
+++ b/apps/hellgraph-service/src/spine.test.ts
@@ -4,6 +4,7 @@
 //   19091 server.test  ·  19093 membrane.test  ·  19094 membrane-off.test
 //   19095 auth.integration  ·  19096 auth.integration spawn  ·  19097 membrane stub gateway
 //   19101 spine.test  ·  19102 spine.test mock gateway
+//   19103 tenant.integration  ·  19104 tenant.integration spawn
 //   dead ports (nothing may ever bind these): 19108 membrane, 19109 spine
 /**
  * W1.3 receipt unification — hellgraph-service side: the sealed engine receipt is

--- a/apps/hellgraph-service/src/tenant.integration.test.ts
+++ b/apps/hellgraph-service/src/tenant.integration.test.ts
@@ -1,0 +1,120 @@
+/**
+ * tenant integration — TENANT_ENFORCE=on over real HTTP: isolation is WIRED into the request handler,
+ * not just a library. A token scopes a caller to ONE tenant; a read sees only that tenant's nodes, a
+ * write into another tenant is refused, an op_set-scoped read excludes other op_sets, endpoints that
+ * can't be scoped here are refused, and TENANT_ENFORCE=on without AUTH_ENFORCE=on refuses to boot.
+ */
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import * as path from 'node:path'
+import { mintGraphToken } from './auth.js'
+
+const SECRET = 'tenant-integration-secret'
+// PORT ALLOCATION (see spine.test.ts): 19103 free for this suite, 19104 for its fail-closed spawn.
+process.env.PORT = String(19103)
+process.env.HELLGRAPH_STORE_DIR = `${process.env.TMPDIR ?? '/tmp'}/hgsvc-tenant-test-${process.pid}`
+process.env.HELLGRAPH_SEED = 'off'
+process.env.HELLGRAPH_LOAD_KKO = 'off'
+process.env.AUTH_ENFORCE = 'on'
+process.env.AUTH_HMAC_SECRET = SECRET
+process.env.TENANT_ENFORCE = 'on'
+delete process.env.MEMBRANE_ENFORCE
+
+const BASE = `http://127.0.0.1:${process.env.PORT}`
+let srv: { close: (cb?: () => void) => void }
+
+before(async () => {
+  const mod = await import('./server')
+  srv = mod.server as unknown as typeof srv
+  await new Promise((r) => setTimeout(r, 150))
+})
+after(() => srv?.close())
+
+// Tokens: acme (may read/write, entitled to op_sets discourse+ingest), globex, and a tenantless token.
+const acme = mintGraphToken(SECRET, { id: 'acme', scopes: ['graph:read', 'graph:write'], tenant: 'acme', op_sets: ['discourse', 'ingest'] })
+const globex = mintGraphToken(SECRET, { id: 'globex', scopes: ['graph:read', 'graph:write'], tenant: 'globex', op_sets: ['discourse'] })
+const tenantless = mintGraphToken(SECRET, { id: 'nobody', scopes: ['graph:read', 'graph:write'] })
+
+async function req(method: string, p: string, token: string, body?: unknown) {
+  const r = await fetch(BASE + p, {
+    method,
+    headers: { authorization: `Bearer ${token}`, ...(body !== undefined ? { 'content-type': 'application/json' } : {}) },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+  return { status: r.status, json: (await r.json()) as any }
+}
+const node = (id: string, tenant: string, op_set: string) =>
+  ({ id, labels: ['clause'], properties: { tenant_id: tenant, op_set } })
+const queryIds = async (token: string, qs = '') =>
+  ((await req('GET', `/api/graph/query${qs}`, token)).json.nodes as { id: string }[]).map((n) => n.id)
+
+test('writes: own-tenant OK; cross-tenant and unlabeled writes are refused 403', async () => {
+  assert.equal((await req('POST', '/api/graph/node', acme, node('acme:doc1', 'acme', 'discourse'))).status, 200)
+  assert.equal((await req('POST', '/api/graph/node', acme, node('acme:ing1', 'acme', 'ingest'))).status, 200)
+  assert.equal((await req('POST', '/api/graph/node', globex, node('gx:doc1', 'globex', 'discourse'))).status, 200)
+
+  // acme's token cannot write into globex, nor write an unlabeled node
+  const cross = await req('POST', '/api/graph/node', acme, node('acme:evil', 'globex', 'discourse'))
+  assert.equal(cross.status, 403)
+  assert.equal(cross.json.reason, 'cross_tenant_write')
+  const unlabeled = await req('POST', '/api/graph/node', acme, { id: 'acme:bare', labels: ['clause'] })
+  assert.equal(unlabeled.status, 403)
+  assert.equal(unlabeled.json.reason, 'cross_tenant_write')
+})
+
+test('reads: a caller sees ONLY its own tenant — cross-tenant nodes are invisible', async () => {
+  const acmeIds = await queryIds(acme)
+  assert.ok(acmeIds.includes('acme:doc1') && acmeIds.includes('acme:ing1'), 'acme sees its own nodes')
+  assert.ok(!acmeIds.includes('gx:doc1'), 'acme must NOT see globex nodes')
+
+  const gxIds = await queryIds(globex)
+  assert.ok(gxIds.includes('gx:doc1'))
+  assert.ok(!gxIds.some((id) => id.startsWith('acme:')), 'globex must NOT see acme nodes')
+
+  // stats are tenant-scoped too (counts are the caller's, not the whole graph's)
+  const gxStats = (await req('GET', '/api/graph/stats', globex)).json
+  assert.equal(gxStats.nodes, 1, 'globex sees exactly its 1 node')
+})
+
+test('op_set scopes within a tenant; an unentitled op_set is refused', async () => {
+  const disc = await queryIds(acme, '?op_set=discourse')
+  assert.ok(disc.includes('acme:doc1'), 'discourse read includes the discourse node')
+  assert.ok(!disc.includes('acme:ing1'), 'discourse read excludes the ingest-op_set node')
+
+  const forbidden = await req('GET', '/api/graph/query?op_set=secret', acme)
+  assert.equal(forbidden.status, 403)
+  assert.equal(forbidden.json.reason, 'op_set_forbidden')
+})
+
+test('a token carrying no tenant is denied every scoped read', async () => {
+  const d = await req('GET', '/api/graph/query', tenantless)
+  assert.equal(d.status, 403)
+  assert.equal(d.json.reason, 'tenant_required')
+})
+
+test('endpoints that cannot be tenant-scoped here are refused (fail-closed)', async () => {
+  for (const p of ['/api/graph/sparql', '/api/graph/cypher', '/api/graph/enrich?label=X']) {
+    const method = p.startsWith('/api/graph/enrich') ? 'GET' : 'POST'
+    const token = p.startsWith('/api/graph/enrich') ? mintGraphToken(SECRET, { id: 'e', scopes: ['graph:enrich'], tenant: 'acme' }) : acme
+    const d = await req(method, p, token, method === 'POST' ? { query: 'x' } : undefined)
+    assert.equal(d.status, 403, `${p} must be refused under TENANT_ENFORCE`)
+    assert.equal(d.json.reason, 'tenant_isolation_unavailable')
+  }
+})
+
+test('fail-closed startup: TENANT_ENFORCE=on without AUTH_ENFORCE=on refuses to boot', () => {
+  const appRoot = path.join(__dirname, '..')
+  const r = spawnSync(process.execPath, ['--import', 'tsx', 'src/server.ts'], {
+    cwd: appRoot,
+    env: {
+      ...process.env, TENANT_ENFORCE: 'on', AUTH_ENFORCE: 'off', PORT: '19104',
+      HELLGRAPH_SEED: 'off', HELLGRAPH_LOAD_KKO: 'off',
+      HELLGRAPH_STORE_DIR: `${process.env.TMPDIR ?? '/tmp'}/hgsvc-tenant-failclosed-${process.pid}`,
+    },
+    encoding: 'utf8',
+    timeout: 30_000,
+  })
+  assert.equal(r.status, 1, `expected exit 1, got ${r.status}; stderr: ${r.stderr}`)
+  assert.match(r.stderr, /requires AUTH_ENFORCE=on/)
+})

--- a/apps/hellgraph-service/src/tenant.test.ts
+++ b/apps/hellgraph-service/src/tenant.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Theorems of tenant/op_set ISOLATION (tenant.ts) — the enforcement half of "operational sets by
+ * default". Cross-tenant reads return nothing, cross-tenant writes are refused, an op_set-scoped read
+ * excludes other op_sets (and INCLUDES a relation's reified role-edges, which carry the same op_set),
+ * and the flag is fail-closed. Pure functions, injectable fake graph — no engine, no server boot.
+ */
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  initTenant, tenantScope, scopeForRead, assertWriteTenant, refuseUnscopable, type TenantState,
+} from './tenant.js'
+
+const ENFORCING: TenantState = { enforce: true }
+const OFF: TenantState = { enforce: false }
+
+// A fake graph: two tenants (acme/globex), two op_sets in acme (ingest/discourse), and a reified
+// hyperedge (an "argument" node + its role-edges) in acme/discourse — exactly what the writer lands.
+function fakeGraph() {
+  const N = (id: string, tenant: string, op_set: string, labels: string[] = ['clause']) =>
+    ({ id, labels, properties: { tenant_id: tenant, op_set } })
+  const E = (from: string, to: string, tenant: string, op_set: string, label = 'support',
+    extra: Record<string, unknown> = {}) =>
+    ({ id: `${from}->${to}`, label, from, to,
+       properties: { tenant_id: tenant, op_set, ...extra } as Record<string, unknown> })
+  const T = (subject: string, object: string, isIri = true) =>
+    ({ subject, predicate: 'p', object, isIri })
+  const nodes = [
+    N('acme:c0', 'acme', 'discourse'), N('acme:p0', 'acme', 'discourse'),
+    N('arg:acme:c0', 'acme', 'discourse', ['argument', 'hyperedge']),  // reified hyperedge node
+    N('acme:ing0', 'acme', 'ingest', ['dataset']),                     // a different op_set in acme
+    N('globex:x0', 'globex', 'discourse'),                             // ANOTHER tenant
+  ]
+  const edges = [
+    E('acme:p0', 'acme:c0', 'acme', 'discourse'),                      // premise -> claim
+    E('arg:acme:c0', 'acme:c0', 'acme', 'discourse', 'claim', { reified_from: 'arg:acme:c0', member_role: 'claim' }),
+    E('arg:acme:c0', 'acme:p0', 'acme', 'discourse', 'premise', { reified_from: 'arg:acme:c0', member_role: 'premise' }),
+    E('globex:x0', 'globex:x0', 'globex', 'discourse'),                // globex-only edge
+  ]
+  const triples = [
+    T('acme:c0', 'acme:p0'), T('globex:x0', 'globex:x0'),
+    T('acme:c0', 'a literal', false),                                  // literal object (not a node)
+  ]
+  return { allNodes: () => nodes, allEdges: () => edges, triples: () => triples }
+}
+
+test('initTenant: off is passthrough with one WARN', () => {
+  let warned = 0
+  const s = initTenant({ TENANT_ENFORCE: 'off' }, () => { warned++ })
+  assert.equal(s.enforce, false)
+  assert.equal(warned, 1)
+})
+
+test('initTenant: on REQUIRES AUTH_ENFORCE=on (fail-closed startup)', () => {
+  assert.throws(() => initTenant({ TENANT_ENFORCE: 'on', AUTH_ENFORCE: 'off' }, () => {}),
+    /requires AUTH_ENFORCE=on/)
+  assert.deepEqual(initTenant({ TENANT_ENFORCE: 'on', AUTH_ENFORCE: 'on' }, () => {}), { enforce: true })
+})
+
+test('tenantScope: a read sees ONLY its own tenant — cross-tenant is invisible', () => {
+  const acme = tenantScope(fakeGraph(), 'acme')
+  const ids = acme.allNodes().map((n) => n.id)
+  assert.ok(ids.includes('acme:c0'))
+  assert.ok(!ids.includes('globex:x0'), 'globex node must not surface for acme')
+  // an induced edge/triple can never cross the boundary
+  assert.ok(acme.allEdges().every((e) => !e.from.startsWith('globex') && !e.to.startsWith('globex')))
+  assert.ok(acme.triples().every((t) => t.subject.startsWith('acme')))
+  // and globex sees only globex
+  const gl = tenantScope(fakeGraph(), 'globex')
+  assert.deepEqual(gl.allNodes().map((n) => n.id), ['globex:x0'])
+})
+
+test('tenantScope: op_set scopes WITHIN a tenant, and a relation keeps its reified role-edges', () => {
+  const disc = tenantScope(fakeGraph(), 'acme', 'discourse')
+  const ids = disc.allNodes().map((n) => n.id)
+  assert.ok(ids.includes('acme:c0') && ids.includes('arg:acme:c0'), 'discourse nodes present')
+  assert.ok(!ids.includes('acme:ing0'), 'the ingest-op_set node is excluded from a discourse read')
+  // THEOREM: the reified hyperedge role-edges carry op_set discourse, so an op_set-scoped edge read
+  // still sees them (a role-edge that dropped op_set would vanish here — the exact #1400 regression).
+  const roleEdges = disc.allEdges().filter((e) => e.properties['reified_from'] === 'arg:acme:c0')
+  assert.equal(roleEdges.length, 2, 'both role-edges of the argument are visible in its op_set')
+  // the other op_set is invisible
+  assert.deepEqual(tenantScope(fakeGraph(), 'acme', 'ingest').allNodes().map((n) => n.id), ['acme:ing0'])
+})
+
+test('scopeForRead: passthrough off; deny no-tenant; deny unentitled op_set; else scope', () => {
+  assert.equal(scopeForRead(OFF, { tenant: 'acme' }, new URL('http://x/api/graph/query')), null)
+  const noTenant = scopeForRead(ENFORCING, { id: 'ops' }, new URL('http://x/api/graph/query'))
+  assert.ok(noTenant && 'code' in noTenant && noTenant.body.reason === 'tenant_required')
+  const forbidden = scopeForRead(ENFORCING, { tenant: 'acme', op_sets: ['discourse'] },
+    new URL('http://x/api/graph/query?op_set=finance'))
+  assert.ok(forbidden && 'code' in forbidden && forbidden.body.reason === 'op_set_forbidden')
+  const ok = scopeForRead(ENFORCING, { tenant: 'acme', op_sets: ['discourse'] },
+    new URL('http://x/api/graph/query?op_set=discourse'))
+  assert.deepEqual(ok, { tenant: 'acme', opSet: 'discourse' })
+})
+
+test('assertWriteTenant: a write into another tenant (or unlabeled) is refused 403', () => {
+  assert.equal(assertWriteTenant(OFF, { tenant: 'acme' }, { tenant_id: 'globex' }), null)  // off = passthrough
+  const cross = assertWriteTenant(ENFORCING, { tenant: 'acme' }, { tenant_id: 'globex' })
+  assert.ok(cross && cross.code === 403 && cross.body.reason === 'cross_tenant_write')
+  const unlabeled = assertWriteTenant(ENFORCING, { tenant: 'acme' }, {})  // no tenant_id
+  assert.ok(unlabeled && unlabeled.body.reason === 'cross_tenant_write')
+  assert.equal(assertWriteTenant(ENFORCING, { tenant: 'acme' }, { tenant_id: 'acme' }), null)  // own tenant OK
+})
+
+test('refuseUnscopable: engine-internal endpoints are refused under enforcement, scopable ones pass', () => {
+  for (const p of ['/api/graph/sparql', '/api/graph/cypher', '/api/graph/reason', '/api/graph/enrich']) {
+    const d = refuseUnscopable(ENFORCING, p)
+    assert.ok(d && d.code === 403 && d.body.reason === 'tenant_isolation_unavailable', `${p} must be refused`)
+  }
+  for (const p of ['/api/graph/query', '/api/graph/subgraph', '/api/graph/surface']) {
+    assert.equal(refuseUnscopable(ENFORCING, p), null, `${p} is scopable, must not be refused`)
+  }
+  assert.equal(refuseUnscopable(OFF, '/api/graph/sparql'), null)  // off = nothing refused
+})

--- a/apps/hellgraph-service/src/tenant.ts
+++ b/apps/hellgraph-service/src/tenant.ts
@@ -1,0 +1,193 @@
+/**
+ * tenant.ts — operational-set / tenant ISOLATION at the graph surface (Wave 2 "doors": the ENFORCEMENT
+ * half of "operational sets by default"; the labeling half ships in the percolation writer, #1400).
+ *
+ * auth.ts proves WHO is calling (a scoped bearer token). This proves WHAT they may see. The graph store
+ * is the fenced engine (getHellGraph) — historically single-tenant with label-only reads — so isolation
+ * is enforced HERE, in the service layer: with TENANT_ENFORCE=on every read is scoped to the caller's
+ * tenant_id (and, when requested, ONE op_set the caller is entitled to) by filtering the nodes/edges the
+ * read sees on properties.tenant_id (+ op_set), and a write whose body targets another tenant is refused.
+ * Because the percolation writer stamps tenant_id + op_set on every object, the label to enforce ON is
+ * always present.
+ *
+ * The raw query LANGUAGES (sparql/gremlin/cypher/reason/shacl) run INSIDE the fenced engine over the whole
+ * atomspace; they cannot be tenant-scoped from this TS layer without reaching into the engine. Rather than
+ * serve possibly-cross-tenant results, they are REFUSED under enforcement (fail-closed) — the scoped read
+ * surfaces (query/subgraph/surface/resource/ground/ask/analytics) stay available. Engine-side scoping of
+ * the query languages is a follow-on inside the (fenced) engine, not a silent leak here.
+ *
+ * Flagged rollout (TENANT_ENFORCE, default "off"), mirroring AUTH_ENFORCE:
+ *   off → passthrough, one startup WARN — reads/writes are NOT tenant-partitioned (today's behavior).
+ *   on  → requires AUTH_ENFORCE=on (isolation needs authenticated principals to scope by); a token that
+ *         carries no tenant is denied. TENANT_ENFORCE=on without AUTH_ENFORCE=on REFUSES STARTUP — an
+ *         isolation door with no identity behind it is the declared-unenforced failure mode, again.
+ */
+import type * as http from 'node:http'
+import { bearer } from '@socioprophet/hellgraph'
+import type { AuthState } from './auth.js'
+
+export interface TenantState {
+  enforce: boolean
+}
+
+/** The identity a graph token carries for isolation: a tenant and the op_sets it is entitled to read. */
+export interface TenantPrincipal {
+  id?: string
+  tenant?: string
+  op_sets?: string[]
+}
+
+export interface TenantDenial {
+  code: 403
+  body: {
+    ok: false
+    error: 'forbidden'
+    reason: 'tenant_required' | 'cross_tenant_write' | 'op_set_forbidden' | 'tenant_isolation_unavailable'
+    detail: string
+  }
+}
+
+/** Endpoints whose result-shaping happens INSIDE the fenced engine (a raw query language, or an
+ *  `engine.*` call), so this TS layer cannot verify the result is tenant-scoped. Refused under
+ *  enforcement rather than risk a cross-tenant leak — the doctrine is "verify or fail-closed", not
+ *  "assume the engine scopes". Engine-side scoping of these is a follow-on inside the fenced engine.
+ *  The scoped read surfaces (query/subgraph/surface/resource/ground/ask/analytics/stats) stay live. */
+export const UNSCOPABLE_UNDER_ENFORCE: ReadonlySet<string> = new Set([
+  '/api/graph/sparql',
+  '/api/graph/gremlin',
+  '/api/graph/cypher',
+  '/api/graph/reason',
+  '/api/graph/shacl',
+  '/api/graph/enrich',   // engine.enrichClass — recommender over engine internals
+  '/api/graph/explore',  // engine.exploreFrom — traversal over engine internals
+])
+
+/** Read TENANT_ENFORCE. Fail-closed: enforce-on without AUTH_ENFORCE=on throws (callers refuse startup).
+ *  Off = passthrough, announced by exactly one WARN (mirrors initAuth). */
+export function initTenant(
+  env: NodeJS.ProcessEnv = process.env,
+  warn: (msg: string) => void = console.warn,
+): TenantState {
+  const enforce = (env['TENANT_ENFORCE'] ?? 'off').trim().toLowerCase() === 'on'
+  if (!enforce) {
+    warn('[tenant] WARN TENANT_ENFORCE=off — graph reads/writes are NOT partitioned by tenant/op_set ' +
+      '(flagged rollout; set TENANT_ENFORCE=on WITH AUTH_ENFORCE=on to isolate per tenant/op_set).')
+    return { enforce: false }
+  }
+  const authOn = (env['AUTH_ENFORCE'] ?? 'off').trim().toLowerCase() === 'on'
+  if (!authOn) {
+    throw new Error('TENANT_ENFORCE=on requires AUTH_ENFORCE=on — tenant isolation needs authenticated ' +
+      'principals to scope by (fail-closed). Set AUTH_ENFORCE=on + AUTH_HMAC_SECRET, or TENANT_ENFORCE=off.')
+  }
+  return { enforce: true }
+}
+
+/** The verified principal (tenant + entitled op_sets) behind a request, or null when the token is absent
+ *  or invalid. Verifies via the same HMAC verifier auth.ts already gated the request with. */
+export function tenantPrincipal(auth: AuthState, req: http.IncomingMessage): TenantPrincipal | null {
+  if (!auth.verifier) return null
+  const token = bearer(req.headers['authorization'])
+  if (!token) return null
+  return auth.verifier.verify(token) as TenantPrincipal | null
+}
+
+interface PropsNode { id: string; properties?: Record<string, unknown> | null }
+interface EndpointEdge { from: string; to: string }
+interface TripleLite { subject: string; object: unknown; isIri?: boolean }
+
+/** A read-only view of the graph scoped to ONE tenant (and, if given, one op_set). allNodes()/allEdges()/
+ *  triples() return only in-scope objects. Edges AND triples are INDUCED — kept only when both endpoints
+ *  (an edge's from/to; a triple's subject and, when it is an IRI, its object) are in-scope nodes — so a
+ *  cross-tenant edge or fact can never surface even if its own label were mislabeled. A triple whose
+ *  subject is not an in-scope node (e.g. a shared-ontology fact) is conservatively excluded: over-filter
+ *  before leak. Generic over the concrete shapes so labels + properties pass through untouched. */
+export function tenantScope<N extends PropsNode, E extends EndpointEdge, T extends TripleLite>(
+  g: { allNodes(): N[]; allEdges(): E[]; triples(): T[] },
+  tenant: string,
+  opSet?: string,
+): { allNodes(): N[]; allEdges(): E[]; triples(): T[] } {
+  const inScope = (n: N): boolean => {
+    const p = n.properties ?? {}
+    if (p['tenant_id'] !== tenant) return false
+    if (opSet !== undefined && p['op_set'] !== opSet) return false
+    return true
+  }
+  const scopedIds = (): Set<string> => new Set(g.allNodes().filter(inScope).map((n) => n.id))
+  return {
+    allNodes(): N[] {
+      return g.allNodes().filter(inScope)
+    },
+    allEdges(): E[] {
+      const keep = scopedIds()
+      return g.allEdges().filter((e) => keep.has(e.from) && keep.has(e.to))
+    },
+    triples(): T[] {
+      const keep = scopedIds()
+      return g.triples().filter((t) => keep.has(t.subject) && (t.isIri ? keep.has(String(t.object)) : true))
+    },
+  }
+}
+
+/** Resolve the scope of a READ: passthrough (null) when not enforcing; a denial when the token carries no
+ *  tenant or requests an op_set it is not entitled to; else the { tenant, opSet } to scope by. */
+export function scopeForRead(
+  state: TenantState,
+  principal: TenantPrincipal | null,
+  url: URL,
+): { tenant: string; opSet?: string } | TenantDenial | null {
+  if (!state.enforce) return null
+  if (!principal?.tenant) {
+    return {
+      code: 403,
+      body: { ok: false, error: 'forbidden', reason: 'tenant_required',
+        detail: 'TENANT_ENFORCE=on but the bearer token carries no tenant — cannot scope this read' },
+    }
+  }
+  const requested = url.searchParams.get('op_set') ?? undefined
+  if (requested !== undefined && Array.isArray(principal.op_sets) && !principal.op_sets.includes(requested)) {
+    return {
+      code: 403,
+      body: { ok: false, error: 'forbidden', reason: 'op_set_forbidden',
+        detail: `token for tenant '${principal.tenant}' is not entitled to op_set '${requested}'` },
+    }
+  }
+  return { tenant: principal.tenant, opSet: requested }
+}
+
+/** Guard a WRITE: a node/edge may be written only into the caller's OWN tenant. A body whose tenant_id is
+ *  absent or differs from the principal's tenant is refused (no cross-tenant overwrite, no unlabeled write). */
+export function assertWriteTenant(
+  state: TenantState,
+  principal: TenantPrincipal | null,
+  properties: Record<string, unknown> | undefined | null,
+): TenantDenial | null {
+  if (!state.enforce) return null
+  if (!principal?.tenant) {
+    return {
+      code: 403,
+      body: { ok: false, error: 'forbidden', reason: 'tenant_required',
+        detail: 'TENANT_ENFORCE=on but the bearer token carries no tenant — cannot attribute this write' },
+    }
+  }
+  const bodyTenant = (properties ?? {})['tenant_id']
+  if (bodyTenant !== principal.tenant) {
+    return {
+      code: 403,
+      body: { ok: false, error: 'forbidden', reason: 'cross_tenant_write',
+        detail: `write targets tenant ${JSON.stringify(bodyTenant)} but the token is scoped to '${principal.tenant}'` },
+    }
+  }
+  return null
+}
+
+/** Refuse an endpoint that cannot be tenant-scoped in this layer (fail-closed under enforcement). */
+export function refuseUnscopable(state: TenantState, pathname: string): TenantDenial | null {
+  if (!state.enforce || !UNSCOPABLE_UNDER_ENFORCE.has(pathname)) return null
+  return {
+    code: 403,
+    body: { ok: false, error: 'forbidden', reason: 'tenant_isolation_unavailable',
+      detail: `${pathname} runs in the graph engine over all tenants and cannot be tenant-scoped in the ` +
+        'service layer; it is refused under TENANT_ENFORCE=on. Use the scoped read surfaces ' +
+        '(query/subgraph/surface/resource/ground/ask/analytics).' },
+  }
+}


### PR DESCRIPTION
## The gap this closes
Adversarial review of the hellgraph percolation pattern found isolation **declared but not enforced** at the service. The percolation writer (#1400) now labels every node/edge/hyperedge with `tenant_id` + `op_set`, but the **service never partitioned on them**:
- `grep op_set` across `apps/hellgraph-service/src` = **0 hits**
- `authorize()` ignored `principal.tenant`; `server.ts:650` comment: *"this single-tenant HTTP service"*
- reads were **label-only** → tenant B's `GET /api/graph/query?label=X` returned tenant A's nodes
- `POST /api/graph/node` upserts by id with **no tenant check** → cross-tenant overwrite

This PR is the **enforcement half** (the labeling half shipped in #1400).

## Design
- **Flagged rollout** `TENANT_ENFORCE` (default `off`, mirrors `AUTH_ENFORCE`). `on` **requires** `AUTH_ENFORCE=on` (isolation needs an authenticated principal) or **refuses startup fail-closed**.
- **`tenant.ts`** — `tenantScope(g, tenant, op_set)` filters `allNodes`/`allEdges`/`triples` to the caller's tenant (+ op_set). Edges **and** triples are **induced** (kept only when both endpoints are in scope), so a cross-tenant relation/fact can never surface. Plus `scopeForRead` / `assertWriteTenant` / `refuseUnscopable`.
- **Reads** (query/subgraph/surface/stats/analytics/resource/ground/ask) go through the scoped `gv`.
- **Writes** (node/edge) are guarded → `403 cross_tenant_write` on a body targeting another tenant or an unlabeled write. Tokenless-tenant → denied; an unentitled `op_set` → refused.
- **Fail-closed on what can't be scoped here**: the raw query languages + engine recommenders (`sparql`/`gremlin`/`cypher`/`reason`/`shacl`/`enrich`/`explore`) run **inside the fenced engine** over the whole atomspace, so they are **refused under enforcement** rather than risk a leak — *verify or fail-closed*, not *assume the engine scopes*. Engine-side scoping of those is a follow-on.
- `kko` (shared type lattice) stays unscoped — not tenant data. **Rust engine under `native/` untouched** (fenced lane).

## Verification
- `tenant.test.ts` — **7 unit theorems** (scoping, op_set, write-guard, refuse, fail-closed init).
- `tenant.integration.test.ts` — **6 over real HTTP with both flags on**: cross-tenant read invisible, cross-tenant/unlabeled write `403`, op_set scoping + unentitled refusal, tenantless denial, unscopable refusal, fail-closed startup.
- **Full suite 107/107, `tsc` clean.** Behavior is byte-identical when `TENANT_ENFORCE` is off (`gv === g`, guards no-op). Also fixed a test **port collision** (19097 was `membrane.test`'s stub gateway) and updated the port-allocation registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)