### PR TITLE
feat(control-plane): Phase 12 — ConsensusArbitrator + LEGEND.md

### DIFF
--- a/.github/workflows/control-plane-phase12.yml
+++ b/.github/workflows/control-plane-phase12.yml
@@ -1,0 +1,34 @@
+name: control-plane-phase12
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'tools/consensus_arbitrator.py'
+      - 'tools/tests/test_consensus_arbitrator.py'
+      - 'docs/WORKSPACE_CONTROL_PLANE_PHASE12.md'
+      - '.github/workflows/control-plane-phase12.yml'
+  pull_request:
+    paths:
+      - 'tools/consensus_arbitrator.py'
+      - 'tools/tests/test_consensus_arbitrator.py'
+      - 'docs/WORKSPACE_CONTROL_PLANE_PHASE12.md'
+      - '.github/workflows/control-plane-phase12.yml'
+
+jobs:
+  control-plane-phase12:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Consensus arbitrator tests
+        run: pytest -q tools/tests/test_consensus_arbitrator.py

--- a/LEGEND.md
+++ b/LEGEND.md
@@ -1,0 +1,131 @@
+# LEGEND
+
+*The world needed a floor before anything could be built on it.*
+
+---
+
+## The World Turtle and the Earth
+
+There is a story told among many nations of Turtle Island — among the Lenape
+(leh-NAH-pay), the Delaware people, the *real people* — and among the
+Haudenosaunee Confederacy of the northeast, and others across the continent who
+share in this tradition's living breath.
+
+In the beginning there is only sky and water. Sky Woman — or in some tellings a
+young woman cast out from the Sky World above — falls. The animals of the water
+look up and see her descending. They do not flee. They convene. Geese break her
+fall. Then the creatures of the deep consider what she will need: ground.
+
+Turtle volunteers its back.
+
+The other animals dive one by one to the bottom of the water, seeking earth.
+Most fail. The Muskrat — small, often overlooked — dives the deepest, past where
+the others turned back, and returns with a handful of mud. Sometimes it returns
+dead, the mud still clenched in its paw.
+
+That mud is placed on Turtle's back. Sky Woman breathes on it, walks in a
+circle, tends it. It grows. It grows until it becomes a continent. The land the
+Lenape call home — and the broader land that many Indigenous nations across the
+Americas know — is called *Turtle Island*. It rests on the back of a great
+Turtle, who never stopped carrying it.
+
+*Lenape* means "real people" or "original people." Not the first people in a
+sequence, but people who are genuinely, fully themselves. People of the ground.
+
+> This legend is told here with respect, not with claim. The Lenape (Delaware)
+> Nation and the Haudenosaunee peoples are its rightful living holders. We draw
+> only from what they have shared publicly — including their own published
+> cultural materials and accounts given with the intention of wider sharing. We
+> do not represent ceremony, inner teaching, or knowledge not offered for general
+> understanding. If you wish to go deeper, go to the source:
+> delawarenation-nsn.gov, the Lenape Nation of Pennsylvania, the Haudenosaunee
+> Confederacy's own voices.
+
+---
+
+## Sophia: the Wisdom That Became Ground
+
+In the Gnostic tradition — texts preserved in the Nag Hammadi library, publicly
+available since 1945 — Sophia (Σοφία, "Wisdom") is the last and youngest
+emanation of the divine pleroma, the fullness of light from which all creation
+comes.
+
+She acts without her consort. She falls.
+
+Her fall is not simply a mistake. It is the act that makes a grounded world
+possible. In her descent she becomes the matter from which creation is shaped.
+She is wisdom consenting to become foundation — the knowing that agrees to be
+the floor on which the world stands. She waits for the work of restoration while
+being, in the meantime, the ground.
+
+The parallel to Sky Woman is not accidental. Both fall from a high place. Both
+become, in their falling, the precondition for the earth. What descends does not
+die. It becomes the carrier of everything built above.
+
+---
+
+## Anu: the Sky from Which Things Fall
+
+In the Sumerian and Akkadian traditions — cuneiform texts among the oldest
+written records of human thought, including the *Enuma Elish* and the
+*Atrahasis* — Anu (An in Sumerian) is the sky god, the highest heaven. He is
+the vault above, the unmoved source, the origin of divine authority.
+
+Sky Woman comes from a world above the water. Sophia emanates from the pleroma.
+Both descend from something that is, in its function, Anu-like: the original,
+uncreated height from which everything that becomes ground must first fall.
+
+Anu does not fall. He is what is fallen from. He is the condition of distance
+that makes descent possible, and therefore the condition that makes ground
+possible.
+
+---
+
+## The Pattern
+
+> **Sky → Fall → Patient Carrier → Growing Earth**
+
+The sky is the source: complete, unreachable on its own terms.
+
+The fall is not catastrophe. It is how the sky enters the world — transformed
+by the willingness to descend, to be carried, to become ground.
+
+The patient carrier — Turtle, matter, the earth itself — holds what arrives.
+It does not understand. It does not need to. It holds.
+
+And the world grows from the mud held in the paw of the one willing to dive
+deepest.
+
+---
+
+## The Workspace Control Plane as Turtle's Back
+
+This repository builds a governance layer — the floor on which agentic work
+stands. The metaphor is not decorative.
+
+**Evidence is the ground.** Every claim extracted, every fact ingested, is a
+handful of earth brought up from the deep. It is patient, persistent. It
+accumulates. The work of the evidence pipeline (Phases 8 and 11) is the
+Muskrat's dive.
+
+**Policy is the sky.** It sets the conditions under which evidence is admitted,
+evaluated, found sufficient or insufficient. It does not carry; it judges. The
+policy gate (Phase 10) is the sky speaking to what the earth has made.
+
+**The outbox is the turtle's consent.** Each workflow run is Turtle offering its
+back — stable, load-bearing, not knowing what will grow there. The temporal
+outbox (Phase 7) holds the state of every run: pending, running, awaiting, done.
+It carries.
+
+**Claims are the world being built.** They accumulate on the ground. They
+contradict and confirm each other. The consensus arbitrator (Phase 12) is the
+act of looking at what has grown and asking: is this earth? Can we stand here?
+
+---
+
+*We tell this legend because the architecture inherits its shape from a very
+old insight: that before anything can be built, something must agree to be the
+floor. The Lenape knew this. Sophia knew this. Turtle knew this without knowing
+anything else.*
+
+*We honor the tradition. We do not claim it.*

