### PR TITLE
fix(compute-gateway): bounded/lazy boot hydration — resident memory no longer scales with the store

### DIFF
--- a/apps/compute-gateway/src/compute_gateway/artifacts.py
+++ b/apps/compute-gateway/src/compute_gateway/artifacts.py
@@ -75,8 +75,11 @@ class SqliteBackend:
 
 
 _backend: Backend = MemoryBackend()
-# receipt id → the ordered artifact digests it produced (the data-lineage index). A cache
-# hydrated from durable storage on boot and written through on store_outputs when enabled.
+# receipt id → the ordered artifact digests it produced (the data-lineage index).
+#   persistence ENABLED: a write-through cache — store_outputs writes here AND to SQLite; boot no
+#     longer loads the whole index (that scaled with the store), so a cache miss on for_receipt is
+#     served lazily from SQLite. Flat boot memory.
+#   persistence DISABLED: this dict IS the ephemeral index (nowhere else to live).
 _by_receipt: dict[str, list[str]] = {}
 _stats = {"puts": 0, "dedup_hits": 0}
 
@@ -87,13 +90,13 @@ def set_backend(b: Backend) -> None:
 
 
 def hydrate() -> None:
-    """Point at the durable backend and reload the data-lineage index. No-op when
-    persistence is disabled. Called at import so restarts keep full data lineage."""
+    """Point at the durable backend. Does NOT reload the whole data-lineage index — that scaled
+    with the store and was part of the 2026-08-04 boot OOM; for_receipt() now serves misses lazily
+    from SQLite. No-op when persistence is disabled. Called at import."""
     if not persistence.enabled():
         return
     set_backend(SqliteBackend())
     _by_receipt.clear()
-    _by_receipt.update(persistence.load_index())
 
 
 def store_outputs(receipt_id: str, outputs: list[Any]) -> list[str]:
@@ -129,14 +132,22 @@ def get(d: str) -> Any | None:
 
 
 def for_receipt(receipt_id: str) -> list[str]:
-    return list(_by_receipt.get(receipt_id, []))
+    """The ordered artifact digests a receipt produced. From the in-process cache, else (enabled)
+    lazily from SQLite — so a restarted process resolves data lineage without the whole index
+    resident. Empty when unknown."""
+    cached = _by_receipt.get(receipt_id)
+    if cached is not None:
+        return list(cached)
+    if not persistence.enabled():
+        return []
+    return persistence.load_index_for(receipt_id)
 
 
 def diff(a_receipt: str, b_receipt: str) -> dict[str, list[str]]:
     """Data-level diff of two runs: which output blobs are shared, added, removed.
     A pure set operation over content digests — reproducibility you can SEE."""
-    a = set(_by_receipt.get(a_receipt, []))
-    b = set(_by_receipt.get(b_receipt, []))
+    a = set(for_receipt(a_receipt))
+    b = set(for_receipt(b_receipt))
     return {
         "a": a_receipt, "b": b_receipt,
         "shared": sorted(a & b),
@@ -147,9 +158,15 @@ def diff(a_receipt: str, b_receipt: str) -> dict[str, list[str]]:
 
 
 def stats() -> dict[str, Any]:
-    unique = len({d for ds in _by_receipt.values() for d in ds})
+    # When persistence is enabled the index is not fully resident, so count it in SQL rather than
+    # from the (partial) cache; disabled, the cache IS the index.
+    if persistence.enabled():
+        unique, receipts_indexed = persistence.index_stats()
+    else:
+        unique = len({d for ds in _by_receipt.values() for d in ds})
+        receipts_indexed = len(_by_receipt)
     return {"unique_blobs": unique, "puts": _stats["puts"],
-            "dedup_hits": _stats["dedup_hits"], "receipts_indexed": len(_by_receipt)}
+            "dedup_hits": _stats["dedup_hits"], "receipts_indexed": receipts_indexed}
 
 
 def _reset() -> None:   # test hook

