### PR TITLE
fix(gitea): set fsGroup so rootless gitea can write its PVC (+ digest-pin) — sovereign SCM was down

### DIFF
--- a/deploy/gitea-authority/k8s/gitea-sovereign.yaml
+++ b/deploy/gitea-authority/k8s/gitea-sovereign.yaml
@@ -40,13 +40,16 @@ spec:
   template:
     metadata: { labels: { app: gitea } }
     spec:
-      # gitea/gitea:*-rootless runs as UID/GID 1000 and must write /var/lib/gitea on the mounted
-      # PVC. WITHOUT fsGroup the volume is root-owned and the container gets "Permission denied"
-      # at setup → CrashLoopBackOff forever. This is the exact bug that ran unnoticed for 26h.
-      securityContext: { runAsNonRoot: true, runAsUser: 1000, runAsGroup: 1000, fsGroup: 1000 }
+      # gitea/gitea:*-rootless runs as UID/GID 1000 and must write /var/lib/gitea on the mounted PVC.
+      # WITHOUT fsGroup the volume is root-owned and the container gets "Permission denied" at setup →
+      # CrashLoopBackOff (the bug that ran unnoticed for 26h; Kyverno require-fsgroup-for-pvc-writers
+      # named it). runAsNonRoot/runAsUser/runAsGroup pin the identity; fsGroup makes the volume
+      # group-writable; OnRootMismatch avoids re-chowning the 20Gi repo volume on every mount.
+      securityContext: { runAsNonRoot: true, runAsUser: 1000, runAsGroup: 1000, fsGroup: 1000, fsGroupChangePolicy: OnRootMismatch }
       containers:
         - name: gitea
-          image: gitea/gitea:1.26.2-rootless
+          # digest-pinned (Kyverno require-image-digest): 1.26.2-rootless resolved 2026-08-04.
+          image: gitea/gitea:1.26.2-rootless@sha256:c5c21a7705a16f2b2369384a3b7d67c5ed761a818bbb0a55187b5cf98cdc2e68
           ports: [{ containerPort: 3000 }, { containerPort: 22 }]
           env:
             - { name: GITEA__server__ROOT_URL, value: "https://gitea.sourceos.dev/" }


### PR DESCRIPTION
## Enhancement on the base gitea fsGroup fix
A concurrent session already landed the core fix on main (`runAsNonRoot/runAsUser/runAsGroup/fsGroup: 1000`) — good. This PR rebases to the **union** and adds two things it was missing:
- **`fsGroupChangePolicy: OnRootMismatch`** — the `gitea-data` PVC is 20Gi of repos; without this, fsGroup re-chowns the whole volume on *every* mount (slow pod starts, needless I/O). OnRootMismatch chowns only when the root dir's group is wrong.
- **digest-pin** the image (`gitea/gitea:1.26.2-rootless@sha256:c5c21a77…`) — clears the other Kyverno audit, `require-image-digest`.

## Context (the outage)
`gitea` — the sovereign SCM behind **code.socioprophet.ai** / **gitea.sourceos.dev** (PVC `gitea-data` = repos) — CrashLoopBackOff'd ~26h then scaled to 0 because the rootless image (UID 1000) couldn't write its root-owned PVC. Restored live via emergency patch (1/1, `/api/v1/version`=1.26.2, repos intact); the manifest fix (base on main + this enhancement) keeps `deploy-gitea-authority.yml` (workflow_dispatch) from re-applying a spec that re-breaks it. `registry.socioprophet.ai` is **zot**, unrelated; `gitea-authority` is a separate signing service. `IMAGE_PLACEHOLDER` stays for the workflow's substitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)