### PR TITLE
feat(zot): least-privilege `ci-push` identity — CI can push, CI cannot delete

### DIFF
--- a/infra/k8s/zot/README.md
+++ b/infra/k8s/zot/README.md
@@ -21,15 +21,58 @@ without Harbor's Postgres+Redis+jobservice fleet. JFrog rejected as heavy/commer
 Secrets are created out of band, like `minio-credentials`:
 
 1. **`minio-credentials`** (reused for the S3 backend) — already created in `socioprophet`.
-2. **`zot-htpasswd`** — bootstrap `admin` + `ci` users. Create with:
+2. **`zot-htpasswd`** — bootstrap `admin` + `ci-push` users. Create with:
    ```sh
-   # bcrypt htpasswd for admin + ci (use strong, stored passwords)
-   htpasswd -Bbn admin "<ADMIN_PW>"  > /tmp/zot.htpasswd
-   htpasswd -Bbn ci    "<CI_PW>"    >> /tmp/zot.htpasswd
+   # bcrypt htpasswd (use strong, stored passwords)
+   htpasswd -Bbn admin   "<ADMIN_PW>"    > /tmp/zot.htpasswd
+   htpasswd -Bbn ci-push "<CI_PUSH_PW>" >> /tmp/zot.htpasswd
    kubectl create secret generic zot-htpasswd -n socioprophet --from-file=htpasswd=/tmp/zot.htpasswd
    rm /tmp/zot.htpasswd
    ```
-   Persist both passwords in the secret manager. `ci` is the identity CI uses to push images.
+   Persist both passwords in the secret manager.
+
+### `ci-push` — the identity CI uses to push images
+`ci-push` holds `read, create, update` and **NOT `delete`** (see the accessControl block in
+`base/configmap.yaml`). A publishing pipeline needs to push; it has no reason to be able to erase
+production images, so a leaked CI credential cannot empty the registry. Deleting stays with `admin`
+and with zot's own retention/gc, which is what actually reclaims space.
+
+**Adding a user to accessControl grants authorization only** — zot authenticates against this
+htpasswd file, so a user that is not in it gets a 401 on `podman login` no matter what the policy
+says. To add `ci-push` to an EXISTING deployment without disturbing the other users:
+
+```sh
+kubectl get secret zot-htpasswd -n socioprophet -o jsonpath='{.data.htpasswd}' | base64 -d > /tmp/zot.htpasswd
+htpasswd -Bbn ci-push "<CI_PUSH_PW>" >> /tmp/zot.htpasswd
+kubectl create secret generic zot-htpasswd -n socioprophet \
+  --from-file=htpasswd=/tmp/zot.htpasswd --dry-run=client -o yaml | kubectl apply -f -
+rm /tmp/zot.htpasswd
+kubectl rollout restart deployment/zot -n socioprophet    # zot does NOT hot-reload
+```
+
+**Verify the credential locally before putting it in CI** — a wrong password is a 401 you would
+otherwise discover as a red pipeline:
+
+```sh
+podman login registry.socioprophet.ai -u ci-push
+```
+
+Then set it once as an **org** secret (one credential, one rotation point — never a copy per repo):
+
+```sh
+gh secret set ZOT_CI_USERNAME --org SocioProphet --visibility selected \
+  --repos prophet-platform,sociosphere --body ci-push
+gh secret set ZOT_CI_PASSWORD --org SocioProphet --visibility selected \
+  --repos prophet-platform,sociosphere          # no --body → interactive paste, stays out of shell history
+```
+
+**Rotation** is ordered and needs a restart: regenerate the htpasswd entry → apply the secret →
+`kubectl rollout restart deployment/zot` → re-paste the org secret. Doing GitHub first breaks CI;
+doing zot first breaks CI. For zero downtime add a second user, cut CI over, then drop the old one.
+
+> Follow-up (not done here): `ci` and `github-ci` still hold `delete`. Once every pipeline is on
+> `ci-push`, demote or remove them so no CI identity can delete. Left alone in this change because
+> prophet-platform's image pipeline is actively publishing with them.
 
 ## Deploy checklist
 1. Create the `zot-htpasswd` secret (above).