--- a/apps/compute-gateway/src/compute_gateway/persistence.py
+++ b/apps/compute-gateway/src/compute_gateway/persistence.py
@@ -90,6 +90,32 @@ def save_receipt(project: str, seq: int, receipt_id: str, body_json: str) -> Non
         c.commit()
 
 
+def load_tips() -> list[tuple[str, str, int]]:
+    """(project, tip_receipt_id, count) per project — the last receipt's id and the chain
+    length, computed in SQL so a restart loads O(projects), NEVER O(receipts). `count` is the
+    next seal's seq (chains are contiguous 0..count-1). This is what keeps boot memory flat as
+    the store grows — the 2026-08-04 OOM was hydrate() materializing every receipt at import.
+    Empty when persistence is disabled."""
+    if not enabled():
+        return []
+    c = _conn()
+    tips = c.execute(
+        "SELECT project, id, seq FROM receipts WHERE (project, seq) IN "
+        "(SELECT project, MAX(seq) FROM receipts GROUP BY project)"
+    ).fetchall()
+    counts = dict(c.execute("SELECT project, COUNT(*) FROM receipts GROUP BY project").fetchall())
+    return [(project, rid, int(counts.get(project, seq + 1))) for (project, rid, seq) in tips]
+
+
+def load_project(project: str) -> list[dict]:
+    """One project's receipt bodies in seal order — for lazy chain materialization on read.
+    The caller rebuilds Receipt objects. Empty when persistence is disabled."""
+    if not enabled():
+        return []
+    return [json.loads(body) for (body,) in _conn().execute(
+        "SELECT body FROM receipts WHERE project=? ORDER BY seq", (project,)).fetchall()]
+
+
 # ── content-addressed artifact blobs + the receipt→digests index ─────────────
 def get_blob(d: str) -> Any | None:
     if not enabled():
@@ -132,6 +158,26 @@ def save_index(receipt_id: str, digests: list[str]) -> None:
         c.executemany("INSERT OR REPLACE INTO artifact_index (receipt_id, ord, digest) VALUES (?,?,?)",
                       [(receipt_id, i, d) for i, d in enumerate(digests)])
         c.commit()
+
+
+def load_index_for(receipt_id: str) -> list[str]:
+    """One receipt's ordered artifact digests — for lazy data-lineage lookup, so the whole index
+    need not be resident. Empty when persistence is disabled."""
+    if not enabled():
+        return []
+    return [d for (d,) in _conn().execute(
+        "SELECT digest FROM artifact_index WHERE receipt_id=? ORDER BY ord", (receipt_id,)).fetchall()]
+
+
+def index_stats() -> tuple[int, int]:
+    """(unique_blobs, receipts_indexed) computed in SQL — so artifacts.stats() need not hold the
+    whole lineage index in memory. (0, 0) when persistence is disabled."""
+    if not enabled():
+        return (0, 0)
+    c = _conn()
+    (uniq,) = c.execute("SELECT COUNT(DISTINCT digest) FROM artifact_index").fetchone()
+    (recs,) = c.execute("SELECT COUNT(DISTINCT receipt_id) FROM artifact_index").fetchone()
+    return (int(uniq), int(recs))
 
 
 def _reset_connection() -> None:

--- a/apps/compute-gateway/src/compute_gateway/receipts.py
+++ b/apps/compute-gateway/src/compute_gateway/receipts.py
@@ -11,15 +11,40 @@ import hashlib
 import json
 import threading
 import time
-from typing import Any
+from collections import OrderedDict
+from typing import Any, Iterator
 
 from . import persistence, signing
 from .contract import EpistemicStatus, Receipt
 