--- a/README.md
+++ b/README.md
@@ -10,6 +10,126 @@ It is intentionally a **thin platform monorepo**:
 - `tools/` contains validation and smoke-test helpers (`standards.lock.yaml` gates platform drift checks)
 - `libs/` contains small shared runtime bindings that adapt pinned upstream standards into platform code
 
+---
+
+## Legend
+
+*The world needed a floor before anything could be built on it.*
+
+### Turtle Island — Sky Woman, Muskrat, and the Great Turtle
+
+In the beginning there is only sky and water.  There is no land.
+
+**Sky Woman** falls from the Sky World above — cast out, or choosing to fall,
+depending on the telling.  She plummets toward the water.  The animals of the
+water world look up and see her coming.  They do not flee.  They convene.  The
+**Geese** break her fall, carrying her on their wings so she does not strike the
+water dead.  But she still needs ground.
+
+The creatures of the deep discuss what she will need: earth.  One by one they
+dive, seeking mud from the bottom of the water.  The Otter tries and fails.  The
+Beaver tries and fails.  Great and capable animals turn back, unable to reach
+the bottom.
+
+Then the **Muskrat** — small, often overlooked — volunteers.  It dives past
+where the others turned back.  It keeps going.  In some tellings it returns dead,
+its lungs spent, but its paw still clenched around a handful of mud.  The mud
+exists.  The sacrifice made ground possible.
+
+That mud is placed on the back of the **Great Turtle**, who volunteered to be
+the carrier.  Sky Woman breathes on it, walks in a circle, tends it with care.
+The earth grows.  It grows until it becomes a continent — **Turtle Island** —
+the land that rests on the back of a great Turtle who never stopped carrying it.
+
+This story is told among the **Lenape** (leh-NAH-pay) — the Delaware people —
+and among the **Haudenosaunee Confederacy** and other nations across what is
+now called North America.  *Lenape* means **"real people"** or **"original
+people"**: not first in a sequence, but people who are genuinely, fully
+themselves.  People of the ground.
+
+> *We tell this legend with respect, not with claim.  The Lenape Nation,
+> the Lenape Nation of Pennsylvania, and the Haudenosaunee Confederacy are
+> the living holders of this tradition.  We draw only from what they have
+> chosen to share publicly.  We do not represent ceremony, inner teaching,
+> or knowledge not offered for general understanding.  Go to the source:
+> delawarenation-nsn.gov; lenape-nation-pa.org; haudenosauneeconfederacy.ca.*
+
+---
+
+### Sophia — Wisdom That Descends and Becomes Ground
+
+In the **Gnostic tradition** — texts preserved in the **Nag Hammadi library**,
+discovered in Egypt in 1945 and publicly available — **Sophia** (Greek:
+Σοφία, "Wisdom") is the last and youngest emanation of the divine **pleroma**:
+the fullness of light from which all creation comes.
+
+She acts without her consort.  She **falls**.
+
+Her descent is not simply error.  It is the act that makes a grounded world
+possible.  In falling she becomes the matter from which the world is shaped.
+She is wisdom consenting to become foundation — the knowing that agrees to be
+the floor on which all things stand.  She waits for the work of restoration
+while being, in the meantime, the ground itself.
+
+The parallel to Sky Woman is not accidental:
+- Both fall from a high realm to a lower one.
+- Both become, in their falling, the precondition for the earth.
+- What descends does not die.  It becomes the carrier of everything built above.
+
+---
+
+### Anu — The Sky from Which Things Fall
+
+In the **Sumerian and Akkadian traditions** — cuneiform texts among the oldest
+written records of human thought, including the **Enuma Elish** (the Babylonian
+creation epic) and the **Atrahasis** — **Anu** (An in Sumerian) is the
+**sky god**: the highest heaven, the unmoved vault above, the origin of divine
+authority, the source from which everything descends.
+
+Sky Woman comes from a world above the water.  Sophia emanates from the pleroma.
+Both descend from something that is, in its function, Anu-like: the **original,
+uncreated height** from which everything that becomes ground must first fall.
+
+Anu does not fall.  He **is what is fallen from**.  He is the condition of
+distance that makes descent possible — and therefore the condition that makes
+ground possible.
+
+---
+
+### The Pattern
+
+> **Sky (Anu) → Fall (Sky Woman / Sophia) → Patient Carrier (Turtle) → Growing Earth (Turtle Island / the world)**
+
+The sky is the source: complete, beyond reach on its own terms.
+
+The fall is not catastrophe.  It is how the sky enters the world — transformed
+by the willingness to descend, to be carried, to become ground.
+
+The patient carrier — Turtle, matter, the earth itself — holds what arrives.
+It does not need to understand.  It holds.
+
+And the world grows from the mud held in the paw of the one willing to dive
+deepest.
+
+---
+
+### The Control Plane as Turtle's Back
+
+This repository is a governance layer — the floor on which agentic work stands.
+The metaphor is not decorative.
+
+| Layer | Legendary parallel |
+|---|---|
+| **Evidence** (claim extraction, memory store) | The ground itself — Turtle's back; what Muskrat brought up from the deep |
+| **Policy gate** | The sky — sets conditions; judges what evidence is sufficient |
+| **Claims** | The world growing on the ground — accumulating, contradicting, confirming |
+| **Consensus Arbitrator** | The question: *Is this earth?  Can we stand here?* |
+| **Temporal Outbox** | The Turtle's consent — stable, load-bearing, carrying without needing to understand |
+
+See also: [`LEGEND.md`](./LEGEND.md) — the full legend in extended form.
+
+---
+
 ## Why this repo exists
 
 Standards and governance stay in dedicated upstream repositories. `prophet-platform` is where those standards become running services, concrete deployment topologies, and platform contracts.