--- a/infra/k8s/zot/base/configmap.yaml
+++ b/infra/k8s/zot/base/configmap.yaml
@@ -8,6 +8,19 @@
 # MinIO bucket unattended: gc reclaims unreferenced blobs (gcDelay/gcInterval), and the retention policy
 # prunes untagged manifests and referrers while KEEPING `latest`, anything pulled within 90 days
 # (2160h), and the 100 most-recently-pushed tags per repo.
+#
+# LEAST-PRIVILEGE PUSH IDENTITY (`ci-push`).
+# A publishing pipeline needs to PUSH; it has no reason to be able to DELETE. `ci` and `github-ci`
+# hold `delete` on `**`, which means a leaked CI credential — or a bug in a workflow — can remove
+# any image in the sovereign registry, including the ones currently serving production. `ci-push`
+# is the credential CI should carry: read + create + update, no delete. Deleting stays with
+# `admin` and with zot's own retention/gc above, which is what actually reclaims space.
+# (This block is JSON, which has no comments, so the reasoning lives here.)
+#
+# Adding a user here grants AUTHORIZATION only. Zot authenticates against the htpasswd file in the
+# `zot-htpasswd` secret, so `ci-push` must also be added there or every login is a 401:
+#   htpasswd -Bbn ci-push "<CI_PUSH_PW>" >> /tmp/zot.htpasswd   # alongside the existing entries
+# and zot must be RESTARTED afterwards — it does not hot-reload this config or the htpasswd file.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -59,7 +72,9 @@ data:
           "repositories": {
             "**": {
               "policies": [
-                { "users": ["admin", "ci", "github-ci"], "actions": ["read", "create", "update", "delete"] },
+                { "users": ["admin"], "actions": ["read", "create", "update", "delete"] },
+                { "users": ["ci-push"], "actions": ["read", "create", "update"] },
+                { "users": ["ci", "github-ci"], "actions": ["read", "create", "update", "delete"] },
                 { "users": ["k8s-pull"], "actions": ["read"] }
               ],
               "defaultPolicy": [],


### PR DESCRIPTION
## Why

`ci` and `github-ci` hold `read, create, update, **delete**` on `**`. A leaked CI credential — or a buggy workflow — can **remove any image in the sovereign registry**, including the ones currently serving production. A publishing pipeline needs to push; it has no reason to erase.

## What

Adds **`ci-push`** with `read, create, update` and **no `delete`**. Deleting stays with `admin` and with zot's own retention/gc, which is what actually reclaims space.

`ci` / `github-ci` are **left untouched on purpose** — prophet-platform's image pipeline is publishing with them right now. Demoting them is the follow-up once every pipeline is on `ci-push`; that note is in the README so it doesn't get lost.

## The half that authorization can't do

accessControl grants **authz**. zot **authenticates** against the htpasswd file — so a user absent from `zot-htpasswd` gets a 401 no matter what the policy says. The README now carries:

- the add-a-user-without-disturbing-the-others recipe
- the required `kubectl rollout restart` (**zot does not hot-reload**)
- **local `podman login` verification before trusting a credential in CI**
- the one-org-secret wiring (one credential, one rotation point — never a per-repo copy)
- the ordered rotation procedure, and how to do it with zero downtime

## Context

sociosphere's first credentialed push **401'd**. zot is healthy — prophet-platform pushed **8/8** zot-targeted images in the same window — and the username resolved correctly, so the stored password for `ci` doesn't match the vault copy. Rather than guess at it, `ci-push` gets a known password **and** least privilege in one step, without touching the credential that currently works.

## Verified

YAML parses and the embedded `config.json` parses; policy block reads:

```
['admin']            -> read, create, update, delete
['ci-push']          -> read, create, update
['ci','github-ci']   -> read, create, update, delete   (unchanged, follow-up)
['k8s-pull']         -> read
```

⚠️ Infra/prod config — needs the htpasswd entry + a zot restart to take effect (both documented).