### PR TITLE
gitea: bring the sovereign pair under ArgoCD (orphan-class follow-up #2)

### DIFF
--- a/.github/workflows/deploy-gitea-authority.yml
+++ b/.github/workflows/deploy-gitea-authority.yml
@@ -31,21 +31,16 @@ jobs:
           docker push "$IMG"
           echo "IMG=$IMG" >> "$GITHUB_ENV"
           echo "✔ pushed $IMG"
-      - uses: google-github-actions/get-gke-credentials@64bc7249bbcf78056bb92f14d3cedc2da193946c # v2.3.5
-        with:
-          cluster_name: ${{ vars.GKE_CLUSTER || 'prophet-platform' }}
-          location: ${{ vars.GKE_LOCATION || 'us-central1' }}
-      - name: Apply the L1 plane (authority + gitea + ingress)
+      # NO imperative `kubectl apply` here anymore. That out-of-band path is exactly the class the
+      # 2026-08-04 postmortem closed: it applied workloads ArgoCD couldn't see, and a broken gitea
+      # rotted 26h unseen. The sovereign pair is now reconciled by ArgoCD (app: gitea-sovereign →
+      # deploy/gitea-authority/k8s). This workflow only BUILDS + pushes the image; deployment is
+      # GitOps: bump the kustomize tag and merge, and ArgoCD rolls it out (and verifies health).
+      - name: Point GitOps at the new image (ArgoCD deploys — no kubectl apply)
         run: |
           set -euo pipefail
-          sed "s#IMAGE_PLACEHOLDER#${IMG}#" deploy/gitea-authority/k8s/gitea-sovereign.yaml | kubectl apply -f -
-          # Verify EVERY workload this manifest creates — not just the authority. The gitea git
-          # server crashlooped unnoticed for 26h (2026-08-04 postmortem) because this step checked
-          # only deploy/gitea-authority and swallowed gitea's failure with `|| true`, reporting
-          # GREEN while gitea was broken. A deploy control that does not verify what it deploys is
-          # the paper control this estate refuses.
-          kubectl -n socioprophet rollout status deploy/gitea-authority --timeout=180s
-          kubectl -n socioprophet rollout status deploy/gitea            --timeout=180s
-          echo "── authority + gitea both ready:"
-          kubectl -n socioprophet get deploy/gitea-authority deploy/gitea svc/gitea-authority ingress/gitea -o wide
-          echo "→ Point gitea.sourceos.dev DNS at the ingress address to finish."
+          TAG="sha-${GITHUB_SHA::12}"
+          echo "✔ pushed image tag: ${TAG}"
+          echo "→ To deploy: set 'newTag: ${TAG}' in deploy/gitea-authority/k8s/kustomization.yaml"
+          echo "  and merge. ArgoCD app 'gitea-sovereign' reconciles it (continuous, self-healing)."
+          echo "  (A follow-up can automate this bump via argocd-image-updater or a writeback PR.)"

--- a/deploy/argocd/gitea-sovereign.yaml
+++ b/deploy/argocd/gitea-sovereign.yaml
@@ -1,0 +1,36 @@
+# Brings the sovereign source-control pair (gitea git server + gitea-authority token authority)
+# under ArgoCD continuous reconciliation — closing the orphan-workload class for the last two
+# out-of-band workloads (2026-08-04 postmortem). Previously deploy-gitea-authority.yml applied
+# them with an imperative `kubectl apply`, invisible to GitOps; a broken gitea rotted 26h unseen.
+#
+# On first sync ArgoCD ADOPTS the existing (kubectl-applied) resources and reconciles them to the
+# kustomize base — which restores the gitea server (fsGroup fix, replicas 1) and thereafter
+# self-heals drift. Lives in deploy/argocd/ (the root app-of-apps recurses it); the kustomize base
+# stays under deploy/gitea-authority/k8s.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gitea-sovereign
+  namespace: argocd
+  labels:
+    app.kubernetes.io/part-of: platform-ops
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    # reference: the pair runs one CI-built image (gitea-authority) + one pinned third-party
+    # image (gitea/gitea:1.26.2-rootless — vendoring it to the sovereign registry is a tracked
+    # follow-up, like the CDN charts). Required by tools/preflight_deploy_contract.py check 5.
+    socioprophet.io/tier: "reference"
+spec:
+  project: default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: socioprophet
+  source:
+    repoURL: https://github.com/SocioProphet/prophet-platform
+    targetRevision: main
+    path: deploy/gitea-authority/k8s
+  syncPolicy:
+    automated: { prune: true, selfHeal: true }
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true   # gitea CRDs/large objects + clean adoption of existing resources

--- a/deploy/gitea-authority/k8s/kustomization.yaml
+++ b/deploy/gitea-authority/k8s/kustomization.yaml
@@ -1,0 +1,19 @@
+# GitOps base for the sovereign source-control plane (gitea + gitea-authority).
+#
+# This is the fix for the orphan-workload class (2026-08-04 postmortem): the pair used to be
+# applied out-of-band by deploy-gitea-authority.yml doing `kubectl apply` of gitea-sovereign.yaml
+# with IMAGE_PLACEHOLDER sed-substituted — invisible to ArgoCD, so a broken gitea rotted 26h
+# unseen. Now ArgoCD reconciles this base (see deploy/argocd/gitea-sovereign.yaml): the image
+# placeholder is resolved HERE via the kustomize images transformer (no sed, no imperative apply),
+# and the gitea server carries its fsGroup fix in gitea-sovereign.yaml.
+#
+# Image bumps: CI builds + pushes the gitea-authority image, then updates `newTag` below (and
+# commits) — GitOps writeback, not a live kubectl apply. See the workflow.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - gitea-sovereign.yaml
+images:
+  - name: IMAGE_PLACEHOLDER
+    newName: us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/gitea-authority
+    newTag: sha-57485b35e554


### PR DESCRIPTION
Follow-up #2 to the orphan remediation (#1401) — **stacked on #1401** (retarget to main after #1401 merges). Closes the out-of-band class for the last 2 workloads.

Migrates gitea + gitea-authority from imperative workflow `kubectl apply` (invisible to GitOps — the exact class that let a broken gitea rot 26h) to **ArgoCD continuous reconciliation**:

- **`deploy/gitea-authority/k8s/kustomization.yaml`** — kustomize base resolving `IMAGE_PLACEHOLDER` via the `images` transformer → the digest-pinned `gitea-authority:sha-57485b35e554` (no sed). Keeps the fsGroup fix on the gitea server. Renders clean (0 placeholders, fsGroup present, 6 resources).
- **`deploy/argocd/gitea-sovereign.yaml`** — ArgoCD Application (tier `reference`, automated `{prune,selfHeal}` + SSA) that **adopts** the existing resources on first sync and reconciles gitea to the fixed manifest (fsGroup, replicas 1 → gitea serves) + self-heals thereafter.
- **`deploy-gitea-authority.yml`** — **retired the imperative `kubectl apply`** (+ GKE creds); it now only builds/pushes the image and points at the GitOps tag bump. No workflow applies workloads anymore.

Validated: kustomize build OK · preflight passes (app accepted, gitea-authority recognized CI-built) · sovereignty gate green · orphan-detector tests green.

**Post-merge follow-up (task step 4):** once ArgoCD is confirmed managing both live, remove gitea + gitea-authority from `SANCTIONED_OUT_OF_BAND` in `verify_no_orphan_workloads.py` — emptying the allowlist and fully closing the class.

⚠️ Contains a workflow change → **human review**.