-# per-project hash chain — the in-memory index. When GATEWAY_STORE_DIR is set it is a
-# cache hydrated from durable storage on boot (see hydrate) and written through on seal,
-# so the chain survives a restart; unset, it is the whole store (ephemeral).
-_CHAINS: dict[str, list[Receipt]] = {}
+# per-project hash chain — the in-memory structure.
+#   persistence DISABLED (tests / ephemeral dev): _CHAINS IS the whole store — seal appends here,
+#     reads come from here, and there is nowhere else for a receipt to live.
+#   persistence ENABLED (prod): _CHAINS is a BOUNDED LRU cache over the SQLite-backed store. Boot no
+#     longer materializes it (see hydrate) — only _TIPS is loaded, O(projects) — so resident memory
+#     does not scale with the store. The 2026-08-04 OOM was hydrate() reading EVERY receipt into this
+#     dict at import, on top of the hellgraph + embedding libs, OOMKilling the pod ~9s into startup.
+#   OrderedDict so the enabled-mode cache can evict least-recently-used projects; tests that call
+#   _CHAINS.clear() or index _CHAINS["p"] keep working unchanged (both are OrderedDict operations).
+_CHAINS: "OrderedDict[str, list[Receipt]]" = OrderedDict()
+_CACHE_MAX_PROJECTS = 64  # enabled-mode cache bound; boot memory is bounded by _TIPS alone
+
+
+class _Tip:
+    """The last receipt id + chain length for one project — all seal() needs to compute the next
+    receipt's `prev` and `seq` without the whole chain resident. Loaded O(projects) at boot."""
+
+    __slots__ = ("tip_id", "count")
+
+    def __init__(self, tip_id: str | None, count: int) -> None:
+        self.tip_id = tip_id
+        self.count = count
+
+
+# Per-project tips — the authoritative project index in ENABLED mode (loaded at boot, advanced on
+# seal). In DISABLED mode this stays empty and _CHAINS is authoritative, so a test's _CHAINS.clear()
+# remains a full reset.
+_TIPS: dict[str, _Tip] = {}
 
 # per-project seal lock. The seal window (setdefault chain → read prev → attest → append
 # → persist) is a read-modify-write on the chain: two concurrent seals for the same
@@ -52,14 +77,53 @@ def _project_lock(project: str) -> threading.Lock:
 
 
 def hydrate() -> None:
-    """Rebuild the in-memory chains from durable storage. Idempotent; a no-op when
-    persistence is disabled. Called at import so a restarted process comes up with its
-    full, verifiable history already in hand."""
+    """Load ONLY per-project tips (id + count) from durable storage — O(projects), NOT O(receipts).
+    Full chains are materialized lazily by chain()/verify() and bounded by the _CHAINS LRU. Idempotent;
+    a no-op when persistence is disabled (then _CHAINS is the ephemeral store). This is the fix for the
+    2026-08-04 OOM: a restarted process comes up ready to seal and verify with FLAT boot memory no
+    matter how large /data has grown, instead of reading the whole store into RAM at import."""
     if not persistence.enabled():
         return
-    _CHAINS.clear()
-    for project, bodies in persistence.load_receipts().items():
-        _CHAINS[project] = [Receipt(**b) for b in bodies]
+    with _LOCKS_LOCK:
+        _TIPS.clear()
+        _CHAINS.clear()
+        for project, tip_id, count in persistence.load_tips():
+            _TIPS[project] = _Tip(tip_id, count)
+
+
+def _project_names() -> list[str]:
+    """Every known project. _TIPS is authoritative when persistence is enabled (loaded at boot +
+    advanced on seal); otherwise _CHAINS is the store. Snapshotted under _LOCKS_LOCK so a concurrent
+    seal creating a new project cannot change the dict mid-iteration."""
+    with _LOCKS_LOCK:
+        return list(_TIPS.keys()) if persistence.enabled() else list(_CHAINS.keys())
+
+
+def _load_chain(project: str) -> list[Receipt]:
+    """The project's full chain as the LIVE cached list (callers copy). Cache hit → LRU-touch and
+    return. Miss + enabled → materialize from SQLite, cache, evict LRU. Miss + disabled → empty (not
+    cached means it does not exist — _CHAINS is the whole store in that mode). Call under the
+    per-project lock so a concurrent seal cannot mutate the list during materialization."""
+    cached = _CHAINS.get(project)
+    if cached is not None:
+        _CHAINS.move_to_end(project)
+        return cached
+    if not persistence.enabled():
+        return []
+    receipts = [Receipt(**b) for b in persistence.load_project(project)]
+    _CHAINS[project] = receipts
+    _CHAINS.move_to_end(project)
+    while len(_CHAINS) > _CACHE_MAX_PROJECTS:
+        _CHAINS.popitem(last=False)  # evict LRU — the durable copy stays in SQLite, the tip in _TIPS
+    return receipts
+
+
+def _read_chain_fresh(project: str) -> list[Receipt]:
+    """A chain read that does NOT pollute the LRU cache — for full scans (snapshot_all) that would
+    otherwise churn it. From SQLite when enabled, else a copy of the in-memory store."""
+    if not persistence.enabled():
+        return list(_CHAINS.get(project, []))
+    return [Receipt(**b) for b in persistence.load_project(project)]
 
 
 def sha(obj: Any) -> str:
@@ -87,20 +151,21 @@ def seal(project: str, *, kind: str, backend: str, runtime: str, inputs: Any,
     # committed by the time it runs. Do NOT hold across arbitrary caller code — the
     # window is bounded to hash + attest + persist, all pure/local.
     with _project_lock(project):
-        # Copilot #1106 round 2: the setdefault below GROWS _CHAINS the first time
-        # a project is sealed, and snapshot_all() iterates its keyset. The prior
-        # revision leaned on the incidental fact that _project_lock() briefly holds
-        # _LOCKS_LOCK on the create-path — but that lock is already RELEASED by
-        # the time we get here, so a concurrent snapshot_all() could still catch
-        # the dict mid-mutation and raise `RuntimeError: dictionary changed size
-        # during iteration`. Hold _LOCKS_LOCK for the mutation itself so the
-        # keyset snapshot and the new-project insert are properly serialized. The
-        # window is a single dict lookup — no risk of contention starvation, and
-        # snapshot_all() only takes _LOCKS_LOCK to snapshot keys (not per-project
-        # locks), so there is no reversed-order lock cycle.
-        with _LOCKS_LOCK:
-            chain = _CHAINS.setdefault(project, [])
-        prev = chain[-1].id if chain else None
+        # Read prev + seq for THIS receipt. Enabled: from the O(projects) tip index; the whole chain
+        # is never needed to append. Disabled: straight from _CHAINS, which is the store. Either read
+        # that MUTATES a dict (creating a new project's entry) is done under _LOCKS_LOCK, because
+        # snapshot_all()/_project_names() snapshot the keyset and a concurrent create would otherwise
+        # raise `RuntimeError: dictionary changed size during iteration` (Copilot #1106 round 2).
+        if persistence.enabled():
+            with _LOCKS_LOCK:
+                tip = _TIPS.get(project)
+            prev = tip.tip_id if tip is not None else None
+            seq = tip.count if tip is not None else 0
+        else:
+            with _LOCKS_LOCK:
+                stored = _CHAINS.setdefault(project, [])
+            prev = stored[-1].id if stored else None
+            seq = len(stored)
         body = {
             "project": project, "kind": kind, "backend": backend, "runtime": runtime,
             "inputs_sha": sha(inputs), "outputs_sha": sha(outputs), "status": status,
@@ -113,34 +178,43 @@ def seal(project: str, *, kind: str, backend: str, runtime: str, inputs: Any,
         # standards-based authenticity, layered on top of the chain's integrity:
         # in-toto Statement v1 + Ed25519 signature (unsigned if no key configured).
         signing.attest(receipt, signing.load_signing_key())
-        chain.append(receipt)
-        # write-through AFTER attestation so the durable copy carries the signature/statement,
-        # and at the receipt's chain position so the ordered prev-links reload intact.
-        persistence.save_receipt(project, len(chain) - 1, receipt.id, receipt.model_dump_json())
+        # write-through AFTER attestation so the durable copy carries the signature/statement, and at
+        # the receipt's chain position (seq) so the ordered prev-links reload intact. No-op when disabled.
+        persistence.save_receipt(project, seq, receipt.id, receipt.model_dump_json())
+        if persistence.enabled():
+            # Advance the tip (create-or-replace under _LOCKS_LOCK, safe vs the keyset snapshot), and
+            # keep the cache coherent if this project's chain is currently materialized — so a reader
+            # holding a cached chain sees the new receipt without a reload.
+            with _LOCKS_LOCK:
+                _TIPS[project] = _Tip(receipt.id, seq + 1)
+            cached = _CHAINS.get(project)
+            if cached is not None:
+                cached.append(receipt)
+                _CHAINS.move_to_end(project)
+        else:
+            stored.append(receipt)  # disabled: _CHAINS is the store — append the receipt in place
     return receipt
 
 
 def chain(project: str) -> list[Receipt]:
-    return list(_CHAINS.get(project, []))
+    """The project's full chain — lazily materialized from SQLite and LRU-cached when persistence is
+    enabled; straight from the in-memory store when disabled. Returns a copy."""
+    with _project_lock(project):
+        return list(_load_chain(project))
 
 
-def snapshot_all() -> list[tuple[str, list[Receipt]]]:
-    """A consistent (project, chain) snapshot for read-only aggregators like
-    /healthz's signed_ratio. Copilot #1106: iterating `_CHAINS.values()` in the
-    server hits `RuntimeError: dictionary changed size during iteration` when a
-    concurrent seal() runs setdefault() on a new project. Take the dict snapshot
-    under `_LOCKS_LOCK` (which setdefault contends with because _project_lock()
-    holds it while creating a new entry) and per-chain snapshots under the
-    per-project seal lock so we do not observe a chain mid-append."""
-    with _LOCKS_LOCK:
-        projects = list(_CHAINS.keys())
-    out: list[tuple[str, list[Receipt]]] = []
-    for project in projects:
+def snapshot_all() -> Iterator[tuple[str, list[Receipt]]]:
+    """Yield (project, chain) for EVERY project, one at a time, for read-only aggregators like
+    /healthz's signed_ratio. A GENERATOR, not a list: peak memory is a single project's chain, not
+    O(total receipts) — so the aggregation that folds over the whole store cannot itself reproduce
+    the boot-time OOM. Projects are snapshotted under _LOCKS_LOCK (so a concurrent seal creating a
+    new project cannot change the set mid-iteration — Copilot #1106), and each chain is read under
+    its per-project lock so we never observe one mid-append. Reads bypass the LRU cache so a full
+    scan does not churn it."""
+    for project in _project_names():
         with _project_lock(project):
-            # Copy defensively: the receipt list may have grown or been rebuilt
-            # by hydrate() since we snapshotted the keyset.
-            out.append((project, list(_CHAINS.get(project, []))))
-    return out
+            ch = _read_chain_fresh(project)
+        yield (project, ch)
 
 
 def verify(project: str) -> dict:
@@ -152,7 +226,7 @@ def verify(project: str) -> dict:
     that carries a signature which does NOT verify fails the whole check
     (`valid=False`) — a broken signature is tampering, not "unsigned".
     """
-    ch = _CHAINS.get(project, [])
+    ch = chain(project)  # lazily materialized (cached) when persistence is enabled
     prev: str | None = None
     signed = 0
     for r in ch:

--- a/apps/compute-gateway/tests/test_bounded_hydration.py
+++ b/apps/compute-gateway/tests/test_bounded_hydration.py
@@ -1,0 +1,107 @@
+"""Bounded/lazy boot hydration — the 2026-08-04 compute-gateway OOM, pinned two ways.
+
+1. Boot-time resident memory does NOT scale with the receipt store (the OOM invariant), proven with
+   the estate-wide boot-memory-invariance harness (tools/boot_memory_invariance.py, INV-DEP-16).
+2. The lazy boot still reloads the FULL, verifiable history: after a restart that loads only tips,
+   chain()/verify() materialize the whole chain from SQLite, verify passes, and a fresh seal continues
+   the hash chain with the correct prev — so the memory fix costs nothing in correctness.
+"""
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[3]  # apps/compute-gateway/tests -> repo root
+sys.path.insert(0, str(_REPO / "tools"))                       # the shared gate harness
+sys.path.insert(0, str(_REPO / "apps" / "compute-gateway" / "src"))  # compute_gateway (for spawn children)
+
+from boot_memory_invariance import assert_boot_memory_invariant  # noqa: E402
+from compute_gateway import persistence, receipts  # noqa: E402
+
+
+# ── 1. boot memory is invariant to store size ──────────────────────────────────────────────────
+def _seed_receipts(store: Path, n: int) -> None:
+    """Write n receipts to a gateway.db. hydrate() reads only tips (project/id/seq in SQL) so the
+    body content is immaterial here — what matters is that N rows exist to (not) load into RAM."""
+    db = sqlite3.connect(store / "gateway.db")
+    db.execute("CREATE TABLE IF NOT EXISTS receipts "
+               "(project TEXT NOT NULL, seq INTEGER NOT NULL, id TEXT NOT NULL, body TEXT NOT NULL, "
+               "PRIMARY KEY (project, seq))")
+    body = json.dumps({"project": "demo", "kind": "graph-query", "prev": None, "ts": 0.0,
+                       "pad": "x" * 512})  # ~0.5KB/receipt — a whole-store load would be unmistakable
+    db.executemany("INSERT OR REPLACE INTO receipts (project, seq, id, body) VALUES (?,?,?,?)",
+                   [("demo", i, f"sha256:{i:064x}", body) for i in range(n)])
+    db.commit()
+    db.close()
+
+
+def _boot_hydrate(store: Path) -> None:
+    """Boot the receipt store the way a restarted pod does: point at it and hydrate."""
+    os.environ["GATEWAY_STORE_DIR"] = str(store)
+    from compute_gateway import persistence as p, receipts as r
+    p._reset_connection()
+    r.hydrate()
+
+
+def test_boot_memory_does_not_scale_with_receipt_count():
+    # 64 vs 8192 receipts (128x): tips-only hydrate keeps the delta flat; the pre-fix hydrate that
+    # built a Receipt per row would grow it ~linearly and blow the budget.
+    assert_boot_memory_invariant(_seed_receipts, _boot_hydrate, small_n=64, large_n=8192, budget_kb=8192)
+
+
+# ── 2. lazy boot preserves the full, verifiable chain across a restart ──────────────────────────
+def _seal_n(project: str, n: int) -> list[str]:
+    ids = []
+    for i in range(n):
+        r = receipts.seal(project, kind="graph-query", backend="hellgraph", runtime="gateway",
+                          inputs={"i": i}, outputs={"i": i}, status="ok", actor="tester",
+                          epistemic_status="attested")
+        ids.append(r.id)
+    return ids
+
+
+def test_restart_reloads_full_verifiable_history_and_continues_the_chain():
+    prev_env = os.environ.get("GATEWAY_STORE_DIR")
+    with tempfile.TemporaryDirectory() as d:
+        try:
+            os.environ["GATEWAY_STORE_DIR"] = d
+            persistence._reset_connection()
+            receipts._CHAINS.clear()
+            receipts._TIPS.clear()
+
+            sealed = _seal_n("proj", 5)
+
+            # Simulate a pod restart: drop every in-memory structure, reopen the store, hydrate.
+            receipts._CHAINS.clear()
+            receipts._TIPS.clear()
+            persistence._reset_connection()
+            receipts.hydrate()
+
+            # Boot loaded only tips — the cache is empty until something reads it.
+            assert "proj" not in receipts._CHAINS, "boot must not materialize any chain"
+            assert receipts._TIPS["proj"].tip_id == sealed[-1]
+            assert receipts._TIPS["proj"].count == 5
+
+            # chain()/verify() lazily materialize the WHOLE history from SQLite and it verifies.
+            ch = receipts.chain("proj")
+            assert [r.id for r in ch] == sealed, "full chain reloads in seal order"
+            v = receipts.verify("proj")
+            assert v["valid"] and v["count"] == 5, v
+
+            # A fresh seal continues the chain from the correct tip — prev links stay intact.
+            sixth = receipts.seal("proj", kind="graph-query", backend="hellgraph", runtime="gateway",
+                                  inputs={"i": 5}, outputs={"i": 5}, status="ok", actor="tester",
+                                  epistemic_status="attested")
+            assert sixth.prev == sealed[-1]
+            assert receipts.verify("proj")["valid"], "chain still verifies after post-restart seal"
+        finally:
+            receipts._CHAINS.clear()
+            receipts._TIPS.clear()
+            if prev_env is None:
+                os.environ.pop("GATEWAY_STORE_DIR", None)
+            else:
+                os.environ["GATEWAY_STORE_DIR"] = prev_env
+            persistence._reset_connection()
+            receipts.hydrate()

--- a/apps/compute-gateway/tests/test_config_plane.py
+++ b/apps/compute-gateway/tests/test_config_plane.py
@@ -27,7 +27,12 @@ def durable():
     with tempfile.TemporaryDirectory() as d:
         os.environ["GATEWAY_STORE_DIR"] = d
         persistence._reset_connection()
+        # Reset BOTH the chain cache and the tip index for the fresh store. seal() reads prev/seq
+        # from _TIPS in persistence-enabled mode, so a stale tip carried from a prior durable()
+        # context would give the first receipt a bogus prev and break verify(). (The restart-sim
+        # test below reloads tips via receipts.hydrate() for the same reason.)
         receipts._CHAINS.clear()
+        receipts._TIPS.clear()
         try:
             yield d
         finally:
@@ -37,6 +42,7 @@ def durable():
                 os.environ["GATEWAY_STORE_DIR"] = prev
             persistence._reset_connection()
             receipts._CHAINS.clear()
+            receipts._TIPS.clear()
 
 
 def test_reads_are_open_so_an_outage_cannot_be_made_worse():


### PR DESCRIPTION
## The root cause of the 2026-08-04 outage
`receipts.hydrate()` materialized **every receipt** into `_CHAINS` at import, and `artifacts.hydrate()` loaded the whole data-lineage index — so resident memory grew with `/data` and OOMKilled the pod ~9s into boot (31 restarts, the whole gateway down). #1365 raised the limit to 1Gi as a mitigation; this removes the scaling.

## The fix — bounded/lazy, dual-mode
- **Boot loads only per-project TIPS** (`_TIPS`: last-id + count), computed in SQL — **O(projects), not O(receipts)**. `hydrate()` no longer builds a single Receipt.
- **`seal()`** reads `prev`/`seq` from the tip index (it never needed the whole chain), writes SQLite, advances the tip.
- **`chain()`/`verify()`** materialize a project lazily from SQLite behind a **bounded LRU** (`_CHAINS`, 64 projects); **`snapshot_all()` is now a generator** (one chain resident at a time), so even the `/healthz` fold can't reproduce the OOM.
- **artifacts** `for_receipt`/`stats` resolve lazily via SQL; `hydrate()` stops loading the full index.
- **Persistence-disabled mode is unchanged** (tests/ephemeral): `_CHAINS` stays the in-memory store, so `_CHAINS.clear()` remains a full reset.

## Invariants preserved (verified)
- The per-project **seal lock** + the Copilot #1106 keyset-snapshot discipline are intact; chain integrity (id-hash + prev-links) and signatures unchanged.
- **Seal-bypass check**: the only `save_receipt(project, seq, …)` call is inside `seal()`, so `_TIPS` can't go stale in prod (single-writer RWO store).
- `durable()` fixture now resets `_TIPS` alongside `_CHAINS` (the restart-sim already re-hydrated).

## Tests
- **254 pass** (all existing gateway tests: persistence, restart, tamper, concurrency).
- **New**: adopts the INV-DEP-16 **boot-memory-invariance** harness — 64 vs 8192 receipts hydrate within a flat RSS budget (the pre-fix per-row build blows it); plus a **restart-integrity** test — after a tips-only boot the cache is empty, `chain()`/`verify()` lazily reload the whole history and it verifies, and a fresh seal continues the chain with the correct `prev`.

## Follow-up (not here)
With boot memory now flat, the `deploy/values/compute-gateway.yaml` limit *could* step back toward the chart default — but the 1Gi also covers the hellgraph + embedding baseline, so that's a separate measured decision, not a side effect of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)