### PR TITLE
harden(hellgraph): op_set-by-default + lossless reification + fail-closed writer (recovers #1400 hardening)

### DIFF
--- a/contracts/crystal-atlas/schemas/graph-hyperedge.v0.schema.json
+++ b/contracts/crystal-atlas/schemas/graph-hyperedge.v0.schema.json
@@ -4,14 +4,14 @@
   "description": "An N-ary typed relation over two or more graph nodes, each in a declared role — the AtomSpace/KKO hyperedge the binary graph-edge.v0 cannot express (e.g. a claim together with its premises and stance as ONE relation, not three edges). Tenant- and operational-set-scoped: isolation is a property of the relation itself.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["hyperedge_id", "tenant_id", "hyperedge_type", "members", "created_at", "updated_at"],
+  "required": ["hyperedge_id", "tenant_id", "op_set", "hyperedge_type", "members", "created_at", "updated_at"],
   "properties": {
     "hyperedge_id": { "type": "string", "minLength": 3 },
     "tenant_id": { "type": "string", "minLength": 1 },
     "op_set": {
       "type": "string",
       "minLength": 1,
-      "description": "Operational set / namespace within the tenant. Isolation boundary by default: a read scoped to one op_set never sees another."
+      "description": "Operational set / namespace within the tenant — REQUIRED, the isolation label the relation always carries. An op_set-scoped reader partitions on it; the label is mandatory so there is always a boundary to enforce ON (enforcement itself is the graph service's responsibility, not this contract's)."
     },
     "hyperedge_type": { "type": "string", "minLength": 1 },
     "members": {

--- a/tools/hellgraph_percolation/argument_materializer.py
+++ b/tools/hellgraph_percolation/argument_materializer.py
@@ -16,15 +16,20 @@ from __future__ import annotations
 from typing import Mapping
 
 
-def materialize(argument_graph: Mapping, *, tenant_id: str, op_set: str = "discourse",
-                doc_id: str = "", now: str = "") -> dict:
-    """ArgumentGraph.to_dict() → graph-upsert-request.v0. Unit ids are namespaced by `doc_id` so two
-    documents' units never collide in the shared graph."""
+def materialize(argument_graph: Mapping, *, tenant_id: str, doc_id: str, op_set: str = "discourse",
+                now: str = "") -> dict:
+    """ArgumentGraph.to_dict() → graph-upsert-request.v0. `doc_id` is REQUIRED and namespaces every
+    unit id, so two documents' claims/premises never collide in the shared graph — a bare "u0" from
+    two different documents would otherwise merge into one node (and one "arg:u0" hyperedge). Empty
+    doc_id is refused fail-closed rather than silently producing colliding ids."""
+    if not doc_id:
+        raise ValueError("materialize requires a non-empty doc_id — it namespaces node/hyperedge ids "
+                         "to prevent cross-document collision in the shared graph")
     units = argument_graph.get("units", [])
     relations = argument_graph.get("relations", [])
 
     def nid(uid: str) -> str:
-        return f"{doc_id}:{uid}" if doc_id else uid
+        return f"{doc_id}:{uid}"
 
     nodes = [{
         "node_id": nid(u["id"]),

--- a/tools/hellgraph_percolation/percolation.py
+++ b/tools/hellgraph_percolation/percolation.py
@@ -66,7 +66,8 @@ class PercolationResult:
 class Writer(Protocol):
     """Anything that accepts a graph-upsert-request.v0 — the real engine client, or a recorder."""
 
-    def upsert(self, request: dict) -> None: ...
+    def upsert(self, request: dict) -> None:
+        """Accept a graph-upsert-request.v0 and apply it (the engine client, or a recorder)."""
 
 
 @dataclass

--- a/tools/hellgraph_percolation/percolation.py
+++ b/tools/hellgraph_percolation/percolation.py
@@ -9,8 +9,11 @@ Properties, by construction:
 - **Incremental** — only the affected closure re-materialises, never the whole graph.
 - **Bounded / governed** — the dependency graph must be a DAG; a cycle is fail-closed (CycleError),
   not an open loop.
-- **Isolated by default** — every emitted write carries its object's own tenant_id (+ op_set for
-  hyperedges), so a materialisation can't bleed across operational sets.
+- **Isolated by default** — every emitted write carries its object's own tenant_id AND op_set (op_set
+  top-level on a hyperedge, in `attributes` on a node/edge), so the isolation label is ALWAYS present.
+  Enforcing that boundary at read/write time is the graph service's responsibility (see the W2 "doors"
+  governance layer); this trigger's job is to guarantee there is a label to enforce ON — never to emit
+  an unlabelled object that a later reader cannot scope.
 - **Engine-agnostic** — it emits `graph-upsert-request.v0` (the Crystal-Atlas MLN write interface)
   through a pluggable Writer; it never reaches inside the (fenced) graph engine.
 
@@ -117,12 +120,20 @@ class Catalog:
 
 
 def to_upsert_request(obj: CatalogObject) -> dict:
-    """Wrap an object's body in a graph-upsert-request.v0 envelope, scoped to its tenant. The op_set
-    is stamped onto a hyperedge body so isolation travels with the relation."""
+    """Wrap an object's body in a graph-upsert-request.v0 envelope, scoped to its tenant AND its
+    operational set. op_set travels with EVERY object so isolation is by default, not best-effort:
+    top-level on a hyperedge (graph-hyperedge.v0 has the field), and in `attributes.op_set` on a
+    node/edge — graph-node/edge.v0 are additionalProperties:false, so the open `attributes` bag is
+    op_set's home, where the writer and any op_set-scoped reader look for it. The attributes dict is
+    copied, never mutated in place, so the catalog's payload is untouched."""
     body = dict(obj.payload)
     body.setdefault("tenant_id", obj.tenant_id)
     if obj.materializes == HYPEREDGE:
         body.setdefault("op_set", obj.op_set)
+    else:
+        attrs = dict(body.get("attributes") or {})
+        attrs.setdefault("op_set", obj.op_set)
+        body["attributes"] = attrs
     return {"tenant_id": obj.tenant_id, _ARRAY[obj.materializes]: [body]}
 
 

--- a/tools/hellgraph_percolation/writer_hellgraph.py
+++ b/tools/hellgraph_percolation/writer_hellgraph.py
@@ -17,14 +17,14 @@ from typing import Callable, Mapping, Optional
 Poster = Callable[[str, dict], None]  # (path, json_body) -> None
 
 
-def _http_poster(base_url: str, token: Optional[str]) -> Poster:
+def _http_poster(base_url: str, token: Optional[str], timeout: float = 30.0) -> Poster:
     def post(path: str, body: dict) -> None:
         headers = {"content-type": "application/json"}
         if token:
             headers["authorization"] = f"Bearer {token}"  # graph:write scope when AUTH_ENFORCE=on
         req = urllib.request.Request(base_url.rstrip("/") + path, method="POST",
                                      data=json.dumps(body).encode("utf-8"), headers=headers)
-        urllib.request.urlopen(req).read()
+        urllib.request.urlopen(req, timeout=timeout).read()  # bounded: a hung service is a failure, not an open wait
     return post
 
 
@@ -44,11 +44,13 @@ def _node_body(n: Mapping) -> dict:
 
 
 def _edge_body(e: Mapping) -> dict:
+    attrs = e.get("attributes") or {}
     return {
         "label": e["edge_type"], "from": e["src"], "to": e["dst"],
-        "properties": _clean({"tenant_id": e["tenant_id"], "confidence": e.get("confidence"),
+        "properties": _clean({"tenant_id": e["tenant_id"], "op_set": attrs.get("op_set"),
+                              "confidence": e.get("confidence"),
                               "claim_refs": e.get("claim_refs"), "evidence_refs": e.get("evidence_refs"),
-                              **(e.get("attributes") or {})}),
+                              **attrs}),
     }
 
 
@@ -61,6 +63,12 @@ class HellgraphServiceWriter:
         self._validate = validate
 
     def upsert(self, request: Mapping) -> None:
+        if request.get("claims") or request.get("evidence"):
+            # graph-upsert-request.v0 permits claims[]/evidence[], but this service boundary exposes
+            # no endpoint to land them. Silently dropping would lose provenance, so refuse fail-closed
+            # rather than pretend they were written.
+            raise ValueError("HellgraphServiceWriter cannot land claims[]/evidence[] (no service "
+                             "endpoint) — materialise them upstream or extend the writer; never drop silently")
         if self._validate:
             _check(request)
         for node in request.get("nodes", []):
@@ -71,19 +79,24 @@ class HellgraphServiceWriter:
             self._reify(he)
 
     def _reify(self, he: Mapping) -> None:
-        # the hyperedge becomes a node carrying a "hyperedge" label ...
+        # the hyperedge becomes a node carrying a "hyperedge" label + its FULL provenance (confidence,
+        # claim/evidence refs, timestamps) so reification is lossless, not a bare shell ...
         self._post("/api/graph/node", {
             "id": he["hyperedge_id"],
             "labels": [he["hyperedge_type"], "hyperedge"],
             "properties": _clean({"tenant_id": he["tenant_id"], "op_set": he.get("op_set"),
+                                  "confidence": he.get("confidence"), "claim_refs": he.get("claim_refs"),
+                                  "evidence_refs": he.get("evidence_refs"),
+                                  "created_at": he.get("created_at"), "updated_at": he.get("updated_at"),
                                   **(he.get("attributes") or {})}),
         })
-        # ... and each roled member becomes a labelled edge out of it
+        # ... and each roled member becomes a labelled edge out of it, carrying the SAME isolation
+        # scope (tenant_id + op_set) as the relation, so an op_set-scoped edge read sees its role edges.
         for m in he["members"]:
             self._post("/api/graph/edge", {
                 "label": m["role"], "from": he["hyperedge_id"], "to": m["node_id"],
-                "properties": {"member_role": m["role"], "reified_from": he["hyperedge_id"],
-                               "tenant_id": he["tenant_id"]},
+                "properties": _clean({"member_role": m["role"], "reified_from": he["hyperedge_id"],
+                                      "tenant_id": he["tenant_id"], "op_set": he.get("op_set")}),
             })
 
 

--- a/tools/tests/test_hellgraph_writer.py
+++ b/tools/tests/test_hellgraph_writer.py
@@ -41,19 +41,30 @@ def test_edge_translates_to_service_edge_add():
     assert body == {"label": "supports", "from": "a", "to": "b", "properties": {"tenant_id": "t1"}}
 
 
-def test_hyperedge_is_reified_into_a_node_plus_role_edges():
-    # THEOREM: a binary property-graph can't hold an N-ary relation, so the hyperedge reifies into
-    # a node (labelled "hyperedge") + one role-labelled edge per member.
+def test_hyperedge_is_reified_losslessly_with_isolation_on_every_object():
+    # THEOREM: a binary property-graph can't hold an N-ary relation, so the hyperedge reifies into a
+    # node (labelled "hyperedge") + one role-labelled edge per member. Reification is LOSSLESS (the
+    # node keeps confidence/claim_refs/evidence_refs) and ISOLATED (the node AND every role-edge carry
+    # op_set + tenant_id) — a role-edge that dropped op_set would be invisible to an op_set-scoped read.
     rec = RecPost()
     he = {"hyperedge_id": "h1", "tenant_id": "t1", "op_set": "discourse", "hyperedge_type": "argument",
           "members": [{"role": "claim", "node_id": "c1"}, {"role": "premise", "node_id": "p1"}],
+          "confidence": 0.9, "claim_refs": ["cl:1"], "evidence_refs": ["ev:1"],
           "created_at": "T", "updated_at": "T"}
     _writer(rec).upsert({"tenant_id": "t1", "hyperedges": [he]})
     assert len(rec.calls) == 3
     (np, nb), (ep1, eb1), (ep2, eb2) = rec.calls
+    # reified node: labelled, isolated, and provenance-complete (lossless)
     assert np == "/api/graph/node" and nb["id"] == "h1" and "hyperedge" in nb["labels"]
+    assert nb["properties"]["tenant_id"] == "t1" and nb["properties"]["op_set"] == "discourse"
+    assert nb["properties"]["confidence"] == 0.9 and nb["properties"]["claim_refs"] == ["cl:1"]
+    assert nb["properties"]["evidence_refs"] == ["ev:1"]
+    # role edges: right shape AND carrying the relation's own isolation scope
     assert ep1 == "/api/graph/edge" and eb1["from"] == "h1" and eb1["to"] == "c1" and eb1["label"] == "claim"
     assert eb2["to"] == "p1" and eb2["label"] == "premise"
+    for _, eb in (rec.calls[1], rec.calls[2]):
+        assert eb["properties"]["op_set"] == "discourse" and eb["properties"]["tenant_id"] == "t1"
+        assert eb["properties"]["reified_from"] == "h1"
 
 
 def test_fail_closed_on_missing_tenant():
@@ -63,11 +74,26 @@ def test_fail_closed_on_missing_tenant():
     assert rec.calls == []  # nothing written
 
 
-def test_plugs_into_percolate_as_the_actuator():
+def test_fail_closed_on_claims_or_evidence_it_cannot_land():
+    # THEOREM: the service boundary exposes no claims/evidence endpoint; rather than silently drop
+    # them (losing provenance) the writer refuses fail-closed.
+    rec = RecPost()
+    with pytest.raises(ValueError):
+        _writer(rec).upsert({"tenant_id": "t1", "claims": [{"claim_id": "c1"}]})
+    assert rec.calls == []
+
+
+def test_plugs_into_percolate_and_stamps_op_set_by_default():
+    # THEOREM (isolation by default): a node whose payload carries NO op_set still lands WITH one —
+    # percolate stamps the catalog object's op_set into attributes so no materialised object is ever
+    # unlabelled. Regression guard: the write path previously dropped op_set for nodes/edges.
     rec = RecPost()
     cat = pc.Catalog().add(pc.CatalogObject(
         id="n1", materializes=pc.NODE, tenant_id="t1", op_set="s1", produced_by="script",
         payload={"node_id": "n1", "tenant_id": "t1", "node_kind": "dataset", "display_name": "n1",
-                 "created_at": "T", "updated_at": "T"}))
-    pc.percolate(cat, ["n1"], writer=_writer(rec, validate=False), now="T")
-    assert rec.calls and rec.calls[0][0] == "/api/graph/node"
+                 "created_at": "T", "updated_at": "T"}))  # NOTE: payload has no attributes.op_set
+    pc.percolate(cat, ["n1"], writer=_writer(rec), now="T")  # validate=True: the stamped op_set is present
+    (path, body), = rec.calls
+    assert path == "/api/graph/node"
+    assert body["properties"]["op_set"] == "s1"     # the catalog's op_set reached the wire
+    assert body["properties"]["tenant_id"] == "t1"