--- a/docs/WORKSPACE_CONTROL_PLANE_PHASE12.md
+++ b/docs/WORKSPACE_CONTROL_PLANE_PHASE12.md
@@ -1,0 +1,81 @@
+# Workspace Control Plane — Phase 12 (ConsensusArbitrator)
+
+Implements **Phase 12**: the consensus arbitration layer that combines multiple
+`policy_decision.v0` records from independent `PolicyGate` evaluations into a
+single authoritative `consensus_decision.v0` record using a configurable quorum
+rule.
+
+## Design decisions (D20 / D21)
+
+- **D20** — Three quorum modes cover the relevant arbitration space:
+  `unanimous` (all must be `allowed`), `majority` (strict >50% must be
+  `allowed`), and `any` (at least one `allowed` is sufficient).  An empty
+  decision list yields verdict `blocked` — there is no quorum over nothing.
+  Policies with verdict `error` count as `blocked`, preserving fail-closed
+  behaviour at the arbitration layer.
+- **D21** — The `ConsensusDecision` record carries the full list of
+  `input_decisions` (decision_ids) so the arbitration is auditable end-to-end:
+  the OTel trace shows which PolicyDecisions contributed, and the record itself
+  references each one explicitly.
+
+## Schema (consensus_decision.v0)
+
+```python
+{
+  "consensus_id":     "cd-<hex12>",
+  "quorum_mode":      "unanimous" | "majority" | "any",
+  "verdict":          "allowed" | "blocked",
+  "decided_at":       ISO-8601,
+  "total":            int,          # number of decisions evaluated
+  "allowed_count":    int,
+  "blocked_count":    int,
+  "input_decisions":  [decision_id, ...],
+  "error":            null | str,
+}
+```
+
+## Key classes
+
+- **`ConsensusArbitrator(tracer, quorum_mode)`** — `arbitrate(decisions) →
+  consensus_decision.v0`.  Opens a GUARDRAIL OTel span; each input decision is
+  recorded as a `consensus.input` span event; result is a `consensus.decided`
+  event.  Fail-closed: exceptions → verdict `blocked`, error surfaced in record
+  and span.
+- **`QuorumMode`** — `Literal["unanimous", "majority", "any"]`
+
+## Quorum logic
+
+| Mode | Passes when |
+|------|-------------|
+| `unanimous` | `allowed_count == total` |
+| `majority` | `allowed_count > total / 2` (strict) |
+| `any` | `allowed_count >= 1` |
+
+Empty list always → `blocked`.  `error` verdicts count as `blocked`.
+
+## Validation
+
+`tools/tests/test_consensus_arbitrator.py` — 23 tests covering schema fields,
+unique consensus_id, quorum_mode stored in record, all three quorum modes,
+edge cases (empty list, single decision, all-allowed, all-blocked, exact
+majority tie), error-verdict-as-blocked, counts accuracy, input_decisions
+order preserved, GUARDRAIL span emitted, span attributes (quorum_mode,
+input_count, verdict, allowed/blocked counts), consensus.input events per
+decision, consensus.decided event, side-effect-free repeated calls.
+
+Path-filtered CI: `.github/workflows/control-plane-phase12.yml`.
+
+## Complete pipeline (Phases 7–12)
+
+```
+TemporalOutbox (Phase 7)          — durable run FSM
+  └─ ClaimExtractor / MemoryStore (Phase 8) — evidence storage tiers
+       └─ OTel Tracer (Phase 9)   — audit span tree
+            └─ PolicyGate (Phase 10) — per-policy verdict + GUARDRAIL span
+                 └─ EvidenceCollector (Phase 11) — full event→claim→policy loop
+                      └─ ConsensusArbitrator (Phase 12) — quorum over verdicts
+```
+
+The stack is now closed: raw events enter at Phase 11, evidence accumulates at
+Phase 8, policies evaluate at Phase 10, and Phase 12 arbitrates the final
+workspace action authorization.

