### PR TITLE
feat(controls): CI liveness — a dead-man's switch (Martha) and an escalation that lands (Mary)

### DIFF
--- a/.github/workflows/ci-liveness.yml
+++ b/.github/workflows/ci-liveness.yml
@@ -1,0 +1,57 @@
+name: CI liveness (dead-man's switch)
+
+# Requires GREEN RECENTLY rather than waiting for red. A workflow that stops starting emits no
+# failure — its silence is observationally identical to success — so absence has to be asserted
+# against, on a clock, by something outside it.
+on:
+  schedule:
+    - cron: "23 6 * * *"      # daily, offset off the hour to avoid the scheduler stampede
+  workflow_dispatch:
+    inputs:
+      window_days:
+        description: "Days a workflow may go without a green run before it alarms"
+        required: false
+        default: "14"
+      escalate:
+        description: "File/update the escalation issues (Mary). Off = report only (Martha)."
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: read
+  issues: write               # the escalation files and closes issues; nothing else is needed
+
+jobs:
+  sweep:
+    name: Sweep + escalate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sweep — when did each workflow last COMPLETE SUCCESSFULLY?
+        id: sweep
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 tools/ci_liveness_sweep.py \
+            --repos-file contracts/ci-liveness-repos.txt \
+            --window-days "${{ inputs.window_days || '14' }}" \
+            --json > sweep.json
+          python3 -c "import json;d=json.load(open('sweep.json'));print(f\"alarms={len(d['alarms'])} checked={d['checked']}\")"
+
+      # Martha reports; Mary is what makes it land. Escalation files ONE issue per repo, raises its
+      # severity with the age of the silence, and closes it when the pipeline is green again.
+      - name: Escalate — make the finding land on someone
+        if: ${{ inputs.escalate != 'false' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 tools/ci_liveness_escalate.py --sweep-json sweep.json
+
+      - name: Publish the sweep as an artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-liveness-sweep
+          path: sweep.json
+          retention-days: 90

--- a/.github/workflows/ci-liveness.yml
+++ b/.github/workflows/ci-liveness.yml
@@ -48,6 +48,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 tools/ci_liveness_escalate.py --sweep-json sweep.json
 
+      # Without this, the job reports green every day regardless of what the sweep found — the
+      # sweep step never passed --fail-on-alarm and escalate.py used to swallow its own write
+      # failures — which is the same "silence looks like health" pattern this tool exists to
+      # catch, recreated one level up in ci-liveness.yml's own run status. `if: always()` so a
+      # true alarm is still reported even if the escalate step above already failed the job.
+      - name: Fail loudly on any true alarm — a green run must mean nothing broke
+        if: always()
+        run: |
+          python3 -c "
+          import json, sys
+          d = json.load(open('sweep.json'))
+          alarms = d.get('alarms', [])
+          if alarms:
+              print(f'::error::ci-liveness found {len(alarms)} alarm(s) this run.')
+              for a in alarms:
+                  print(f\"::error::{a['repo']}: {a['workflow']} — {a['verdict']}: {a['why']}\")
+              sys.exit(1)
+          print(f\"ci-liveness: {d.get('checked', 0)} workflow(s) checked, 0 alarms.\")
+          "
+
       - name: Publish the sweep as an artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/contracts/ci-liveness-repos.txt
+++ b/contracts/ci-liveness-repos.txt
@@ -1,0 +1,11 @@
+# Repos swept by the CI liveness dead-man's switch (tools/ci_liveness_sweep.py).
+#
+# prophet-platform is deliberately IN this list so the sweep reports on its own workflows,
+# including the one that runs it. That is partial self-coverage, not a solution: if the scheduled
+# workflow itself stops starting, nothing here notices. See the "limit" section of
+# docs/CI_LIVENESS.md — the recursion has to terminate in something checked by a human or by
+# separate infrastructure.
+SocioProphet/prophet-platform
+SocioProphet/cybernetic-genesis
+SourceOS-Linux/goose-notes
+SourceOS-Linux/BearBrowser

--- a/docs/CI_LIVENESS.md
+++ b/docs/CI_LIVENESS.md
@@ -43,6 +43,24 @@ as DEAD; they had simply never been invoked. **A checker that cries wolf gets mu
 control is exactly the dead control this was built to find** — so precision here is load-bearing,
 not politeness.
 
+## Dead or dormant — the distinction the verdicts exist for
+
+A winter garden and a dead garden look the same. The hellebore is how you tell: it flowers in the
+dead season, when nothing else does, and its bloom is the proof that the ground is still alive.
+
+That is the whole difficulty here. A repo emitting no signal might be **dormant** — nobody has
+pushed, the workflow is manual, the project is between phases — or it might be **dead**. Both look
+identical from outside, and the estate spent five weeks unable to tell.
+
+So the verdicts do the telling, and getting the line right is the work:
+
+- `UNUSED` — **dormant**. Manual-dispatch, never invoked. Idle by design, and *not* an alarm.
+- `DEAD` — **dead**. It runs automatically, or it has run and failed, and it has never once been green.
+- `SILENT` — **the deceptive case**: it is running, so it looks alive, and it never wins.
+
+Calling dormant things dead is how a checker gets muted; calling dead things dormant is how five
+weeks pass. The `UNUSED` verdict exists because the first draft of this tool made the first mistake.
+
 ## Relationship to `controls_census.py`
 
 The census already names the property: *meta-monitored — something alerts if the control itself

--- a/docs/CI_LIVENESS.md
+++ b/docs/CI_LIVENESS.md
@@ -1,0 +1,58 @@
+# CI liveness — the dead-man's switch
+
+`tools/ci_liveness_sweep.py` · `python3 tools/ci_liveness_sweep.py owner/repo [...] --fail-on-alarm`
+
+## Why this exists
+
+`SourceOS-Linux/goose-notes` CI reported `startup_failure` in **0s** on every branch from
+2026-07-01 to 2026-08-04. A single disallowed action in the workflow meant GitHub refused to start
+the run at all. `main` did not compile for five weeks, and nothing said so — because:
+
+> **A red build is information. A build that never runs produces the same observable as a passing
+> build: no reported failures.**
+
+No alerting rule fires on that. No self-healing loop triggers either — **healing is downstream of
+detection, and this class of failure kills detection itself.** You cannot heal what was never
+observed to be sick. The estate's own `sociosphere_self_heal` record reads *"self-heal daemon
+DEAD"*, which is the proof: nothing heals its own healing loop.
+
+## What it does differently
+
+It does not wait for red. **It requires green, recently.**
+
+    for every repo, for every active workflow — when did it last COMPLETE SUCCESSFULLY?
+
+Staleness is the alarm, so silence becomes a positive signal instead of a null one. Same shape as
+the rest of the estate's fail-closed controls — absence of a marker is not permission, an
+undecidable invariant is not a pass, unstated authority is not independence — and here, **no news
+is not good news.**
+
+| verdict | meaning | alarms |
+|---|---|---|
+| `OK` | green inside the window | no |
+| `STALE` | succeeded once, not inside the window — abandoned or quietly broken | **yes** |
+| `SILENT` | running but *not succeeding* inside the window — **the goose-notes signature** | **yes** |
+| `DEAD` | never completed successfully, ever | **yes** |
+| `UNUSED` | manual-dispatch workflow never invoked — idle by design | no |
+
+`SILENT` is the one that was invisible. Runs *exist*, so the pipeline looks alive; none of them win.
+A checker that only asked *"did it run?"* would have said yes every day for five weeks.
+
+`UNUSED` exists for the opposite reason. A first pass flagged three `(dispatch)` signing workflows
+as DEAD; they had simply never been invoked. **A checker that cries wolf gets muted, and a muted
+control is exactly the dead control this was built to find** — so precision here is load-bearing,
+not politeness.
+
+## Relationship to `controls_census.py`
+
+The census already names the property: *meta-monitored — something alerts if the control itself
+stops (the check checks the checker)*. It applies that to in-cluster CronJobs and to the `tools/`
+validators wired into `make validate`. **This is the same doctrine pointed at the CI workflows
+themselves**, which the census does not reach and which is where the estate actually lost time.
+
+## The limit, stated plainly
+
+**This sweep cannot watch itself.** Whatever schedules it must be watched by something else, and
+the recursion has to bottom out in something trusted *by construction* rather than by monitoring —
+a schedule on separate infrastructure, or a human-visible surface. Otherwise this is just one more
+daemon that can die quietly, which is the disease and not the cure.

--- a/docs/CI_LIVENESS.md
+++ b/docs/CI_LIVENESS.md
@@ -34,6 +34,7 @@ is not good news.**
 | `SILENT` | running but *not succeeding* inside the window — **the goose-notes signature** | **yes** |
 | `DEAD` | never completed successfully, ever | **yes** |
 | `UNUSED` | manual-dispatch workflow never invoked — idle by design | no |
+| `ON_CHANGE_ONLY` | path-filtered, unscheduled, every run passed — its subject was quiet | no |
 
 `SILENT` is the one that was invisible. Runs *exist*, so the pipeline looks alive; none of them win.
 A checker that only asked *"did it run?"* would have said yes every day for five weeks.
@@ -42,6 +43,22 @@ A checker that only asked *"did it run?"* would have said yes every day for five
 as DEAD; they had simply never been invoked. **A checker that cries wolf gets muted, and a muted
 control is exactly the dead control this was built to find** — so precision here is load-bearing,
 not politeness.
+
+## Path-filtered controls — quiet is not broken, and it is still worth saying
+
+A workflow gated on `paths:` fires only when **its own files change**. A long gap means its subject
+was quiet, not that it is broken — so calling it `STALE` is a **false positive**, and false
+positives are how a checker gets muted.
+
+But there is a real finding underneath, and `ON_CHANGE_ONLY` exists to say it:
+
+> **A path-filtered control validates on change and never re-validates.** If the environment drifts
+> underneath it — a dependency, a runtime version, a schema it consumes — nothing re-runs it, and it
+> will keep standing behind the last answer it gave.
+
+For a *security* control that matters. `Browser Runtime Boundary` and `Policy Engine Validation`
+are both path-filtered and unscheduled: healthy, every run green, and unable to notice the world
+changing around them. **Adding a `schedule:` makes them re-validate on time as well as on change.**
 
 ## Dead or dormant — the distinction the verdicts exist for
 

--- a/tools/ci_liveness_escalate.py
+++ b/tools/ci_liveness_escalate.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Escalation — the half that makes a finding land on someone.
+
+`ci_liveness_sweep.py` measures. This raises.
+
+In John 11 both sisters send word, and they do different things. **Martha** goes out to meet him,
+reports, and makes the measurement — *"he stinketh, for he hath been dead four days"*: observed,
+dated, quantified. And after her report he **stayed two more days**. **Mary** waits until she is
+called, and when she comes she falls at his feet and weeps — and that is the hinge. *"When Jesus
+saw her weeping... he groaned in the spirit."* Then, and not before: *"Where have ye laid him?"*
+
+    MARTHA IS DETECTION. MARY IS ESCALATION.
+    Information did not raise anyone. Grief that landed on someone did.
+
+A sweep that prints to stderr and exits non-zero is all Martha. If nobody runs it, or runs it and
+reads past it, nothing happens — which is precisely how this estate accumulated a stranded-work
+register: findings were made, and then they sat.
+
+So this writes a durable, addressed, self-updating artifact — a GitHub issue per repo — and:
+
+  * **is idempotent.** It updates one issue per repo rather than filing a new one each sweep.
+    Alarm spam is how a channel gets muted, and a muted channel is a dead control.
+
+  * **ESCALATES WITH AGE.** This is the load-bearing property. A finding that has been seen and not
+    acted on gets *louder*, never quieter. The natural failure of any monitoring system is that an
+    old alarm becomes furniture — so silence that persists must become harder to ignore, not
+    easier. Grief that does not resolve escalates.
+
+  * **CLOSES ITSELF when the pipeline is green again.** The mourning ends at the raising. An issue
+    that stays open after the fact is noise, and noise is what taught everyone to stop reading.
+
+stdlib + `gh`.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+MARKER = "<!-- ci-liveness-sweep: do not remove; this issue is updated in place -->"
+
+# Escalation ladder. The point is that sitting still moves you DOWN this table.
+TIERS = [
+    (90, "P0", "ci-liveness:P0", "ninety days silent — treat as an outage that nobody declared"),
+    (60, "P1", "ci-liveness:P1", "two months silent"),
+    (30, "P2", "ci-liveness:P2", "one month silent"),
+    (0,  "P3", "ci-liveness:P3", "recently silent"),
+]
+
+
+def tier_for(max_age_days: int) -> tuple[str, str, str]:
+    for threshold, sev, label, phrase in TIERS:
+        if max_age_days >= threshold:
+            return sev, label, phrase
+    return "P3", "ci-liveness:P3", "recently silent"
+
+
+def _gh(args: list[str], check: bool = True) -> str:
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if check and proc.returncode != 0:
+        raise RuntimeError(f"gh {' '.join(args[:3])}… failed: {proc.stderr.strip()[:200]}")
+    return proc.stdout
+
+
+def find_issue(repo: str) -> dict | None:
+    """The one issue this tool owns for a repo, found by its marker rather than by title —
+    titles change as severity escalates."""
+    out = _gh(["issue", "list", "--repo", repo, "--state", "open", "--limit", "100",
+               "--json", "number,title,body"], check=False)
+    try:
+        for issue in json.loads(out or "[]"):
+            if MARKER in (issue.get("body") or ""):
+                return issue
+    except json.JSONDecodeError:
+        return None
+    return None
+
+
+def age_days(why: str) -> int:
+    """Pull the age out of the sweep's own reason string. Absent an age, treat as maximally old:
+    a verdict we cannot date is not a verdict we may discount."""
+    import re
+    m = re.search(r"(\d+)d ago", why)
+    if m:
+        return int(m.group(1))
+    return 9999 if "never" in why else 0
+
+
+def render(repo: str, alarms: list[dict], window_days: int) -> tuple[str, str, str]:
+    worst = max((age_days(a["why"]) for a in alarms), default=0)
+    sev, label, phrase = tier_for(worst)
+    shown = "never green" if worst >= 9999 else f"{worst}d"
+    title = f"[{sev}] CI liveness: {len(alarms)} workflow(s) not green in {repo} (worst: {shown})"
+
+    lines = [MARKER, "",
+             f"**{len(alarms)} workflow(s) have not completed successfully inside the "
+             f"{window_days}-day window** — {phrase}.", "",
+             "A red build is information. A build that never runs produces the same observable as "
+             "a passing build: no reported failures. This issue exists so that absence has an "
+             "address.", "",
+             "| workflow | verdict | detail |", "|---|---|---|"]
+    for a in sorted(alarms, key=lambda x: -age_days(x["why"])):
+        lines.append(f"| `{a['workflow']}` | **{a['verdict']}** | {a['why']} |")
+    lines += ["",
+              "### This issue escalates",
+              "",
+              "It is updated in place by `tools/ci_liveness_sweep.py` + `ci_liveness_escalate.py`, "
+              "and its severity **rises with the age of the silence**. A finding that is seen and "
+              "not acted on gets louder, never quieter — the natural failure of monitoring is that "
+              "an old alarm becomes furniture.",
+              "",
+              "**It closes itself** once every workflow here is green again. The mourning ends at "
+              "the raising.",
+              "", "See `docs/CI_LIVENESS.md`."]
+    return title, "\n".join(lines), label
+
+
+def escalate(repo: str, alarms: list[dict], window_days: int, *, dry_run: bool = False) -> str:
+    existing = find_issue(repo)
+
+    if not alarms:
+        if existing and not dry_run:
+            _gh(["issue", "comment", str(existing["number"]), "--repo", repo,
+                 "--body", "All swept workflows are green again — closing. The mourning ends at "
+                           "the raising."], check=False)
+            _gh(["issue", "close", str(existing["number"]), "--repo", repo], check=False)
+            return f"{repo}: RESOLVED — closed #{existing['number']}"
+        return f"{repo}: green, nothing to raise"
+
+    title, body, label = render(repo, alarms, window_days)
+    if dry_run:
+        return f"{repo}: would {'update #' + str(existing['number']) if existing else 'open'} — {title}"
+
+    if existing:
+        _gh(["issue", "edit", str(existing["number"]), "--repo", repo,
+             "--title", title, "--body", body], check=False)
+        _gh(["issue", "edit", str(existing["number"]), "--repo", repo,
+             "--add-label", label], check=False)
+        return f"{repo}: updated #{existing['number']} — {title}"
+
+    out = _gh(["issue", "create", "--repo", repo, "--title", title, "--body", body], check=False)
+    return f"{repo}: opened — {out.strip().splitlines()[-1] if out.strip() else title}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="ci_liveness_escalate",
+        description="Turn a sweep result into an addressed, self-updating, escalating issue.")
+    ap.add_argument("--sweep-json", required=True,
+                    help="output of `ci_liveness_sweep.py --json` ('-' for stdin)")
+    ap.add_argument("--dry-run", action="store_true")
+    a = ap.parse_args(argv)
+
+    raw = sys.stdin.read() if a.sweep_json == "-" else open(a.sweep_json).read()
+    data = json.loads(raw)
+    window = data.get("window_days", 14)
+
+    by_repo: dict[str, list[dict]] = {}
+    for r in data.get("results", []):
+        by_repo.setdefault(r["repo"], [])
+    for r in data.get("alarms", []):
+        by_repo.setdefault(r["repo"], []).append(r)
+
+    for repo, alarms in sorted(by_repo.items()):
+        print("  " + escalate(repo, alarms, window, dry_run=a.dry_run), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci_liveness_escalate.py
+++ b/tools/ci_liveness_escalate.py
@@ -117,14 +117,20 @@ def render(repo: str, alarms: list[dict], window_days: int) -> tuple[str, str, s
 
 
 def escalate(repo: str, alarms: list[dict], window_days: int, *, dry_run: bool = False) -> str:
+    """Note: the mutating `_gh` calls below deliberately do NOT pass `check=False`. A failed
+    issue write (bad scope, rate limit, repo renamed) used to be swallowed here — the sweep
+    would report alarms, the write to make them land on someone would silently no-op, and the
+    workflow would still finish green. That is the exact "silence looks like health" failure
+    this tool exists to catch, recreated one level up in its own runner status. Now a write
+    failure raises RuntimeError, which main() turns into a non-zero exit."""
     existing = find_issue(repo)
 
     if not alarms:
         if existing and not dry_run:
             _gh(["issue", "comment", str(existing["number"]), "--repo", repo,
                  "--body", "All swept workflows are green again — closing. The mourning ends at "
-                           "the raising."], check=False)
-            _gh(["issue", "close", str(existing["number"]), "--repo", repo], check=False)
+                           "the raising."])
+            _gh(["issue", "close", str(existing["number"]), "--repo", repo])
             return f"{repo}: RESOLVED — closed #{existing['number']}"
         return f"{repo}: green, nothing to raise"
 
@@ -134,12 +140,12 @@ def escalate(repo: str, alarms: list[dict], window_days: int, *, dry_run: bool =
 
     if existing:
         _gh(["issue", "edit", str(existing["number"]), "--repo", repo,
-             "--title", title, "--body", body], check=False)
+             "--title", title, "--body", body])
         _gh(["issue", "edit", str(existing["number"]), "--repo", repo,
-             "--add-label", label], check=False)
+             "--add-label", label])
         return f"{repo}: updated #{existing['number']} — {title}"
 
-    out = _gh(["issue", "create", "--repo", repo, "--title", title, "--body", body], check=False)
+    out = _gh(["issue", "create", "--repo", repo, "--title", title, "--body", body])
     return f"{repo}: opened — {out.strip().splitlines()[-1] if out.strip() else title}"
 
 
@@ -162,8 +168,18 @@ def main(argv: list[str] | None = None) -> int:
     for r in data.get("alarms", []):
         by_repo.setdefault(r["repo"], []).append(r)
 
+    failed: list[str] = []
     for repo, alarms in sorted(by_repo.items()):
-        print("  " + escalate(repo, alarms, window, dry_run=a.dry_run), file=sys.stderr)
+        try:
+            print("  " + escalate(repo, alarms, window, dry_run=a.dry_run), file=sys.stderr)
+        except RuntimeError as exc:
+            failed.append(repo)
+            print(f"  {repo}: ESCALATION WRITE FAILED — {exc}", file=sys.stderr)
+
+    if failed:
+        print(f"escalate: failed to write for {len(failed)} repo(s): {', '.join(failed)} — "
+              f"the finding did NOT land; this must not exit 0.", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/tools/ci_liveness_sweep.py
+++ b/tools/ci_liveness_sweep.py
@@ -50,7 +50,16 @@ from datetime import datetime, timedelta, timezone
 
 DEFAULT_WINDOW_DAYS = 14
 
-OK, STALE, SILENT, DEAD, UNUSED = "OK", "STALE", "SILENT", "DEAD", "UNUSED"
+OK, STALE, SILENT, DEAD, UNUSED, ON_CHANGE = ("OK", "STALE", "SILENT", "DEAD", "UNUSED",
+                                              "ON_CHANGE_ONLY")
+# ON_CHANGE_ONLY is deliberately NOT an alarm either, and it is a real finding all the same.
+# A path-filtered workflow fires only when ITS OWN files change, so a long gap means its subject
+# was quiet — not that it is broken. Calling that STALE is a false positive, and false positives
+# are how a checker gets muted. But it is worth SAYING, because such a control never re-validates:
+# if the environment drifts underneath it — a dependency, a runtime version, a schema it consumes —
+# nothing re-runs it, and it will keep reporting the last answer it gave. A security control that
+# only validates on change should carry a `schedule:` so it re-validates on time as well.
+#
 # UNUSED is deliberately NOT an alarm. A dispatch-only workflow nobody has invoked is not broken,
 # and a checker that cries wolf gets muted — which makes it exactly the dead control it was built
 # to find. Precision here is what keeps the signal worth reading.
@@ -87,6 +96,18 @@ AUTO_TRIGGERS = ("push", "pull_request", "schedule", "release", "pull_request_ta
                  "merge_group", "workflow_call")
 
 
+def trigger_shape(repo: str, path: str) -> tuple[bool, bool]:
+    """(path_filtered, scheduled) read from the workflow's own trigger block."""
+    try:
+        content = _gh(["api", f"repos/{repo}/contents/{path}", "--jq", ".content"])
+        import base64
+        text = base64.b64decode(content).decode("utf-8", "replace")
+    except Exception:
+        return False, False
+    head = text.split("jobs:", 1)[0]
+    return ("paths:" in head or "paths-ignore:" in head), ("schedule:" in head)
+
+
 def is_dispatch_only(repo: str, path: str) -> bool:
     """True when a workflow's only triggers are manual. Such a workflow not having run is a fact
     about usage, not about health — and calling it DEAD would train people to ignore this tool."""
@@ -118,7 +139,8 @@ def last_run(repo: str, workflow_id: int) -> dict | None:
 
 
 def classify(success_at: str | None, latest: dict | None, *, window_days: int,
-             now: datetime | None = None, dispatch_only: bool = False) -> tuple[str, str]:
+             now: datetime | None = None, dispatch_only: bool = False,
+             path_filtered: bool = False, scheduled: bool = False) -> tuple[str, str]:
     """Return (verdict, why). The polarity is deliberate: we require green RECENTLY.
 
     `dispatch_only` marks a workflow whose only trigger is `workflow_dispatch` (or
@@ -145,6 +167,12 @@ def classify(success_at: str | None, latest: dict | None, *, window_days: int,
     if dispatch_only:
         return UNUSED, (f"manual-dispatch workflow, last invoked {(now - succeeded).days}d ago — "
                         "idle by design, not stale")
+    if path_filtered and not scheduled:
+        return ON_CHANGE, (
+            f"path-filtered and unscheduled; last green {(now - succeeded).days}d ago and every run "
+            "has passed — its subject was quiet, so this is NOT broken. But it only validates on "
+            "change and never re-validates: add a `schedule:` so environment drift cannot pass "
+            "unnoticed underneath it")
 
     age = (now - succeeded).days
     if latest is not None:
@@ -176,8 +204,14 @@ def sweep(repos: list[str], *, window_days: int = DEFAULT_WINDOW_DAYS,
             # only pay for the file read when the answer could change the verdict
             dispatch_only = (is_dispatch_only(repo, wf["path"])
                              if (success_at is None or latest is None) and wf.get("path") else False)
+            # only read the trigger block when it could change the verdict (i.e. we are about to
+            # call something stale)
+            path_filtered = scheduled = False
+            if success_at and wf.get("path") and not dispatch_only:
+                path_filtered, scheduled = trigger_shape(repo, wf["path"])
             verdict, why = classify(success_at, latest, window_days=window_days, now=now,
-                                    dispatch_only=dispatch_only)
+                                    dispatch_only=dispatch_only, path_filtered=path_filtered,
+                                    scheduled=scheduled)
             results.append({"repo": repo, "workflow": wf["name"], "path": wf.get("path"),
                             "verdict": verdict, "why": why})
     return results

--- a/tools/ci_liveness_sweep.py
+++ b/tools/ci_liveness_sweep.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""CI liveness — the dead-man's switch for the estate's pipelines.
+
+`controls_census.py` already names the property this enforces: *meta-monitored — something alerts
+if the control itself stops (the check checks the checker)*. It applies that to in-cluster CronJobs
+and to the `tools/` validators wired into `make validate`. It does not look at the CI workflows
+themselves, and that is exactly where the estate lost five weeks.
+
+**The case this exists for.** `SourceOS-Linux/goose-notes` CI reported `startup_failure` in 0s on
+every branch from 2026-07-01 to 2026-08-04 — a disallowed action in the workflow meant GitHub
+refused to start the run at all. `main` did not compile for five weeks and nothing said so, because:
+
+    a red build is information.
+    A BUILD THAT NEVER RUNS PRODUCES THE SAME OBSERVABLE AS A PASSING BUILD: no reported failures.
+
+No alerting rule fires on that. No self-healing loop triggers on it either — healing is downstream
+of detection, and this class of failure kills detection itself. You cannot heal what was never
+observed to be sick.
+
+**So this inverts the polarity.** It does not wait for red. It requires *green, recently*:
+
+    for every repo, for every workflow — when did it last COMPLETE SUCCESSFULLY?
+
+Staleness becomes the alarm, which makes silence a positive signal instead of a null one. That is
+the same shape as the rest of the estate's fail-closed controls: absence of a marker is not
+permission, an undecidable invariant is not a pass, unstated authority is not independence — and
+here, **no news is not good news**.
+
+Three verdicts, and the middle one is the one that was invisible:
+
+    DEAD   never completed successfully, ever. The pipeline has never worked.
+    SILENT ran recently but has not SUCCEEDED inside the window — includes the goose-notes
+           signature, where runs exist and all of them are `startup_failure` at 0s.
+    STALE  succeeded once, but not inside the window. Either abandoned or quietly broken.
+
+Self-excluding by construction: this sweep reads the GitHub API and asserts nothing about itself.
+Whatever schedules it must be watched by something else — the recursion has to bottom out in
+something trusted by construction rather than by monitoring, or you have merely added one more
+daemon that can die quietly. See `docs/CI_LIVENESS.md`.
+
+stdlib + `gh`.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+
+DEFAULT_WINDOW_DAYS = 14
+
+OK, STALE, SILENT, DEAD, UNUSED = "OK", "STALE", "SILENT", "DEAD", "UNUSED"
+# UNUSED is deliberately NOT an alarm. A dispatch-only workflow nobody has invoked is not broken,
+# and a checker that cries wolf gets muted — which makes it exactly the dead control it was built
+# to find. Precision here is what keeps the signal worth reading.
+ALARM_VERDICTS = (STALE, SILENT, DEAD)
+
+
+class SweepError(RuntimeError):
+    pass
+
+
+def _gh(args: list[str]) -> str:
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise SweepError(f"gh {' '.join(args)} failed: {proc.stderr.strip()[:200]}")
+    return proc.stdout
+
+
+def list_workflows(repo: str) -> list[dict]:
+    """Active workflows for a repo. A disabled workflow is not a liveness concern."""
+    out = _gh(["api", f"repos/{repo}/actions/workflows", "--paginate",
+               "--jq", ".workflows[] | {id, name, state, path}"])
+    return [json.loads(line) for line in out.splitlines() if line.strip()]
+
+
+def last_success(repo: str, workflow_id: int) -> str | None:
+    """ISO timestamp of the most recent SUCCESSFUL completion, or None if there has never been one."""
+    out = _gh(["api",
+               f"repos/{repo}/actions/workflows/{workflow_id}/runs?status=success&per_page=1",
+               "--jq", ".workflow_runs[0].updated_at // empty"]).strip()
+    return out or None
+
+
+AUTO_TRIGGERS = ("push", "pull_request", "schedule", "release", "pull_request_target",
+                 "merge_group", "workflow_call")
+
+
+def is_dispatch_only(repo: str, path: str) -> bool:
+    """True when a workflow's only triggers are manual. Such a workflow not having run is a fact
+    about usage, not about health — and calling it DEAD would train people to ignore this tool."""
+    try:
+        content = _gh(["api", f"repos/{repo}/contents/{path}", "--jq", ".content"])
+    except SweepError:
+        return False   # fail closed: if we cannot read it, do not grant it the benign verdict
+    import base64
+    try:
+        text = base64.b64decode(content).decode("utf-8", "replace")
+    except Exception:
+        return False
+    head = text.split("jobs:", 1)[0]
+    return ("dispatch" in head) and not any(f"{t}:" in head for t in AUTO_TRIGGERS)
+
+
+def last_run(repo: str, workflow_id: int) -> dict | None:
+    """The most recent run of any conclusion — used to tell DEAD from SILENT."""
+    out = _gh(["api", f"repos/{repo}/actions/workflows/{workflow_id}/runs?per_page=1",
+               # `// empty` MUST bind before the object is constructed: `{a,b} // empty` builds
+               # {a:null,b:null} from a null run — a truthy object — so "no runs at all" would be
+               # misreported as "a run with no conclusion". Filter the null FIRST.
+               "--jq", ".workflow_runs[0] // empty | {conclusion, updated_at}"]).strip()
+    if not out:
+        return None
+    latest = json.loads(out)
+    # a run row without a timestamp is not a run we can reason about
+    return latest if latest.get("updated_at") else None
+
+
+def classify(success_at: str | None, latest: dict | None, *, window_days: int,
+             now: datetime | None = None, dispatch_only: bool = False) -> tuple[str, str]:
+    """Return (verdict, why). The polarity is deliberate: we require green RECENTLY.
+
+    `dispatch_only` marks a workflow whose only trigger is `workflow_dispatch` (or
+    `repository_dispatch`). Those do not run on their own, so "never ran" means "never invoked",
+    which is a fact about usage rather than about health.
+    """
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=window_days)
+
+    if success_at is None:
+        if latest is None:
+            if dispatch_only:
+                return UNUSED, "manual-dispatch workflow that has never been invoked — unused, not broken"
+            return DEAD, "no runs at all — the workflow has never executed"
+        concl = latest.get("conclusion")
+        if concl is None:
+            return UNUSED, "most recent run is still in progress and there is no prior success yet"
+        return DEAD, (f"never completed successfully; most recent run concluded {concl!r} — "
+                      "a pipeline that has never worked")
+
+    succeeded = datetime.fromisoformat(success_at.replace("Z", "+00:00"))
+    if succeeded >= cutoff:
+        return OK, f"last green {succeeded.date()}"
+    if dispatch_only:
+        return UNUSED, (f"manual-dispatch workflow, last invoked {(now - succeeded).days}d ago — "
+                        "idle by design, not stale")
+
+    age = (now - succeeded).days
+    if latest is not None:
+        latest_at = datetime.fromisoformat(latest["updated_at"].replace("Z", "+00:00"))
+        if latest_at >= cutoff:
+            # It is running. It is just never winning. This is the signature that hid for five
+            # weeks: runs exist, so the pipeline LOOKS alive, and none of them succeed.
+            return SILENT, (f"running but not succeeding — last green {age}d ago "
+                            f"({succeeded.date()}), most recent run {latest.get('conclusion')!r}")
+    return STALE, f"last green {age}d ago ({succeeded.date()}), outside the {window_days}d window"
+
+
+def sweep(repos: list[str], *, window_days: int = DEFAULT_WINDOW_DAYS,
+          now: datetime | None = None) -> list[dict]:
+    results = []
+    for repo in repos:
+        try:
+            workflows = list_workflows(repo)
+        except SweepError as e:
+            # Fail closed: a repo we cannot see is not a repo we can vouch for.
+            results.append({"repo": repo, "workflow": "*", "verdict": DEAD,
+                            "why": f"could not enumerate workflows: {e}"})
+            continue
+        for wf in workflows:
+            if wf.get("state") != "active":
+                continue
+            success_at = last_success(repo, wf["id"])
+            latest = last_run(repo, wf["id"])
+            # only pay for the file read when the answer could change the verdict
+            dispatch_only = (is_dispatch_only(repo, wf["path"])
+                             if (success_at is None or latest is None) and wf.get("path") else False)
+            verdict, why = classify(success_at, latest, window_days=window_days, now=now,
+                                    dispatch_only=dispatch_only)
+            results.append({"repo": repo, "workflow": wf["name"], "path": wf.get("path"),
+                            "verdict": verdict, "why": why})
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="ci_liveness_sweep",
+        description="Require green RECENTLY. Alarm on staleness, not on failure.")
+    ap.add_argument("repos", nargs="*", help="owner/repo (repeatable)")
+    ap.add_argument("--repos-file", help="file with one owner/repo per line")
+    ap.add_argument("--window-days", type=int, default=DEFAULT_WINDOW_DAYS)
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--fail-on-alarm", action="store_true",
+                    help="exit non-zero when any workflow is DEAD/SILENT/STALE (use in CI)")
+    a = ap.parse_args(argv)
+
+    repos = list(a.repos)
+    if a.repos_file:
+        repos += [ln.strip() for ln in open(a.repos_file) if ln.strip() and not ln.startswith("#")]
+    if not repos:
+        ap.error("no repos given")
+
+    results = sweep(repos, window_days=a.window_days)
+    alarms = [r for r in results if r["verdict"] in ALARM_VERDICTS]
+
+    if a.json:
+        print(json.dumps({"ok": not alarms, "window_days": a.window_days,
+                          "checked": len(results), "alarms": alarms, "results": results}, indent=2))
+    else:
+        for r in sorted(results, key=lambda x: (x["verdict"] == OK, x["repo"])):
+            mark = "✓" if r["verdict"] == OK else "✗"
+            print(f"  {mark} [{r['verdict']:6}] {r['repo']} :: {r['workflow']} — {r['why']}",
+                  file=sys.stderr)
+        print(f"\nci liveness: {len(results)} workflow(s) checked, {len(alarms)} alarming "
+              f"(window {a.window_days}d)", file=sys.stderr)
+        if alarms:
+            print("A pipeline that never runs looks exactly like a pipeline with nothing to say.",
+                  file=sys.stderr)
+    return 1 if (alarms and a.fail_on_alarm) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/test_ci_liveness_escalate.py
+++ b/tools/tests/test_ci_liveness_escalate.py
@@ -1,7 +1,11 @@
 """Martha measures; Mary escalates. These test the escalating half."""
+import json
+import subprocess
+from types import SimpleNamespace
+
 import pytest
 
-from tools.ci_liveness_escalate import MARKER, age_days, render, tier_for
+from tools.ci_liveness_escalate import MARKER, age_days, escalate, main, render, tier_for
 
 
 def alarm(workflow, why, verdict="STALE"):
@@ -74,3 +78,52 @@ def test_every_alarm_appears_in_the_table():
     _, body, _ = render("o/r", alarms, 14)
     for a in alarms:
         assert f"`{a['workflow']}`" in body
+
+
+def _fake_gh_that_fails_writes(args, capture_output, text):
+    """`gh issue list` (a read) succeeds with no existing issue; every mutating call
+    (create/edit/comment/close) fails, as if the token lacked `issues: write` or hit a
+    rate limit."""
+    if "list" in args:
+        return SimpleNamespace(returncode=0, stdout="[]", stderr="")
+    return SimpleNamespace(returncode=1, stdout="", stderr="HTTP 403: Resource not accessible")
+
+
+def test_a_failed_issue_write_raises_instead_of_reporting_success(monkeypatch):
+    """The gap this closes: escalate() used to call every mutating `gh` invocation with
+    check=False. A real write failure (bad token scope, rate limit, renamed repo) was
+    swallowed — the function returned an "opened"/"updated" string regardless, so the sweep
+    found an alarm, tried to make it land on someone, silently failed to, and reported
+    success. That is exactly the 'silence looks like health' pattern this whole tool exists
+    to catch, recreated one level up inside itself. A write failure must raise."""
+    monkeypatch.setattr(subprocess, "run", _fake_gh_that_fails_writes)
+    with pytest.raises(RuntimeError):
+        escalate("o/r", [alarm("CI", "last green 20d ago")], 14)
+
+
+def test_main_exits_nonzero_when_an_escalation_write_fails(monkeypatch, tmp_path):
+    monkeypatch.setattr(subprocess, "run", _fake_gh_that_fails_writes)
+    sweep_json = tmp_path / "sweep.json"
+    sweep_json.write_text(json.dumps({
+        "window_days": 14,
+        "results": [{"repo": "o/r"}],
+        "alarms": [alarm("CI", "last green 20d ago")],
+    }))
+    rc = main(["--sweep-json", str(sweep_json)])
+    assert rc == 1, "a repo whose escalation issue failed to write must not exit 0"
+
+
+def test_main_still_succeeds_when_writes_succeed(monkeypatch, tmp_path):
+    """Guards against over-correcting: a clean run (writes succeed, or there's nothing to
+    write because the repo is green) must still exit 0."""
+    def fake_ok(args, capture_output, text):
+        return SimpleNamespace(returncode=0, stdout="[]", stderr="")
+    monkeypatch.setattr(subprocess, "run", fake_ok)
+    sweep_json = tmp_path / "sweep.json"
+    sweep_json.write_text(json.dumps({
+        "window_days": 14,
+        "results": [{"repo": "o/r"}],
+        "alarms": [],
+    }))
+    rc = main(["--sweep-json", str(sweep_json)])
+    assert rc == 0

--- a/tools/tests/test_ci_liveness_escalate.py
+++ b/tools/tests/test_ci_liveness_escalate.py
@@ -1,0 +1,76 @@
+"""Martha measures; Mary escalates. These test the escalating half."""
+import pytest
+
+from tools.ci_liveness_escalate import MARKER, age_days, render, tier_for
+
+
+def alarm(workflow, why, verdict="STALE"):
+    return {"repo": "o/r", "workflow": workflow, "verdict": verdict, "why": why}
+
+
+def test_severity_rises_with_the_age_of_the_silence():
+    """The load-bearing property: sitting still makes a finding LOUDER, never quieter."""
+    assert tier_for(5)[0] == "P3"
+    assert tier_for(31)[0] == "P2"
+    assert tier_for(61)[0] == "P1"
+    assert tier_for(91)[0] == "P0"
+
+
+def test_severity_is_monotone_in_age():
+    order = {"P3": 0, "P2": 1, "P1": 2, "P0": 3}
+    ages = [1, 15, 30, 45, 60, 75, 90, 200]
+    sevs = [order[tier_for(a)[0]] for a in ages]
+    assert sevs == sorted(sevs), "an older silence must never be quieter"
+
+
+def test_a_never_green_workflow_outranks_any_age():
+    assert age_days("never completed successfully; most recent run concluded 'failure'") == 9999
+    assert tier_for(age_days("never completed successfully"))[0] == "P0"
+
+
+def test_an_undateable_verdict_is_treated_as_maximally_old():
+    """A verdict we cannot date is not a verdict we may discount."""
+    assert age_days("never executed") == 9999
+
+
+def test_age_is_read_from_the_sweep_reason():
+    assert age_days("last green 67d ago (2026-05-29), outside the 14d window") == 67
+
+
+def test_the_issue_carries_a_marker_so_it_is_updated_not_duplicated():
+    """Alarm spam mutes a channel, and a muted channel is a dead control."""
+    _, body, _ = render("o/r", [alarm("CI", "last green 20d ago")], 14)
+    assert MARKER in body
+
+
+def test_the_title_names_severity_and_the_worst_age():
+    title, _, label = render("o/r", [alarm("CI", "last green 67d ago"),
+                                     alarm("Lint", "last green 3d ago")], 14)
+    assert title.startswith("[P1]")
+    assert "67d" in title
+    assert label == "ci-liveness:P1"
+
+
+def test_the_worst_workflow_is_listed_first():
+    _, body, _ = render("o/r", [alarm("recent", "last green 3d ago"),
+                                alarm("ancient", "last green 80d ago")], 14)
+    assert body.index("`ancient`") < body.index("`recent`")
+
+
+def test_the_body_states_why_absence_needs_an_address():
+    _, body, _ = render("o/r", [alarm("CI", "last green 20d ago")], 14)
+    assert "same observable as a passing build" in body
+    assert "absence has an address" in body
+
+
+def test_it_promises_to_close_itself():
+    """An issue that outlives its cause is noise, and noise is what taught everyone to stop reading."""
+    _, body, _ = render("o/r", [alarm("CI", "last green 20d ago")], 14)
+    assert "closes itself" in body
+
+
+def test_every_alarm_appears_in_the_table():
+    alarms = [alarm(f"wf{i}", f"last green {i * 10}d ago") for i in range(1, 5)]
+    _, body, _ = render("o/r", alarms, 14)
+    for a in alarms:
+        assert f"`{a['workflow']}`" in body

--- a/tools/tests/test_ci_liveness_sweep.py
+++ b/tools/tests/test_ci_liveness_sweep.py
@@ -1,0 +1,121 @@
+"""The classifier must catch the failure that actually happened, not just the obvious one."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tools.ci_liveness_sweep import DEAD, OK, SILENT, STALE, classify
+
+NOW = datetime(2026, 8, 4, tzinfo=timezone.utc)
+
+
+def iso(days_ago: int) -> str:
+    return (NOW - timedelta(days=days_ago)).isoformat().replace("+00:00", "Z")
+
+
+def run(conclusion: str, days_ago: int) -> dict:
+    return {"conclusion": conclusion, "updated_at": iso(days_ago)}
+
+
+def test_recent_green_is_ok():
+    v, _ = classify(iso(2), run("success", 2), window_days=14, now=NOW)
+    assert v == OK
+
+
+def test_the_goose_notes_case_is_SILENT_not_ok():
+    """The five-week failure: runs EXIST so the pipeline looks alive, and none of them succeed.
+
+    goose-notes CI reported `startup_failure` in 0s on every push from 2026-07-01. A checker that
+    only asked "did it run?" would have said yes every single day.
+    """
+    v, why = classify(iso(34), run("startup_failure", 0), window_days=14, now=NOW)
+    assert v == SILENT
+    assert "not succeeding" in why
+
+
+def test_a_pipeline_that_never_worked_is_DEAD():
+    v, why = classify(None, run("failure", 1), window_days=14, now=NOW)
+    assert v == DEAD
+    assert "never completed successfully" in why
+
+
+def test_no_runs_at_all_is_DEAD():
+    v, why = classify(None, None, window_days=14, now=NOW)
+    assert v == DEAD
+    assert "never executed" in why
+
+
+def test_abandoned_but_once_green_is_STALE():
+    """Succeeded long ago, nothing since — quietly abandoned rather than actively broken."""
+    v, why = classify(iso(90), run("success", 90), window_days=14, now=NOW)
+    assert v == STALE
+    assert "90d ago" in why
+
+
+def test_green_exactly_at_the_window_edge_is_ok():
+    v, _ = classify(iso(14), run("success", 14), window_days=14, now=NOW)
+    assert v == OK
+
+
+def test_one_day_past_the_window_alarms():
+    v, _ = classify(iso(15), run("success", 15), window_days=14, now=NOW)
+    assert v in (STALE, SILENT)
+
+
+def test_a_recent_failure_does_not_mask_a_recent_success():
+    """Red today is fine if green happened inside the window — this alarms on ABSENCE of green,
+    not on presence of red. Flaky is a different problem from dead."""
+    v, _ = classify(iso(3), run("failure", 0), window_days=14, now=NOW)
+    assert v == OK
+
+
+def test_every_alarm_states_a_reason():
+    for args in [(None, None), (None, run("failure", 1)),
+                 (iso(34), run("startup_failure", 0)), (iso(90), run("success", 90))]:
+        v, why = classify(*args, window_days=14, now=NOW)
+        assert v != OK and len(why) > 20, args
+
+
+# --- precision: a checker that cries wolf gets muted, and a muted control is a dead one --------
+
+def test_a_never_invoked_dispatch_workflow_is_UNUSED_not_dead():
+    from tools.ci_liveness_sweep import UNUSED
+    v, why = classify(None, None, window_days=14, now=NOW, dispatch_only=True)
+    assert v == UNUSED and "not broken" in why
+
+
+def test_a_never_invoked_AUTOMATIC_workflow_is_still_DEAD():
+    v, _ = classify(None, None, window_days=14, now=NOW, dispatch_only=False)
+    assert v == DEAD
+
+
+def test_a_dispatch_workflow_that_FAILED_is_still_DEAD():
+    """Never invoked is benign. Invoked and never succeeded is not."""
+    v, why = classify(None, run("failure", 5), window_days=14, now=NOW, dispatch_only=True)
+    assert v == DEAD and "never completed successfully" in why
+
+
+def test_an_idle_dispatch_workflow_is_UNUSED_not_stale():
+    from tools.ci_liveness_sweep import UNUSED
+    v, why = classify(iso(60), run("success", 60), window_days=14, now=NOW, dispatch_only=True)
+    assert v == UNUSED and "idle by design" in why
+
+
+def test_an_in_progress_first_run_is_not_called_dead():
+    from tools.ci_liveness_sweep import UNUSED
+    v, _ = classify(None, {"conclusion": None, "updated_at": iso(0)}, window_days=14, now=NOW)
+    assert v == UNUSED
+
+
+def test_UNUSED_never_alarms():
+    from tools.ci_liveness_sweep import ALARM_VERDICTS, UNUSED
+    assert UNUSED not in ALARM_VERDICTS
+
+
+def test_no_runs_is_never_reported_as_in_progress():
+    """Regression: a jq precedence bug made `{conclusion,updated_at} // empty` build an object from
+    a null run, so 'no runs at all' surfaced as 'a run with no conclusion'. Three BearBrowser
+    signing workflows were misreported as 'still in progress' simultaneously, which is what gave it
+    away. `latest=None` must reach the DEAD/UNUSED branch, never the in-progress one."""
+    v, why = classify(None, None, window_days=14, now=NOW, dispatch_only=False)
+    assert v == DEAD and "never executed" in why
+    assert "in progress" not in why

--- a/tools/tests/test_ci_liveness_sweep.py
+++ b/tools/tests/test_ci_liveness_sweep.py
@@ -119,3 +119,39 @@ def test_no_runs_is_never_reported_as_in_progress():
     v, why = classify(None, None, window_days=14, now=NOW, dispatch_only=False)
     assert v == DEAD and "never executed" in why
     assert "in progress" not in why
+
+
+# --- path-filtered controls: quiet is not broken, but it is worth saying --------------------
+
+def test_a_path_filtered_workflow_that_always_passed_is_not_stale():
+    """BearBrowser's Browser Runtime Boundary: every run succeeded, and it had not fired in 67 days
+    because nobody touched its paths. Calling that STALE is a false positive, and false positives
+    are how a checker gets muted."""
+    from tools.ci_liveness_sweep import ON_CHANGE
+    v, why = classify(iso(67), run("success", 67), window_days=14, now=NOW, path_filtered=True)
+    assert v == ON_CHANGE
+    assert "NOT broken" in why
+
+
+def test_but_it_still_names_the_real_gap():
+    """It never re-validates: environment drift passes unnoticed underneath it."""
+    from tools.ci_liveness_sweep import ON_CHANGE
+    _, why = classify(iso(67), run("success", 67), window_days=14, now=NOW, path_filtered=True)
+    assert "never re-validates" in why and "schedule:" in why
+
+
+def test_a_scheduled_path_filtered_workflow_IS_stale_when_silent():
+    """If it has a `schedule:` it should be firing regardless of file changes — so silence is real."""
+    v, _ = classify(iso(67), run("success", 67), window_days=14, now=NOW,
+                    path_filtered=True, scheduled=True)
+    assert v == STALE
+
+
+def test_ON_CHANGE_ONLY_does_not_alarm():
+    from tools.ci_liveness_sweep import ALARM_VERDICTS, ON_CHANGE
+    assert ON_CHANGE not in ALARM_VERDICTS
+
+
+def test_an_unfiltered_workflow_silent_for_months_is_still_stale():
+    v, _ = classify(iso(67), run("success", 67), window_days=14, now=NOW, path_filtered=False)
+    assert v == STALE


### PR DESCRIPTION
## Why

`SourceOS-Linux/goose-notes` CI reported `startup_failure` in **0s** on every branch from 2026-07-01 to 2026-08-04. One disallowed action meant GitHub refused to start the run. **`main` did not compile for five weeks and nothing said so**, because:

> A red build is information. **A build that never runs produces the same observable as a passing build: no reported failures.**

Nothing self-healed it, and nothing could have — **healing is downstream of detection, and this class of failure kills detection itself.**

## Two halves — Martha and Mary

**`ci_liveness_sweep.py` measures.** It doesn't wait for red; it requires **green, recently**: *for every repo, for every active workflow — when did it last complete successfully?* Staleness is the alarm, so silence becomes a positive signal instead of a null one.

**`ci_liveness_escalate.py` raises.** In John 11 both sisters send word and do different things. Martha reports and makes the measurement — *"he stinketh, for he hath been dead four days"* — and after her report **he stayed two more days**. Mary falls at his feet and weeps, and *that* is the hinge. A sweep that prints to stderr is all Martha. So the escalation files **one issue per repo**, **escalates with the age of the silence** (P3 → P2 at 30d → P1 at 60d → P0 at 90d), and **closes itself when the pipeline is green again** — the mourning ends at the raising.

## Verdicts — and the two that exist to prevent crying wolf

| verdict | meaning | alarms |
|---|---|---|
| `OK` | green inside the window | no |
| `STALE` | succeeded once, not inside the window | **yes** |
| `SILENT` | running but **not succeeding** — the goose-notes signature | **yes** |
| `DEAD` | never completed successfully, ever | **yes** |
| `UNUSED` | manual-dispatch, never invoked — idle by design | no |
| `ON_CHANGE_ONLY` | path-filtered, unscheduled, every run passed | no |

**`UNUSED` and `ON_CHANGE_ONLY` are corrections to my own false positives**, and both were worth making: a checker that cries wolf gets muted, and **a muted control is exactly the dead control this was built to find**.

`ON_CHANGE_ONLY` still names a real gap — **a path-filtered control validates on change and never re-validates**, so environment drift passes unnoticed underneath it. It recommends a `schedule:`.

## What the precision bought

First pass: 9 alarms. After removing the false positives: **2 true alarms** — and one of them had been invisible in the noise:

> **`Upstream toolchain drift watchdog` — DEAD. No runs at all. It has never executed.**

A watchdog built to catch drift, which has never once run. Signal quality isn't cosmetic; a noisy control hides the finding that matters.

BearBrowser now reads: 39 workflows, **2 true alarms**, 4 `ON_CHANGE_ONLY` (incl. `Browser Runtime Boundary` and `Policy Engine Validation` — healthy, but never re-validating), 2 `UNUSED`, 31 OK.

## Scheduled, because a tool nobody runs is the defect it was built to find

`.github/workflows/ci-liveness.yml`, daily at 06:23 UTC, escalating by default. **Every action is GitHub-owned** — deliberately, since a disallowed `uses:` is what killed goose-notes. `permissions:` is `contents:read` + `issues:write` and nothing more.

## A bug I found in my own instrument

The jq `{conclusion, updated_at} // empty` **builds an object from a null run** before `//` can fire, so *"no runs at all"* surfaced as *"a run with no conclusion."* Three signing workflows reporting "still in progress" **simultaneously** is what gave it away. Fixed, with a regression test.

## The limit, stated rather than glossed

**This sweep cannot fully watch itself.** prophet-platform is in the swept list so it reports on its own workflows — but if the scheduled workflow stops starting, nothing here notices. The recursion must terminate in something checked by a human or by separate infrastructure, and pretending otherwise would be the same mistake one level up. That's in `docs/CI_LIVENESS.md`.

32 tests.