### PR DESCRIPTION
## Why
#1400 auto-merged at commit `c853aaeb` — **before** its hardening landed. The op_set/reification/fail-closed fixes were pushed to the branch *after* the merge fired, so they were orphaned and never reached main. This PR lands them.

Main currently has the **un-hardened** percolation code — the exact declared-not-enforced gaps an adversarial review found: `to_upsert_request` stamps op_set only on hyperedges (nodes/edges/role-edges lose it), reification drops `confidence`/`claim_refs`/`evidence_refs`, `claims[]`/`evidence[]` are silently dropped, and `argument_materializer` defaults `doc_id=""` (colliding ids across documents).

## What (identical to the orphaned #1400 hardening, cherry-picked onto current main)
- **op_set by default**: `to_upsert_request` stamps op_set on **every** object (attributes for node/edge, top-level for hyperedge); `_reify` carries op_set onto every role-edge. `graph-hyperedge.v0` makes `op_set` **required**.
- **Lossless reification**: the reified hyperedge node keeps confidence/claim_refs/evidence_refs/timestamps.
- **Fail-closed writer**: refuses `claims[]`/`evidence[]` it has no endpoint to land (no silent drop); 30s HTTP timeout.
- **`argument_materializer`**: `doc_id` required, fail-closed on empty.
- **Tests strengthened** so the drops can't ship green again (reified node provenance + role-edge op_set asserted; op_set-by-default proven end-to-end; claims/evidence fail-closed).

## Verification
`25/25` percolation + writer + materializer + catalog + sense tests green. Empirical op_set capture flips DROPPED→ENFORCED on nodes and role-edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)