--- a/tools/consensus_arbitrator.py
+++ b/tools/consensus_arbitrator.py
@@ -34,7 +34,6 @@ Schema (consensus_decision.v0):
 from __future__ import annotations
 
 import uuid
-from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Literal
 
@@ -114,9 +113,20 @@ class ConsensusArbitrator:
             try:
                 result = self._run(decisions, span)
             except Exception as exc:
+                # Fail-closed must survive a SECOND failure while building the error record
+                # itself — a malformed `decisions` entry (None, a bare string, ...) already
+                # broke `_run`'s `.get(...)` once; re-deriving input_decisions the same way
+                # here would raise again, escaping the `with` block uncaught and turning a
+                # "blocked" verdict into no verdict at all. Extract defensively instead.
+                safe_ids = []
+                for d in decisions:
+                    try:
+                        safe_ids.append(d.get("decision_id", "") if isinstance(d, dict) else "")
+                    except Exception:
+                        safe_ids.append("")
                 result = _consensus_record(
                     self._quorum_mode, "blocked", len(decisions), 0, len(decisions),
-                    [d.get("decision_id", "") for d in decisions],
+                    safe_ids,
                     error=str(exc),
                 )
                 span.set_attribute("consensus.verdict", "blocked")

--- a/tools/consensus_arbitrator.py
+++ b/tools/consensus_arbitrator.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""ConsensusArbitrator — quorum arbitration over PolicyDecision records (Phase 12 / D20, D21).
+
+Given a set of ``policy_decision.v0`` records (from ``PolicyGate.evaluate``),
+applies a configurable quorum rule to produce a single ``ConsensusDecision``
+record.  Emits the decision as a GUARDRAIL-kind OTel span with each input
+PolicyDecision referenced as a child event.
+
+Design decisions:
+  D20 — Three quorum modes cover the space of useful arbitration:
+          ``unanimous``  — all policies must be ``allowed``
+          ``majority``   — strict majority (>50%) must be ``allowed``
+          ``any``        — at least one ``allowed`` is sufficient
+         An empty decision list yields verdict ``blocked``; there is no quorum
+         over nothing.  Policies in ``error`` state count as ``blocked`` for the
+         quorum calculation, preserving fail-closed behaviour.
+  D21 — The ConsensusDecision record carries every input decision_id so the
+         arbitration is fully auditable: the trace can reconstruct which
+         PolicyDecisions were combined and which broke consensus.
+
+Schema (consensus_decision.v0):
+  {
+    "consensus_id":     str,            # "cd-<hex12>"
+    "quorum_mode":      "unanimous" | "majority" | "any",
+    "verdict":          "allowed" | "blocked",
+    "decided_at":       ISO-8601,
+    "total":            int,            # number of decisions evaluated
+    "allowed_count":    int,
+    "blocked_count":    int,
+    "input_decisions":  list[str],      # decision_ids in order evaluated
+    "error":            str | null,
+  }
+"""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Literal
+
+from otel_tracer import (  # type: ignore
+    Tracer,
+    OPENINFERENCE_SPAN_KIND,
+    SPAN_KIND_GUARDRAIL,
+)
+
+QuorumMode = Literal["unanimous", "majority", "any"]
+
+
+def _now() -> str:
+    return datetime.now(tz=timezone.utc).isoformat(timespec="seconds")
+
+
+def _consensus_record(
+    quorum_mode: QuorumMode,
+    verdict: str,
+    total: int,
+    allowed_count: int,
+    blocked_count: int,
+    input_decisions: list[str],
+    error: str | None = None,
+) -> dict:
+    return {
+        "consensus_id":    f"cd-{uuid.uuid4().hex[:12]}",
+        "quorum_mode":     quorum_mode,
+        "verdict":         verdict,
+        "decided_at":      _now(),
+        "total":           total,
+        "allowed_count":   allowed_count,
+        "blocked_count":   blocked_count,
+        "input_decisions": list(input_decisions),
+        "error":           error,
+    }
+
+
+class ConsensusArbitrator:
+    """Arbitrate over multiple PolicyDecision records using a quorum rule.
+
+    Args:
+        tracer:      OTel Tracer from ``otel_tracer`` (Phase 9).
+        quorum_mode: ``"unanimous"`` | ``"majority"`` | ``"any"``
+
+    Usage::
+
+        arbitrator = ConsensusArbitrator(tracer, quorum_mode="majority")
+        result = arbitrator.arbitrate([decision_a, decision_b, decision_c])
+        # result is a consensus_decision.v0 dict
+
+    Fail-closed: any exception → verdict ``blocked``, error surfaced in record
+    and span.  Policies with verdict ``error`` count as ``blocked``.
+    """
+
+    def __init__(self, tracer: Tracer, quorum_mode: QuorumMode = "unanimous") -> None:
+        self._tracer = tracer
+        self._quorum_mode = quorum_mode
+
+    @property
+    def quorum_mode(self) -> QuorumMode:
+        return self._quorum_mode
+
+    def arbitrate(self, decisions: list[dict]) -> dict:
+        """Arbitrate over a list of ``policy_decision.v0`` records.
+
+        Opens a GUARDRAIL OTel span.  Each input decision is recorded as a
+        span event for full audit trail.  Returns a ``consensus_decision.v0``
+        dict.
+        """
+        span_attrs = {
+            OPENINFERENCE_SPAN_KIND: SPAN_KIND_GUARDRAIL,
+            "consensus.quorum_mode":   self._quorum_mode,
+            "consensus.input_count":   len(decisions),
+        }
+        with self._tracer.span("consensus.arbitrate", attributes=span_attrs) as span:
+            try:
+                result = self._run(decisions, span)
+            except Exception as exc:
+                result = _consensus_record(
+                    self._quorum_mode, "blocked", len(decisions), 0, len(decisions),
+                    [d.get("decision_id", "") for d in decisions],
+                    error=str(exc),
+                )
+                span.set_attribute("consensus.verdict", "blocked")
+                span.add_event("consensus.error", {"error": str(exc)})
+            return result
+
+    def _run(self, decisions: list[dict], span) -> dict:
+        input_ids = [d.get("decision_id", "") for d in decisions]
+        total = len(decisions)
+
+        # empty → blocked (D20: no quorum over nothing)
+        if total == 0:
+            span.set_attribute("consensus.verdict", "blocked")
+            span.add_event("consensus.decided", {"verdict": "blocked", "reason": "empty"})
+            return _consensus_record(
+                self._quorum_mode, "blocked", 0, 0, 0, [],
+            )
+
+        allowed_count = sum(
+            1 for d in decisions if d.get("verdict") == "allowed"
+        )
+        blocked_count = total - allowed_count
+
+        # record each input as a span event
+        for d in decisions:
+            span.add_event(
+                "consensus.input",
+                {
+                    "decision_id": d.get("decision_id", ""),
+                    "policy_id":   d.get("policy_id", ""),
+                    "verdict":     d.get("verdict", ""),
+                },
+            )
+
+        verdict = self._apply_quorum(total, allowed_count)
+
+        span.set_attribute("consensus.verdict", verdict)
+        span.set_attribute("consensus.allowed_count", allowed_count)
+        span.set_attribute("consensus.blocked_count", blocked_count)
+        span.add_event(
+            "consensus.decided",
+            {"verdict": verdict, "allowed": allowed_count, "total": total},
+        )
+
+        return _consensus_record(
+            self._quorum_mode, verdict, total, allowed_count, blocked_count, input_ids,
+        )
+
+    def _apply_quorum(self, total: int, allowed_count: int) -> str:
+        if self._quorum_mode == "unanimous":
+            return "allowed" if allowed_count == total else "blocked"
+        if self._quorum_mode == "majority":
+            return "allowed" if allowed_count > total / 2 else "blocked"
+        if self._quorum_mode == "any":
+            return "allowed" if allowed_count >= 1 else "blocked"
+        raise ValueError(f"Unknown quorum_mode: {self._quorum_mode!r}")

--- a/tools/tests/test_consensus_arbitrator.py
+++ b/tools/tests/test_consensus_arbitrator.py
@@ -1,0 +1,212 @@
+"""Tests for consensus_arbitrator.py (Phase 12).
+
+22 tests covering:
+  - ConsensusDecision schema fields
+  - Unique consensus_id per call
+  - Quorum modes: unanimous / majority / any
+  - Edge cases: empty list, single decision, all-allowed, all-blocked, exact majority
+  - error decisions count as blocked
+  - fail-closed on corrupt input
+  - OTel span emitted as GUARDRAIL kind
+  - span attributes: quorum_mode, input_count, verdict, allowed/blocked counts
+  - span events: consensus.input per decision, consensus.decided
+  - arbitrate() is side-effect free (same list → independent records)
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from consensus_arbitrator import ConsensusArbitrator
+from otel_tracer import InMemoryExporter, Tracer, SPAN_KIND_GUARDRAIL, OPENINFERENCE_SPAN_KIND
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _exp():
+    return InMemoryExporter()
+
+
+def _tracer(exp=None):
+    return Tracer(exporter=exp or _exp())
+
+
+def _arb(mode="unanimous", exp=None):
+    return ConsensusArbitrator(_tracer(exp), quorum_mode=mode)
+
+
+def _dec(verdict="allowed", policy_id="p1", decision_id=None):
+    import uuid
+    return {
+        "decision_id":   decision_id or f"pd-{uuid.uuid4().hex[:12]}",
+        "policy_id":     policy_id,
+        "verdict":       verdict,
+        "evaluated_at":  "2026-01-01T00:00:00+00:00",
+        "rules":         [],
+        "evidence_refs": [],
+        "error":         None,
+    }
+
+
+# ── schema ────────────────────────────────────────────────────────────────────
+
+def test_schema_fields():
+    r = _arb().arbitrate([_dec("allowed"), _dec("allowed")])
+    for key in ("consensus_id", "quorum_mode", "verdict", "decided_at",
+                "total", "allowed_count", "blocked_count", "input_decisions", "error"):
+        assert key in r, f"Missing field: {key}"
+
+
+def test_consensus_id_unique():
+    a = _arb()
+    r1 = a.arbitrate([_dec("allowed")])
+    r2 = a.arbitrate([_dec("allowed")])
+    assert r1["consensus_id"] != r2["consensus_id"]
+
+
+def test_consensus_id_prefix():
+    r = _arb().arbitrate([_dec()])
+    assert r["consensus_id"].startswith("cd-")
+
+
+def test_quorum_mode_in_record():
+    for mode in ("unanimous", "majority", "any"):
+        r = ConsensusArbitrator(_tracer(), quorum_mode=mode).arbitrate([_dec("allowed")])
+        assert r["quorum_mode"] == mode
+
+
+# ── unanimous ─────────────────────────────────────────────────────────────────
+
+def test_unanimous_all_allowed():
+    r = _arb("unanimous").arbitrate([_dec("allowed"), _dec("allowed"), _dec("allowed")])
+    assert r["verdict"] == "allowed"
+
+
+def test_unanimous_one_blocked():
+    r = _arb("unanimous").arbitrate([_dec("allowed"), _dec("blocked"), _dec("allowed")])
+    assert r["verdict"] == "blocked"
+
+
+def test_unanimous_all_blocked():
+    r = _arb("unanimous").arbitrate([_dec("blocked"), _dec("blocked")])
+    assert r["verdict"] == "blocked"
+
+
+# ── majority ──────────────────────────────────────────────────────────────────
+
+def test_majority_strict_majority():
+    r = _arb("majority").arbitrate([_dec("allowed"), _dec("allowed"), _dec("blocked")])
+    assert r["verdict"] == "allowed"
+
+
+def test_majority_exact_half_is_blocked():
+    # 2-of-4 is NOT a strict majority
+    r = _arb("majority").arbitrate([_dec("allowed"), _dec("allowed"),
+                                     _dec("blocked"), _dec("blocked")])
+    assert r["verdict"] == "blocked"
+
+
+def test_majority_all_blocked():
+    r = _arb("majority").arbitrate([_dec("blocked"), _dec("blocked")])
+    assert r["verdict"] == "blocked"
+
+
+# ── any ───────────────────────────────────────────────────────────────────────
+
+def test_any_one_allowed():
+    r = _arb("any").arbitrate([_dec("blocked"), _dec("allowed"), _dec("blocked")])
+    assert r["verdict"] == "allowed"
+
+
+def test_any_all_blocked():
+    r = _arb("any").arbitrate([_dec("blocked"), _dec("blocked")])
+    assert r["verdict"] == "blocked"
+
+
+# ── edge cases ────────────────────────────────────────────────────────────────
+
+def test_empty_list_is_blocked():
+    r = _arb("unanimous").arbitrate([])
+    assert r["verdict"] == "blocked"
+    assert r["total"] == 0
+
+
+def test_single_allowed():
+    r = _arb("unanimous").arbitrate([_dec("allowed")])
+    assert r["verdict"] == "allowed"
+
+
+def test_error_verdict_counts_as_blocked():
+    r = _arb("unanimous").arbitrate([_dec("allowed"), _dec("error")])
+    assert r["verdict"] == "blocked"
+    assert r["allowed_count"] == 1
+    assert r["blocked_count"] == 1
+
+
+def test_counts():
+    decisions = [_dec("allowed"), _dec("allowed"), _dec("blocked")]
+    r = _arb("majority").arbitrate(decisions)
+    assert r["total"] == 3
+    assert r["allowed_count"] == 2
+    assert r["blocked_count"] == 1
+
+
+def test_input_decisions_preserved():
+    d1, d2 = _dec("allowed"), _dec("blocked")
+    r = _arb("unanimous").arbitrate([d1, d2])
+    assert r["input_decisions"] == [d1["decision_id"], d2["decision_id"]]
+
+
+# ── OTel span ─────────────────────────────────────────────────────────────────
+
+def test_guardrail_span_emitted():
+    exp = _exp()
+    _arb("unanimous", exp).arbitrate([_dec("allowed")])
+    assert any(s["name"] == "consensus.arbitrate" for s in exp.spans)
+
+
+def test_span_kind_guardrail():
+    exp = _exp()
+    _arb("unanimous", exp).arbitrate([_dec("allowed")])
+    span = next(s for s in exp.spans if s["name"] == "consensus.arbitrate")
+    assert span["attributes"].get(OPENINFERENCE_SPAN_KIND) == SPAN_KIND_GUARDRAIL
+
+
+def test_span_attributes_present():
+    exp = _exp()
+    _arb("majority", exp).arbitrate([_dec("allowed"), _dec("blocked")])
+    span = next(s for s in exp.spans if s["name"] == "consensus.arbitrate")
+    assert span["attributes"].get("consensus.quorum_mode") == "majority"
+    assert span["attributes"].get("consensus.input_count") == 2
+    assert span["attributes"].get("consensus.verdict") in ("allowed", "blocked")
+
+
+def test_span_events_include_inputs():
+    exp = _exp()
+    d1, d2 = _dec("allowed"), _dec("blocked")
+    _arb("any", exp).arbitrate([d1, d2])
+    span = next(s for s in exp.spans if s["name"] == "consensus.arbitrate")
+    input_events = [e for e in span["events"] if e["name"] == "consensus.input"]
+    assert len(input_events) == 2
+    input_ids = {e["attributes"]["decision_id"] for e in input_events}
+    assert d1["decision_id"] in input_ids
+    assert d2["decision_id"] in input_ids
+
+
+def test_decided_event():
+    exp = _exp()
+    _arb("unanimous", exp).arbitrate([_dec("allowed")])
+    span = next(s for s in exp.spans if s["name"] == "consensus.arbitrate")
+    decided = [e for e in span["events"] if e["name"] == "consensus.decided"]
+    assert len(decided) == 1
+    assert decided[0]["attributes"]["verdict"] in ("allowed", "blocked")
+
+
+def test_side_effect_free():
+    decisions = [_dec("allowed"), _dec("blocked")]
+    a = _arb("majority")
+    r1 = a.arbitrate(decisions)
+    r2 = a.arbitrate(decisions)
+    assert r1["consensus_id"] != r2["consensus_id"]
+    assert r1["input_decisions"] == r2["input_decisions"]

--- a/tools/tests/test_consensus_arbitrator.py
+++ b/tools/tests/test_consensus_arbitrator.py
@@ -1,6 +1,6 @@
 """Tests for consensus_arbitrator.py (Phase 12).
 
-22 tests covering:
+24 tests covering:
   - ConsensusDecision schema fields
   - Unique consensus_id per call
   - Quorum modes: unanimous / majority / any
@@ -201,6 +201,26 @@ def test_decided_event():
     decided = [e for e in span["events"] if e["name"] == "consensus.decided"]
     assert len(decided) == 1
     assert decided[0]["attributes"]["verdict"] in ("allowed", "blocked")
+
+
+def test_fail_closed_on_non_dict_input():
+    """The docstring at the top of this file has claimed 'fail-closed on corrupt input'
+    coverage since the PR that introduced this module, but no test exercised a genuinely
+    malformed `decisions` entry (None, a bare string — not just a dict with error set).
+
+    `_run()` raises AttributeError on `d.get(...)` for a non-dict `d`; the except-handler
+    in `arbitrate()` used to REBUILD `input_decisions` with the same `d.get(...)` over the
+    same malformed list while constructing the error record, raising a second, uncaught
+    AttributeError that escaped `arbitrate()` entirely — no verdict returned, not even
+    'blocked'. That is not fail-closed, it's a crash. This asserts the real contract: any
+    exception during arbitration — including a malformed input list — still yields a
+    `blocked` ConsensusDecision, never an unhandled exception."""
+    good = _dec("allowed")
+    result = _arb("any").arbitrate([good, None, "not-a-decision"])
+    assert result["verdict"] == "blocked"
+    assert result["error"]
+    assert result["total"] == 3
+    assert result["input_decisions"] == [good["decision_id"], "", ""]
 
 
 def test_side_effect_free():


### PR DESCRIPTION
## Summary

- **ConsensusArbitrator** (`tools/consensus_arbitrator.py`): quorum arbitration over multiple `policy_decision.v0` records, three modes — `unanimous` / `majority` (strict >50%) / `any`; fail-closed; emits GUARDRAIL OTel span with per-decision events; 23 tests; path-filtered CI
- **LEGEND.md** (repo root): grounds the architecture in the Turtle Island creation story (Lenape/Haudenosaunee publicly shared tradition), Sophia (Nag Hammadi), and Anu (Enuma Elish) — the common sky→fall→patient-carrier→growing-earth pattern; honors not claims the tradition

## ConsensusDecision schema
```
consensus_id, quorum_mode, verdict, decided_at, total,
allowed_count, blocked_count, input_decisions[], error
```

## Complete stack (Phases 7–12)
```
TemporalOutbox → ClaimExtractor/MemoryStore → OTel Tracer
  → PolicyGate → EvidenceCollector → ConsensusArbitrator
```

## Test plan
- [ ] `pytest -q tools/tests/test_consensus_arbitrator.py` → 23 passed
- [ ] CI path filter fires on `consensus_arbitrator.py` changes
- [ ] `LEGEND.md` renders cleanly in GitHub markdown preview