### PR TITLE
fix(socioprophet-web): restore governance components dropped by cockpit revendor

### DIFF
--- a/apps/socioprophet-web/src/App.vue
+++ b/apps/socioprophet-web/src/App.vue
@@ -174,6 +174,13 @@
         >◈ Graph</button>
         <button
           type="button"
+          class="sp-graph-toggle"
+          :class="{ on: cockpit.extractOpen }"
+          title="Toggle extraction — live entities/claims + promote to graph (⌘E / Ctrl+E)"
+          @click="cockpit.toggleExtract()"
+        >⌖ Extract</button>
+        <button
+          type="button"
           class="sp-noetica-toggle"
           :class="{ on: cockpit.dockOpen }"
           title="Toggle Noetica assistant (⌘J / Ctrl+J)"
@@ -221,6 +228,9 @@
 
     <!-- Global knowledge-graph dock (⌘G / Ctrl+G) -->
     <GraphDock :open="cockpit.graphOpen" @close="cockpit.closeGraph()" />
+
+    <!-- Ubiquitous IE: global extraction dock on every surface (⌘E / Ctrl+E) -->
+    <ExtractDock :open="cockpit.extractOpen" @close="cockpit.closeExtract()" />
   </div>
 </template>
 
@@ -236,6 +246,7 @@ import QuakeTerminal from './components/QuakeTerminal.vue';
 import CommandPalette from './components/CommandPalette.vue';
 import NoeticaDock from './components/NoeticaDock.vue';
 import GraphDock from './components/GraphDock.vue';
+import ExtractDock from './components/ExtractDock.vue';
 import { useOperatorTerminal } from './composables/useOperatorTerminal';
 import { useNoeticaChat } from './composables/useNoeticaChat';
 import { domainSurfaces, surfaceForRoute, surfacesForDomain } from './config/domainRoutes';
@@ -380,6 +391,12 @@ function onTermHotkey(e: KeyboardEvent) {
   if ((e.metaKey || e.ctrlKey) && (e.key === 'g' || e.key === 'G')) {
     e.preventDefault();
     cockpit.toggleGraph();
+    return;
+  }
+  // Cmd/Ctrl+E — toggle the ubiquitous extraction dock (live IE, every surface).
+  if ((e.metaKey || e.ctrlKey) && (e.key === 'e' || e.key === 'E')) {
+    e.preventDefault();
+    cockpit.toggleExtract();
     return;
   }
   if (e.key === 'Escape' && cockpit.dockOpen && !termOpen.value) { cockpit.closeDock(); return; }

--- a/apps/socioprophet-web/src/__tests__/workstationDevSecOpsRoute.test.ts
+++ b/apps/socioprophet-web/src/__tests__/workstationDevSecOpsRoute.test.ts
@@ -1,0 +1,23 @@
+// The cockpit revendor (#1428) restored DevSecOpsWorkroomReportCard.vue, TritFabricReadinessLabels.vue
+// and WorkstationDevSecOps.vue byte-for-byte (#1432), but never carried forward main.ts's import and
+// route registration for WorkstationDevSecOps — CI's own validators only inspect the .vue files'
+// content, never main.ts, so a page with no route pointing at it passed CI silently. Read main.ts as
+// text (not a router harness) so this proves the file the build actually ships, not a fixture written
+// to agree with the assertion.
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MAIN_TS = readFileSync(resolve(HERE, '../main.ts'), 'utf-8');
+
+describe('WorkstationDevSecOps is actually reachable', () => {
+  it('main.ts imports the page component', () => {
+    expect(MAIN_TS).toMatch(/import\s+WorkstationDevSecOps\s+from\s+['"]\.\/pages\/WorkstationDevSecOps\.vue['"]/);
+  });
+
+  it('main.ts registers a route to it', () => {
+    expect(MAIN_TS).toMatch(/path:\s*['"]\/workstation\/devsecops['"],\s*component:\s*WorkstationDevSecOps/);
+  });
+});

--- a/apps/socioprophet-web/src/components/DevSecOpsWorkroomReportCard.vue
+++ b/apps/socioprophet-web/src/components/DevSecOpsWorkroomReportCard.vue
@@ -1,0 +1,264 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+
+type EvidenceItem = {
+  evidence_ref: string
+  evidence_type: string
+  producer: string
+  summary: string
+}
+
+type RcaClaim = {
+  claim_id: string
+  claim_status: string
+  confidence: string
+  statement: string
+}
+
+type ActionGrant = {
+  action_class: string
+  approval_required: boolean
+  grant_id: string
+  scope: string
+  status: string
+}
+
+type GuardrailBinding = {
+  grant_ref: string
+  guardrail_fixture_ref: string
+  guardrail_expected_decision: string
+  binding_status: string
+}
+
+type RemediationPlan = {
+  plan_id: string
+  plan_status: string
+  risk_class: string
+  summary: string
+}
+
+type WorkroomReport = {
+  report_id: string
+  workroom: {
+    workroom_id: string
+    lane: string
+    runtime_parity_level: string
+    incident_ref: string
+    topology_ref: string
+    blast_radius_ref: string
+  }
+  event: {
+    event_type: string
+    status: string
+    decision_state: string
+    summary: string
+  }
+  evidence: EvidenceItem[]
+  rca_claims: RcaClaim[]
+  gaia_blast_radius: {
+    radius_status: string
+    affected_node_refs: string[]
+    candidate_consumer_refs: string[]
+    confidence: string
+  }
+  action_grants: ActionGrant[]
+  guardrail_decision_bindings: {
+    action_grant_bindings: GuardrailBinding[]
+  }
+  remediation_plans: RemediationPlan[]
+  non_claims: string[]
+}
+
+type RuntimeParityBridge = {
+  bridge_id: string
+  decision_state: string
+  observed_evidence: {
+    fogstack_parity_status: string
+    fogstack_parity_target: string
+    svf_adapter_readiness_status: string
+    svf_adapter_merge_readiness: string
+    fogstack_checked_lanes: Record<string, string>
+  }
+  certified_claims: string[]
+  non_certified_claims: string[]
+  next_required_evidence: string[]
+  non_claims: string[]
+}
+
+const report = ref<WorkroomReport | null>(null)
+const runtimeBridge = ref<RuntimeParityBridge | null>(null)
+const loading = ref(false)
+const error = ref('')
+
+async function loadReport() {
+  loading.value = true
+  error.value = ''
+  try {
+    const [reportRes, bridgeRes] = await Promise.all([
+      fetch('/api/v1/workroom/report'),
+      fetch('/api/v1/workroom/runtime-parity-bridge')
+    ])
+    if (!reportRes.ok) throw new Error(`report request failed: ${reportRes.status}`)
+    if (!bridgeRes.ok) throw new Error(`runtime parity bridge request failed: ${bridgeRes.status}`)
+    report.value = await reportRes.json()
+    runtimeBridge.value = await bridgeRes.json()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'report request failed'
+    report.value = null
+    runtimeBridge.value = null
+  } finally {
+    loading.value = false
+  }
+}
+
+const confirmedClaims = computed(() =>
+  report.value?.rca_claims.filter((claim) => claim.claim_status === 'confirmed_causal_claim') ?? []
+)
+
+const executedPlans = computed(() =>
+  report.value?.remediation_plans.filter((plan) => plan.plan_status === 'executed') ?? []
+)
+
+const bridgeLaneEntries = computed(() =>
+  Object.entries(runtimeBridge.value?.observed_evidence.fogstack_checked_lanes ?? {})
+)
+
+onMounted(loadReport)
+</script>
+
+<template>
+  <section style="border:1px solid #cbd5e1;border-radius:16px;padding:1rem;margin-top:1.5rem;background:#f8fafc;">
+    <div style="display:flex;gap:.75rem;align-items:flex-start;justify-content:space-between;">
+      <div>
+        <div style="font-size:12px;text-transform:uppercase;letter-spacing:.08em;opacity:.65;font-weight:700;">
+          DevSecOps Intelligence Workroom
+        </div>
+        <h2 style="margin:.4rem 0 .35rem 0;font-size:1.35rem;font-weight:750;">Fixture report surface</h2>
+        <p style="margin:0;opacity:.78;max-width:760px;">
+          Deterministic Workroom report rendered from fixture contracts. This surface separates evidence, claims, topology context, Guardrail bindings, remediation candidates, runtime parity bridge posture, and non-claims.
+        </p>
+      </div>
+      <button @click="loadReport" style="padding:.45rem .75rem;border:1px solid #94a3b8;border-radius:8px;background:white;white-space:nowrap;">
+        {{ loading ? 'Loading…' : 'Reload' }}
+      </button>
+    </div>
+
+    <p v-if="error" style="border:1px solid #fecaca;background:#fef2f2;border-radius:10px;padding:.75rem;margin:1rem 0 0 0;color:#991b1b;">
+      {{ error }}
+    </p>
+
+    <div v-if="report" style="margin-top:1rem;display:grid;gap:1rem;">
+      <section style="border:1px solid #e2e8f0;border-radius:12px;background:white;padding:.85rem;">
+        <h3 style="margin:0 0 .6rem 0;font-size:1rem;">Event state</h3>
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:.6rem;">
+          <div><strong>Lane</strong><br><code>{{ report.workroom.lane }}</code></div>
+          <div><strong>Parity</strong><br><code>{{ report.workroom.runtime_parity_level }}</code></div>
+          <div><strong>Event</strong><br><code>{{ report.event.event_type }}</code></div>
+          <div><strong>Decision</strong><br><code>{{ report.event.decision_state }}</code></div>
+        </div>
+        <p style="margin:.75rem 0 0 0;">{{ report.event.summary }}</p>
+      </section>
+
+      <section v-if="runtimeBridge" style="border:1px solid #cbd5e1;border-radius:12px;background:white;padding:.85rem;">
+        <h3 style="margin:0 0 .6rem 0;font-size:1rem;">Runtime parity bridge</h3>
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:.6rem;">
+          <div><strong>Decision</strong><br><code>{{ runtimeBridge.decision_state }}</code></div>
+          <div><strong>FogStack parity</strong><br><code>{{ runtimeBridge.observed_evidence.fogstack_parity_status }}</code></div>
+          <div><strong>SVF adapter</strong><br><code>{{ runtimeBridge.observed_evidence.svf_adapter_readiness_status }}</code></div>
+          <div><strong>Merge readiness</strong><br><code>{{ runtimeBridge.observed_evidence.svf_adapter_merge_readiness }}</code></div>
+        </div>
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;margin-top:.75rem;">
+          <article style="border:1px solid #e2e8f0;border-radius:10px;padding:.65rem;">
+            <h4 style="margin:0 0 .45rem 0;">Checked lanes</h4>
+            <ul style="margin:0;padding-left:1rem;">
+              <li v-for="([lane, state]) in bridgeLaneEntries" :key="lane" style="margin:.3rem 0;">
+                <code>{{ lane }}</code> — {{ state }}
+              </li>
+            </ul>
+          </article>
+          <article style="border:1px solid #e2e8f0;border-radius:10px;padding:.65rem;">
+            <h4 style="margin:0 0 .45rem 0;">Not certified</h4>
+            <ul style="margin:0;padding-left:1rem;">
+              <li v-for="claim in runtimeBridge.non_certified_claims" :key="claim" style="margin:.3rem 0;">{{ claim }}</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+        <article style="border:1px solid #e2e8f0;border-radius:12px;background:white;padding:.85rem;">
+          <h3 style="margin:0 0 .6rem 0;font-size:1rem;">Evidence</h3>
+          <ul style="margin:0;padding-left:1rem;">
+            <li v-for="item in report.evidence" :key="item.evidence_ref" style="margin:.45rem 0;">
+              <strong>{{ item.evidence_type }}</strong> — {{ item.summary }}
+              <div style="font-size:.82rem;opacity:.65;"><code>{{ item.evidence_ref }}</code></div>
+            </li>
+          </ul>
+        </article>
+
+        <article style="border:1px solid #e2e8f0;border-radius:12px;background:white;padding:.85rem;">
+          <h3 style="margin:0 0 .6rem 0;font-size:1rem;">RCA claims</h3>
+          <ul style="margin:0;padding-left:1rem;">
+            <li v-for="claim in report.rca_claims" :key="claim.claim_id" style="margin:.45rem 0;">
+              <strong>{{ claim.claim_status }}</strong> / {{ claim.confidence }} — {{ claim.statement }}
+            </li>
+          </ul>
+          <p v-if="confirmedClaims.length === 0" style="margin:.75rem 0 0 0;font-size:.9rem;opacity:.72;">
+            No confirmed causal claim is present in the fixture report.
+          </p>
+        </article>
+      </section>
+
+      <section style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+        <article style="border:1px solid #e2e8f0;border-radius:12px;background:white;padding:.85rem;">
+          <h3 style="margin:0 0 .6rem 0;font-size:1rem;">GAIA blast radius</h3>
+          <p style="margin:0 0 .5rem 0;"><strong>Status:</strong> <code>{{ report.gaia_blast_radius.radius_status }}</code></p>
+          <p style="margin:.35rem 0;"><strong>Affected:</strong> {{ report.gaia_blast_radius.affected_node_refs.join(', ') }}</p>
+          <p style="margin:.35rem 0;"><strong>Candidate consumers:</strong> {{ report.gaia_blast_radius.candidate_consumer_refs.join(', ') }}</p>
+          <p style="margin:.35rem 0;"><strong>Confidence:</strong> {{ report.gaia_blast_radius.confidence }}</p>
+        </article>
+
+        <article style="border:1px solid #e2e8f0;border-radius:12px;background:white;padding:.85rem;">
+          <h3 style="margin:0 0 .6rem 0;font-size:1rem;">Action safety</h3>
+          <ul style="margin:0;padding-left:1rem;">
+            <li v-for="grant in report.action_grants" :key="grant.grant_id" style="margin:.45rem 0;">
+              <strong>{{ grant.action_class }}</strong> — <code>{{ grant.status }}</code>
+              <span v-if="grant.approval_required"> / approval required</span>
+            </li>
+          </ul>
+        </article>
+      </section>
+
+      <section style="border:1px solid #e2e8f0;border-radius:12px;background:white;padding:.85rem;">
+        <h3 style="margin:0 0 .6rem 0;font-size:1rem;">Guardrail decision bindings</h3>
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:.75rem;">
+          <div v-for="binding in report.guardrail_decision_bindings.action_grant_bindings" :key="binding.grant_ref" style="border:1px solid #e2e8f0;border-radius:10px;padding:.65rem;">
+            <div><strong>{{ binding.binding_status }}</strong> — expected <code>{{ binding.guardrail_expected_decision }}</code></div>
+            <div style="font-size:.82rem;opacity:.7;margin-top:.35rem;"><code>{{ binding.grant_ref }}</code></div>
+          </div>
+        </div>
+      </section>
+
+      <section style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:1rem;">
+        <article style="border:1px solid #e2e8f0;border-radius:12px;background:white;padding:.85rem;">
+          <h3 style="margin:0 0 .6rem 0;font-size:1rem;">Remediation</h3>
+          <ul style="margin:0;padding-left:1rem;">
+            <li v-for="plan in report.remediation_plans" :key="plan.plan_id" style="margin:.45rem 0;">
+              <strong>{{ plan.risk_class }}</strong> / <code>{{ plan.plan_status }}</code> — {{ plan.summary }}
+            </li>
+          </ul>
+          <p v-if="executedPlans.length === 0" style="margin:.75rem 0 0 0;font-size:.9rem;opacity:.72;">
+            No remediation is executed by this fixture report.
+          </p>
+        </article>
+
+        <article style="border:1px solid #e2e8f0;border-radius:12px;background:white;padding:.85rem;">
+          <h3 style="margin:0 0 .6rem 0;font-size:1rem;">Non-claims</h3>
+          <ul style="margin:0;padding-left:1rem;">
+            <li v-for="item in report.non_claims" :key="item" style="margin:.35rem 0;">{{ item }}</li>
+          </ul>
+        </article>
+      </section>
+    </div>
+  </section>
+</template>

--- a/apps/socioprophet-web/src/components/EvidenceGraph.vue
+++ b/apps/socioprophet-web/src/components/EvidenceGraph.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+// EvidenceGraph — the reusable ego-network. Radial focus+context: an ego node centered, its
+// 1-hop neighbours on a ring, typed by colour, edges labelled by relation and STYLED BY PROVENANCE
+// (solid = record/org, dashed = news-derived, dotted = personal). Click a node to re-centre, click
+// an edge to open its evidence. This is the moat applied to any entity: LinkedIn/Palantir show
+// connections; we show why to believe each one. Powers both the People associates graph and the Law
+// citation panel (cites / cited-by). Pure SVG, no graph lib.
+import { computed } from 'vue';
+
+export interface EgoNode { id: string; label: string; type?: string }
+export interface EgoLink { node: EgoNode; rel?: string; provenance?: 'record' | 'news' | 'personal' | 'derived'; evidence?: string; dir?: 'in' | 'out' }
+
+const props = withDefaults(
+  defineProps<{ center: EgoNode; links: EgoLink[]; w?: number; h?: number }>(),
+  { w: 320, h: 240 },
+);
+const emit = defineEmits<{ (e: 'select', node: EgoNode): void; (e: 'evidence', link: EgoLink): void }>();
+
+const TYPE_COLORS: Record<string, string> = {
+  person: '#5aa9ff', org: '#c9a3ff', company: '#c9a3ff', gov: '#e3b341', place: '#6fbf8b',
+  topic: '#a3e635', rule: '#8fb0ff', law: '#d8a250', money: '#e3b341', default: '#8b949e',
+};
+const col = (t?: string) => TYPE_COLORS[(t || 'default').toLowerCase()] || TYPE_COLORS.default;
+const initials = (s: string) => s.split(/\s+/).slice(0, 2).map((w) => w[0]?.toUpperCase() ?? '').join('');
+const short = (s: string) => (s.length > 14 ? s.slice(0, 13) + '…' : s);
+const dash = (p?: string) => (p === 'news' || p === 'derived' ? '5 4' : p === 'personal' ? '1.5 4' : '0');
+
+const layout = computed(() => {
+  const cx = props.w / 2, cy = props.h / 2;
+  const R = Math.min(props.w, props.h) * 0.34;
+  const n = props.links.length || 1;
+  return {
+    cx, cy,
+    nodes: props.links.map((lk, i) => {
+      const ang = -Math.PI / 2 + (i / n) * Math.PI * 2;
+      return { lk, x: +(cx + R * Math.cos(ang)).toFixed(1), y: +(cy + R * Math.sin(ang)).toFixed(1) };
+    }),
+  };
+});
+</script>
+
+<template>
+  <svg class="eg" :viewBox="`0 0 ${w} ${h}`" role="img" aria-label="Evidence-backed relationship graph">
+    <g v-for="(nd, i) in layout.nodes" :key="'e' + i">
+      <line class="eg-edge" :x1="layout.cx" :y1="layout.cy" :x2="nd.x" :y2="nd.y" :stroke-dasharray="dash(nd.lk.provenance)"
+            @click.stop="emit('evidence', nd.lk)" />
+      <text v-if="nd.lk.rel" class="eg-rel" :x="(layout.cx + nd.x) / 2" :y="(layout.cy + nd.y) / 2 - 3" text-anchor="middle">{{ nd.lk.rel }}</text>
+    </g>
+    <g v-for="(nd, i) in layout.nodes" :key="'n' + i" class="eg-node" @click.stop="emit('select', nd.lk.node)">
+      <title>{{ nd.lk.node.label }}{{ nd.lk.evidence ? ' · evidence: ' + nd.lk.evidence : '' }}</title>
+      <circle :cx="nd.x" :cy="nd.y" r="13" :fill="col(nd.lk.node.type)" />
+      <text :x="nd.x" :y="nd.y + 3.5" text-anchor="middle" class="eg-init">{{ initials(nd.lk.node.label) }}</text>
+      <text :x="nd.x" :y="nd.y + 27" text-anchor="middle" class="eg-lab">{{ short(nd.lk.node.label) }}</text>
+    </g>
+    <circle :cx="layout.cx" :cy="layout.cy" r="18" :fill="col(center.type)" stroke="#fff" stroke-width="1.5" />
+    <text :x="layout.cx" :y="layout.cy + 4.5" text-anchor="middle" class="eg-init ego">{{ initials(center.label) }}</text>
+  </svg>
+</template>
+
+<style scoped>
+.eg { width: 100%; height: auto; display: block; }
+.eg-edge { stroke: rgba(237, 238, 242, 0.28); stroke-width: 1.3; cursor: pointer; }
+.eg-edge:hover { stroke: var(--accent); }
+.eg-rel { fill: rgba(237, 238, 242, 0.42); font-size: 7.5px; text-transform: uppercase; letter-spacing: 0.04em; pointer-events: none; }
+.eg-node { cursor: pointer; }
+.eg-node:hover circle { stroke: #fff; stroke-width: 1.2; }
+.eg-init { fill: #0d0f13; font-size: 9px; font-weight: 700; pointer-events: none; }
+.eg-init.ego { fill: #0d0f13; font-size: 11px; }
+.eg-lab { fill: rgba(237, 238, 242, 0.6); font-size: 8.5px; pointer-events: none; }
+</style>

--- a/apps/socioprophet-web/src/components/ExtractDock.vue
+++ b/apps/socioprophet-web/src/components/ExtractDock.vue
@@ -1,0 +1,77 @@
+<template>
+  <!-- Ubiquitous IE: the live extraction stack (entities / claims / topics + promote-to-graph)
+       as a global slide-in dock, available on EVERY surface (⌘E / Ctrl+E) — mirror of the Graph
+       and Noetica docks. Seeds from the current surface's context text; editable so you can extract
+       any selection or pasted text anywhere. -->
+  <Transition name="xdock">
+    <aside v-if="open" class="xdock" role="complementary" aria-label="Extraction">
+      <header class="xdock-head">
+        <span class="xdock-glyph" aria-hidden="true">⌖</span>
+        <span class="xdock-title">Extract</span>
+        <span v-if="ctx.surface" class="xdock-ctx">{{ ctx.surface }}</span>
+        <button class="xdock-x" type="button" aria-label="Close extraction" @click="$emit('close')">✕</button>
+      </header>
+
+      <label class="xdock-in">
+        <span class="xdock-in-h">Text</span>
+        <textarea
+          v-model="text"
+          rows="3"
+          spellcheck="false"
+          placeholder="Extract from this surface, a selection, or paste any text…"
+        ></textarea>
+      </label>
+
+      <div class="xdock-body">
+        <ExtractionPanel v-if="text.trim()" :text="text" :source="ctx.surface || 'Extract dock'" />
+        <p v-else class="xdock-empty">Type or paste text — or open a surface with a selected item — to pull live entities, claims, and topics, and promote them into the graph.</p>
+      </div>
+    </aside>
+  </Transition>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue';
+import ExtractionPanel from './ExtractionPanel.vue';
+import { useCockpit } from '../stores/cockpit';
+
+const props = defineProps<{ open: boolean }>();
+defineEmits<{ (e: 'close'): void }>();
+const cockpit = useCockpit();
+const ctx = computed(() => cockpit.context);
+
+// Seed the textarea from the surface's context text (or its entity label) whenever the dock opens
+// or the context changes — but keep it editable so the user can extract anything on any page.
+const text = ref('');
+function seed() {
+  const c = cockpit.context;
+  const from = c.text || [c.entityLabel, c.detail].filter(Boolean).join(' — ');
+  if (from && from.trim()) text.value = from;
+}
+watch(() => props.open, (o) => { if (o) seed(); });
+watch(() => cockpit.context, () => { if (props.open) seed(); }, { deep: true });
+</script>
+
+<style scoped>
+.xdock {
+  position: fixed; top: 0; right: 0; bottom: 0; width: min(400px, 92vw); z-index: 60;
+  display: flex; flex-direction: column; gap: 0.6rem;
+  background: var(--surface); border-left: 1px solid var(--line-2);
+  box-shadow: -18px 0 44px rgba(0, 0, 0, 0.45); padding: 0.85rem 0.95rem;
+}
+.xdock-head { display: flex; align-items: center; gap: 0.5rem; }
+.xdock-glyph { color: var(--accent); }
+.xdock-title { font-size: 0.8rem; font-weight: 700; letter-spacing: 0.02em; }
+.xdock-ctx { margin-left: auto; font-size: 0.68rem; color: var(--text-3); text-transform: uppercase; letter-spacing: 0.06em; }
+.xdock-x { border: none; background: transparent; color: var(--text-3); cursor: pointer; font-size: 0.8rem; }
+.xdock-x:hover { color: var(--text); }
+.xdock-in { display: flex; flex-direction: column; gap: 0.25rem; }
+.xdock-in-h { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-3); }
+.xdock-in textarea { resize: vertical; background: var(--bg); border: 1px solid var(--line-2); border-radius: 8px; color: var(--text); font: inherit; font-size: 0.82rem; line-height: 1.5; padding: 0.45rem 0.6rem; outline: none; }
+.xdock-in textarea:focus { border-color: color-mix(in srgb, var(--accent) 45%, transparent); }
+.xdock-body { min-height: 0; overflow-y: auto; }
+.xdock-empty { font-size: 0.8rem; color: var(--text-3); line-height: 1.5; padding: 0.5rem 0.1rem; }
+
+.xdock-enter-active, .xdock-leave-active { transition: transform 0.18s ease, opacity 0.18s ease; }
+.xdock-enter-from, .xdock-leave-to { transform: translateX(16px); opacity: 0; }
+</style>

--- a/apps/socioprophet-web/src/components/GroundedTutor.vue
+++ b/apps/socioprophet-web/src/components/GroundedTutor.vue
@@ -1,0 +1,207 @@
+<template>
+  <div class="gt">
+    <div class="gt-head">
+      <span class="gt-title">Grounded Tutor</span>
+      <span v-if="course" class="gt-persona">in the voice of {{ course.teacher }}</span>
+    </div>
+    <p class="gt-blurb">{{ course ? 'Ask about the course.' : 'Ask about this standard.' }} Every answer is <b>quoted and cited</b> to captured material — it never invents.</p>
+
+    <form class="gt-ask" @submit.prevent="ask">
+      <input v-model="qText" class="gt-input" type="text" placeholder="e.g. why doesn't a ball fall faster if you throw it sideways?" aria-label="Ask the tutor" />
+      <button class="gt-go" type="submit" :disabled="!qText.trim() || loading">Ask</button>
+    </form>
+
+    <!-- Engine switch — the local+cloud seam: Auto tries cloud academy ingest → local Noetica → Commons. -->
+    <div class="gt-src" role="group" aria-label="Retrieval engine">
+      <span class="gt-src-h">engine</span>
+      <button v-for="s in SOURCES" :key="s.v" type="button" class="gt-src-btn" :class="{ on: source === s.v }" @click="source = s.v">{{ s.label }}</button>
+    </div>
+
+    <div v-if="loading" class="gt-loading"><span class="gt-load-dot" /> grounding…</div>
+
+    <div v-else-if="!answer" class="gt-seeds">
+      <span class="gt-seeds-h">try:</span>
+      <button v-for="s in SEEDS" :key="s" class="gt-seed" @click="qText = s; ask()">{{ s }}</button>
+    </div>
+
+    <div v-else class="gt-answer" :class="{ nomatch: !answer.cited }">
+      <template v-if="answer.cited">
+        <p class="gt-persona-line">{{ answer.intro }}</p>
+        <blockquote class="gt-quote">“{{ answer.quote }}”</blockquote>
+        <!-- Commons: jump to the in-app lecture. Cloud/local with a URL: open it. Else: static ref. -->
+        <button v-if="answer.lessonId" class="gt-cite" @click="$emit('jump', answer.lessonId)">
+          <span class="gt-cite-g">◆</span>
+          <span>Lecture {{ answer.lessonN }} · {{ answer.title }}</span>
+          <code>{{ answer.chunkRef }}</code>
+          <span class="gt-cite-open">open →</span>
+        </button>
+        <a v-else-if="answer.uri" class="gt-cite" :href="answer.uri" target="_blank" rel="noreferrer">
+          <span class="gt-cite-g">◆</span><span>{{ answer.title }}</span><code>{{ answer.chunkRef }}</code><span class="gt-cite-open">open ↗</span>
+        </a>
+        <div v-else class="gt-cite static">
+          <span class="gt-cite-g">◆</span><span>{{ answer.title }}</span><code>{{ answer.chunkRef }}</code>
+        </div>
+        <div class="gt-prov">
+          <span class="gt-prov-tag">extractive · quoted, not generated</span>
+          <span class="gt-origin" :class="answer.origin" :title="originMeta[answer.origin].label">{{ originMeta[answer.origin].glyph }} {{ originMeta[answer.origin].label }}</span>
+          <span v-if="answer.concepts.length" class="gt-prov-concepts">on {{ answer.concepts.join(', ') }}</span>
+        </div>
+      </template>
+      <template v-else>
+        <p class="gt-nomatch">I answer only from the captured corpus, and I don’t find this yet. This standard’s material isn’t captured — the Commons is still filling in.<span v-if="topConcepts.length"> Try: <b>{{ topConcepts.join(', ') }}</b>.</span></p>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue';
+import type { Course } from '../data/courseFixture';
+import { retrievePassages, ORIGIN_META, type AcademySource, type PassageOrigin } from '../services/academyApi';
+
+// `course` is optional: with it, Commons falls back to the in-app lecture transcripts; without it
+// (e.g. the Homeschool planner teaching a standard) the tutor grounds purely on the live academy
+// ingest / local Noetica. `seed` prefills + auto-asks a question — used to teach a specific standard.
+const props = defineProps<{ course?: Course; seed?: string }>();
+defineEmits<{ (e: 'jump', lessonId: string): void }>();
+
+const qText = ref('');
+const SEEDS = [
+  'what is the difference between velocity and acceleration?',
+  'why do action and reaction forces not cancel?',
+  'is there a centrifugal force?',
+];
+
+const STOP = new Set(['the', 'a', 'an', 'is', 'are', 'of', 'to', 'in', 'on', 'and', 'or', 'do', 'does', 'why', 'what', 'how', 'if', 'you', 'your', 'it', 'its', 'be', 'for', 'that', 'this', 'at', 'as', 'with', 'not', 'no', 'they', 'them', 'from', 'by', 'can', 'we', 'i', 'me', 'my']);
+function tokens(s: string): string[] {
+  return s.toLowerCase().replace(/[^a-z0-9\s]/g, ' ').split(/\s+/).filter((t) => t.length > 1 && !STOP.has(t));
+}
+
+const topConcepts = computed(() => {
+  const all = (props.course?.lessons ?? []).flatMap((l) => l.concepts);
+  return [...new Set(all)].slice(0, 5);
+});
+
+interface Answer { cited: boolean; intro: string; quote: string; lessonId: string; lessonN: number; title: string; chunkRef: string; concepts: string[]; origin: PassageOrigin; uri?: string }
+const answer = ref<Answer | null>(null);
+const loading = ref(false);
+const source = ref<AcademySource>('auto');
+const SOURCES: { v: AcademySource; label: string }[] = [
+  { v: 'auto', label: 'Auto' }, { v: 'cloud', label: 'Cloud' }, { v: 'local', label: 'Local' }, { v: 'fixture', label: 'Commons' },
+];
+const originMeta = ORIGIN_META;
+
+// Pick the single most query-relevant sentence from a passage (tightest quote).
+function sentenceOf(text: string, qt: string[]): string {
+  const sentences = text.split(/(?<=[.!?])\s+/).filter((s) => s.trim().length > 0);
+  let best = sentences[0] ?? text; let sc = -1;
+  for (const s of sentences) {
+    const st = new Set(tokens(s));
+    const overlap = qt.reduce((n, t) => n + (st.has(t) ? 1 : 0), 0);
+    if (overlap > sc) { sc = overlap; best = s; }
+  }
+  return best.trim();
+}
+
+// Commons grounding — extractive over the in-app captured transcripts (the guaranteed fallback).
+function fixtureAnswer(qt: string[]): Answer {
+  const lessons = props.course?.lessons ?? [];
+  if (lessons.length === 0) return { cited: false, intro: '', quote: '', lessonId: '', lessonN: 0, title: '', chunkRef: '', concepts: [], origin: 'fixture' };
+  let best: { lesson: typeof lessons[number]; score: number } | null = null;
+  for (const lesson of lessons) {
+    const conceptToks = new Set(lesson.concepts.flatMap(tokens));
+    const titleToks = new Set(tokens(lesson.title));
+    const bodyToks = new Set(tokens(lesson.transcript));
+    let score = 0;
+    for (const t of qt) {
+      if (conceptToks.has(t)) score += 3;
+      if (titleToks.has(t)) score += 2;
+      if (bodyToks.has(t)) score += 1;
+    }
+    if (!best || score > best.score) best = { lesson, score };
+  }
+  if (!best || best.score === 0) {
+    return { cited: false, intro: '', quote: '', lessonId: '', lessonN: 0, title: '', chunkRef: '', concepts: [], origin: 'fixture' };
+  }
+  const hitConcepts = best.lesson.concepts.filter((c) => tokens(c).some((t) => qt.includes(t)));
+  return {
+    cited: true,
+    intro: `Here's what ${props.course?.teacher ?? 'the source'} says on this:`,
+    quote: sentenceOf(best.lesson.transcript, qt),
+    lessonId: best.lesson.id, lessonN: best.lesson.n, title: best.lesson.title, chunkRef: best.lesson.chunkRef,
+    concepts: hitConcepts.length ? hitConcepts : best.lesson.concepts.slice(0, 2),
+    origin: 'fixture',
+  };
+}
+
+async function ask() {
+  const query = qText.value.trim();
+  if (!query) return;
+  const qt = tokens(query);
+  if (qt.length === 0) { answer.value = fixtureAnswer(qt); return; }
+  loading.value = true;
+  try {
+    // Try the live engine(s) first (cloud academy ingest / local Noetica), unless Commons is forced.
+    if (source.value !== 'fixture') {
+      const { passages, origin } = await retrievePassages(query, source.value);
+      if (passages.length) {
+        const top = passages[0]!;
+        answer.value = {
+          cited: true,
+          intro: `From the ${originMeta[origin].label}:`,
+          quote: sentenceOf(top.text, qt) || top.text,
+          lessonId: '', lessonN: 0, title: top.title, chunkRef: top.chunkRef, concepts: [],
+          origin, uri: top.uri,
+        };
+        return;
+      }
+    }
+    // Nothing live (or Commons forced) → extractive over the captured transcripts.
+    answer.value = fixtureAnswer(qt);
+  } finally {
+    loading.value = false;
+  }
+}
+
+// Teach a specific standard/topic: when `seed` changes, prefill and ask against the live corpus.
+watch(() => props.seed, (s) => { if (s) { qText.value = s; void ask(); } }, { immediate: true });
+</script>
+
+<style scoped>
+.gt { border: 1px solid var(--line-2); border-radius: 12px; background: var(--surface); padding: 0.85rem; display: flex; flex-direction: column; gap: 0.6rem; }
+.gt-head { display: flex; align-items: baseline; gap: 0.5rem; flex-wrap: wrap; }
+.gt-title { font-size: 0.9rem; font-weight: 700; color: var(--text); }
+.gt-persona { font-size: 0.7rem; color: var(--accent); }
+.gt-blurb { margin: 0; font-size: 0.74rem; color: var(--text-3); line-height: 1.5; } .gt-blurb b { color: var(--text-2); }
+.gt-ask { display: flex; gap: 0.5rem; }
+.gt-input { flex: 1; min-width: 0; border: 1px solid var(--line-2); background: var(--surface-2, rgba(255,255,255,0.02)); color: var(--text); border-radius: 8px; padding: 0.45rem 0.6rem; font-size: 0.82rem; }
+.gt-input:focus { outline: none; border-color: var(--accent); }
+.gt-go { border: 1px solid var(--accent); background: var(--accent-soft, rgba(120,160,255,0.14)); color: var(--accent); border-radius: 8px; padding: 0.45rem 0.9rem; font-size: 0.8rem; font-weight: 600; cursor: pointer; } .gt-go:disabled { opacity: 0.5; cursor: default; }
+.gt-seeds { display: flex; flex-wrap: wrap; gap: 0.35rem; align-items: center; }
+.gt-seeds-h { font-size: 0.68rem; color: var(--text-3); }
+.gt-seed { border: 1px solid var(--line-2); background: transparent; color: var(--text-2); border-radius: 999px; padding: 0.18rem 0.55rem; font-size: 0.7rem; cursor: pointer; text-align: left; } .gt-seed:hover { border-color: var(--accent); color: var(--accent); }
+
+.gt-answer { border-top: 1px solid var(--line); padding-top: 0.6rem; }
+.gt-persona-line { margin: 0 0 0.4rem; font-size: 0.78rem; color: var(--text-2); }
+.gt-quote { margin: 0 0 0.55rem; padding: 0.5rem 0.7rem; border-left: 3px solid var(--accent); background: var(--surface-2, rgba(255,255,255,0.015)); border-radius: 0 8px 8px 0; font-size: 0.9rem; line-height: 1.6; color: var(--text); }
+.gt-cite { display: flex; align-items: center; gap: 0.5rem; width: 100%; text-align: left; border: 1px solid var(--line-2); border-radius: 8px; padding: 0.4rem 0.6rem; background: transparent; color: var(--text-2); cursor: pointer; font-size: 0.76rem; } .gt-cite:hover { border-color: var(--accent); }
+.gt-cite-g { color: var(--accent); } .gt-cite code { font-family: ui-monospace, monospace; font-size: 0.68rem; color: var(--text-3); } .gt-cite-open { margin-left: auto; color: var(--accent); }
+.gt-prov { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; margin-top: 0.4rem; }
+.gt-prov-tag { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 700; color: var(--up); background: rgba(63,185,80,0.12); border: 1px solid rgba(63,185,80,0.35); border-radius: 4px; padding: 0.05rem 0.4rem; }
+.gt-prov-concepts { font-size: 0.68rem; color: var(--text-3); }
+.gt-nomatch { margin: 0; font-size: 0.8rem; color: var(--text-2); line-height: 1.55; } .gt-nomatch b { color: var(--text); }
+
+/* Engine switch (local + cloud seam) */
+.gt-src { display: flex; align-items: center; gap: 0.3rem; }
+.gt-src-h { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-3); margin-right: 0.15rem; }
+.gt-src-btn { border: 1px solid var(--line-2); background: transparent; color: var(--text-3); border-radius: 6px; padding: 0.14rem 0.5rem; font-size: 0.68rem; cursor: pointer; } .gt-src-btn.on { border-color: var(--accent); color: var(--accent); background: var(--accent-soft, rgba(120,160,255,0.12)); }
+.gt-loading { display: flex; align-items: center; gap: 0.4rem; font-size: 0.76rem; color: var(--text-3); padding: 0.3rem 0; }
+.gt-load-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--accent); animation: gtPulse 0.9s ease-in-out infinite; }
+@keyframes gtPulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
+@media (prefers-reduced-motion: reduce) { .gt-load-dot { animation: none; } }
+.gt-cite.static { cursor: default; }
+.gt-origin { display: inline-flex; align-items: center; gap: 0.25rem; font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.04em; font-weight: 700; border-radius: 4px; padding: 0.05rem 0.4rem; border: 1px solid var(--line-2); color: var(--text-3); }
+.gt-origin.cloud { color: #58a6ff; border-color: rgba(88,166,255,0.4); }
+.gt-origin.local { color: #6ee7b7; border-color: rgba(63,185,80,0.4); }
+.gt-origin.fixture { color: var(--text-3); }
+</style>

--- a/apps/socioprophet-web/src/components/MacroForecastChart.vue
+++ b/apps/socioprophet-web/src/components/MacroForecastChart.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+// MacroForecastChart — the wedge. FRED/Economist/NYT/WSJ show the past; this draws the FUTURE:
+// the history line, auto contraction-shading (runs below zero — a real recession heuristic for
+// growth-type series), a dashed forecast median, and a 50/80% fan of uncertainty that widens with
+// the horizon. The forecast is a mean-reverting model projection computed from the series' own
+// recent level + volatility — a transparent stand-in, wireable to the economic-prophet engine
+// (pass `forecast`/`band` props) with no visual change. Pure SVG, no chart lib.
+import { computed } from 'vue';
+
+const props = withDefaults(
+  defineProps<{
+    series: number[];
+    horizon?: number;
+    target?: number | null;   // mean-revert target; default = mean of last 8
+    events?: { i: number; label: string }[];
+    tone?: string;            // history line colour
+    w?: number;
+    h?: number;
+  }>(),
+  { horizon: 10, target: null, events: () => [], tone: '#8fd3a6', w: 640, h: 200 },
+);
+
+const geo = computed(() => {
+  const hist = props.series ?? [];
+  const nH = hist.length;
+  if (nH < 2) return null;
+  const last = hist[nH - 1]!;
+  const tail = hist.slice(-8);
+  const target = props.target ?? tail.reduce((a, b) => a + b, 0) / tail.length;
+  const nF = Math.max(2, props.horizon);
+
+  // volatility from recent absolute diffs → the fan half-width per √horizon
+  const diffs = hist.slice(1).map((v, i) => Math.abs(v - hist[i]!));
+  const vol = Math.max(0.05, diffs.reduce((a, b) => a + b, 0) / (diffs.length || 1) || 0.1);
+
+  const fc: number[] = [], lo80: number[] = [], hi80: number[] = [], lo50: number[] = [], hi50: number[] = [];
+  let fv = last;
+  for (let j = 0; j < nF; j++) {
+    fv += (target - fv) * 0.2;
+    const s = vol * Math.sqrt(j + 1);
+    fc.push(fv); lo80.push(fv - s * 1.28); hi80.push(fv + s * 1.28); lo50.push(fv - s * 0.67); hi50.push(fv + s * 0.67);
+  }
+
+  const total = nH + nF - 1;
+  const all = hist.concat(fc, lo80, hi80);
+  const min = Math.min(...all), max = Math.max(...all), span = max - min || 1;
+  const padT = 12, padB = 6, padX = 2, W = props.w, H = props.h;
+  const X = (i: number) => padX + (i / total) * (W - padX * 2);
+  const Y = (v: number) => padT + (H - padT - padB) * (1 - (v - min) / span);
+
+  const histLine = hist.map((v, i) => `${i ? 'L' : 'M'}${X(i).toFixed(1)} ${Y(v).toFixed(1)}`).join(' ');
+  const histArea = `M${X(0).toFixed(1)} ${H} ${histLine.replace(/^M/, 'L')} L${X(nH - 1).toFixed(1)} ${H} Z`;
+  const fcLine = `M${X(nH - 1).toFixed(1)} ${Y(last).toFixed(1)} ` + fc.map((v, k) => `L${X(nH + k).toFixed(1)} ${Y(v).toFixed(1)}`).join(' ');
+  const band = (loA: number[], hiA: number[]) => {
+    let d = `M${X(nH - 1).toFixed(1)} ${Y(last).toFixed(1)}`;
+    for (let k = 0; k < nF; k++) d += ` L${X(nH + k).toFixed(1)} ${Y(hiA[k]!).toFixed(1)}`;
+    for (let k = nF - 1; k >= 0; k--) d += ` L${X(nH + k).toFixed(1)} ${Y(loA[k]!).toFixed(1)}`;
+    return d + ' Z';
+  };
+
+  // contraction shading: contiguous runs where the series is below zero
+  const recs: { x: number; w: number }[] = [];
+  let runStart = -1;
+  for (let i = 0; i < nH; i++) {
+    const neg = hist[i]! < 0;
+    if (neg && runStart < 0) runStart = i;
+    if ((!neg || i === nH - 1) && runStart >= 0) {
+      const end = neg ? i : i - 1;
+      recs.push({ x: X(runStart), w: X(end) - X(runStart) });
+      runStart = -1;
+    }
+  }
+
+  return {
+    W, H, nowX: X(nH - 1), y0: Y(0), showZero: min < 0,
+    histLine, histArea, fcLine, band80: band(lo80, hi80), band50: band(lo50, hi50),
+    lastX: X(nH - 1), lastY: Y(last), fcEndX: X(total), fcEndY: Y(fc[nF - 1]!),
+    recs, evs: (props.events ?? []).filter((e) => e.i >= 0 && e.i < nH).map((e) => ({ x: X(e.i), y: Y(hist[e.i]!), label: e.label })),
+    fcTarget: +fc[nF - 1]!.toFixed(2), fcBand: +(hi80[nF - 1]! - fc[nF - 1]!).toFixed(2),
+  };
+});
+
+defineExpose({ geo });
+</script>
+
+<template>
+  <svg v-if="geo" class="mfc" :viewBox="`0 0 ${geo.W} ${geo.H}`" preserveAspectRatio="none" role="img" aria-label="Indicator history with model forecast fan">
+    <rect v-for="(r, i) in geo.recs" :key="'r' + i" :x="r.x" y="0" :width="r.w" :height="geo.H" fill="rgba(237,238,242,0.07)" />
+    <line v-if="geo.showZero" x1="0" :y1="geo.y0" :x2="geo.W" :y2="geo.y0" stroke="rgba(237,238,242,0.10)" stroke-dasharray="2 4" />
+    <path :d="geo.band80" fill="rgba(216,162,80,0.12)" />
+    <path :d="geo.band50" fill="rgba(216,162,80,0.20)" />
+    <path :d="geo.histArea" fill="rgba(237,238,242,0.05)" />
+    <path :d="geo.histLine" fill="none" :stroke="tone" stroke-width="2" stroke-linejoin="round" />
+    <path :d="geo.fcLine" fill="none" stroke="#d8a250" stroke-width="2" stroke-dasharray="5 4" stroke-linejoin="round" />
+    <line :x1="geo.nowX" y1="5" :x2="geo.nowX" :y2="geo.H - 6" stroke="rgba(237,238,242,0.22)" stroke-dasharray="3 3" />
+    <template v-for="(e, i) in geo.evs" :key="'e' + i">
+      <circle :cx="e.x" :cy="e.y" r="2.6" fill="#edeef2" />
+      <text :x="e.x" :y="e.y - 7" text-anchor="middle" fill="rgba(237,238,242,0.6)" font-size="9">{{ e.label }}</text>
+    </template>
+    <circle :cx="geo.lastX" :cy="geo.lastY" r="3" :fill="tone" />
+    <circle :cx="geo.fcEndX" :cy="geo.fcEndY" r="3" fill="#d8a250" />
+  </svg>
+</template>
+
+<style scoped>
+.mfc { width: 100%; height: 100%; display: block; }
+</style>

--- a/apps/socioprophet-web/src/components/TritFabricReadinessLabels.vue
+++ b/apps/socioprophet-web/src/components/TritFabricReadinessLabels.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+// Vendored copy of contracts/integrations/tritfabric-ui-labels.v0.json — the client-vue image
+// build only copies apps/socioprophet-web, so a repo-root import would break the Docker build.
+// The root contract is kept in sync and is what validate_tritfabric_ui_component.py checks.
+import labelContract from '../contracts/tritfabric-ui-labels.v0.json'
+
+type Label = {
+  surface_id: string
+  display_label: string
+  status_label: string
+  must_show: string[]
+  forbidden_badges: string[]
+}
+
+const labels = labelContract.labels as Label[]
+const claimBoundary = labelContract.claim_boundary
+</script>
+
+<template>
+  <section style="border:1px solid #e2e8f0;border-radius:16px;padding:1rem;margin-top:1.5rem;">
+    <div style="font-size:12px;text-transform:uppercase;letter-spacing:.08em;opacity:.65;font-weight:700;">
+      TritFabric readiness labels
+    </div>
+    <h2 style="margin:.4rem 0 0.6rem 0;font-size:1.4rem;font-weight:700;">
+      Governed product-consumption surfaces
+    </h2>
+    <p style="margin:0 0 1rem 0;opacity:.82;">
+      Label contract for displaying TritFabric-derived Community Learning, Network Atlas, model-card evidence, and Serve readiness surfaces without implying runtime authority.
+    </p>
+
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:.75rem;margin-bottom:1rem;">
+      <article v-for="label in labels" :key="label.surface_id" style="border:1px solid #e2e8f0;border-radius:12px;padding:.75rem;">
+        <div style="font-size:12px;text-transform:uppercase;opacity:.65;font-weight:700;">{{ label.status_label }}</div>
+        <h3 style="margin:.35rem 0 .5rem 0;font-size:1rem;font-weight:700;">{{ label.display_label }}</h3>
+        <div style="font-size:.8rem;opacity:.62;margin-bottom:.5rem;">{{ label.surface_id }}</div>
+        <section>
+          <div style="font-size:.82rem;font-weight:700;margin-bottom:.25rem;">Must show</div>
+          <ul style="margin:0 0 .75rem 0;padding-left:1rem;">
+            <li v-for="item in label.must_show" :key="`${label.surface_id}-must-${item}`" style="margin:.25rem 0;">{{ item }}</li>
+          </ul>
+        </section>
+        <section>
+          <div style="font-size:.82rem;font-weight:700;margin-bottom:.25rem;">Forbidden badges</div>
+          <ul style="margin:0;padding-left:1rem;">
+            <li v-for="item in label.forbidden_badges" :key="`${label.surface_id}-forbidden-${item}`" style="margin:.25rem 0;">{{ item }}</li>
+          </ul>
+        </section>
+      </article>
+    </div>
+
+    <section style="border:1px dashed #cbd5e1;border-radius:12px;padding:.75rem;">
+      <div style="font-size:.82rem;font-weight:700;margin-bottom:.25rem;">Claim boundary</div>
+      <p style="margin:0;opacity:.78;">{{ claimBoundary }}</p>
+    </section>
+  </section>
+</template>

--- a/apps/socioprophet-web/src/components/WaterfallChart.vue
+++ b/apps/socioprophet-web/src/components/WaterfallChart.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+// WaterfallChart — the "story" chart for a decision tool (Bostock rent-vs-buy lesson): baseline →
+// each driver's signed contribution (green up / red down) → the total, as floating bars with
+// connectors. Zoomed y-axis (starts near the baseline, not 0) so small uplifts on a large base are
+// actually visible. Reusable for the GYG valuation and the Finance decision-tool suite. Pure SVG.
+import { computed } from 'vue';
+
+export interface WaterfallSeg { label: string; value: number }
+
+const props = withDefaults(
+  defineProps<{
+    baseline: number;
+    segments: WaterfallSeg[];
+    total: number;
+    baselineLabel?: string;
+    totalLabel?: string;
+    fmt?: (n: number) => string;
+    w?: number;
+    h?: number;
+  }>(),
+  { baselineLabel: 'Baseline', totalLabel: 'Projected', fmt: (n: number) => Math.round(n).toLocaleString(), w: 660, h: 240 },
+);
+
+const geo = computed(() => {
+  const segs = props.segments ?? [];
+  // running totals to find the value range (bars float between running levels)
+  let run = props.baseline;
+  const levels: number[] = [props.baseline];
+  for (const s of segs) { run += s.value; levels.push(run); }
+  levels.push(props.total);
+  const lo = Math.min(...levels), hi = Math.max(...levels);
+  const pad = (hi - lo || Math.abs(hi) || 1) * 0.12;
+  const yMin = lo - pad, yMax = hi + pad, span = yMax - yMin || 1;
+
+  const n = segs.length + 2; // baseline + segments + total
+  const padX = 6, padT = 10, padB = 26, W = props.w, H = props.h;
+  const bw = (W - padX * 2) / n * 0.62;
+  const gap = (W - padX * 2) / n;
+  const X = (i: number) => padX + gap * i + (gap - bw) / 2;
+  const Y = (v: number) => padT + (H - padT - padB) * (1 - (v - yMin) / span);
+
+  const bars: Array<{ x: number; y: number; w: number; h: number; kind: string; label: string; val: string; cxLine?: number }> = [];
+  // baseline (full-ish column from yMin)
+  bars.push({ x: X(0), y: Y(props.baseline), w: bw, h: Y(yMin) - Y(props.baseline), kind: 'base', label: props.baselineLabel, val: props.fmt(props.baseline) });
+  let cur = props.baseline;
+  segs.forEach((s, i) => {
+    const next = cur + s.value;
+    const yTop = Y(Math.max(cur, next)), yBot = Y(Math.min(cur, next));
+    bars.push({ x: X(i + 1), y: yTop, w: bw, h: Math.max(1.5, yBot - yTop), kind: s.value >= 0 ? 'up' : 'down', label: s.label, val: (s.value >= 0 ? '+' : '') + props.fmt(s.value) });
+    cur = next;
+  });
+  bars.push({ x: X(n - 1), y: Y(props.total), w: bw, h: Y(yMin) - Y(props.total), kind: 'total', label: props.totalLabel, val: props.fmt(props.total) });
+
+  // connectors between successive bar tops (running level)
+  const conns: Array<{ x1: number; y1: number; x2: number; y2: number }> = [];
+  let lvl = props.baseline;
+  for (let i = 0; i < segs.length; i++) {
+    const y = Y(lvl);
+    conns.push({ x1: X(i) + bw, y1: y, x2: X(i + 1), y2: y });
+    lvl += segs[i]!.value;
+  }
+  conns.push({ x1: X(segs.length) + bw, y1: Y(lvl), x2: X(segs.length + 1), y2: Y(lvl) });
+
+  return { W, H, bars, conns };
+});
+</script>
+
+<template>
+  <svg class="wf" :viewBox="`0 0 ${geo.W} ${geo.H}`" role="img" aria-label="Value waterfall: baseline to projected by driver">
+    <line v-for="(c, i) in geo.conns" :key="'c' + i" :x1="c.x1" :y1="c.y1" :x2="c.x2" :y2="c.y2" class="wf-conn" />
+    <g v-for="(b, i) in geo.bars" :key="'b' + i">
+      <rect :x="b.x" :y="b.y" :width="b.w" :height="b.h" :class="['wf-bar', b.kind]" rx="1.5" />
+      <text :x="b.x + b.w / 2" :y="b.y - 3" text-anchor="middle" class="wf-val" :class="b.kind">{{ b.val }}</text>
+      <text :x="b.x + b.w / 2" :y="geo.H - 12" text-anchor="middle" class="wf-lab">{{ b.label }}</text>
+    </g>
+  </svg>
+</template>
+
+<style scoped>
+.wf { width: 100%; height: auto; display: block; }
+.wf-conn { stroke: rgba(237, 238, 242, 0.22); stroke-width: 1; stroke-dasharray: 2 3; }
+.wf-bar.base, .wf-bar.total { fill: color-mix(in srgb, var(--accent) 55%, transparent); }
+.wf-bar.up { fill: color-mix(in srgb, var(--up) 80%, transparent); }
+.wf-bar.down { fill: color-mix(in srgb, var(--down) 80%, transparent); }
+.wf-val { font-size: 9px; font-variant-numeric: tabular-nums; fill: var(--text-2); }
+.wf-val.up { fill: var(--up); } .wf-val.down { fill: var(--down); } .wf-val.base, .wf-val.total { fill: var(--accent); }
+.wf-lab { font-size: 8.5px; fill: var(--text-3); }
+</style>

--- a/apps/socioprophet-web/src/components/depth/DepthControl.vue
+++ b/apps/socioprophet-web/src/components/depth/DepthControl.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+// W11.6 — the depth control. Writes the STORED preference (stores/settings.ts → localStorage),
+// so setting it once changes every proof surface, on this visit and the next.
+//
+// It is a segmented control rather than a hidden "advanced" switch on purpose: TA-E's premise
+// is that depth is a property of the CONSUMER, so it has to be as visible and as durable as a
+// theme setting. What it does NOT do is change any claim — see features/depth/expertise.ts.
+import { computed } from 'vue';
+import { useSettings } from '../../stores/settings';
+import { EXPERTISE_LEVELS, depthPolicy, type Expertise } from '../../features/depth/expertise';
+
+withDefaults(defineProps<{ compact?: boolean }>(), { compact: false });
+
+const settings = useSettings();
+const level = computed<Expertise>(() => settings.expertise as Expertise);
+const policy = computed(() => depthPolicy(level.value));
+</script>
+
+<template>
+  <div class="dc" role="group" aria-label="Detail depth">
+    <span class="dc-l">depth</span>
+    <div class="dc-seg">
+      <button
+        v-for="l in EXPERTISE_LEVELS"
+        :key="l"
+        class="dc-opt"
+        type="button"
+        :class="{ on: level === l }"
+        :aria-pressed="level === l"
+        @click="settings.setExpertise(l)"
+      >
+        {{ depthPolicy(l).label }}
+      </button>
+    </div>
+    <span v-if="!compact" class="dc-blurb">{{ policy.blurb }}</span>
+    <!-- The guarantee, stated where the control is, because a depth control is exactly the
+         affordance a reader would suspect of hiding bad news. -->
+    <span v-if="!compact" class="dc-vow">
+      Depth changes what is shown, never what is claimed — warrant type, seal state and
+      model-generated markers show at every depth.
+    </span>
+  </div>
+</template>
+
+<style scoped>
+.dc {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.dc-l {
+  color: var(--faint);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.dc-seg {
+  display: inline-flex;
+  border: 1px solid var(--border-2);
+  border-radius: var(--r-1);
+  overflow: hidden;
+}
+.dc-opt {
+  background: transparent;
+  color: var(--muted);
+  border: 0;
+  border-right: 1px solid var(--border-2);
+  padding: 2px 10px;
+  font-size: 0.68rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+.dc-opt:last-child {
+  border-right: 0;
+}
+.dc-opt:hover {
+  color: var(--ink);
+  background: var(--surface);
+}
+.dc-opt.on {
+  color: var(--accent-ink);
+  background: var(--accent-wash);
+}
+.dc-opt:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.dc-blurb {
+  color: var(--faint);
+  font-size: 0.64rem;
+}
+.dc-vow {
+  flex-basis: 100%;
+  color: var(--faint);
+  font-size: 0.6rem;
+  line-height: 1.45;
+  border-left: 2px solid var(--hairline-strong);
+  padding-left: 0.45rem;
+}
+</style>

--- a/apps/socioprophet-web/src/components/nuggets/NuggetCard.vue
+++ b/apps/socioprophet-web/src/components/nuggets/NuggetCard.vue
@@ -1,0 +1,352 @@
+<script setup lang="ts">
+// W11.5 — one KnowledgeNugget, with its warrant on the front.
+//
+// The schema's normative rule is that model-generated content stays VISIBLY distinguishable on
+// every downstream surface. So the difference is carried three ways at once, not buried in a
+// tooltip: the epistemic stripe down the left edge, the <Warrant> badge, and — for
+// model-generated only — a standing banner. Any one of them could be missed; all three cannot.
+//
+// Depth (W11.6) folds away evidence lists, provenance chains, URNs, hashes and payloads.
+// It never folds away the warrant badge, the stripe, the model-generated banner, or the
+// unsealed/unknown seal state. Those render at every level, by construction — there is no
+// depth flag capable of hiding them.
+import { computed } from 'vue';
+import Warrant from '../warrant/Warrant.vue';
+import {
+  nuggetWarrantInput,
+  refLabel,
+  type KnowledgeNugget,
+} from '../../features/nuggets/types';
+import { clampText, depthPolicy, warrantGloss, type Expertise } from '../../features/depth/expertise';
+import { isModelGenerated, pct } from '../../features/warrant/types';
+
+const props = defineProps<{ nugget: KnowledgeNugget; level: Expertise }>();
+
+const policy = computed(() => depthPolicy(props.level));
+const kind = computed(() => props.nugget.warrant.type);
+const modelGenerated = computed(() => isModelGenerated(kind.value));
+const gloss = computed(() => warrantGloss(kind.value, props.level));
+const w = computed(() => nuggetWarrantInput(props.nugget));
+const body = computed(() => clampText(props.nugget.text, policy.value));
+const span = computed(() => props.nugget.sourceRef.span);
+
+/**
+ * The stripe hue, by WARRANT KIND — a different axis from seal state.
+ *
+ * Deliberately mixed down to 62% rather than using the raw `--epi-*` token. A nugget's seal is
+ * always `unknown` (no receipt exists for it), so `warrantView().epistemic` is `unknown` and
+ * the <Warrant> badge beside this stripe renders desaturated. A full-strength `--epi-observed`
+ * stripe next to an `unknown` badge would be a surface arguing with itself, and would re-open
+ * the "colour outranks proof" hole that #1052 closed on the plan surfaces.
+ *
+ * So: hue still separates a quote from a model guess at a glance (which W11.5 requires), but
+ * the intensity never claims proof the nugget does not carry.
+ */
+const KIND_HUE: Record<string, string> = {
+  'direct-quote': 'var(--epi-observed)',
+  computed: 'var(--epi-derived)',
+  inferred: 'var(--epi-derived)',
+  'model-generated': 'var(--epi-hypothesis)',
+};
+const stripe = computed(
+  () => `color-mix(in srgb, ${KIND_HUE[kind.value] ?? 'var(--epi-unknown)'} 62%, var(--panel))`,
+);
+
+const payload = computed(() => {
+  const p = props.nugget.canonicalPayload;
+  return p && typeof p === 'object' ? (p as Record<string, unknown>) : null;
+});
+</script>
+
+<template>
+  <article class="ng" :class="{ 'ng-model': modelGenerated }" :style="{ '--epi': stripe }">
+    <!-- Warrant row. Always first, always present, at every depth. -->
+    <header class="ng-head">
+      <Warrant :w="w" />
+      <span class="ng-kind">{{ kind }}</span>
+      <span v-if="policy.showConfidence" class="ng-conf tnum" :title="'Producer-stated confidence'">
+        {{ pct(nugget.warrant.confidence) }}
+      </span>
+      <time class="ng-time" :datetime="nugget.wallTime">{{ nugget.wallTime.slice(0, 16).replace('T', ' ') }}</time>
+    </header>
+
+    <!--
+      The banner is unconditional for model-generated. Not depth-gated, not collapsible:
+      the schema says "MUST remain visibly distinguishable on every downstream surface".
+    -->
+    <p v-if="modelGenerated" class="ng-banner">
+      <b>Model-generated.</b> Not warranted by the source. The span below is the window the model
+      was conditioned on — it is not evidence for this statement.
+    </p>
+
+    <p class="ng-text" :class="{ quote: kind === 'direct-quote' }">{{ body.text }}</p>
+    <p v-if="body.truncated" class="ng-trunc">
+      Shortened for {{ policy.label.toLowerCase() }} depth — the full text is unchanged, raise depth to read it.
+    </p>
+
+    <!-- Plain-language reading of the warrant, at this depth. Never stronger than the warrant. -->
+    <p class="ng-gloss">{{ gloss.text }}</p>
+
+    <dl class="ng-meta">
+      <div class="ng-row">
+        <dt>Source</dt>
+        <dd>
+          <span v-if="policy.showRawRefs" class="mono">{{ nugget.sourceRef.docRef }}</span>
+          <span v-else>{{ refLabel(nugget.sourceRef.docRef) }}</span>
+          <span v-if="policy.showSpanOffsets" class="ng-span tnum">
+            {{ modelGenerated ? 'conditioning window' : 'span' }} [{{ span.start }},{{ span.end }})
+            <template v-if="span.page">· p{{ span.page }}</template>
+          </span>
+        </dd>
+      </div>
+
+      <div v-if="policy.showRawRefs" class="ng-row">
+        <dt>Content hash</dt>
+        <dd><code class="mono ng-hash">{{ nugget.sourceRef.contentHash }}</code></dd>
+      </div>
+
+      <!-- Evidence. For computed/inferred the schema guarantees >= 1; for model-generated the
+           absence is itself the point, so it is stated rather than left blank. -->
+      <div v-if="policy.showEvidenceList" class="ng-row">
+        <dt>Evidence</dt>
+        <dd>
+          <template v-if="nugget.warrant.evidence.length">
+            <span v-for="e in nugget.warrant.evidence" :key="e" class="ng-chip mono">
+              {{ policy.showRawRefs ? e : refLabel(e) }}
+            </span>
+          </template>
+          <span v-else-if="kind === 'direct-quote'" class="ng-none">
+            none cited — a direct quote is grounded by its source span itself
+          </span>
+          <span v-else class="ng-none warn">none cited</span>
+        </dd>
+      </div>
+
+      <div v-if="policy.showPolicyLabels && nugget.policyLabels.length" class="ng-row">
+        <dt>Policy</dt>
+        <dd><span v-for="p in nugget.policyLabels" :key="p" class="ng-chip">{{ p }}</span></dd>
+      </div>
+
+      <div v-if="policy.showCanonicalPayload && payload" class="ng-row">
+        <dt>Canonical</dt>
+        <dd>
+          <span v-if="payload['normalizationRegime']" class="ng-regime mono">
+            regime {{ payload['normalizationRegime'] }}
+          </span>
+          <code class="ng-payload mono">{{ JSON.stringify(payload) }}</code>
+        </dd>
+      </div>
+
+      <div v-if="policy.showProvenanceChain && nugget.provenance?.length" class="ng-row">
+        <dt>Provenance</dt>
+        <dd>
+          <span v-for="p in nugget.provenance" :key="`${p.rel}|${p.ref}`" class="ng-prov">
+            <span class="ng-rel">{{ p.rel }}</span>
+            <span class="mono">{{ policy.showRawRefs ? p.ref : refLabel(p.ref) }}</span>
+          </span>
+        </dd>
+      </div>
+
+      <div v-if="policy.showRawRefs" class="ng-row">
+        <dt>Nugget</dt>
+        <dd>
+          <code class="mono ng-hash">{{ nugget.id }}</code>
+          <span class="ng-by">by <span class="mono">{{ nugget.createdBy }}</span></span>
+          <span class="ng-by">logical {{ nugget.logicalTime }}</span>
+        </dd>
+      </div>
+    </dl>
+
+    <!-- Seal state, stated once per card. `unknown` is not `unsealed`, and neither is `sealed`. -->
+    <p class="ng-seal">
+      Seal: <b>unknown</b> — KnowledgeNugget 0.1.0 carries no receipt reference. The extractor
+      seals the emitted BATCH, not the individual nugget, so nothing here proves this one is on
+      the chain.
+    </p>
+  </article>
+</template>
+
+<style scoped>
+.ng {
+  position: relative;
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.7rem 0.85rem 0.7rem 1rem;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--r-3);
+}
+/* The epistemic stripe — the at-a-glance signal. */
+.ng::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  border-radius: var(--r-3) 0 0 var(--r-3);
+  background: var(--epi);
+}
+/* Model-generated is dimmer and dashed: it must not read like the quotes around it. */
+.ng-model {
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--epi-hypothesis) 46%, transparent);
+  background: color-mix(in srgb, var(--epi-hypothesis) 7%, var(--panel));
+}
+
+.ng-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.ng-kind {
+  color: var(--epi);
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 700;
+}
+.ng-conf {
+  color: var(--muted);
+  font-size: 0.64rem;
+}
+.ng-time {
+  margin-left: auto;
+  color: var(--faint);
+  font-size: 0.62rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.ng-banner {
+  margin: 0;
+  padding: 0.35rem 0.5rem;
+  border-radius: var(--r-1);
+  background: color-mix(in srgb, var(--epi-hypothesis) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--epi-hypothesis) 44%, transparent);
+  color: var(--ink-2);
+  font-size: 0.66rem;
+  line-height: 1.45;
+}
+.ng-banner b {
+  color: var(--epi-hypothesis);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ng-text {
+  margin: 0;
+  color: var(--ink);
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+/* A verbatim cut looks like a quotation. Nothing else does. */
+.ng-text.quote {
+  border-left: 2px solid color-mix(in srgb, var(--epi-observed) 55%, transparent);
+  padding-left: 0.55rem;
+  font-style: italic;
+}
+.ng-trunc,
+.ng-gloss {
+  margin: 0;
+  color: var(--faint);
+  font-size: 0.66rem;
+  line-height: 1.45;
+}
+
+.ng-meta {
+  display: grid;
+  gap: 0.25rem;
+  margin: 0.1rem 0 0;
+}
+.ng-row {
+  display: grid;
+  grid-template-columns: 6rem 1fr;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+.ng-row dt {
+  color: var(--faint);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.ng-row dd {
+  margin: 0;
+  color: var(--ink-2);
+  font-size: 0.68rem;
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  align-items: baseline;
+}
+.ng-span {
+  color: var(--faint);
+  font-size: 0.62rem;
+}
+.ng-hash {
+  color: var(--muted);
+  font-size: 0.6rem;
+  overflow-wrap: anywhere;
+}
+.ng-chip {
+  border: 1px solid var(--border-2);
+  border-radius: var(--pill);
+  padding: 0 7px;
+  font-size: 0.62rem;
+  color: var(--muted);
+}
+.ng-none {
+  color: var(--faint);
+  font-style: italic;
+  font-size: 0.64rem;
+}
+.ng-none.warn {
+  color: var(--epi-hypothesis);
+  font-style: normal;
+}
+.ng-regime {
+  color: var(--epi-derived);
+  font-size: 0.62rem;
+}
+.ng-payload {
+  color: var(--muted);
+  font-size: 0.6rem;
+  overflow-wrap: anywhere;
+}
+.ng-prov {
+  display: inline-flex;
+  gap: 0.3rem;
+  align-items: baseline;
+  font-size: 0.62rem;
+}
+.ng-rel {
+  color: var(--faint);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.56rem;
+}
+.ng-by {
+  color: var(--faint);
+  font-size: 0.6rem;
+}
+.ng-seal {
+  margin: 0;
+  padding-top: 0.35rem;
+  border-top: 1px solid var(--hairline);
+  color: var(--faint);
+  font-size: 0.62rem;
+  line-height: 1.45;
+}
+.ng-seal b {
+  color: var(--epi-unknown);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.mono {
+  font-family: var(--mono);
+}
+.tnum {
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/apps/socioprophet-web/src/components/warrant/AnnotationOverlay.vue
+++ b/apps/socioprophet-web/src/components/warrant/AnnotationOverlay.vue
@@ -1,0 +1,463 @@
+<script setup lang="ts">
+// W11.4 — the annotation overlay. The question, with every competing reading kept.
+//
+// Consumed spans are lit; hover or keyboard-focus a span to see EVERY ontology concept that
+// competed for those characters, each with its annotator and confidence, and which one the plan
+// actually bound. The interesting cases get their own marks:
+//
+//   • ambiguous          more than one distinct concept claimed the span
+//   • overridden         the plan did NOT take the highest-confidence candidate  ← the EBA lesson
+//   • unconsumed         annotated, but no plan node bound anything here
+//
+// "Used" is read from the selected variant's provenance, never guessed from confidence order —
+// which is the only reason `overridden` can be detected at all.
+//
+// Depth (W11.6) folds the losing candidates and the numbers away for a novice. It never folds
+// away the fact that a span was ambiguous or that the plan overrode the ranking: those are
+// warrant-bearing, so they render at every depth.
+import { computed } from 'vue';
+import {
+  buildAnnotationOverlay,
+  conceptLabel,
+  type AnnotatedSpan,
+} from '../../features/warrant/annotations';
+import { depthPolicy, type Expertise } from '../../features/depth/expertise';
+import { pct, type NodeProvenance, type PlanNode, type TokenAnnotation } from '../../features/warrant/types';
+
+const props = withDefaults(
+  defineProps<{
+    question: string;
+    annotations: readonly TokenAnnotation[];
+    /** The SELECTED variant's provenance — node-level grounding. */
+    provenance: readonly NodeProvenance[];
+    /** The SELECTED variant's plan, so binding-level consumption is counted too. */
+    plan?: PlanNode | null;
+    level: Expertise;
+  }>(),
+  { plan: null },
+);
+
+const overlay = computed(() =>
+  buildAnnotationOverlay(props.question, props.annotations, props.provenance, props.plan),
+);
+const policy = computed(() => depthPolicy(props.level));
+
+/** Candidates to render: at novice depth, only the one the plan used (if any). */
+function shown(s: AnnotatedSpan) {
+  if (policy.value.showLosingCandidates) return s.candidates;
+  const used = s.candidates.filter((c) => c.used);
+  return used.length > 0 ? used : s.candidates.slice(0, 1);
+}
+function hiddenCount(s: AnnotatedSpan) {
+  return s.candidates.length - shown(s).length;
+}
+function spanClass(s: AnnotatedSpan) {
+  return {
+    'sp-consumed': s.consumed,
+    'sp-unconsumed': !s.consumed,
+    'sp-ambiguous': s.ambiguous,
+    'sp-overridden': s.overrodeTopConfidence,
+  };
+}
+</script>
+
+<template>
+  <div class="ao">
+    <!-- Counts first: the shape of the ambiguity, before the detail. -->
+    <div class="ao-summary">
+      <span class="ao-stat"
+        ><b class="tnum">{{ overlay.spans.length }}</b> annotated span{{ overlay.spans.length === 1 ? '' : 's' }}</span
+      >
+      <span v-if="overlay.ambiguousCount" class="ao-stat s-amb"
+        ><b class="tnum">{{ overlay.ambiguousCount }}</b> ambiguous</span
+      >
+      <span v-if="overlay.overriddenCount" class="ao-stat s-ovr"
+        ><b class="tnum">{{ overlay.overriddenCount }}</b> plan overrode top confidence</span
+      >
+      <span v-if="overlay.unconsumedCount" class="ao-stat s-unc"
+        ><b class="tnum">{{ overlay.unconsumedCount }}</b> annotated but unconsumed</span
+      >
+    </div>
+
+    <!-- The question itself. -->
+    <p class="ao-text">
+      <template v-for="(seg, i) in overlay.segments" :key="i">
+        <span v-if="!seg.annotated" class="ao-plain">{{ seg.text }}</span>
+        <span v-else class="ao-span" :class="spanClass(seg.annotated)" tabindex="0" role="button"
+          :aria-label="`${seg.text}: ${seg.annotated.candidates.length} candidate concept(s), ${seg.annotated.consumed ? 'consumed by the plan' : 'not consumed'}`"
+        >
+          <span class="ao-span-t">{{ seg.text }}</span>
+          <span v-if="seg.annotated.ambiguous" class="ao-mark" aria-hidden="true">⑂</span>
+
+          <!-- the competing-concepts popover -->
+          <span class="ao-pop" role="tooltip">
+            <span class="ao-pop-head">
+              <b>“{{ seg.text }}”</b>
+              <span v-if="policy.showSpanOffsets" class="ao-off tnum"
+                >[{{ seg.annotated.span.start }},{{ seg.annotated.span.end }})</span
+              >
+              <span class="ao-pop-n"
+                >{{ seg.annotated.candidates.length }} candidate{{ seg.annotated.candidates.length === 1 ? '' : 's' }}</span
+              >
+            </span>
+
+            <!-- Warrant-bearing notices. Rendered at EVERY depth. -->
+            <span v-if="seg.annotated.overrodeTopConfidence" class="ao-warn">
+              The plan bound <b>{{ conceptLabel(seg.annotated.usedConceptRef ?? '') }}</b
+              >, which is NOT the highest-confidence candidate
+              (<b>{{ conceptLabel(seg.annotated.topConfidenceConceptRef ?? '') }}</b
+              >). Ranking and choice disagree here.
+            </span>
+            <span v-else-if="!seg.annotated.consumed" class="ao-warn">
+              No plan node consumed this span. It was annotated and then left on the floor —
+              this is a coverage gap, not a resolved reading.
+            </span>
+            <span v-else-if="seg.annotated.ambiguous" class="ao-note">
+              {{ seg.annotated.candidates.length }} readings competed; the plan took one.
+            </span>
+
+            <ul class="ao-cands">
+              <li
+                v-for="c in shown(seg.annotated)"
+                :key="`${c.conceptRef}|${c.source}`"
+                class="ao-cand"
+                :class="{ used: c.used }"
+              >
+                <span class="ao-cand-top">
+                  <span class="ao-cand-mark" aria-hidden="true">{{ c.used ? '●' : '○' }}</span>
+                  <span class="ao-cand-c mono">{{ conceptLabel(c.conceptRef) }}</span>
+                  <span v-if="c.used" class="ao-cand-used">used by the plan</span>
+                  <span v-else class="ao-cand-lost">not used</span>
+                </span>
+                <span v-if="policy.showConfidence" class="ao-cand-meta">
+                  <span class="tnum">{{ pct(c.confidence) }}</span> confidence · annotator
+                  <span class="mono">{{ c.source }}</span>
+                </span>
+                <span v-if="policy.showRawRefs" class="ao-cand-ref mono">{{ c.conceptRef }}</span>
+                <span v-if="c.used && c.usedBy.length" class="ao-cand-by">
+                  bound by
+                  <span v-for="(u, j) in c.usedBy" :key="`${u.nodeId}|${u.via}|${u.input ?? ''}`" class="mono"
+                    >{{ u.actionName }}<span class="ao-nid">
+                      ({{ u.nodeId }}<template v-if="u.via === 'binding'"> · {{ u.input }}</template
+                      >)</span
+                    ><span v-if="j < c.usedBy.length - 1">, </span></span
+                  >
+                </span>
+              </li>
+            </ul>
+
+            <!-- Never let depth silently swallow competitors: say how many are folded. -->
+            <span v-if="hiddenCount(seg.annotated) > 0" class="ao-hidden">
+              {{ hiddenCount(seg.annotated) }} competing reading{{ hiddenCount(seg.annotated) === 1 ? '' : 's' }}
+              hidden at this depth — raise depth to see {{ hiddenCount(seg.annotated) === 1 ? 'it' : 'them' }}.
+            </span>
+          </span>
+        </span>
+      </template>
+    </p>
+
+    <!-- Spans that could not be laid out inline because they overlap one that was. Shown, not
+         dropped: a hidden competitor is the bug this surface exists to fix. -->
+    <div v-if="overlay.overlapped.length" class="ao-overlap">
+      <span class="ao-overlap-l">overlapping spans (not shown inline)</span>
+      <span v-for="s in overlay.overlapped" :key="`${s.span.start}:${s.span.end}`" class="ao-overlap-i">
+        “{{ s.span.text }}”
+        <span v-if="policy.showSpanOffsets" class="ao-off tnum">[{{ s.span.start }},{{ s.span.end }})</span>
+        →
+        <span v-for="(c, j) in s.candidates" :key="c.conceptRef + c.source" class="mono">
+          {{ conceptLabel(c.conceptRef) }}<span v-if="c.used" class="ao-cand-used"> ·used</span
+          ><span v-if="j < s.candidates.length - 1">, </span>
+        </span>
+      </span>
+    </div>
+
+    <div class="ao-legend">
+      <span><i class="lg lg-consumed" />consumed by the plan</span>
+      <span><i class="lg lg-unconsumed" />annotated, unconsumed</span>
+      <span><i class="lg lg-overridden" />plan overrode top confidence</span>
+      <span>⑂ more than one concept competed</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.ao {
+  display: grid;
+  gap: 0.7rem;
+}
+.ao-summary {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.ao-stat {
+  font-size: 0.66rem;
+  color: var(--muted);
+  border: 1px solid var(--border-2);
+  border-radius: var(--pill);
+  padding: 1px 9px;
+}
+.ao-stat b {
+  color: var(--ink);
+}
+.ao-stat.s-amb {
+  color: var(--epi-derived);
+  border-color: color-mix(in srgb, var(--epi-derived) 40%, transparent);
+}
+.ao-stat.s-amb b {
+  color: var(--epi-derived);
+}
+.ao-stat.s-ovr {
+  color: var(--warn);
+  border-color: color-mix(in srgb, var(--warn) 44%, transparent);
+  background: var(--warn-wash);
+}
+.ao-stat.s-ovr b {
+  color: var(--warn);
+}
+.ao-stat.s-unc {
+  color: var(--epi-hypothesis);
+  border-color: color-mix(in srgb, var(--epi-hypothesis) 40%, transparent);
+}
+.ao-stat.s-unc b {
+  color: var(--epi-hypothesis);
+}
+
+.ao-text {
+  margin: 0;
+  font-size: 1.02rem;
+  line-height: 2.1;
+  color: var(--ink-2);
+  background: var(--sunken);
+  border: 1px solid var(--hairline);
+  border-radius: var(--r-2);
+  padding: 0.7rem 0.8rem;
+}
+.ao-plain {
+  color: var(--faint);
+}
+
+.ao-span {
+  position: relative;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 2px;
+  cursor: help;
+  border-radius: var(--r-1);
+  padding: 1px 4px;
+  border-bottom: 2px solid var(--idle);
+  color: var(--ink);
+}
+.ao-span:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+/* Consumed = lit on the observed rung; unconsumed stays grey and dashed. */
+.ao-span.sp-consumed {
+  background: color-mix(in srgb, var(--epi-observed) 16%, transparent);
+  border-bottom-color: var(--epi-observed);
+}
+.ao-span.sp-unconsumed {
+  color: var(--muted);
+  border-bottom-style: dashed;
+  border-bottom-color: var(--epi-hypothesis);
+}
+.ao-span.sp-ambiguous {
+  border-bottom-color: var(--epi-derived);
+}
+/* Override is the loudest state — warn, because ranking and choice disagreed. */
+.ao-span.sp-overridden {
+  background: var(--warn-wash);
+  border-bottom-color: var(--warn);
+}
+.ao-mark {
+  font-size: 0.7rem;
+  color: var(--epi-derived);
+  line-height: 1;
+}
+.sp-overridden .ao-mark {
+  color: var(--warn);
+}
+
+.ao-pop {
+  position: absolute;
+  z-index: 60;
+  bottom: calc(100% + 8px);
+  left: 0;
+  display: grid;
+  gap: 0.35rem;
+  width: max-content;
+  max-width: 27rem;
+  padding: 0.6rem 0.7rem;
+  border-radius: var(--r-3);
+  background: var(--surface);
+  border: 1px solid var(--hairline-strong);
+  box-shadow: var(--e-3);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(4px);
+  transition: opacity 0.12s ease, transform 0.12s ease;
+  font-size: 0.72rem;
+  line-height: 1.45;
+  text-align: left;
+  white-space: normal;
+  color: var(--ink-2);
+}
+.ao-span:hover .ao-pop,
+.ao-span:focus-visible .ao-pop {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+.ao-pop-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  color: var(--ink);
+  font-size: 0.74rem;
+}
+.ao-pop-n {
+  margin-left: auto;
+  color: var(--faint);
+  font-size: 0.62rem;
+}
+.ao-off {
+  color: var(--faint);
+  font-size: 0.62rem;
+}
+
+.ao-warn {
+  color: var(--warn);
+  background: var(--warn-wash);
+  border: 1px solid color-mix(in srgb, var(--warn) 34%, transparent);
+  border-radius: var(--r-1);
+  padding: 0.3rem 0.4rem;
+  font-size: 0.66rem;
+}
+.ao-note {
+  color: var(--epi-derived);
+  font-size: 0.66rem;
+}
+
+.ao-cands {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.3rem;
+}
+.ao-cand {
+  display: grid;
+  gap: 1px;
+  padding: 0.3rem 0.4rem;
+  border-radius: var(--r-1);
+  background: var(--sunken);
+  border-left: 3px solid var(--idle);
+}
+.ao-cand.used {
+  border-left-color: var(--epi-observed);
+  background: var(--epi-observed-wash);
+}
+.ao-cand-top {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+}
+.ao-cand-mark {
+  color: var(--idle);
+  font-size: 0.6rem;
+}
+.ao-cand.used .ao-cand-mark {
+  color: var(--epi-observed);
+}
+.ao-cand-c {
+  color: var(--ink);
+  font-size: 0.7rem;
+}
+.ao-cand-used {
+  margin-left: auto;
+  color: var(--epi-observed);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 700;
+}
+.ao-cand-lost {
+  margin-left: auto;
+  color: var(--faint);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.ao-cand-meta,
+.ao-cand-by {
+  color: var(--faint);
+  font-size: 0.62rem;
+}
+.ao-cand-ref {
+  color: var(--muted);
+  font-size: 0.6rem;
+  overflow-wrap: anywhere;
+}
+.ao-nid {
+  color: var(--faint);
+}
+.ao-hidden {
+  color: var(--faint);
+  font-size: 0.62rem;
+  border-top: 1px solid var(--hairline);
+  padding-top: 0.3rem;
+}
+
+.ao-overlap {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.5rem 0.6rem;
+  border: 1px dashed var(--border-2);
+  border-radius: var(--r-2);
+}
+.ao-overlap-l {
+  color: var(--faint);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+.ao-overlap-i {
+  color: var(--ink-2);
+  font-size: 0.68rem;
+}
+
+.ao-legend {
+  display: flex;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+  color: var(--faint);
+  font-size: 0.62rem;
+  align-items: center;
+}
+.lg {
+  display: inline-block;
+  width: 10px;
+  height: 3px;
+  border-radius: 2px;
+  margin-right: 5px;
+  vertical-align: middle;
+}
+.lg-consumed {
+  background: var(--epi-observed);
+}
+.lg-unconsumed {
+  background: var(--epi-hypothesis);
+}
+.lg-overridden {
+  background: var(--warn);
+}
+.mono {
+  font-family: var(--mono);
+}
+.tnum {
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/apps/socioprophet-web/src/components/warrant/PlanTree.vue
+++ b/apps/socioprophet-web/src/components/warrant/PlanTree.vue
@@ -1,0 +1,149 @@
+<template>
+  <!-- W11.1 — the PLAN, not just the answer.
+       The NLQ compiler returns ranked variant plans as typed action trees. This renders one
+       of them: a collapsible tree of typed actions, each node carrying its own <Warrant>,
+       above a strip of the original question with the consumed spans lit up — which is what
+       "coverage" means, made literal. -->
+  <div class="pt">
+    <div v-if="question" class="pt-question">
+      <span class="pt-q-l">question</span>
+      <span class="pt-q-text">
+        <span v-for="(seg, i) in segments" :key="i" :class="seg.consumed ? 'pt-q-hit' : 'pt-q-miss'">{{ seg.text }}</span>
+      </span>
+    </div>
+
+    <ul class="pt-root">
+      <PlanTreeNode :node="plan" :provenance="provenance" :seal="seal" :walk="walk" :depth="0" />
+    </ul>
+
+    <div class="pt-legend">
+      <span><i class="lg lg-obs" />grounded in a span</span>
+      <span><i class="lg lg-der" />registry default</span>
+      <span><i class="lg lg-hyp" />model-generated</span>
+      <span class="pt-legend-note">every node's badge opens its receipt walk</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import PlanTreeNode from './PlanTreeNode.vue';
+import type {
+  NodeProvenance,
+  PlanNode,
+  ReceiptVerifyWalk,
+  SealOutcome,
+} from '../../features/warrant/types';
+
+const props = withDefaults(
+  defineProps<{
+    plan: PlanNode;
+    provenance: NodeProvenance[];
+    /** The question the plan was compiled from, for the span strip. */
+    question?: string;
+    seal?: SealOutcome | null;
+    walk?: ReceiptVerifyWalk | null;
+  }>(),
+  { question: '', seal: null, walk: null },
+);
+
+/**
+ * Split the question into consumed / not-consumed segments using the plan's own token spans.
+ * Spans are `[start, end)` character offsets into the question — the compiler guarantees every
+ * downstream claim can point back at the exact characters, so no re-tokenizing here.
+ */
+const segments = computed(() => {
+  const q = props.question;
+  if (!q) return [];
+  const spans = props.provenance
+    .map((p) => p.tokenSpan)
+    .filter((s): s is NonNullable<typeof s> => !!s)
+    .sort((a, b) => a.start - b.start);
+
+  const out: { text: string; consumed: boolean }[] = [];
+  let cursor = 0;
+  for (const s of spans) {
+    if (s.start < cursor) continue; // overlapping spans: first one wins
+    if (s.start > cursor) out.push({ text: q.slice(cursor, s.start), consumed: false });
+    out.push({ text: q.slice(s.start, s.end), consumed: true });
+    cursor = s.end;
+  }
+  if (cursor < q.length) out.push({ text: q.slice(cursor), consumed: false });
+  return out;
+});
+</script>
+
+<style scoped>
+.pt {
+  display: grid;
+  gap: 0.5rem;
+}
+.pt-question {
+  display: grid;
+  gap: 3px;
+  padding: 0.45rem 0.55rem;
+  background: var(--sunken, #080b10);
+  border: 1px solid var(--hairline, #232c38);
+  border-radius: var(--r-2, 5px);
+}
+.pt-q-l {
+  color: var(--faint, #5d6a78);
+  font-size: 0.58rem;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+}
+.pt-q-text {
+  font-size: 0.82rem;
+  line-height: 1.6;
+  color: var(--muted, #8a97a5);
+}
+.pt-q-hit {
+  color: var(--ink, #e8eef5);
+  background: color-mix(in srgb, var(--epi-observed, #5b95f9) 22%, transparent);
+  border-bottom: 1px solid var(--epi-observed, #5b95f9);
+  border-radius: 2px;
+  padding: 1px 1px;
+}
+.pt-q-miss {
+  color: var(--faint, #5d6a78);
+}
+.pt-root {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.pt-legend {
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+  align-items: center;
+  color: var(--faint, #5d6a78);
+  font-size: 0.62rem;
+  border-top: 1px solid var(--hairline, #232c38);
+  padding-top: 0.4rem;
+}
+.pt-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+.lg {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  display: inline-block;
+}
+.lg-obs {
+  background: var(--epi-observed, #5b95f9);
+}
+.lg-der {
+  background: var(--epi-derived, #a082f8);
+}
+.lg-hyp {
+  background: var(--epi-hypothesis, #8592a3);
+}
+.pt-legend-note {
+  margin-left: auto;
+  font-style: italic;
+}
+</style>

--- a/apps/socioprophet-web/src/components/warrant/PlanTreeNode.vue
+++ b/apps/socioprophet-web/src/components/warrant/PlanTreeNode.vue
@@ -1,0 +1,283 @@
+<template>
+  <!-- One typed action node. Recursive: a binding whose `kind === 'action'` carries a
+       sub-plan in `via`, and that sub-plan is rendered by this same component. -->
+  <li class="pt-node" :class="{ 'pt-ungrounded': node.grounding.kind === 'ungrounded' }">
+    <div class="pt-row">
+      <button
+        v-if="children.length"
+        class="pt-twist"
+        type="button"
+        :aria-expanded="open"
+        :aria-label="open ? `Collapse ${node.actionName}` : `Expand ${node.actionName}`"
+        @click="open = !open"
+      >
+        {{ open ? '▾' : '▸' }}
+      </button>
+      <span v-else class="pt-twist pt-leaf" aria-hidden="true">·</span>
+
+      <span class="pt-id mono">{{ node.nodeId }}</span>
+      <span class="pt-name">{{ node.actionName }}</span>
+
+      <span class="pt-type mono" :title="node.outputTypeRef">
+        → {{ shortRef(node.outputTypeRef) }}<span class="pt-card">{{ node.outputCardinality === 'many' ? '[]' : '' }}</span>
+      </span>
+
+      <!-- An effect-request leaf is a PROPOSAL. Never executed at search time; an
+           EffectDecision must precede any world change. Flag it loudly. -->
+      <span v-if="node.sideEffects === 'effect-request'" class="pt-effect" title="Proposed effect — requires an EffectDecision before execution">
+        effect-request
+      </span>
+
+      <Warrant class="pt-warrant" :w="warrantFor(node)" compact />
+    </div>
+
+    <div v-if="open && node.bindings.length" class="pt-bindings">
+      <div v-for="b in node.bindings" :key="b.input" class="pt-bind" :class="{ 'pt-unbound': b.kind === 'unbound' }">
+        <span class="pt-bind-name mono">{{ b.input }}</span>
+        <span class="pt-bind-type mono" :title="b.typeRef">
+          {{ shortRef(b.typeRef) }}<span v-if="b.cardinality === 'many'">[]</span>
+        </span>
+        <span class="pt-bind-kind" :class="`k-${b.kind}`">{{ b.kind }}</span>
+        <span v-if="b.required" class="pt-req" title="Required input">req</span>
+
+        <span v-if="b.literal !== undefined" class="pt-bind-val">
+          literal “<mark>{{ b.literal }}</mark
+          >”
+        </span>
+        <span v-else-if="b.defaultLabel" class="pt-bind-val">default: {{ b.defaultLabel }}</span>
+        <span v-else-if="b.conceptRef && b.kind !== 'action'" class="pt-bind-val mono">{{ shortRef(b.conceptRef) }}</span>
+
+        <span
+          v-if="b.subsumption && !b.subsumption.direct"
+          class="pt-subsume mono"
+          :title="`${b.subsumption.concept} ⊑ ${b.subsumption.satisfies} — subsumption licensed this bind`"
+        >
+          ⊑ {{ shortRef(b.subsumption.satisfies) }}
+        </span>
+      </div>
+    </div>
+
+    <ul v-if="open && children.length" class="pt-children">
+      <PlanTreeNode
+        v-for="c in children"
+        :key="c.nodeId"
+        :node="c"
+        :provenance="provenance"
+        :seal="seal"
+        :walk="walk"
+        :depth="depth + 1"
+      />
+    </ul>
+  </li>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import Warrant from './Warrant.vue';
+import type {
+  NodeProvenance,
+  PlanNode,
+  ReceiptVerifyWalk,
+  SealOutcome,
+  WarrantInput,
+} from '../../features/warrant/types';
+
+const props = withDefaults(
+  defineProps<{
+    node: PlanNode;
+    /** The variant's per-node provenance, keyed by nodeId. */
+    provenance: NodeProvenance[];
+    /** Compilation-level seal — an unsealed compilation makes EVERY node unsealed. */
+    seal?: SealOutcome | null;
+    walk?: ReceiptVerifyWalk | null;
+    depth?: number;
+  }>(),
+  { seal: null, walk: null, depth: 0 },
+);
+
+// Open by default. The compiler's DEFAULT_MAX_DEPTH is 4, so a plan is at most a handful of
+// levels — and this surface exists to make the plan VISIBLE. Collapsing by default would hide
+// exactly the leaf detail (literals, subsumption witnesses) that the proof lives in. The user
+// can collapse what they don't want; the default must not do the hiding for them.
+const open = ref(true);
+
+const children = computed(() =>
+  props.node.bindings.map((b) => b.via).filter((v): v is PlanNode => v !== undefined),
+);
+
+/** Trim a URI to its last path/# segment for display; the full ref stays in the title attr. */
+function shortRef(ref: string): string {
+  const tail = ref.split(/[#/:]/).filter(Boolean).pop();
+  return tail || ref;
+}
+
+/**
+ * Build the node's warrant. The claim is what the node ASSERTS; the grounding is the
+ * compiler's own account of why the node is in the plan; the seal is inherited from the
+ * compilation, because a node cannot be more proven than the run that produced it.
+ */
+function warrantFor(n: PlanNode): WarrantInput {
+  const prov = props.provenance.find((p) => p.nodeId === n.nodeId);
+  const via =
+    n.grounding.kind === 'token-span'
+      ? `grounded in “${n.grounding.tokenSpan?.text ?? ''}”`
+      : n.grounding.kind === 'registry-default'
+        ? `supplied by registry default ${n.grounding.defaultLabel ?? ''}`
+        : 'invented — nothing in the question evoked it';
+  const weight = prov ? ` (weight ${prov.weight.toFixed(2)})` : '';
+  return {
+    claim: `${n.actionName} produces ${shortRef(n.outputTypeRef)} — ${via}${weight}`,
+    grounding: n.grounding,
+    seal: props.seal ?? undefined,
+    walk: props.walk ?? undefined,
+  };
+}
+</script>
+
+<style scoped>
+.pt-node {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.pt-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  padding: 3px 4px;
+  border-radius: var(--r-1, 3px);
+  font-size: 0.74rem;
+}
+.pt-row:hover {
+  background: var(--surface-2, #18202a);
+}
+.pt-twist {
+  width: 1rem;
+  flex: 0 0 auto;
+  background: none;
+  border: 0;
+  color: var(--muted, #8a97a5);
+  cursor: pointer;
+  font-size: 0.7rem;
+  padding: 0;
+  line-height: 1;
+  font-family: inherit;
+}
+.pt-twist:focus-visible {
+  outline: 1px solid var(--accent, #5b95f9);
+}
+.pt-leaf {
+  cursor: default;
+  color: var(--faint, #5d6a78);
+  text-align: center;
+}
+.pt-id {
+  color: var(--faint, #5d6a78);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 0.64rem;
+}
+.pt-name {
+  color: var(--ink, #e8eef5);
+  font-weight: 600;
+}
+.pt-type {
+  color: var(--epi-derived, #a082f8);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 0.66rem;
+}
+.pt-card {
+  color: var(--faint, #5d6a78);
+}
+.pt-effect {
+  color: var(--warn, #d29922);
+  background: var(--warn-wash, #241d0a);
+  border: 1px solid color-mix(in srgb, var(--warn, #d29922) 38%, transparent);
+  border-radius: var(--r-1, 3px);
+  padding: 0 5px;
+  font-size: 0.6rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.pt-warrant {
+  margin-left: auto;
+}
+.pt-ungrounded > .pt-row .pt-name {
+  color: var(--epi-hypothesis, #8592a3);
+  font-style: italic;
+}
+
+.pt-bindings {
+  display: grid;
+  gap: 2px;
+  margin: 2px 0 3px 1.4rem;
+  padding-left: 0.5rem;
+  border-left: 1px dashed var(--hairline, #232c38);
+}
+.pt-bind {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  font-size: 0.66rem;
+  color: var(--muted, #8a97a5);
+}
+.pt-bind-name {
+  color: var(--ink-2, #b4c0cd);
+  font-family: var(--mono, ui-monospace, monospace);
+}
+.pt-bind-type {
+  color: var(--faint, #5d6a78);
+  font-family: var(--mono, ui-monospace, monospace);
+}
+.pt-bind-kind {
+  font-size: 0.58rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0 4px;
+  border-radius: var(--r-1, 3px);
+  border: 1px solid var(--hairline-strong, #33404f);
+}
+.k-annotation {
+  color: var(--epi-observed, #5b95f9);
+}
+.k-action {
+  color: var(--epi-derived, #a082f8);
+}
+.k-default {
+  color: var(--epi-simulated, #e0975a);
+}
+.k-unbound {
+  color: var(--fail, #e5534b);
+  border-color: color-mix(in srgb, var(--fail, #e5534b) 40%, transparent);
+}
+.pt-unbound {
+  color: var(--fail, #e5534b);
+}
+.pt-req {
+  color: var(--warn, #d29922);
+  font-size: 0.58rem;
+  text-transform: uppercase;
+}
+.pt-bind-val mark {
+  background: color-mix(in srgb, var(--epi-observed, #5b95f9) 24%, transparent);
+  color: var(--ink, #e8eef5);
+  border-radius: 2px;
+  padding: 0 2px;
+}
+.pt-subsume {
+  color: var(--epi-derived, #a082f8);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 0.62rem;
+}
+.pt-children {
+  list-style: none;
+  margin: 0 0 0 1.4rem;
+  padding-left: 0.5rem;
+  border-left: 1px solid var(--hairline, #232c38);
+}
+.mono {
+  font-family: var(--mono, ui-monospace, monospace);
+}
+</style>

--- a/apps/socioprophet-web/src/components/warrant/SenseMetricBadge.vue
+++ b/apps/socioprophet-web/src/components/warrant/SenseMetricBadge.vue
@@ -1,0 +1,326 @@
+<template>
+  <!-- W11.3 — the sense metric as three LEGIBLE axes, not one opaque number.
+       coverage · groundedness(creativity) · similarity, each with its weight and its
+       actual contribution to the composite. When a reference metric is supplied (the
+       winner's), every axis also shows its delta — so the surface answers WHY a plan
+       lost, not merely that it did.
+
+       Creativity is not a separate axis: it is `1 − groundedness`, the ungrounded-node
+       penalty routed through claim-admissibility. The ledger below names each node that
+       cost the plan groundedness and the discount the gate applied. -->
+  <div class="sm" :class="{ 'sm-compact': compact }">
+    <div class="sm-axes">
+      <div v-for="a in axes" :key="a.key" class="sm-axis" :style="{ '--ax': a.color }">
+        <div class="sm-axis-top">
+          <span class="sm-axis-name">{{ a.label }}</span>
+          <span class="sm-axis-val tnum">{{ pct(a.value) }}</span>
+          <span v-if="reference" class="sm-delta tnum" :class="deltaClass(a.delta)">{{ signed(a.delta) }}</span>
+        </div>
+        <div class="sm-bar" role="img" :aria-label="`${a.label} ${pct(a.value)}`">
+          <span class="sm-bar-fill" :style="{ width: `${Math.max(0, Math.min(1, a.value)) * 100}%` }" />
+          <!-- the weighted contribution, marked on the same track -->
+          <span class="sm-bar-tick" :style="{ left: `${Math.max(0, Math.min(1, a.value * a.weight)) * 100}%` }" />
+        </div>
+        <div v-if="!compact" class="sm-axis-foot">
+          <span class="sm-w tnum">w {{ a.weight.toFixed(2) }}</span>
+          <span class="sm-contrib tnum">contributes {{ (a.value * a.weight).toFixed(3) }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="sm-composite">
+      <span class="sm-comp-l">composite</span>
+      <span class="sm-comp-v tnum">{{ metric.composite.toFixed(3) }}</span>
+      <span v-if="reference" class="sm-delta tnum" :class="deltaClass(metric.composite - reference.composite)">
+        {{ signed(metric.composite - reference.composite) }}
+      </span>
+    </div>
+
+    <template v-if="!compact">
+      <!-- Creativity, stated as the mechanism rather than as a vibe. -->
+      <div class="sm-creativity" :class="{ 'sm-clean': metric.ungroundedNodes === 0 }">
+        <span class="sm-cr-head">
+          <b>creativity</b>
+          <span class="tnum">{{ pct(metric.creativity) }}</span>
+          <span class="sm-cr-def">= 1 − groundedness</span>
+        </span>
+        <span class="sm-cr-body">
+          <template v-if="metric.ungroundedNodes === 0">
+            Every one of the {{ metric.nodes }} plan node{{ metric.nodes === 1 ? '' : 's' }} is grounded — no
+            invention, no admissibility discount.
+          </template>
+          <template v-else>
+            {{ metric.ungroundedNodes }} of {{ metric.nodes }} node{{ metric.nodes === 1 ? '' : 's' }} invented.
+            Each is filed as a <i>model-generated</i> claim; the admissibility gate's weight IS the
+            groundedness contribution.
+          </template>
+        </span>
+        <ul v-if="metric.admissibility.length" class="sm-adm">
+          <li v-for="entry in metric.admissibility" :key="entry.nodeId" class="sm-adm-row">
+            <code class="mono">{{ entry.nodeId }}</code>
+            <span class="sm-adm-action mono">{{ entry.actionId }}</span>
+            <span class="sm-adm-reason">{{ REASON_TEXT[entry.reason] ?? entry.reason }}</span>
+            <span class="sm-adm-w tnum">×{{ entry.weight.toFixed(2) }}</span>
+          </li>
+        </ul>
+      </div>
+
+      <div class="sm-cov">
+        consumed <span class="tnum">{{ metric.consumedContentTokens }}</span> of
+        <span class="tnum">{{ metric.contentTokens }}</span> content tokens ·
+        <span class="tnum">{{ metric.groundedNodes }}</span> grounded /
+        <span class="tnum">{{ metric.nodes }}</span> nodes
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { pct, type SenseMetric, type UngroundedReason } from '../../features/warrant/types';
+
+const props = withDefaults(
+  defineProps<{
+    metric: SenseMetric;
+    /** The winner's metric, to show per-axis deltas — i.e. exactly where this plan lost. */
+    reference?: SenseMetric | null;
+    compact?: boolean;
+  }>(),
+  { reference: null, compact: false },
+);
+
+const REASON_TEXT: Record<UngroundedReason, string> = {
+  'no-token-span': 'no token span — nothing in the question evoked it',
+  'unbound-required-input': 'a required input never bound',
+};
+
+/** One saturated colour per axis, off the epistemic ramp so the moat stays the one hue family. */
+const axes = computed(() => {
+  const m = props.metric;
+  const r = props.reference;
+  return [
+    {
+      key: 'coverage',
+      label: 'coverage',
+      value: m.coverage,
+      weight: m.weights.coverage,
+      color: 'var(--epi-observed, #5b95f9)',
+      delta: r ? m.coverage - r.coverage : 0,
+    },
+    {
+      key: 'groundedness',
+      label: 'groundedness',
+      value: m.groundedness,
+      weight: m.weights.groundedness,
+      color: 'var(--epi-verified, #2dd4bf)',
+      delta: r ? m.groundedness - r.groundedness : 0,
+    },
+    {
+      key: 'similarity',
+      label: 'similarity',
+      value: m.similarity,
+      weight: m.weights.similarity,
+      color: 'var(--epi-derived, #a082f8)',
+      delta: r ? m.similarity - r.similarity : 0,
+    },
+  ];
+});
+
+function signed(d: number): string {
+  if (Math.abs(d) < 0.0005) return '±0';
+  return `${d > 0 ? '+' : '−'}${Math.abs(d).toFixed(3)}`;
+}
+
+function deltaClass(d: number): string {
+  if (Math.abs(d) < 0.0005) return 'd-flat';
+  return d > 0 ? 'd-up' : 'd-down';
+}
+</script>
+
+<style scoped>
+.sm {
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.72rem;
+  color: var(--ink-2, #b4c0cd);
+}
+.sm-axes {
+  display: grid;
+  gap: 0.4rem;
+}
+.sm-compact .sm-axes {
+  gap: 0.25rem;
+}
+.sm-axis {
+  display: grid;
+  gap: 2px;
+}
+.sm-axis-top {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  font-size: 0.66rem;
+}
+.sm-axis-name {
+  color: var(--muted, #8a97a5);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.6rem;
+}
+.sm-axis-val {
+  margin-left: auto;
+  color: var(--ax);
+  font-weight: 700;
+}
+.sm-bar {
+  position: relative;
+  height: 5px;
+  border-radius: 999px;
+  background: var(--sunken, #080b10);
+  border: 1px solid var(--hairline, #232c38);
+  overflow: hidden;
+}
+.sm-compact .sm-bar {
+  height: 4px;
+}
+.sm-bar-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--ax);
+  opacity: 0.85;
+  border-radius: 999px;
+}
+/* Where the axis lands AFTER its weight — the honest picture of what it actually bought. */
+.sm-bar-tick {
+  position: absolute;
+  top: -1px;
+  bottom: -1px;
+  width: 2px;
+  background: var(--ink, #e8eef5);
+  opacity: 0.75;
+}
+.sm-axis-foot {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.6rem;
+  color: var(--faint, #5d6a78);
+}
+.sm-contrib {
+  margin-left: auto;
+}
+.sm-composite {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  border-top: 1px solid var(--hairline, #232c38);
+  padding-top: 0.35rem;
+}
+.sm-comp-l {
+  color: var(--muted, #8a97a5);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.6rem;
+}
+.sm-comp-v {
+  margin-left: auto;
+  color: var(--ink, #e8eef5);
+  font-weight: 700;
+  font-size: 0.84rem;
+}
+.sm-delta {
+  font-size: 0.62rem;
+  font-weight: 600;
+  padding: 0 4px;
+  border-radius: var(--r-1, 3px);
+}
+.d-up {
+  color: var(--ok, #3fb950);
+  background: var(--ok-wash, #0f2417);
+}
+.d-down {
+  color: var(--fail, #e5534b);
+  background: var(--fail-wash, #2a1315);
+}
+.d-flat {
+  color: var(--faint, #5d6a78);
+}
+
+.sm-creativity {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.4rem 0.5rem;
+  border-radius: var(--r-1, 3px);
+  background: var(--epi-hypothesis-wash, #1a2029);
+  border: 1px solid color-mix(in srgb, var(--epi-hypothesis, #8592a3) 30%, transparent);
+}
+.sm-creativity.sm-clean {
+  background: var(--epi-verified-wash, #0e2c2b);
+  border-color: color-mix(in srgb, var(--epi-verified, #2dd4bf) 30%, transparent);
+}
+.sm-cr-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  font-size: 0.66rem;
+}
+.sm-cr-head b {
+  color: var(--epi-hypothesis, #8592a3);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.6rem;
+}
+.sm-clean .sm-cr-head b {
+  color: var(--epi-verified, #2dd4bf);
+}
+.sm-cr-def {
+  margin-left: auto;
+  color: var(--faint, #5d6a78);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 0.6rem;
+}
+.sm-cr-body {
+  color: var(--faint, #5d6a78);
+  font-size: 0.64rem;
+  line-height: 1.45;
+}
+.sm-adm {
+  list-style: none;
+  margin: 0.15rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 2px;
+}
+.sm-adm-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  font-size: 0.62rem;
+  flex-wrap: wrap;
+}
+.sm-adm-row code {
+  color: var(--epi-hypothesis, #8592a3);
+  font-family: var(--mono, ui-monospace, monospace);
+}
+.sm-adm-action {
+  color: var(--muted, #8a97a5);
+  font-family: var(--mono, ui-monospace, monospace);
+}
+.sm-adm-reason {
+  color: var(--faint, #5d6a78);
+}
+.sm-adm-w {
+  margin-left: auto;
+  color: var(--warn, #d29922);
+  font-weight: 700;
+}
+.sm-cov {
+  color: var(--faint, #5d6a78);
+  font-size: 0.62rem;
+}
+.mono {
+  font-family: var(--mono, ui-monospace, monospace);
+}
+.tnum {
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/apps/socioprophet-web/src/components/warrant/VariantRail.vue
+++ b/apps/socioprophet-web/src/components/warrant/VariantRail.vue
@@ -1,0 +1,313 @@
+<template>
+  <!-- W11.2 — the alternatives that LOST.
+       The compiler keeps every variant that type-checked, ranked by composite. Showing only
+       the winner hides the fact that a choice was made at all. This rail shows the whole
+       ranked field, each with its three axes, each with the one axis that actually cost it
+       the win — and lets the user re-run on any of them. -->
+  <div class="vr">
+    <div class="vr-head">
+      <span class="vr-title">Ranked variants</span>
+      <span class="vr-count tnum">{{ variants.length }}</span>
+      <span class="vr-sub">ranked by composite · {{ weightsLabel }}</span>
+    </div>
+
+    <p v-if="!variants.length" class="vr-empty">
+      Nothing type-checked. The compiler returned no admissible variant for this question.
+    </p>
+
+    <ul v-else class="vr-list">
+      <li
+        v-for="v in variants"
+        :key="v.rank"
+        class="vr-item"
+        :class="{ 'vr-on': v.rank === selectedRank, 'vr-winner': v.rank === 1 }"
+      >
+        <button
+          class="vr-pick"
+          type="button"
+          :aria-pressed="v.rank === selectedRank"
+          :aria-label="`Variant ${v.rank}, composite ${v.senseMetric.composite.toFixed(3)}`"
+          @click="emit('select', v.rank)"
+        >
+          <span class="vr-rank tnum">#{{ v.rank }}</span>
+          <span class="vr-plan">
+            <span class="vr-plan-name">{{ v.plan.actionName }}</span>
+            <span class="vr-plan-meta tnum">
+              {{ v.senseMetric.nodes }} node{{ v.senseMetric.nodes === 1 ? '' : 's' }}
+              <template v-if="v.senseMetric.ungroundedNodes">
+                · <span class="vr-ung">{{ v.senseMetric.ungroundedNodes }} invented</span>
+              </template>
+            </span>
+          </span>
+          <span class="vr-comp tnum">{{ v.senseMetric.composite.toFixed(3) }}</span>
+          <span v-if="v.rank === 1" class="vr-crown" title="Winning variant">won</span>
+        </button>
+
+        <SenseMetricBadge :metric="v.senseMetric" :reference="v.rank === 1 ? null : winnerMetric" compact />
+
+        <!-- The whole point of the rail: not that it lost, but WHERE. -->
+        <p v-if="v.rank !== 1 && lossOf(v)" class="vr-why">
+          lost on <b>{{ lossOf(v)!.axis }}</b>
+          <span class="tnum">
+            ({{ lossOf(v)!.delta.toFixed(3) }} × w{{ lossOf(v)!.weight.toFixed(2) }} =
+            {{ lossOf(v)!.cost.toFixed(3) }} of the gap)
+          </span>
+        </p>
+
+        <!-- An invalid comparison is named, not quietly rendered as a valid one. -->
+        <p v-if="weightsDiffer(v)" class="vr-wmismatch">
+          scored under different weights than the winner — this gap is not a like-for-like
+          comparison, and the axis above is computed in the winner's weighting
+        </p>
+
+        <div class="vr-actions">
+          <button class="vr-rerun" type="button" @click="emit('rerun', v)">
+            Re-run on #{{ v.rank }}
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import SenseMetricBadge from './SenseMetricBadge.vue';
+import type { PlanVariant, SenseMetric } from '../../features/warrant/types';
+
+const props = withDefaults(
+  defineProps<{
+    variants: PlanVariant[];
+    /** Rank of the variant currently shown in the plan tree. */
+    selectedRank?: number;
+  }>(),
+  { selectedRank: 1 },
+);
+
+const emit = defineEmits<{
+  (e: 'select', rank: number): void;
+  (e: 'rerun', variant: PlanVariant): void;
+}>();
+
+const winnerMetric = computed<SenseMetric | null>(
+  () => props.variants.find((v) => v.rank === 1)?.senseMetric ?? null,
+);
+
+const weightsLabel = computed(() => {
+  const w = props.variants[0]?.senseMetric.weights;
+  if (!w) return '';
+  return `cov ${w.coverage} · grd ${w.groundedness} · sim ${w.similarity}`;
+});
+
+/**
+ * The axis that cost this variant the most, in COMPOSITE POINTS — deficit × weight. A big
+ * raw gap on a 0.2-weighted axis matters less than a small gap on a 0.5-weighted one, and
+ * saying "lost on coverage" when similarity did the damage would be a nicer-sounding lie.
+ *
+ * The weights come from the WINNER, deliberately. A deficit is a statement about one
+ * comparison — "how many composite points behind the winner is this variant" — and a
+ * comparison has to be run under a single rubric or it is not a comparison at all. Scoring
+ * the loser's gap in the loser's own weights is apples-to-oranges: it can name an axis that
+ * contributed nothing to the ranking that actually happened, since the ranking is by
+ * composite and only one weighting produced that ordering. The winner's weighting is the one
+ * the field was ranked under, so it is the honest denominator.
+ *
+ * If the weights ever DO diverge across variants, the number is unsound however it is
+ * computed — so that case is surfaced rather than silently averaged over (`weightsDiffer`).
+ */
+function lossOf(v: PlanVariant): { axis: string; delta: number; weight: number; cost: number } | null {
+  const w = winnerMetric.value;
+  if (!w || v.rank === 1) return null;
+  const m = v.senseMetric;
+  const wt = w.weights;
+  const rows = [
+    { axis: 'coverage', delta: m.coverage - w.coverage, weight: wt.coverage },
+    { axis: 'groundedness', delta: m.groundedness - w.groundedness, weight: wt.groundedness },
+    { axis: 'similarity', delta: m.similarity - w.similarity, weight: wt.similarity },
+  ].map((r) => ({ ...r, cost: r.delta * r.weight }));
+  const worst = rows.reduce((a, b) => (b.cost < a.cost ? b : a));
+  return worst.cost < 0 ? worst : null;
+}
+
+/**
+ * Did this variant get scored under a different rubric than the winner? Then the "lost on X"
+ * line is comparing two things that were never on the same scale, and the rail says so
+ * instead of printing a confident number over an invalid comparison.
+ */
+function weightsDiffer(v: PlanVariant): boolean {
+  const w = winnerMetric.value;
+  if (!w || v.rank === 1) return false;
+  const a = v.senseMetric.weights;
+  const b = w.weights;
+  return (
+    a.coverage !== b.coverage || a.groundedness !== b.groundedness || a.similarity !== b.similarity
+  );
+}
+</script>
+
+<style scoped>
+.vr {
+  display: grid;
+  gap: 0.5rem;
+}
+.vr-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+.vr-title {
+  color: var(--ink-2, #b4c0cd);
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  font-weight: 600;
+}
+.vr-count {
+  color: var(--accent, #5b95f9);
+  background: var(--accent-wash, #16233b);
+  border-radius: var(--pill, 999px);
+  padding: 0 6px;
+  font-size: 0.62rem;
+  font-weight: 700;
+}
+.vr-sub {
+  margin-left: auto;
+  color: var(--faint, #5d6a78);
+  font-size: 0.6rem;
+  font-family: var(--mono, ui-monospace, monospace);
+}
+.vr-empty {
+  color: var(--muted, #8a97a5);
+  font-size: 0.72rem;
+  margin: 0;
+  padding: 0.6rem;
+  background: var(--sunken, #080b10);
+  border: 1px dashed var(--hairline-strong, #33404f);
+  border-radius: var(--r-2, 5px);
+}
+.vr-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+.vr-item {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.5rem 0.55rem;
+  border-radius: var(--r-2, 5px);
+  background: var(--surface, #141b24);
+  border: 1px solid var(--hairline, #232c38);
+  border-left: 3px solid var(--idle, #6b7684);
+}
+.vr-item.vr-winner {
+  border-left-color: var(--epi-verified, #2dd4bf);
+}
+.vr-item.vr-on {
+  border-color: var(--accent, #5b95f9);
+  background: var(--accent-wash, #16233b);
+}
+.vr-pick {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+  font-family: inherit;
+}
+.vr-pick:focus-visible {
+  outline: 2px solid var(--accent, #5b95f9);
+  outline-offset: 2px;
+}
+.vr-rank {
+  color: var(--faint, #5d6a78);
+  font-size: 0.66rem;
+  font-weight: 700;
+  flex: 0 0 auto;
+}
+.vr-plan {
+  display: grid;
+  gap: 1px;
+  min-width: 0;
+}
+.vr-plan-name {
+  color: var(--ink, #e8eef5);
+  font-size: 0.76rem;
+  font-weight: 600;
+}
+.vr-plan-meta {
+  color: var(--faint, #5d6a78);
+  font-size: 0.62rem;
+}
+.vr-ung {
+  color: var(--epi-hypothesis, #8592a3);
+}
+.vr-comp {
+  margin-left: auto;
+  color: var(--ink, #e8eef5);
+  font-size: 0.86rem;
+  font-weight: 700;
+  flex: 0 0 auto;
+}
+.vr-crown {
+  color: var(--epi-verified, #2dd4bf);
+  background: var(--epi-verified-wash, #0e2c2b);
+  border-radius: var(--pill, 999px);
+  padding: 0 6px;
+  font-size: 0.58rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  flex: 0 0 auto;
+}
+.vr-why {
+  margin: 0;
+  color: var(--warn, #d29922);
+  font-size: 0.64rem;
+}
+.vr-wmismatch {
+  margin: 0;
+  color: var(--fail, #e5534b);
+  font-size: 0.62rem;
+  line-height: 1.45;
+}
+.vr-why b {
+  font-weight: 700;
+}
+.vr-why .tnum {
+  color: var(--faint, #5d6a78);
+}
+.vr-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+.vr-rerun {
+  background: transparent;
+  color: var(--ink-2, #b4c0cd);
+  border: 1px solid var(--hairline-strong, #33404f);
+  border-radius: var(--r-1, 3px);
+  padding: 2px 8px;
+  font-size: 0.64rem;
+  cursor: pointer;
+  font-family: inherit;
+}
+.vr-rerun:hover {
+  border-color: var(--accent, #5b95f9);
+  color: var(--accent-ink, #bcd4ff);
+  background: var(--accent-wash, #16233b);
+}
+.vr-rerun:focus-visible {
+  outline: 2px solid var(--accent, #5b95f9);
+  outline-offset: 1px;
+}
+.tnum {
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/apps/socioprophet-web/src/components/warrant/Warrant.vue
+++ b/apps/socioprophet-web/src/components/warrant/Warrant.vue
@@ -1,0 +1,455 @@
+<template>
+  <!-- W11.0 — the proof chain at three depths, in one primitive.
+       1. BADGE      always on: sealed / UNSEALED / unknown, on the epistemic ramp.
+       2. POPOVER    hover or keyboard focus: the claim, its warrant type, and the source
+                     span it points back at (or "model-generated" when it invented).
+       3. RECEIPT    click: the full three-step verify walk the gateway returns —
+                     gateway signature → engine seal hash → snapshot.seq binding.
+
+       Honest degradation is the contract, not a nicety: an unsealed receipt renders in
+       --fail with the reason spelled out, and the epistemic ramp colour degrades with it.
+       This component must never make an unproven claim look fine. -->
+  <span class="wr" :class="[`wr-${view.seal}`, { 'wr-open': open }]" :style="{ '--epi': epiColor }">
+    <button
+      class="wr-badge"
+      type="button"
+      :aria-label="`Warrant: ${view.kindLabel}, ${view.sealLabel}`"
+      :aria-expanded="open"
+      @click="toggle"
+    >
+      <span class="epi-dot wr-dot" aria-hidden="true" />
+      <span v-if="!compact" class="wr-seal">{{ view.sealLabel }}</span>
+      <span v-if="!compact" class="wr-kind">{{ view.kindLabel }}</span>
+    </button>
+
+    <!-- depth 2 — the popover -->
+    <span class="wr-pop" role="tooltip">
+      <span class="wr-pop-head">
+        <span class="epi-dot wr-dot" aria-hidden="true" />
+        <b>{{ view.sealLabel }}</b>
+        <span class="wr-pop-kind">{{ view.kindLabel }}</span>
+      </span>
+      <span class="wr-pop-claim">{{ view.claim }}</span>
+      <span class="wr-pop-blurb">{{ view.kindBlurb }}</span>
+
+      <span v-if="view.span" class="wr-row">
+        <b>Source span</b>
+        <span class="wr-span"
+          >“<mark>{{ view.span.text }}</mark
+          >” <span class="wr-off tnum">[{{ view.span.start }},{{ view.span.end }})</span></span
+        >
+      </span>
+      <span v-else class="wr-row">
+        <b>Source span</b>
+        <!-- Derived from the KIND, never assumed: a `computed` nugget with no span is missing
+             its span, which is a different fact from being model-generated. -->
+        <span class="wr-nospan">
+          none — {{ isModelGenerated(view.kind) ? view.kindLabel : 'no source span recorded' }}
+        </span>
+      </span>
+
+      <span v-if="view.admissibility" class="wr-row">
+        <b>Admissibility</b>
+        <span>
+          {{ view.admissibility.admitted ? 'admitted' : 'excluded' }}
+          <span class="tnum">· weight {{ view.admissibility.weight.toFixed(2) }}</span>
+          <span v-if="view.admissibility.excludedAt"> · at {{ view.admissibility.excludedAt }}</span>
+        </span>
+      </span>
+
+      <span v-if="view.receiptRef" class="wr-row">
+        <b>Receipt</b><code class="wr-hash">{{ view.receiptRef }}</code>
+      </span>
+
+      <!-- The reason, whenever there is one. This is the honest-degradation surface. -->
+      <span v-if="view.sealDetail" class="wr-why">{{ view.sealDetail }}</span>
+
+      <span class="wr-hint">{{ open ? 'Click to collapse the receipt walk' : 'Click for the full receipt walk' }}</span>
+    </span>
+
+    <!-- depth 3 — the full receipt walk -->
+    <span v-if="open" class="wr-walk">
+      <span class="wr-walk-head">
+        <b>Receipt walk</b>
+        <span v-if="view.receiptRef" class="wr-hash mono">{{ view.receiptRef }}</span>
+        <span class="wr-walk-verdict" :class="view.walk?.valid ? 'v-ok' : 'v-bad'">
+          {{ view.walk ? (view.walk.valid ? 'valid' : 'INVALID') : 'not walked' }}
+        </span>
+      </span>
+
+      <ol v-if="view.walk" class="wr-steps">
+        <li v-for="s in view.walk.steps" :key="s.step" class="wr-step" :class="`s-${s.status}`">
+          <span class="wr-step-top">
+            <span class="wr-step-mark" aria-hidden="true">{{ STEP_GLYPH[s.status] }}</span>
+            <span class="wr-step-name mono">{{ s.step }}</span>
+            <span class="wr-step-status">{{ s.status }}</span>
+          </span>
+          <span class="wr-step-means">{{ meaning(s.step) }}</span>
+          <span v-if="s.detail" class="wr-step-detail mono">{{ s.detail }}</span>
+        </li>
+      </ol>
+
+      <!-- No walk: say so plainly. An unwalked receipt is NOT a verified one. -->
+      <span v-else class="wr-nowalk">
+        <template v-if="view.seal === 'unsealed'">
+          Nothing to walk — this claim was never sealed.
+          <span v-if="view.sealDetail" class="wr-why-inline">{{ view.sealDetail }}</span>
+        </template>
+        <template v-else-if="view.receiptRef">
+          Receipt not yet verified. The three-step walk runs against
+          <code>GET /v1/engine-receipts/{{ view.receiptRef }}/verify</code>.
+        </template>
+        <template v-else>
+          No receipt reference on this claim — its proof chain cannot be walked.
+        </template>
+      </span>
+    </span>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import {
+  WALK_STEP_MEANING,
+  isModelGenerated,
+  warrantView,
+  type WarrantInput,
+} from '../../features/warrant/types';
+
+const props = withDefaults(defineProps<{ w: WarrantInput; compact?: boolean; defaultOpen?: boolean }>(), {
+  compact: false,
+  defaultOpen: false,
+});
+
+const emit = defineEmits<{ (e: 'walk', receiptRef: string): void }>();
+
+const open = ref(props.defaultOpen);
+const view = computed(() => warrantView(props.w));
+
+/** Ramp colour, with literal fallbacks so the badge still reads outside `.studio-scope`. */
+const EPI_FALLBACK: Record<string, string> = {
+  observed: '#5b95f9',
+  derived: '#a082f8',
+  hypothesis: '#8592a3',
+  attested: '#34d399',
+  unknown: '#4a5568',
+};
+const epiColor = computed(() => {
+  // An unsealed warrant is never allowed a reassuring colour.
+  if (view.value.seal === 'unsealed') return 'var(--fail, #e5534b)';
+  const m = view.value.epistemic;
+  return `var(--epi-${m}, ${EPI_FALLBACK[m]})`;
+});
+
+const STEP_GLYPH: Record<string, string> = { ok: '✓', fail: '✕', skipped: '·' };
+
+function meaning(step: string): string {
+  return WALK_STEP_MEANING[step] ?? 'Step reported by the gateway verify walk.';
+}
+
+function toggle() {
+  open.value = !open.value;
+  if (open.value && !view.value.walk && view.value.receiptRef) emit('walk', view.value.receiptRef);
+}
+</script>
+
+<style scoped>
+.wr {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  vertical-align: middle;
+  align-items: flex-start;
+}
+.wr-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  cursor: pointer;
+  border: 1px solid color-mix(in srgb, var(--epi) 42%, transparent);
+  border-radius: var(--r-1, 3px);
+  background: color-mix(in srgb, var(--epi) 12%, transparent);
+  color: var(--epi);
+  padding: 1px 7px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  line-height: 1.5;
+  font-family: inherit;
+}
+.wr-badge:hover {
+  background: color-mix(in srgb, var(--epi) 20%, transparent);
+}
+.wr-badge:focus-visible {
+  outline: 2px solid var(--accent, #5b95f9);
+  outline-offset: 1px;
+}
+.wr-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--epi);
+  flex: 0 0 auto;
+}
+.wr-seal {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 10px;
+}
+.wr-kind {
+  color: var(--muted, #8a97a5);
+  font-weight: 500;
+}
+/* UNSEALED is shouted, deliberately: it is the state most likely to be skimmed past. */
+.wr-unsealed .wr-seal {
+  font-weight: 800;
+}
+
+/* ── depth 2: popover ─────────────────────────────────────────────────────── */
+.wr-pop {
+  position: absolute;
+  z-index: 60;
+  bottom: calc(100% + 6px);
+  left: 0;
+  display: grid;
+  gap: 0.3rem;
+  width: max-content;
+  max-width: 26rem;
+  padding: 0.6rem 0.7rem;
+  border-radius: var(--r-3, 8px);
+  background: var(--surface, #141b24);
+  border: 1px solid var(--hairline-strong, #33404f);
+  box-shadow: var(--e-3, 0 12px 40px rgba(0, 0, 0, 0.6));
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(4px);
+  transition: opacity 0.12s ease, transform 0.12s ease;
+  color: var(--ink-2, #b4c0cd);
+  font-size: 0.72rem;
+  font-weight: 400;
+  text-align: left;
+  white-space: normal;
+}
+.wr-badge:hover + .wr-pop,
+.wr-badge:focus-visible + .wr-pop {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+.wr-pop-head {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--epi);
+  text-transform: uppercase;
+  font-size: 0.66rem;
+  letter-spacing: 0.05em;
+}
+.wr-pop-kind {
+  color: var(--muted, #8a97a5);
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 500;
+}
+.wr-pop-claim {
+  color: var(--ink, #e8eef5);
+  font-size: 0.76rem;
+  line-height: 1.4;
+}
+.wr-pop-blurb {
+  color: var(--faint, #5d6a78);
+  font-size: 0.68rem;
+  line-height: 1.4;
+}
+.wr-row {
+  display: grid;
+  grid-template-columns: 5.2rem 1fr;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+.wr-row b {
+  color: var(--faint, #5d6a78);
+  font-weight: 600;
+  font-size: 0.64rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.wr-span mark {
+  background: color-mix(in srgb, var(--epi) 26%, transparent);
+  color: var(--ink, #e8eef5);
+  border-radius: 2px;
+  padding: 0 2px;
+}
+.wr-off {
+  color: var(--faint, #5d6a78);
+  font-size: 0.64rem;
+}
+.wr-nospan {
+  color: var(--epi-hypothesis, #8592a3);
+  font-style: italic;
+}
+.wr-hash {
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 0.64rem;
+  color: var(--ink-2, #b4c0cd);
+  overflow-wrap: anywhere;
+}
+.wr-why {
+  color: var(--fail, #e5534b);
+  background: var(--fail-wash, #2a1315);
+  border: 1px solid color-mix(in srgb, var(--fail, #e5534b) 34%, transparent);
+  border-radius: var(--r-1, 3px);
+  padding: 0.3rem 0.4rem;
+  font-size: 0.68rem;
+  font-family: var(--mono, ui-monospace, monospace);
+  overflow-wrap: anywhere;
+}
+.wr-hint {
+  color: var(--faint, #5d6a78);
+  font-size: 0.62rem;
+  border-top: 1px solid var(--hairline, #232c38);
+  padding-top: 0.3rem;
+}
+
+/* ── depth 3: the receipt walk ────────────────────────────────────────────── */
+.wr-walk {
+  display: block;
+  margin-top: 6px;
+  width: 100%;
+  min-width: 20rem;
+  max-width: 46rem;
+  background: var(--sunken, #080b10);
+  border: 1px solid var(--hairline, #232c38);
+  border-radius: var(--r-2, 5px);
+  padding: 0.5rem 0.6rem;
+}
+.wr-walk-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.68rem;
+  color: var(--muted, #8a97a5);
+  margin-bottom: 0.4rem;
+}
+.wr-walk-head b {
+  color: var(--ink-2, #b4c0cd);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.62rem;
+}
+.wr-walk-verdict {
+  margin-left: auto;
+  font-weight: 700;
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 1px 6px;
+  border-radius: var(--pill, 999px);
+}
+.v-ok {
+  color: var(--ok, #3fb950);
+  background: var(--ok-wash, #0f2417);
+}
+.v-bad {
+  color: var(--fail, #e5534b);
+  background: var(--fail-wash, #2a1315);
+}
+.wr-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+.wr-step {
+  display: grid;
+  gap: 2px;
+  padding: 0.35rem 0.45rem;
+  border-radius: var(--r-1, 3px);
+  border-left: 3px solid var(--idle, #6b7684);
+  background: var(--surface, #141b24);
+}
+.wr-step.s-ok {
+  border-left-color: var(--ok, #3fb950);
+}
+.wr-step.s-fail {
+  border-left-color: var(--fail, #e5534b);
+  background: var(--fail-wash, #2a1315);
+}
+.wr-step.s-skipped {
+  opacity: 0.6;
+}
+.wr-step-top {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.7rem;
+}
+.wr-step-mark {
+  width: 0.9rem;
+  text-align: center;
+  font-weight: 700;
+}
+.s-ok .wr-step-mark {
+  color: var(--ok, #3fb950);
+}
+.s-fail .wr-step-mark {
+  color: var(--fail, #e5534b);
+}
+.s-skipped .wr-step-mark {
+  color: var(--idle, #6b7684);
+}
+.wr-step-name {
+  color: var(--ink, #e8eef5);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 0.68rem;
+}
+.wr-step-status {
+  margin-left: auto;
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted, #8a97a5);
+}
+.s-fail .wr-step-status {
+  color: var(--fail, #e5534b);
+  font-weight: 700;
+}
+.wr-step-means {
+  color: var(--faint, #5d6a78);
+  font-size: 0.64rem;
+  line-height: 1.4;
+}
+.wr-step-detail {
+  color: var(--ink-2, #b4c0cd);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 0.62rem;
+  overflow-wrap: anywhere;
+  line-height: 1.4;
+}
+.s-fail .wr-step-detail {
+  color: var(--fail, #e5534b);
+}
+.wr-nowalk {
+  display: block;
+  color: var(--muted, #8a97a5);
+  font-size: 0.68rem;
+  line-height: 1.5;
+}
+.wr-nowalk code {
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 0.62rem;
+  color: var(--ink-2, #b4c0cd);
+  overflow-wrap: anywhere;
+}
+.wr-why-inline {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--fail, #e5534b);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 0.64rem;
+  overflow-wrap: anywhere;
+}
+</style>

--- a/apps/socioprophet-web/src/contracts/tritfabric-ui-labels.v0.json
+++ b/apps/socioprophet-web/src/contracts/tritfabric-ui-labels.v0.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "prophet-platform.tritfabric-ui-labels/v0.1",
+  "contract_id": "tritfabric-ui-labels-v0",
+  "labels": [
+    {
+      "surface_id": "community-learning-intake",
+      "display_label": "Community Learning intake readiness",
+      "status_label": "review-gated",
+      "must_show": ["consent", "license", "lineage", "rubric", "manual-review-before-promotion"],
+      "forbidden_badges": ["training-enabled", "auto-promotion", "economic-credit"]
+    },
+    {
+      "surface_id": "network-atlas-framework-catalog",
+      "display_label": "Network Atlas framework catalog",
+      "status_label": "catalog-intake",
+      "must_show": ["adapter-status", "license-status", "claim-boundary"],
+      "forbidden_badges": ["validated-adapter", "production-supported"]
+    },
+    {
+      "surface_id": "model-card-promotion-evidence",
+      "display_label": "Model-card promotion evidence",
+      "status_label": "evidence-display-only",
+      "must_show": ["mathType", "calcOps", "ledgerRef", "artifactRef", "tritStatus"],
+      "forbidden_badges": ["promotion-executor", "transport-exception-only"]
+    },
+    {
+      "surface_id": "serve-readiness",
+      "display_label": "Serve readiness reporting",
+      "status_label": "readiness-only",
+      "must_show": ["readiness-vs-runtime", "rollback-before-active-loop", "claim-boundary"],
+      "forbidden_badges": ["production-ready", "autoscaler-active", "serve-deployed"]
+    }
+  ],
+  "claim_boundary": "UI/readiness label contract only. This does not implement UI components, runtime behavior, event ingestion, workflow execution, model mutation, artifact promotion, adapter validation, Serve deployment, or production readiness."
+}

--- a/apps/socioprophet-web/src/data/courseFixture.ts
+++ b/apps/socioprophet-web/src/data/courseFixture.ts
@@ -1,0 +1,117 @@
+// Flagship course fixture — MIT 8.01 Classical Mechanics (Walter Lewin), the depth-of-one that
+// proves the Academy moat: a lesson stream + a GROUNDED tutor that answers by citing the exact
+// captured lecture passage, and a board-style mastery check. UI-only, but shaped like the real
+// captured-chunk retrieval (search-orchestrator academy ingest) so the tutor's retrieval backend
+// is a later swap. Content is OpenCourseWare (CC BY-NC-SA 4.0); the tutor is EXTRACTIVE over these
+// transcripts — it quotes a real segment rather than generating, so it cannot hallucinate.
+
+export interface Lesson {
+  id: string;
+  n: number;
+  title: string;
+  durationMin: number;
+  chunkRef: string;      // provenance handle, e.g. '8.01SC · L01 · seg 12'
+  objectives: string[];
+  concepts: string[];    // key terms — power the concept map + tutor retrieval
+  transcript: string;    // the captured lecture segment the tutor quotes from
+}
+
+// The mastery-check question as the browser sees it — question + options ONLY. The correct-answer
+// index and the explanation are NOT here: they live in the academy-board service and are revealed
+// only in a graded verdict (see services/academyBoard.ts). Shipping the answer key to the client
+// would make the board trivially cheatable and the "verified assessment" claim a paper tiger.
+export interface AssessmentItem {
+  id: string;
+  concept: string;
+  q: string;
+  options: string[];
+}
+
+export interface Course {
+  id: string;
+  code: string;
+  title: string;
+  program: string;
+  teacher: string;
+  source: string;
+  license: string;
+  summary: string;
+  lessons: Lesson[];
+  assessment: AssessmentItem[];
+}
+
+const PHYSICS_801: Course = {
+  id: 'ocw-801',
+  code: '8.01SC',
+  title: 'Classical Mechanics',
+  program: 'Physics, S.B. (MIT Course 8)',
+  teacher: 'Walter Lewin',
+  source: 'MIT OpenCourseWare',
+  license: 'CC BY-NC-SA 4.0',
+  summary:
+    'The first-semester MIT physics course, taught by Walter Lewin. Units and scaling, kinematics in one and three dimensions, Newton’s laws, and circular motion — the foundation the whole degree stands on.',
+  lessons: [
+    {
+      id: 'l01', n: 1, title: 'Units, Dimensions & Powers of Ten', durationMin: 50, chunkRef: '8.01SC · L01 · seg 12',
+      objectives: ['Reason in SI units', 'Use dimensional analysis to check equations', 'Estimate with orders of magnitude'],
+      concepts: ['units', 'dimensions', 'dimensional analysis', 'powers of ten', 'uncertainty', 'scaling'],
+      transcript:
+        'Any measurement you make without knowledge of its uncertainty is meaningless. In physics we express every quantity in SI units — the meter for length, the kilogram for mass, the second for time. Dimensional analysis is a powerful check: the dimensions on the left of an equation must equal the dimensions on the right, or the equation is simply wrong. If a result for a length comes out with dimensions of time, you have made a mistake, and no amount of algebra will fix it.',
+    },
+    {
+      id: 'l02', n: 2, title: 'One-Dimensional Kinematics', durationMin: 50, chunkRef: '8.01SC · L02 · seg 07',
+      objectives: ['Distinguish position, velocity, acceleration', 'Read motion from x–t and v–t graphs', 'Apply constant-acceleration equations'],
+      concepts: ['position', 'velocity', 'acceleration', 'displacement', 'average velocity', 'instantaneous velocity'],
+      transcript:
+        'Velocity is the rate of change of position with time, and acceleration is the rate of change of velocity with time. Average velocity is displacement divided by the elapsed time, whereas instantaneous velocity is the slope of the position–time curve at a single instant. A crucial point: an object can have zero velocity yet non-zero acceleration — at the top of its flight a ball thrown straight up is momentarily at rest, but gravity is still accelerating it downward at 9.8 meters per second squared.',
+    },
+    {
+      id: 'l03', n: 3, title: 'Vectors & Projectile Motion', durationMin: 50, chunkRef: '8.01SC · L03 · seg 15',
+      objectives: ['Decompose vectors into components', 'Treat horizontal and vertical motion independently', 'Predict the trajectory of a projectile'],
+      concepts: ['vectors', 'components', 'projectile motion', 'trajectory', 'independence of motion', 'range'],
+      transcript:
+        'The great insight of projectile motion is that the horizontal and vertical motions are completely independent. Gravity acts only vertically, so the horizontal velocity is constant while the vertical velocity changes at 9.8 meters per second squared. Because the two are independent, a bullet fired horizontally and a bullet dropped from the same height hit the ground at exactly the same time. The path traced out is a parabola.',
+    },
+    {
+      id: 'l04', n: 4, title: 'Newton’s Laws of Motion', durationMin: 50, chunkRef: '8.01SC · L04 · seg 09',
+      objectives: ['State the three laws', 'Identify action–reaction pairs', 'Build free-body diagrams'],
+      concepts: ['force', 'inertia', 'Newton’s first law', 'Newton’s second law', 'Newton’s third law', 'free-body diagram', 'net force'],
+      transcript:
+        'Newton’s first law says an object stays at rest, or moves at constant velocity, unless a net force acts on it — this is inertia. The second law makes it quantitative: the net force equals mass times acceleration, F equals m a. The third law says that if body A pushes on body B, then B pushes back on A with equal magnitude and opposite direction. These action–reaction forces act on different objects, which is why they never cancel.',
+    },
+    {
+      id: 'l05', n: 5, title: 'Uniform Circular Motion', durationMin: 50, chunkRef: '8.01SC · L05 · seg 04',
+      objectives: ['Explain centripetal acceleration', 'Relate speed, radius and period', 'Identify the force providing the centripetal pull'],
+      concepts: ['circular motion', 'centripetal acceleration', 'centripetal force', 'period', 'angular velocity'],
+      transcript:
+        'An object moving in a circle at constant speed is still accelerating, because the direction of its velocity is always changing. That acceleration points toward the center of the circle and is called centripetal acceleration; its magnitude is v squared divided by r. There is no such thing as centrifugal force pushing you outward — what you feel is your own inertia, and some real force, such as tension or friction, must point inward to keep you on the circular path.',
+    },
+  ],
+  // Questions + options only — the answer key lives server-side in academy-board (keys.ts).
+  assessment: [
+    {
+      id: 'a1', concept: 'acceleration', q: 'A ball is thrown straight up. At the highest point of its flight, what is true?',
+      options: ['Velocity and acceleration are both zero', 'Velocity is zero, acceleration is 9.8 m/s² downward', 'Velocity is maximum, acceleration is zero', 'Both point upward'],
+    },
+    {
+      id: 'a2', concept: 'projectile motion', q: 'A bullet fired horizontally and a bullet dropped from the same height — which lands first?',
+      options: ['The fired bullet', 'The dropped bullet', 'They land at the same time', 'Depends on the muzzle speed'],
+    },
+    {
+      id: 'a3', concept: 'Newton’s third law', q: 'Why do action–reaction force pairs never cancel each other out?',
+      options: ['They are unequal', 'They act on different objects', 'One is always larger', 'They act at different times'],
+    },
+    {
+      id: 'a4', concept: 'centripetal force', q: 'What keeps an object moving in a circle at constant speed?',
+      options: ['An outward centrifugal force', 'No force — it moves freely', 'A net force directed toward the center', 'Its own momentum only'],
+    },
+  ],
+};
+
+export const courses: Course[] = [PHYSICS_801];
+
+// Resolve a course by id; unknown ids fall back to the flagship exemplar (so any
+// explorer link lands on a real, tutor-ready course while the rest are authored).
+export function getCourse(id: string): Course {
+  return courses.find((c) => c.id === id) ?? PHYSICS_801;
+}

--- a/apps/socioprophet-web/src/features/depth/expertise.ts
+++ b/apps/socioprophet-web/src/features/depth/expertise.ts
@@ -1,0 +1,218 @@
+/**
+ * W11.6 — expertise-adaptive depth (DARPA TA-E).
+ *
+ * The same answer, rendered at the depth its consumer can use: novice / journeyman / expert.
+ * Progressive disclosure bound to a STORED preference (see `stores/settings.ts`), not a
+ * per-page toggle that nobody ever flips.
+ *
+ * ── THE ONE RULE ───────────────────────────────────────────────────────────────────────────
+ * Depth changes what is SHOWN. It never changes what is CLAIMED.
+ *
+ * A novice view may hide the evidence URNs, the span arithmetic and the normalization regime.
+ * It may NOT make a weak warrant look strong. That is not a style guideline here — it is
+ * enforced two ways, both testable:
+ *
+ *   1. `DepthPolicy` only ever gates SUPPORTING detail. There is deliberately no flag capable
+ *      of hiding a warrant type, a seal state, or a model-generated marker, so no future edit
+ *      can turn one off by flipping a boolean. What is not expressible cannot regress.
+ *
+ *   2. Every plain-language gloss declares the strength it CONVEYS, and `WARRANT_STRENGTH`
+ *      declares the strength the warrant actually HAS. `src/__tests__/expertiseDepth.test.ts`
+ *      asserts they are equal for every (kind × level) pair. A gloss that flattered its
+ *      warrant would fail the suite rather than ship.
+ *
+ * Note the asymmetry that follows from the rule: glossing DOWN is safe, glossing UP is not.
+ * The novice text for `model-generated` is blunter than the expert text, not softer.
+ */
+import type { WarrantKind } from '../warrant/types';
+
+export type Expertise = 'novice' | 'journeyman' | 'expert';
+
+/** Ordered shallow → deep. The stored preference is one of these. */
+export const EXPERTISE_LEVELS: readonly Expertise[] = ['novice', 'journeyman', 'expert'] as const;
+
+export function isExpertise(v: unknown): v is Expertise {
+  return typeof v === 'string' && (EXPERTISE_LEVELS as readonly string[]).includes(v);
+}
+
+/**
+ * Ordinal epistemic strength of a warrant kind. Higher = a stronger claim on truth.
+ *
+ * This is the yardstick the gloss test measures against, so it is deliberately coarse and
+ * explicit rather than derived from the ramp colour — colour must follow proof, not define it.
+ *
+ *   3  the source (or the chain) vouches for it directly
+ *   2  derived from things that are vouched for
+ *   0  produced by a model; the source does not support it
+ */
+export const WARRANT_STRENGTH: Record<WarrantKind, number> = {
+  // source- or chain-warranted
+  'direct-quote': 3,
+  'token-span': 3,
+  receipt: 3,
+  // derived from warranted inputs
+  computed: 2,
+  inferred: 2,
+  'registry-default': 2,
+  // invented
+  'model-generated': 0,
+  ungrounded: 0,
+};
+
+/**
+ * What a given depth reveals. EVERY field here is supporting detail.
+ *
+ * Warrant type, seal state, the unsealed reason and the model-generated marker are absent by
+ * design: they are unconditional, so there is no switch to get wrong.
+ */
+export interface DepthPolicy {
+  level: Expertise;
+  /** 0 novice … 2 expert. */
+  rank: number;
+  label: string;
+  /** What this level is for, shown next to the control. */
+  blurb: string;
+  /** Raw URNs, content hashes, receipt ids. */
+  showRawRefs: boolean;
+  /** `[start,end)` character arithmetic. */
+  showSpanOffsets: boolean;
+  /** The warrant's cited evidence refs, itemized. */
+  showEvidenceList: boolean;
+  /** Typed provenance chain links (derived_from, extracted_by, supersedes). */
+  showProvenanceChain: boolean;
+  /** Policy labels attached by producers or the policy fabric. */
+  showPolicyLabels: boolean;
+  /** The normalized machine-readable payload + its normalization regime. */
+  showCanonicalPayload: boolean;
+  /** W11.4: the competing concepts a span carried beyond the one the plan bound. */
+  showLosingCandidates: boolean;
+  /** Numeric confidences and annotator names. */
+  showConfidence: boolean;
+  /** Truncate long nugget text to this many characters; null = never truncate. */
+  maxTextChars: number | null;
+}
+
+const POLICIES: Record<Expertise, DepthPolicy> = {
+  novice: {
+    level: 'novice',
+    rank: 0,
+    label: 'Novice',
+    blurb: 'The claim and how far to trust it. Supporting detail stays folded away.',
+    showRawRefs: false,
+    showSpanOffsets: false,
+    showEvidenceList: false,
+    showProvenanceChain: false,
+    showPolicyLabels: false,
+    showCanonicalPayload: false,
+    showLosingCandidates: false,
+    showConfidence: false,
+    maxTextChars: 240,
+  },
+  journeyman: {
+    level: 'journeyman',
+    rank: 1,
+    label: 'Journeyman',
+    blurb: 'Adds the evidence, the competing readings, and stated confidence.',
+    showRawRefs: false,
+    showSpanOffsets: true,
+    showEvidenceList: true,
+    showProvenanceChain: false,
+    showPolicyLabels: true,
+    showCanonicalPayload: false,
+    showLosingCandidates: true,
+    showConfidence: true,
+    maxTextChars: 600,
+  },
+  expert: {
+    level: 'expert',
+    rank: 2,
+    label: 'Expert',
+    blurb: 'Everything on the record: URNs, hashes, provenance chain, normalization regime.',
+    showRawRefs: true,
+    showSpanOffsets: true,
+    showEvidenceList: true,
+    showProvenanceChain: true,
+    showPolicyLabels: true,
+    showCanonicalPayload: true,
+    showLosingCandidates: true,
+    showConfidence: true,
+    maxTextChars: null,
+  },
+};
+
+export function depthPolicy(level: Expertise): DepthPolicy {
+  return POLICIES[level] ?? POLICIES.novice;
+}
+
+/** A depth-appropriate wording, plus the epistemic strength it claims to convey. */
+export interface WarrantGloss {
+  text: string;
+  /** MUST equal WARRANT_STRENGTH[kind]. Proven by test, for every kind × level. */
+  conveys: number;
+}
+
+/**
+ * Plain-language readings of each warrant kind, per depth.
+ *
+ * Read the `model-generated` row: the novice wording is the bluntest of the three. That is the
+ * asymmetry the rule demands — when in doubt, a shallower view must warn harder, not softer.
+ */
+const GLOSSES: Record<WarrantKind, Record<Expertise, string>> = {
+  'direct-quote': {
+    novice: 'Quoted word-for-word from the source.',
+    journeyman: 'The exact source span, cut from the document — the source itself warrants it.',
+    expert: 'direct-quote: text is byte-identical to sourceRef.span over the hashed source state.',
+  },
+  'token-span': {
+    novice: 'Taken straight from the words you asked.',
+    journeyman: 'Grounded in the question text — it points back at the characters that evoked it.',
+    expert: 'token-span grounding: conceptRef bound from an annotated span of the question.',
+  },
+  receipt: {
+    novice: 'Backed by a tamper-evident record.',
+    journeyman: 'Warranted by a receipt on the gateway chain rather than by a plan node.',
+    expert: 'receipt warrant: in-toto statement on the gateway chain, Ed25519-signed, seq-bound.',
+  },
+  computed: {
+    novice: 'Worked out from numbers stated in the source.',
+    journeyman: 'Calculated from cited source values under a declared normalization regime.',
+    expert: 'computed: deterministic normalization over cited values; regime declared in canonicalPayload.',
+  },
+  inferred: {
+    novice: 'Reasoned from things the source says — a step beyond quoting.',
+    journeyman: 'Follows by stated inference from cited premises. The premises are warranted; this step is reasoning.',
+    expert: 'inferred: entailment from cited premises; schema requires ≥1 evidence ref.',
+  },
+  'registry-default': {
+    novice: 'Filled in from a standard setting, not from your question.',
+    journeyman: 'Supplied by an ambient typed value the registry vouches for, not by the question text.',
+    expert: 'registry-default grounding: slot filled from a registered default; no token span.',
+  },
+  'model-generated': {
+    novice: 'Written by the AI. It is NOT in the source — treat it as a suggestion.',
+    journeyman: 'Produced by a model from the source window, and not warranted by it. Discounted wherever used.',
+    expert: 'model-generated: unwarranted by sourceRef; admissibility-discounted, never launderable.',
+  },
+  ungrounded: {
+    novice: 'Invented by the planner. Nothing in your question asked for it.',
+    journeyman: 'Not grounded in the question. Filed as a model-generated claim and discounted by the admissibility gate.',
+    expert: 'ungrounded grounding: no token span; admissibility ruling carries the discount.',
+  },
+};
+
+/** The gloss for a warrant kind at a depth, tagged with the strength it conveys. */
+export function warrantGloss(kind: WarrantKind, level: Expertise): WarrantGloss {
+  const byLevel = GLOSSES[kind];
+  // An unknown kind must never borrow a confident gloss. Strength 0, and it says so.
+  if (!byLevel) return { text: 'Unrecognized warrant — treated as unproven.', conveys: 0 };
+  return { text: byLevel[level] ?? byLevel.novice, conveys: WARRANT_STRENGTH[kind] ?? 0 };
+}
+
+/** Truncate to the depth's budget, on a word boundary, with an explicit ellipsis. */
+export function clampText(text: string, policy: DepthPolicy): { text: string; truncated: boolean } {
+  const max = policy.maxTextChars;
+  if (max === null || text.length <= max) return { text, truncated: false };
+  const cut = text.slice(0, max);
+  const sp = cut.lastIndexOf(' ');
+  return { text: (sp > max * 0.6 ? cut.slice(0, sp) : cut).trimEnd() + '…', truncated: true };
+}

--- a/apps/socioprophet-web/src/features/nuggets/types.ts
+++ b/apps/socioprophet-web/src/features/nuggets/types.ts
@@ -1,0 +1,226 @@
+/**
+ * KnowledgeNugget — the estate's L2 content grain, made renderable.
+ *
+ * STRUCTURAL MIRROR of `KnowledgeNugget.json` @ specVersion 0.1.0 (sourceos-spec #210, vendored
+ * into `apps/nugget-extractor/src/nugget_extractor/schemas/`). Copied field-for-field, not
+ * invented. The producer is `apps/nugget-extractor` (#1042).
+ *
+ * ── THE NORMATIVE RULE THIS FILE EXISTS TO KEEP ────────────────────────────────────────────
+ * From the schema's own description:
+ *
+ *   "warrant.type = model-generated MUST remain visibly distinguishable on every downstream
+ *    surface — retrieval, ranking, rendering, and admissibility weighting all discount
+ *    model-generated nuggets relative to source-warranted ones, and no downstream transform
+ *    may launder a model-generated nugget into a source-warranted one."
+ *
+ * So: no mapping in this file ever widens a warrant. Unparseable input becomes `unreadable`,
+ * which is UNKNOWN — deliberately not "model-generated" (we did not establish that) and
+ * deliberately not a failure verdict (we did not check anything). It is simply not readable,
+ * and it says so.
+ */
+import type { NuggetWarrantType, TokenSpan, WarrantInput } from '../warrant/types';
+
+export type { NuggetWarrantType };
+
+/** KnowledgeNugget.json → sourceRef.span */
+export interface NuggetSpan {
+  /** 0-based inclusive character offset into the hashed source text. */
+  start: number;
+  /** 0-based exclusive offset. For direct-quote, `end - start === text.length` (validator-enforced). */
+  end: number;
+  /** 1-based page, for paginated sources. */
+  page?: number;
+}
+
+/** KnowledgeNugget.json → sourceRef */
+export interface NuggetSourceRef {
+  /** URN of the governed source document. `urn:srcos:<kind>:<local-id>`. */
+  docRef: string;
+  /**
+   * The span within the hashed source text. For `model-generated` this is the CONDITIONING
+   * WINDOW the generation was given — per the schema, it does NOT warrant the text.
+   */
+  span: NuggetSpan;
+  /** `sha256-<64 hex>`. Pins the nugget to an immutable source state so offsets cannot drift. */
+  contentHash: string;
+}
+
+/** KnowledgeNugget.json → warrant */
+export interface NuggetWarrant {
+  type: NuggetWarrantType;
+  /**
+   * Evidence refs grounding the warrant. Schema invariant: `computed` and `inferred` MUST cite
+   * at least one — a derivation with no cited inputs is not a derivation. `direct-quote` is
+   * grounded by sourceRef itself; `model-generated` may be evidence-free, which is exactly why
+   * it is admissibility-discounted.
+   */
+  evidence: string[];
+  /**
+   * Producer-stated confidence, 0..1. NOT admissibility: the schema is explicit that
+   * admissibility is a function of warrant.type FIRST (model-generated is discounted whatever
+   * its confidence) and confidence second. The UI must never let this number outrank the type.
+   */
+  confidence: number;
+}
+
+export interface NuggetProvenanceLink {
+  /** e.g. derived_from, extracted_by, supersedes. */
+  rel: string;
+  ref: string;
+}
+
+/** KnowledgeNugget.json @ 0.1.0 */
+export interface KnowledgeNugget {
+  id: string;
+  type: 'KnowledgeNugget';
+  specVersion: string;
+  sourceRef: NuggetSourceRef;
+  warrant: NuggetWarrant;
+  text: string;
+  kkoTypeRefs?: string[];
+  canonicalPayload?: unknown;
+  provenance?: NuggetProvenanceLink[];
+  policyLabels: string[];
+  createdBy: string;
+  wallTime: string;
+  /** Non-negative integer, or an encoded vector/hybrid clock string. */
+  logicalTime: number | string;
+}
+
+/**
+ * A feed entry. A payload that will not parse is KEPT as `ok: false` with the reason, never
+ * dropped and never coerced into a nugget with default fields.
+ *
+ * Why keep it at all: a silently discarded item makes the feed look cleaner than the data is.
+ * The count of unreadable items is itself a signal, and the surface shows it.
+ */
+export type FeedItem =
+  | { ok: true; nugget: KnowledgeNugget; nodeId: string }
+  | { ok: false; nodeId: string; reason: string };
+
+const WARRANT_TYPES: readonly NuggetWarrantType[] = [
+  'direct-quote',
+  'computed',
+  'inferred',
+  'model-generated',
+];
+
+export function isNuggetWarrantType(v: unknown): v is NuggetWarrantType {
+  return typeof v === 'string' && (WARRANT_TYPES as readonly string[]).includes(v);
+}
+
+const str = (v: unknown): v is string => typeof v === 'string' && v.length > 0;
+const num = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v);
+
+/**
+ * Parse one nugget, fail-closed.
+ *
+ * Every required field of the schema is checked. A nugget missing or mistyping ANY of them is
+ * returned as unreadable with the field named — because the alternative (filling a default) is
+ * how a `model-generated` nugget would eventually get read as something better.
+ *
+ * `warrant.type` is checked against the CLOSED v0.1 enum. An unrecognized value is unreadable,
+ * not silently downgraded to a known member: inventing a type is how a contract bump upstream
+ * turns into a wrong colour downstream.
+ */
+export function parseNugget(raw: unknown, nodeId = ''): FeedItem {
+  const bad = (reason: string): FeedItem => ({ ok: false, nodeId, reason });
+  if (!raw || typeof raw !== 'object') return bad('payload is not an object');
+  const o = raw as Record<string, unknown>;
+
+  if (!str(o['id'])) return bad('missing id');
+  const id = o['id'];
+  if (o['type'] !== 'KnowledgeNugget') return bad(`type is not KnowledgeNugget (got ${String(o['type'])})`);
+  if (!str(o['specVersion'])) return bad('missing specVersion');
+  if (!str(o['text'])) return bad('missing text');
+  if (!str(o['createdBy'])) return bad('missing createdBy');
+  if (!str(o['wallTime'])) return bad('missing wallTime');
+  const logical = o['logicalTime'];
+  if (!num(logical) && !str(logical)) return bad('missing logicalTime');
+
+  const srcRaw = o['sourceRef'];
+  if (!srcRaw || typeof srcRaw !== 'object') return bad('missing sourceRef');
+  const src = srcRaw as Record<string, unknown>;
+  const spanRaw = src['span'];
+  if (!spanRaw || typeof spanRaw !== 'object') return bad('missing sourceRef.span');
+  const sp = spanRaw as Record<string, unknown>;
+  if (!num(sp['start']) || !num(sp['end'])) return bad('sourceRef.span offsets are not numbers');
+  if (!str(src['docRef'])) return bad('missing sourceRef.docRef');
+  if (!str(src['contentHash'])) return bad('missing sourceRef.contentHash');
+
+  const wRaw = o['warrant'];
+  if (!wRaw || typeof wRaw !== 'object') return bad('missing warrant');
+  const w = wRaw as Record<string, unknown>;
+  if (!isNuggetWarrantType(w['type'])) {
+    return bad(`unrecognized warrant.type: ${String(w['type'])}`);
+  }
+  if (!num(w['confidence'])) return bad('missing warrant.confidence');
+  const evidence = Array.isArray(w['evidence']) ? w['evidence'].filter(str) : [];
+  // Schema invariant, re-checked here: a derivation that cites nothing is not a derivation.
+  if ((w['type'] === 'computed' || w['type'] === 'inferred') && evidence.length === 0) {
+    return bad(`${w['type']} warrant cites no evidence (schema requires >= 1)`);
+  }
+
+  const span: NuggetSpan = { start: sp['start'], end: sp['end'] };
+  if (num(sp['page'])) span.page = sp['page'];
+
+  const nugget: KnowledgeNugget = {
+    id,
+    type: 'KnowledgeNugget',
+    specVersion: o['specVersion'],
+    sourceRef: { docRef: src['docRef'], span, contentHash: src['contentHash'] },
+    warrant: { type: w['type'], evidence, confidence: w['confidence'] },
+    text: o['text'],
+    kkoTypeRefs: Array.isArray(o['kkoTypeRefs']) ? o['kkoTypeRefs'].filter(str) : [],
+    policyLabels: Array.isArray(o['policyLabels']) ? o['policyLabels'].filter(str) : [],
+    createdBy: o['createdBy'],
+    wallTime: o['wallTime'],
+    logicalTime: logical,
+  };
+  if ('canonicalPayload' in o) nugget.canonicalPayload = o['canonicalPayload'];
+  if (Array.isArray(o['provenance'])) {
+    nugget.provenance = o['provenance']
+      .filter((p): p is Record<string, unknown> => !!p && typeof p === 'object')
+      .filter((p) => str(p['rel']) && str(p['ref']))
+      .map((p) => ({ rel: p['rel'] as string, ref: p['ref'] as string }));
+  }
+  return { ok: true, nugget, nodeId: nodeId || id };
+}
+
+/**
+ * The nugget's warrant, as the `<Warrant>` primitive's input.
+ *
+ * TWO decisions here are load-bearing:
+ *
+ * 1. `span` is supplied ONLY for `direct-quote`. `<Warrant>` renders `span` as "Source span" —
+ *    the characters the claim points back at — and for a direct quote that is exactly true
+ *    (the schema forces `end - start === text.length`). For computed / inferred /
+ *    model-generated the span is the CONDITIONING WINDOW, and the schema says outright that it
+ *    does not warrant the text. Passing it anyway would render an unwarranted claim as though
+ *    it pointed at proof. The window is still shown on the card — labelled as what it is.
+ *
+ * 2. No `seal` and no `walk` are supplied, so every nugget resolves to `unknown`.
+ *    KnowledgeNugget@0.1.0 has no receipt field: `apps/nugget-extractor`'s emitter seals the
+ *    BATCH (one `POST /v1/compute kind=nugget-emit` receipt per document), not the nugget. So
+ *    per-nugget seal state is genuinely unknown — which is not "unsealed", and is very much
+ *    not "sealed". Fabricating a seal here is the exact failure #1052 closed.
+ */
+export function nuggetWarrantInput(n: KnowledgeNugget): WarrantInput {
+  const input: WarrantInput = { claim: n.text, kind: n.warrant.type };
+  if (n.warrant.type === 'direct-quote') {
+    const span: TokenSpan = {
+      start: n.sourceRef.span.start,
+      end: n.sourceRef.span.end,
+      text: n.text,
+      tokenIndices: [],
+    };
+    input.span = span;
+  }
+  return input;
+}
+
+/** Short display form of a URN or URI: the last meaningful segment. */
+export function refLabel(ref: string): string {
+  const tail = ref.split(/[:/#]/).filter(Boolean).pop();
+  return tail && tail.length > 0 ? tail : ref;
+}

--- a/apps/socioprophet-web/src/features/warrant/annotations.ts
+++ b/apps/socioprophet-web/src/features/warrant/annotations.ts
@@ -1,0 +1,275 @@
+/**
+ * W11.4 — the annotation overlay model. Ambiguity is data, not noise.
+ *
+ * THE LESSON (EBA): one token routinely carries SEVERAL competing ontology annotations, and a
+ * surface that renders only the one the plan bound has quietly deleted the most interesting
+ * fact on the screen — that there was a choice, and that something chose.
+ *
+ * The engine does not hide this. `compileQuestion` (hellgraph `ts/src/nlq.ts` @ v0.4.45, line
+ * ~1160) keeps the FULL annotation list on the compilation and hands the search a separate,
+ * deduped view:
+ *
+ *     const annotations = raw.sort(…)                    // ← everything, kept for provenance
+ *     const bySpanConcept = new Map<string, TokenAnnotation>()
+ *     …                                                   // one per (span, concept), best confidence
+ *     const searchAnnotations = [...bySpanConcept.values()]
+ *
+ * So `NlqCompilation.annotations` already carries every competitor, including several distinct
+ * `conceptRef`s over the same characters and the same concept proposed by several annotators.
+ * The cockpit's job is only to stop throwing that away.
+ *
+ * This module is PURE and framework-free so the honesty rules below are unit-testable:
+ *
+ *   1. Every candidate for a span is kept. Nothing is filtered by confidence.
+ *   2. "Used" is read from the PLAN's provenance, never inferred from confidence rank. When the
+ *      plan bound a lower-confidence concept, `overrodeTopConfidence` records exactly that.
+ *   3. A span nothing consumed is `consumed: false` — reported as unconsumed, never as
+ *      implicitly fine, and never silently omitted.
+ *   4. Overlapping spans cannot be laid out in one linear run, so the ones that do not fit are
+ *      surfaced in `overlapped` rather than dropped. Dropping them would re-commit the exact
+ *      sin this surface exists to fix.
+ */
+import { planNodes, type NodeProvenance, type PlanNode, type TokenAnnotation, type TokenSpan } from './types';
+
+/** How a plan took hold of a span. Both count as consumption — see `gatherConsumption`. */
+export type ConsumptionVia = 'grounding' | 'binding';
+
+export interface ConsumingNode {
+  nodeId: string;
+  actionName: string;
+  via: ConsumptionVia;
+  /** The declared input name, for `via: 'binding'`. */
+  input?: string;
+}
+
+/** One ontology concept proposed for a span, and whether the plan actually took it. */
+export interface ConceptCandidate {
+  conceptRef: string;
+  /** Which annotator proposed it (`lexicon`, `kko-semantic`, or a caller's own). */
+  source: string;
+  /** Annotator confidence in [0,1]. Carried through from the engine; does NOT gate the search. */
+  confidence: number;
+  /** True when the selected plan bound THIS concept for THIS span. Read from the plan, not guessed. */
+  used: boolean;
+  /** Plan nodes that consumed it, when used. */
+  usedBy: ConsumingNode[];
+}
+
+/** A span of the question, with every concept that competed for it. */
+export interface AnnotatedSpan {
+  span: TokenSpan;
+  /** Used first, then confidence descending, then conceptRef for determinism. */
+  candidates: ConceptCandidate[];
+  /** True when the plan consumed any candidate on this span. */
+  consumed: boolean;
+  /** The conceptRef the plan bound, when consumed. */
+  usedConceptRef: string | null;
+  /** True when more than one DISTINCT conceptRef competed here — the ambiguity flag. */
+  ambiguous: boolean;
+  /** The highest-confidence candidate, regardless of what the plan did. */
+  topConfidenceConceptRef: string | null;
+  /**
+   * True when the plan bound a concept that was NOT the highest-confidence candidate. The single
+   * most valuable thing this overlay can tell an operator: the ranking and the choice disagreed.
+   */
+  overrodeTopConfidence: boolean;
+}
+
+/** A run of question text: either plain, or an annotated span. */
+export interface OverlaySegment {
+  text: string;
+  start: number;
+  end: number;
+  /** Null for the plain text between annotated spans. */
+  annotated: AnnotatedSpan | null;
+}
+
+export interface AnnotationOverlay {
+  question: string;
+  segments: OverlaySegment[];
+  /**
+   * Annotated spans that overlap an already-laid-out span and so have no place in the linear
+   * run. Kept and rendered separately — never discarded.
+   */
+  overlapped: AnnotatedSpan[];
+  /** Every annotated span, laid out or overlapped, in document order. */
+  spans: AnnotatedSpan[];
+  /** Spans carrying more than one distinct concept. */
+  ambiguousCount: number;
+  /** Spans where the plan did not take the top-confidence candidate. */
+  overriddenCount: number;
+  /** Annotated spans the plan consumed nothing from. */
+  unconsumedCount: number;
+}
+
+const spanKey = (s: TokenSpan) => `${s.start}:${s.end}`;
+
+/**
+ * (span, concept) → the plan nodes that took it.
+ *
+ * BOTH consumption routes are gathered, because the engine counts both. `scoreVariant`
+ * (nlq.ts @ v0.4.45 :1065-1071) adds a node's grounding span AND every binding span to the
+ * `consumed` set before computing coverage:
+ *
+ *     if (g.tokenSpan) { for (const i of g.tokenSpan.tokenIndices) consumed.add(i); … }
+ *     for (const b of node.bindings) {
+ *       if (b.tokenSpan) for (const i of b.tokenSpan.tokenIndices) consumed.add(i)
+ *     }
+ *
+ * …but `provenance` only ever gets a row PER NODE. So a span consumed solely by a binding —
+ * "Germany" filling a `region` input is the canonical case — is invisible in provenance while
+ * still counting toward coverage. An overlay reading provenance alone would print "annotated
+ * but unconsumed" next to a coverage figure of 100%, and one of the two would be lying.
+ */
+function gatherConsumption(
+  provenance: readonly NodeProvenance[],
+  plan: PlanNode | null,
+): Map<string, ConsumingNode[]> {
+  const consumedBy = new Map<string, ConsumingNode[]>();
+  const add = (span: TokenSpan, conceptRef: string, entry: ConsumingNode) => {
+    const k = `${spanKey(span)}|${conceptRef}`;
+    const list = consumedBy.get(k) ?? [];
+    // A node can appear once per route; don't double-count the same (node, route, input).
+    if (!list.some((e) => e.nodeId === entry.nodeId && e.via === entry.via && e.input === entry.input)) {
+      list.push(entry);
+    }
+    consumedBy.set(k, list);
+  };
+
+  for (const p of provenance) {
+    if (p.tokenSpan && p.conceptRef) {
+      add(p.tokenSpan, p.conceptRef, { nodeId: p.nodeId, actionName: p.actionName, via: 'grounding' });
+    }
+  }
+  if (plan) {
+    for (const node of planNodes(plan)) {
+      for (const b of node.bindings) {
+        if (b.tokenSpan && b.conceptRef) {
+          add(b.tokenSpan, b.conceptRef, {
+            nodeId: node.nodeId,
+            actionName: node.actionName,
+            via: 'binding',
+            input: b.input,
+          });
+        }
+      }
+    }
+  }
+  return consumedBy;
+}
+
+/**
+ * Build the overlay for one question + one plan variant.
+ *
+ * @param question    the compiled question — spans are character offsets into THIS string.
+ * @param annotations `NlqCompilation.annotations` — the full, undeduped competitor list.
+ * @param provenance  the SELECTED variant's `provenance` (node-level grounding).
+ * @param plan        the SELECTED variant's plan, so binding-level consumption is seen too.
+ */
+export function buildAnnotationOverlay(
+  question: string,
+  annotations: readonly TokenAnnotation[],
+  provenance: readonly NodeProvenance[],
+  plan: PlanNode | null = null,
+): AnnotationOverlay {
+  const consumedBy = gatherConsumption(provenance, plan);
+
+  // Group every annotation by the exact characters it covers.
+  const groups = new Map<string, { span: TokenSpan; anns: TokenAnnotation[] }>();
+  for (const a of annotations) {
+    const k = spanKey(a.tokenSpan);
+    const g = groups.get(k);
+    if (g) g.anns.push(a);
+    else groups.set(k, { span: a.tokenSpan, anns: [a] });
+  }
+
+  const spans: AnnotatedSpan[] = [...groups.values()]
+    .map(({ span, anns }) => {
+      const candidates: ConceptCandidate[] = anns.map((a) => {
+        const usedBy = consumedBy.get(`${spanKey(span)}|${a.conceptRef}`) ?? [];
+        return {
+          conceptRef: a.conceptRef,
+          source: a.source,
+          confidence: a.confidence,
+          used: usedBy.length > 0,
+          usedBy,
+        };
+      });
+
+      // Top confidence is computed over the candidates as proposed — deliberately NOT
+      // influenced by what the plan did, so the two can be compared.
+      const byConfidence = [...candidates].sort(
+        (x, y) => y.confidence - x.confidence || x.conceptRef.localeCompare(y.conceptRef),
+      );
+      const top = byConfidence[0] ?? null;
+      const used = candidates.find((c) => c.used) ?? null;
+      const distinctConcepts = new Set(candidates.map((c) => c.conceptRef));
+
+      candidates.sort(
+        (x, y) =>
+          Number(y.used) - Number(x.used) ||
+          y.confidence - x.confidence ||
+          x.conceptRef.localeCompare(y.conceptRef) ||
+          x.source.localeCompare(y.source),
+      );
+
+      return {
+        span,
+        candidates,
+        consumed: used !== null,
+        usedConceptRef: used?.conceptRef ?? null,
+        ambiguous: distinctConcepts.size > 1,
+        topConfidenceConceptRef: top?.conceptRef ?? null,
+        // Only meaningful when something WAS used: an unconsumed span did not override anything.
+        overrodeTopConfidence:
+          used !== null && top !== null && used.conceptRef !== top.conceptRef,
+      } satisfies AnnotatedSpan;
+    })
+    // Document order; longer spans first so a container is laid out before anything inside it.
+    .sort((a, b) => a.span.start - b.span.start || b.span.end - a.span.end);
+
+  // Lay out the linear run. Anything that would overlap is set aside, not dropped.
+  const segments: OverlaySegment[] = [];
+  const overlapped: AnnotatedSpan[] = [];
+  let cursor = 0;
+  for (const s of spans) {
+    if (s.span.start < cursor) {
+      overlapped.push(s);
+      continue;
+    }
+    if (s.span.start > cursor) {
+      segments.push({
+        text: question.slice(cursor, s.span.start),
+        start: cursor,
+        end: s.span.start,
+        annotated: null,
+      });
+    }
+    segments.push({
+      text: question.slice(s.span.start, s.span.end),
+      start: s.span.start,
+      end: s.span.end,
+      annotated: s,
+    });
+    cursor = s.span.end;
+  }
+  if (cursor < question.length) {
+    segments.push({ text: question.slice(cursor), start: cursor, end: question.length, annotated: null });
+  }
+
+  return {
+    question,
+    segments,
+    overlapped,
+    spans,
+    ambiguousCount: spans.filter((s) => s.ambiguous).length,
+    overriddenCount: spans.filter((s) => s.overrodeTopConfidence).length,
+    unconsumedCount: spans.filter((s) => !s.consumed).length,
+  };
+}
+
+/** Short display form of a concept URN: the last segment, which is the readable part. */
+export function conceptLabel(ref: string): string {
+  const tail = ref.split(/[:/#]/).filter(Boolean).pop();
+  return tail && tail.length > 0 ? tail : ref;
+}

--- a/apps/socioprophet-web/src/features/warrant/types.ts
+++ b/apps/socioprophet-web/src/features/warrant/types.ts
@@ -1,0 +1,542 @@
+/**
+ * Warrant model — the proof chain, made renderable.
+ *
+ * These types are a STRUCTURAL MIRROR of shapes that already exist server-side. They are
+ * copied field-for-field, not invented, so the cockpit cannot drift from the engine. Each
+ * block names its upstream source; if the source moves, this file is the one place to fix.
+ *
+ *   • Plan / provenance / sense metric — hellgraph `ts/src/nlq.ts` @ v0.4.45
+ *     (the NLQ typed-plan compiler, spec docs/specs/15_NLQ_Typed_Plan_Compiler_v0_1.md).
+ *   • Admissibility ruling      — hellgraph `ts/src/claim-admissibility.ts` @ v0.4.45.
+ *   • Receipt verify walk       — compute-gateway `engine_receipts.py::verify_walk`,
+ *     served by `GET /v1/engine-receipts/{receipt_id}/verify`.
+ *   • Seal outcome              — hellgraph-service `src/membrane.ts::SealOutcome` and
+ *     `src/spine.ts::SpineResult` (the honest-degradation contract).
+ *
+ * The cockpit consumes; it does not define. HellGraph is not this app's lane to edit.
+ */
+
+// ─── Plan compiler: token spans ────────────────────────────────────────────────
+// hellgraph ts/src/nlq.ts :361
+
+/** Character offsets into the question, `[start, end)`, plus the tokens covered. */
+export interface TokenSpan {
+  start: number;
+  end: number;
+  /** The question text covered by the span. */
+  text: string;
+  /** Token stream positions covered, ascending. */
+  tokenIndices: number[];
+}
+
+// ─── Admissibility (the creativity penalty's mechanism) ────────────────────────
+// hellgraph ts/src/claim-admissibility.ts :105
+
+export type AdmissibilityGate =
+  | 'relevance'
+  | 'authentication'
+  | 'hearsay'
+  | 'opinion'
+  | 'prejudice';
+
+export interface GateStep {
+  gate: AdmissibilityGate;
+  passed: boolean;
+  reason: string;
+}
+
+export interface AdmissibilityDecision {
+  admitted: boolean;
+  /** 1.0 by default; discounted by the opinion gate; 0 when excluded. */
+  weight: number;
+  /** One step per gate evaluated, in order. Stops at the excluding gate. */
+  steps: GateStep[];
+  /** The gate that excluded the claim, when `admitted === false`. */
+  excludedAt?: AdmissibilityGate;
+}
+
+// ─── Plan nodes ────────────────────────────────────────────────────────────────
+// hellgraph ts/src/nlq.ts :625-670
+
+export type Cardinality = 'one' | 'many';
+export type SideEffects = 'none' | 'effect-request';
+export type BindingKind = 'annotation' | 'action' | 'default' | 'unbound';
+export type GroundingKind = 'token-span' | 'registry-default' | 'ungrounded';
+export type UngroundedReason = 'no-token-span' | 'unbound-required-input';
+
+/** Witness that a bound type satisfies a declared slot type — the subsumption that licensed the bind. */
+export interface SubsumptionWitness {
+  concept: string;
+  satisfies: string;
+  /** True when the types are identical; false when subsumption did the work (polymorphism). */
+  direct: boolean;
+}
+
+export interface PlanGrounding {
+  kind: GroundingKind;
+  tokenSpan?: TokenSpan;
+  conceptRef?: string;
+  /** Annotator that grounded the node (`kind: 'token-span'`). */
+  source?: string;
+  confidence?: number;
+  /** Registry default that grounded the node (`kind: 'registry-default'`). */
+  defaultLabel?: string;
+  /** Why the node counts as invented (`kind: 'ungrounded'`). */
+  reason?: UngroundedReason;
+  /** Admissibility ruling on an ungrounded node, filed as a `model-generated` claim. */
+  admissibility?: AdmissibilityDecision;
+}
+
+export interface PlanBinding {
+  /** Declared input name. */
+  input: string;
+  typeRef: string;
+  cardinality: Cardinality;
+  required: boolean;
+  kind: BindingKind;
+  conceptRef?: string;
+  tokenSpan?: TokenSpan;
+  /** Literal value lifted straight out of the question text. */
+  literal?: string;
+  defaultLabel?: string;
+  /** Sub-plan producing this input (`kind: 'action'`). */
+  via?: PlanNode;
+  subsumption?: SubsumptionWitness;
+}
+
+export interface PlanNode {
+  /** Deterministic path id: `n0`, `n0.items`, `n0.items.list`, … */
+  nodeId: string;
+  actionId: string;
+  actionName: string;
+  outputTypeRef: string;
+  outputCardinality: Cardinality;
+  sideEffects: SideEffects;
+  grounding: PlanGrounding;
+  bindings: PlanBinding[];
+  effectRequest?: EffectRequestProposal;
+}
+
+/** A proposed effect — never executed at search time. Emitted only for effect-request leaves. */
+export interface EffectRequestProposal {
+  executorRef: string;
+  proposes: string;
+  arguments: { input: string; conceptRef?: string; literal?: string; tokenSpan?: TokenSpan }[];
+  /** Always `proposed`: an EffectDecision must precede any world change. */
+  status: 'proposed';
+}
+
+/** Pre-order (root first) walk of a plan tree. Mirrors `planNodes` in nlq.ts :673. */
+export function planNodes(node: PlanNode): PlanNode[] {
+  const out: PlanNode[] = [node];
+  for (const b of node.bindings) if (b.via) out.push(...planNodes(b.via));
+  return out;
+}
+
+// ─── Sense metric (W11.3's three axes) ─────────────────────────────────────────
+// hellgraph ts/src/nlq.ts :681-712
+
+export interface SenseWeights {
+  coverage: number;
+  groundedness: number;
+  similarity: number;
+}
+
+/** hellgraph ts/src/nlq.ts :687 — the shipped default weighting. */
+export const DEFAULT_SENSE_WEIGHTS: Readonly<SenseWeights> = Object.freeze({
+  coverage: 0.5,
+  groundedness: 0.3,
+  similarity: 0.2,
+});
+
+export interface SenseMetric {
+  /** Content tokens the plan consumes, over content tokens available. */
+  coverage: number;
+  /** Mean admissibility-discounted node weight; 1.0 when every node is grounded. */
+  groundedness: number;
+  /** `1 − groundedness`. The invention penalty, expressed as the admissibility discount. */
+  creativity: number;
+  /** Pre-order/left-to-right concordance of the spans the plan consumes. */
+  similarity: number;
+  /** `coverage·w.coverage + groundedness·w.groundedness + similarity·w.similarity`. */
+  composite: number;
+  weights: SenseWeights;
+  contentTokens: number;
+  consumedContentTokens: number;
+  nodes: number;
+  groundedNodes: number;
+  ungroundedNodes: number;
+  /** One entry per ungrounded node — the admissibility ruling that produced its discount. */
+  admissibility: { nodeId: string; actionId: string; reason: UngroundedReason; weight: number }[];
+}
+
+/** Per-node provenance: token span → concept → action. hellgraph ts/src/nlq.ts :715 */
+export interface NodeProvenance {
+  nodeId: string;
+  actionId: string;
+  actionName: string;
+  tokenSpan?: TokenSpan;
+  conceptRef?: string;
+  source?: string;
+  grounded: boolean;
+  /** Contribution to groundedness: 1.0 grounded, else the admissibility discount. */
+  weight: number;
+}
+
+export interface PlanVariant {
+  plan: PlanNode;
+  senseMetric: SenseMetric;
+  /** 1-based rank in the composite ordering. */
+  rank: number;
+  provenance: NodeProvenance[];
+}
+
+/** Identity of the contract every registered action validated against. nlq.ts :120 */
+export interface ContractRef {
+  schema: string;
+  specVersion: string;
+  sha256: string;
+}
+
+/** hellgraph ts/src/nlq.ts :314 */
+export interface Token {
+  text: string;
+  norm: string;
+  start: number;
+  end: number;
+  index: number;
+  /** Function word — excluded from the coverage denominator. */
+  stop: boolean;
+}
+
+/** hellgraph ts/src/nlq.ts :371 */
+export interface TokenAnnotation {
+  tokenSpan: TokenSpan;
+  conceptRef: string;
+  source: string;
+  confidence: number;
+}
+
+export interface NlqCompilation {
+  question: string;
+  method: string;
+  contract: ContractRef;
+  tokens: Token[];
+  annotations: TokenAnnotation[];
+  /** `seq` = the store's monotonic logical clock — the receipt's real binding to graph state. */
+  snapshot: { seq: number; nodes: number; edges: number };
+  weights: SenseWeights;
+  /** Ranked best-first. */
+  variants: PlanVariant[];
+  /** `variants[0]`, or null when nothing type-checked. */
+  winner: PlanVariant | null;
+  /** sha256 over the ranked output + snapshot + contract digest (proof-carrying). */
+  hash: string;
+}
+
+// ─── Receipt verify walk ───────────────────────────────────────────────────────
+// compute-gateway engine_receipts.py::verify_walk, served by
+// GET /v1/engine-receipts/{receipt_id}/verify
+
+/**
+ * `_WALK` is pinned in engine_receipts.py :262 in exactly this order. The walk stops at the
+ * first failure, so every later step comes back `skipped` — that attribution is the point,
+ * and the UI renders it rather than collapsing it to one boolean.
+ */
+export const RECEIPT_WALK_STEPS = [
+  'gateway-signature',
+  'engine-seal-hash',
+  'snapshot-seq-binding',
+] as const;
+
+export type ReceiptWalkStepName = (typeof RECEIPT_WALK_STEPS)[number];
+
+/** Note: `skipped`, NOT `skip` — engine_receipts.py :313. */
+export type ReceiptWalkStatus = 'ok' | 'fail' | 'skipped';
+
+export interface ReceiptWalkStep {
+  /** Field is `step` (not `name`/`id`) — engine_receipts.py :312. */
+  step: string;
+  status: ReceiptWalkStatus;
+  /** Failure text lives here; there is no separate `error` key. May be null. */
+  detail: string | null;
+}
+
+/** Exactly the four keys `verify_walk` returns. `receipt_id` is snake_case upstream. */
+export interface ReceiptVerifyWalk {
+  valid: boolean;
+  receipt_id: string;
+  project: string;
+  /**
+   * Always length 3, in `RECEIPT_WALK_STEPS` order — and that is ENFORCED, not merely
+   * claimed: `warrantApi.ts::parseWalk` refuses any payload of another length, order or
+   * naming as an unrecognized shape rather than coercing it into a walk. A value of this
+   * type therefore only ever reaches a surface having satisfied the contract above.
+   */
+  steps: ReceiptWalkStep[];
+}
+
+/** Plain-English gloss of what each step actually proves, for the receipt-walk view. */
+export const WALK_STEP_MEANING: Record<string, string> = {
+  'gateway-signature':
+    'The receipt is genuinely ON the chain: every id-hash and prev-link re-derived from genesis, plus an Ed25519 signature over the in-toto statement.',
+  'engine-seal-hash':
+    "The engine's sealed sha256 recomputes byte-exactly from the stored receipt (canonical key order, hash field excluded).",
+  'snapshot-seq-binding':
+    'The receipt is pinned to the graph state it was cut from: snapshot.seq matches the sealed binding, and the signed outputs_sha still covers the stored envelope.',
+};
+
+// ─── Honest degradation ────────────────────────────────────────────────────────
+// hellgraph-service src/membrane.ts::SealOutcome :200 and src/spine.ts::SpineResult :33
+
+/**
+ * The membrane's seal outcome. `sealError` is camelCase with a capital E — that exact
+ * spelling is load-bearing; it is what `POST /api/membrane/decide` returns.
+ *
+ * The whole contract: when the gateway is unconfigured, unreachable, or refuses, the
+ * service still answers — with `sealed: false` and a NON-NULL `sealError`. The UI's job
+ * is to make that visible, never to paper over it.
+ */
+export interface SealOutcome {
+  sealed: boolean;
+  receiptRef: string | null;
+  /** e.g. `gateway_unconfigured`, `gateway_503:…`, `gateway_unreachable:…`. Null on success. */
+  sealError: string | null;
+}
+
+/** The engine-receipt spine result attached to /api/graph/enrich | /explore. */
+export type SpineResult = { ok: true; receiptId: string } | { ok: false; reason: string };
+
+/** Normalize a `spine` field onto the seal vocabulary so one badge renders both contracts. */
+export function sealFromSpine(spine: SpineResult): SealOutcome {
+  return spine.ok
+    ? { sealed: true, receiptRef: spine.receiptId, sealError: null }
+    : { sealed: false, receiptRef: null, sealError: spine.reason };
+}
+
+// ─── The normalized warrant the <Warrant> primitive renders ────────────────────
+
+/**
+ * Seal state at a glance. Three values, because "we could not check" and "we checked and
+ * it failed" are different facts and collapsing them is exactly the dishonesty this
+ * component exists to prevent.
+ */
+export type WarrantSealState = 'sealed' | 'unsealed' | 'unknown';
+
+/**
+ * KnowledgeNugget warrant taxonomy — sourceos-spec `KnowledgeNugget.json` @ 0.1.0, the
+ * `warrant.type` enum, closed at v0.1 (widening it is a contract bump).
+ *
+ * This is a SECOND, independent warrant vocabulary. It is kept separate from `GroundingKind`
+ * on purpose: a nugget's `computed` is not a plan node's `registry-default`, and folding one
+ * into the other to save a union member would be precisely the laundering the schema's
+ * normative rule forbids ("no downstream transform may launder a model-generated nugget into
+ * a source-warranted one"). Two vocabularies, both rendered natively, neither translated.
+ */
+export type NuggetWarrantType = 'direct-quote' | 'computed' | 'inferred' | 'model-generated';
+
+/** How a claim earned its place — the warrant TYPE, distinct from whether it is sealed. */
+export type WarrantKind = GroundingKind | 'receipt' | NuggetWarrantType;
+
+export interface WarrantInput {
+  /** What is being asserted. */
+  claim: string;
+  /** The plan node's grounding, when the claim came out of the NLQ compiler. */
+  grounding?: PlanGrounding;
+  /** The seal outcome, when the claim rode a membrane decision or a graph spine result. */
+  seal?: SealOutcome;
+  /** The full three-step verify walk, when the receipt has been walked. */
+  walk?: ReceiptVerifyWalk;
+  /** Receipt id, when known but not yet walked. */
+  receiptRef?: string;
+  /**
+   * Explicit warrant kind, for claims that are not NLQ plan nodes (a KnowledgeNugget's
+   * `warrant.type`). When set it WINS over the grounding-derived kind. Omit for plan nodes.
+   */
+  kind?: WarrantKind;
+  /** Source span, for claims that carry one without a `PlanGrounding` (nuggets). */
+  span?: TokenSpan;
+}
+
+export interface WarrantView {
+  claim: string;
+  kind: WarrantKind;
+  /** Short label for the warrant type, e.g. "token span", "model-generated". */
+  kindLabel: string;
+  /** One sentence on what this warrant type means. */
+  kindBlurb: string;
+  seal: WarrantSealState;
+  sealLabel: string;
+  /** Why it is unsealed — the `sealError`, or the failing walk step's detail. Null when sealed. */
+  sealDetail: string | null;
+  /** Epistemic-ramp mode this warrant maps onto (drives the --epi-* token). */
+  epistemic: 'observed' | 'derived' | 'hypothesis' | 'attested' | 'unknown';
+  /** The source span the claim points back at, when it has one. */
+  span: TokenSpan | null;
+  receiptRef: string | null;
+  walk: ReceiptVerifyWalk | null;
+  /** Admissibility ruling, present only for ungrounded (model-generated) claims. */
+  admissibility: AdmissibilityDecision | null;
+}
+
+const KIND_META: Record<WarrantKind, { label: string; blurb: string; epistemic: WarrantView['epistemic'] }> = {
+  'token-span': {
+    label: 'token span',
+    blurb: 'Grounded in the question itself — the claim points back at the exact characters that evoked it.',
+    epistemic: 'observed',
+  },
+  'registry-default': {
+    label: 'registry default',
+    blurb: 'Supplied by an ambient typed value the registry vouches for, not by the question text.',
+    epistemic: 'derived',
+  },
+  ungrounded: {
+    label: 'model-generated',
+    blurb: 'Invented, not grounded. Filed as a model-generated claim and discounted by the admissibility gate.',
+    epistemic: 'hypothesis',
+  },
+  receipt: {
+    label: 'sealed receipt',
+    blurb: 'Warranted by a receipt on the gateway chain rather than by a plan node.',
+    epistemic: 'attested',
+  },
+
+  // ── KnowledgeNugget warrants (sourceos-spec KnowledgeNugget.json @ 0.1.0) ──
+  // The ramp descends with the warrant: you can SEE a direct quote in the source; a computed
+  // value is derived from cited ones; an inference is derived from stated premises; a
+  // model-generated statement is a hypothesis the source does not support. `model-generated`
+  // shares the `hypothesis` rung with `ungrounded` because they are the same epistemic fact.
+  'direct-quote': {
+    label: 'direct quote',
+    blurb: 'The exact source span, cut from the document — warranted by the source itself.',
+    epistemic: 'observed',
+  },
+  computed: {
+    label: 'computed',
+    blurb: 'Derived by deterministic computation over cited source values, under a declared normalization regime.',
+    epistemic: 'derived',
+  },
+  inferred: {
+    label: 'inferred',
+    blurb: 'Follows by stated inference from cited premises. The premises are warranted; this step is reasoning.',
+    epistemic: 'derived',
+  },
+  'model-generated': {
+    label: 'model-generated',
+    blurb:
+      'Produced by a model conditioned on the source window, and NOT warranted by it. Admissibility-discounted wherever it is used.',
+    epistemic: 'hypothesis',
+  },
+};
+
+/** Warrant kinds the source itself vouches for — mirrors contract.py SOURCE_WARRANTED. */
+const SOURCE_WARRANTED: ReadonlySet<WarrantKind> = new Set<WarrantKind>([
+  'direct-quote',
+  'computed',
+  'inferred',
+  'token-span',
+]);
+
+/**
+ * True when a warrant is model-produced rather than source-warranted.
+ *
+ * The KnowledgeNugget schema makes this NORMATIVE: "model-generated MUST remain visibly
+ * distinguishable on every downstream surface". Surfaces call this rather than string-matching
+ * a label, so the rule has exactly one implementation to audit.
+ */
+export function isModelGenerated(kind: WarrantKind): boolean {
+  return kind === 'model-generated' || kind === 'ungrounded';
+}
+
+/** True when the source vouches for the content. `unknown`/invented kinds are never included. */
+export function isSourceWarranted(kind: WarrantKind): boolean {
+  return SOURCE_WARRANTED.has(kind);
+}
+
+const SEAL_LABEL: Record<WarrantSealState, string> = {
+  sealed: 'sealed',
+  unsealed: 'UNSEALED',
+  unknown: 'unknown',
+};
+
+/**
+ * Resolve the badge state. Order matters, and it is deliberately pessimistic:
+ *
+ *  1. A walk that ran is the strongest evidence — `valid: false` means UNSEALED even if a
+ *     `seal.sealed === true` claims otherwise. A seal is a claim; a walk is a check.
+ *  2. `sealed: false` is ALWAYS unsealed, with `sealError` carried through as the reason.
+ *     Never rendered as merely absent, never as silently fine.
+ *  3. Nothing to go on renders `unknown` — which is honest, and is NOT the same as sealed.
+ */
+export function resolveSeal(input: WarrantInput): {
+  state: WarrantSealState;
+  detail: string | null;
+} {
+  const { walk, seal } = input;
+  if (walk) {
+    if (walk.valid) return { state: 'sealed', detail: null };
+    const failed = walk.steps.find((s) => s.status === 'fail');
+    return {
+      state: 'unsealed',
+      detail: failed
+        ? `${failed.step}: ${failed.detail ?? 'failed with no detail'}`
+        : 'verify walk returned invalid',
+    };
+  }
+  if (seal) {
+    if (seal.sealed) return { state: 'sealed', detail: null };
+    return { state: 'unsealed', detail: seal.sealError ?? 'sealed:false with no sealError reported' };
+  }
+  return { state: 'unknown', detail: null };
+}
+
+/** Build the full renderable view. The one normalization every W11 surface goes through. */
+export function warrantView(input: WarrantInput): WarrantView {
+  // An explicit kind wins (nuggets); otherwise the plan node's grounding decides; a claim with
+  // neither is riding a receipt. Unknown kinds fall back to the `unknown` ramp rather than
+  // crashing or, worse, borrowing a confident label they did not earn.
+  const kind: WarrantKind = input.kind ?? (input.grounding ? input.grounding.kind : 'receipt');
+  const meta = KIND_META[kind] ?? {
+    label: String(kind),
+    blurb: 'Unrecognized warrant kind — treated as unproven.',
+    epistemic: 'unknown' as const,
+  };
+  const { state, detail } = resolveSeal(input);
+  const g = input.grounding;
+  return {
+    claim: input.claim,
+    kind,
+    kindLabel: meta.label,
+    kindBlurb: meta.blurb,
+    seal: state,
+    sealLabel: SEAL_LABEL[state],
+    sealDetail: detail,
+    // Colour can never outrank proof. ONLY a sealed claim keeps a confident ramp mode;
+    // everything else — `unsealed` (checked, failed) and `unknown` (could not check alike) —
+    // degrades to the `unknown` ramp. An unproven claim wearing "observed" blue is the exact
+    // dishonesty this component exists to prevent, and "we could not check" is not a licence
+    // to look confident.
+    //
+    // The two non-sealed states stay DISTINGUISHABLE, just not by borrowing confidence:
+    // `seal`/`sealLabel` separate them in text ("unknown" vs "UNSEALED"), and <Warrant>
+    // paints `unsealed` in --fail while `unknown` takes the desaturated --epi-unknown. So
+    // "could not check" reads as absence, "checked and failed" reads as alarm, and neither
+    // reads as proof.
+    //
+    // W11.5 note: this is why NO KnowledgeNugget reaches a confident ramp mode. A nugget
+    // carries no receipt, so its seal is `unknown`, so its ramp is `unknown` — regardless of
+    // how strong its WARRANT is. Warrant kind and seal state are different axes, and the ramp
+    // answers the seal one. NuggetCard distinguishes the warrant axis by hue at reduced
+    // strength, deliberately never at full ramp intensity.
+    epistemic: state === 'sealed' ? (kind === 'receipt' ? 'attested' : meta.epistemic) : 'unknown',
+    span: g?.tokenSpan ?? input.span ?? null,
+    receiptRef: input.receiptRef ?? input.walk?.receipt_id ?? input.seal?.receiptRef ?? null,
+    walk: input.walk ?? null,
+    admissibility: g?.admissibility ?? null,
+  };
+}
+
+/** Format a [0,1] score as a percentage string with no decimals. */
+export function pct(n: number): string {
+  return `${Math.round(n * 100)}%`;
+}

--- a/apps/socioprophet-web/src/main.ts
+++ b/apps/socioprophet-web/src/main.ts
@@ -14,6 +14,7 @@ import WorkstationPipelines from './pages/WorkstationPipelines.vue';
 import WorkstationDeploy from './pages/WorkstationDeploy.vue';
 import WorkstationServices from './pages/WorkstationServices.vue';
 import WorkstationTerminal from './pages/WorkstationTerminal.vue';
+import WorkstationDevSecOps from './pages/WorkstationDevSecOps.vue';
 import ModelLabs from './pages/ModelLabs.vue';
 import Studio from './pages/Studio.vue';
 import Discovery from './pages/Discovery.vue';
@@ -169,6 +170,7 @@ const explicitRoutes = [
   { path: '/workstation/deploy', component: WorkstationDeploy },
   { path: '/workstation/services', component: WorkstationServices },
   { path: '/workstation/terminal', component: WorkstationTerminal },
+  { path: '/workstation/devsecops', component: WorkstationDevSecOps },
   { path: '/ai/labs', component: ModelLabs },
   { path: '/studio', component: Studio },
   { path: '/discovery', component: Discovery },

--- a/apps/socioprophet-web/src/pages/WorkstationDevSecOps.vue
+++ b/apps/socioprophet-web/src/pages/WorkstationDevSecOps.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+// DevSecOps Intelligence Workroom surface — the governed RCA / runtime-parity honesty readout.
+// Carried over from Prophet Studio when client-vue became the deployed cockpit (Phase 3): the
+// card is unchanged (fetches /api/v1/workroom/report + /api/v1/workroom/runtime-parity-bridge via
+// the gateway) so the devsecops-workroom-rca-guards governance guard still holds — it just lives
+// on its own route now instead of the old single-page App.vue.
+import DevSecOpsWorkroomReportCard from '../components/DevSecOpsWorkroomReportCard.vue';
+import TritFabricReadinessLabels from '../components/TritFabricReadinessLabels.vue';
+</script>
+
+<template>
+  <section class="sp-page">
+    <header class="sp-page-head">
+      <h1>DevSecOps Workroom</h1>
+      <p>Root-cause analysis, Guardrail bindings, and runtime-parity posture — rendered from the governed fixture contracts, with explicit non-claims.</p>
+    </header>
+    <DevSecOpsWorkroomReportCard />
+    <!-- TritFabric product-consumption readiness labels — a sibling governed-honesty surface
+         (label contract only; renders without implying runtime authority). -->
+    <TritFabricReadinessLabels />
+  </section>
+</template>

--- a/apps/socioprophet-web/src/services/academyApi.ts
+++ b/apps/socioprophet-web/src/services/academyApi.ts
@@ -1,0 +1,99 @@
+// Academy retrieval — the tutor's grounding backend, abstracted over BOTH offerings:
+//   • cloud  → search-orchestrator (POST /v0/search/query), the deployed academy ingest over the
+//              captured Commons chunks.
+//   • local  → on-device Noetica (agent-machine :8080), which is building the same academy path —
+//              so the cockpit tutor can ground against the user's LOCAL corpus too.
+//   • fixture→ the in-app course transcripts (the guaranteed offline fallback).
+//
+// This is the "integrate both ways" seam: one tutor, either engine, same cited-passage contract.
+// 'auto' tries cloud then local then falls back to fixture — always best-effort, never breaks.
+import { resolveBase } from '../config/cockpitRuntime';
+
+export type AcademySource = 'auto' | 'cloud' | 'local' | 'fixture';
+export type PassageOrigin = 'cloud' | 'local' | 'fixture';
+
+export interface TutorPassage {
+  text: string;
+  title: string;
+  chunkRef: string;
+  score: number;
+  origin: PassageOrigin;
+  uri?: string;
+}
+export interface RetrieveResult { passages: TutorPassage[]; origin: PassageOrigin }
+
+const CLOUD = resolveBase('search', 'VITE_SEARCH_BASE', '/svc/search');
+// On-device Noetica — the SAME base the cockpit already uses for the sovereign agent-machine.
+const LOCAL = resolveBase('agentMachine', 'VITE_AGENT_MACHINE', 'http://127.0.0.1:8080');
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isAcademy(r: any): boolean {
+  return /academy|learning|course|lecture|ocw/i.test(String(r?.source ?? r?.entity_type ?? ''));
+}
+
+// Cloud: search-orchestrator fans academy records into /v0/search/query.
+async function cloudRetrieve(query: string, limit: number): Promise<TutorPassage[]> {
+  // scope.cloud_workspace MUST be true — the orchestrator gates academy records behind it.
+  const body = {
+    query_id: `tutor-${Date.now()}`, actor_id: 'cockpit-tutor', text: query, mode: 'academy', limit,
+    scope: { cloud_workspace: true, local_desktop: false, memory: false },
+  };
+  const res = await fetch(`${CLOUD}/v0/search/query`, {
+    method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`search ${res.status}`);
+  const d = (await res.json()) as { results?: unknown[] };
+  return (d.results ?? [])
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .filter((r: any) => isAcademy(r))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .map((r: any) => ({
+      text: String(r.snippet ?? r.title ?? ''),
+      title: String(r.title ?? 'Lecture'),
+      chunkRef: String(r.path_or_uri ?? r.result_id ?? r.object_id ?? ''),
+      score: Number(r.score?.final ?? 0),
+      origin: 'cloud' as const,
+      uri: typeof r.path_or_uri === 'string' && /^https?:/.test(r.path_or_uri) ? r.path_or_uri : undefined,
+    }))
+    .filter((p: TutorPassage) => p.text.length > 0);
+}
+
+// Local: on-device Noetica. Contract mirrors the cloud shape; when Noetica exposes its academy
+// retrieval this lights up with the user's local corpus. Best-effort — fails closed.
+async function localRetrieve(query: string, limit: number): Promise<TutorPassage[]> {
+  const res = await fetch(`${LOCAL}/api/academy/retrieve`, {
+    method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ text: query, limit }),
+  });
+  if (!res.ok) throw new Error(`noetica ${res.status}`);
+  const d = (await res.json()) as { passages?: unknown[] };
+  return (d.passages ?? [])
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .map((p: any) => ({
+      text: String(p.text ?? p.snippet ?? ''),
+      title: String(p.title ?? 'Lecture'),
+      chunkRef: String(p.chunkRef ?? p.ref ?? ''),
+      score: Number(p.score ?? 0),
+      origin: 'local' as const,
+    }))
+    .filter((p: TutorPassage) => p.text.length > 0);
+}
+
+export async function retrievePassages(query: string, source: AcademySource = 'auto', limit = 4): Promise<RetrieveResult> {
+  const order: PassageOrigin[] = source === 'cloud' ? ['cloud']
+    : source === 'local' ? ['local']
+    : source === 'fixture' ? []
+    : ['cloud', 'local'];
+  for (const o of order) {
+    try {
+      const passages = o === 'cloud' ? await cloudRetrieve(query, limit) : await localRetrieve(query, limit);
+      if (passages.length) return { passages: passages.sort((a, b) => b.score - a.score), origin: o };
+    } catch { /* try the next provider, then fixture */ }
+  }
+  return { passages: [], origin: 'fixture' };
+}
+
+export const ORIGIN_META: Record<PassageOrigin, { glyph: string; label: string }> = {
+  cloud: { glyph: '☁', label: 'cloud · academy ingest' },
+  local: { glyph: '⌂', label: 'local · on-device Noetica' },
+  fixture: { glyph: '○', label: 'commons · captured transcript' },
+};

--- a/apps/socioprophet-web/src/stores/cockpit.ts
+++ b/apps/socioprophet-web/src/stores/cockpit.ts
@@ -12,11 +12,13 @@ export interface SurfaceContext {
   entityLabel?: string;   // e.g. 'SPX · S&P 500'
   detail?: string;        // e.g. '5,259.71 · -1.14%'
   route?: string;         // current path
+  text?: string;          // the surface's primary text — feeds the ubiquitous Extract dock (live IE)
 }
 
 export const useCockpit = defineStore('cockpit', () => {
   const dockOpen = ref(false);
   const graphOpen = ref(false);
+  const extractOpen = ref(false);
   const context = ref<SurfaceContext>({ surface: '' });
 
   function setContext(c: SurfaceContext) { context.value = c; }
@@ -25,6 +27,9 @@ export const useCockpit = defineStore('cockpit', () => {
   function toggleDock() { dockOpen.value = !dockOpen.value; }
   function toggleGraph() { graphOpen.value = !graphOpen.value; }
   function closeGraph() { graphOpen.value = false; }
+  // Ubiquitous IE: the Extract dock (live ie-engine) is available on every surface.
+  function toggleExtract() { extractOpen.value = !extractOpen.value; }
+  function closeExtract() { extractOpen.value = false; }
 
   // One-tap "ask Noetica about what I'm looking at": open the dock + send a
   // context-framed prompt into the shared chat session.
@@ -33,5 +38,5 @@ export const useCockpit = defineStore('cockpit', () => {
     useNoeticaChat().send(prompt);
   }
 
-  return { dockOpen, graphOpen, context, setContext, openDock, closeDock, toggleDock, toggleGraph, closeGraph, askAbout };
+  return { dockOpen, graphOpen, extractOpen, context, setContext, openDock, closeDock, toggleDock, toggleGraph, closeGraph, toggleExtract, closeExtract, askAbout };
 });

--- a/apps/socioprophet-web/src/stores/settings.ts
+++ b/apps/socioprophet-web/src/stores/settings.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { ref, watch } from 'vue';
+import { isExpertise, type Expertise } from '../features/depth/expertise';
 
 // User settings + nav personalization, all persisted to localStorage:
 //   operatorMode  when on, the operator/SourceOS drawer sections default to expanded
@@ -7,6 +8,11 @@ import { ref, watch } from 'vue';
 //   theme         'dark' | 'light' — applied as data-theme on <html>.
 //   pinned        surface routes the user pinned to the top of the drawer.
 //   openSections  per-section accordion open/closed state (id -> bool).
+//   expertise     W11.6 — novice | journeyman | expert. Drives progressive disclosure on the
+//                 proof surfaces. Lives HERE, next to the other durable preferences, rather
+//                 than as per-page state: the point of TA-E is that a consumer sets their
+//                 depth once and every surface honours it. Depth gates supporting detail
+//                 only — never a warrant type, a seal state, or a model-generated marker.
 
 type Theme = 'dark' | 'light';
 const LS_KEY = 'sp.settings.v1';
@@ -17,6 +23,7 @@ interface Persisted {
   pinned: string[];
   openSections: Record<string, boolean>;
   meshChat: boolean;
+  expertise: Expertise;
 }
 
 function load(): Persisted {
@@ -30,10 +37,16 @@ function load(): Persisted {
         pinned: Array.isArray(p.pinned) ? p.pinned : [],
         openSections: p.openSections && typeof p.openSections === 'object' ? p.openSections : {},
         meshChat: !!p.meshChat,
+        // Unrecognized/absent → novice. The shallow default is the safe one: it shows less,
+        // and depth can never weaken a warrant, so a wrong guess here cannot mislead.
+        expertise: isExpertise(p.expertise) ? p.expertise : 'novice',
       };
     }
   } catch { /* ignore */ }
-  return { operatorMode: false, theme: 'dark', pinned: [], openSections: {}, meshChat: false };
+  return {
+    operatorMode: false, theme: 'dark', pinned: [], openSections: {}, meshChat: false,
+    expertise: 'novice',
+  };
 }
 
 function applyTheme(theme: Theme) {
@@ -47,18 +60,22 @@ export const useSettings = defineStore('settings', () => {
   const pinned = ref<string[]>(initial.pinned);
   const openSections = ref<Record<string, boolean>>(initial.openSections);
   const meshChat = ref<boolean>(initial.meshChat);
+  const expertise = ref<Expertise>(initial.expertise);
 
   applyTheme(theme.value);
 
-  watch([operatorMode, theme, pinned, openSections, meshChat], () => {
+  watch([operatorMode, theme, pinned, openSections, meshChat, expertise], () => {
     applyTheme(theme.value);
     try {
       localStorage.setItem(LS_KEY, JSON.stringify({
         operatorMode: operatorMode.value, theme: theme.value,
         pinned: pinned.value, openSections: openSections.value, meshChat: meshChat.value,
+        expertise: expertise.value,
       }));
     } catch { /* ignore */ }
   }, { deep: true });
+
+  const setExpertise = (e: Expertise) => { expertise.value = e; };
 
   const toggleMeshChat = () => { meshChat.value = !meshChat.value; };
 
@@ -82,8 +99,8 @@ export const useSettings = defineStore('settings', () => {
   };
 
   return {
-    operatorMode, theme, pinned, openSections, meshChat,
-    toggleOperatorMode, setTheme, toggleTheme, toggleMeshChat,
+    operatorMode, theme, pinned, openSections, meshChat, expertise,
+    toggleOperatorMode, setTheme, toggleTheme, toggleMeshChat, setExpertise,
     isPinned, togglePin, isSectionOpen, toggleSection,
   };
 });


### PR DESCRIPTION
## Summary

PR #1428 (`feat/revendor-cockpit-acquisition`) replaced `apps/socioprophet-web` with content from `client-vue` (the canonical cockpit). The revendor commit did not carry three governance-bound components that CI validators require:

- `apps/socioprophet-web/src/components/DevSecOpsWorkroomReportCard.vue` — workroom RCA / runtime-parity bridge card (checked by `validate_workroom_runtime_parity_ui_component.py`)
- `apps/socioprophet-web/src/components/TritFabricReadinessLabels.vue` — TritFabric label-contract projection (checked by `validate_tritfabric_ui_component.py`)
- `apps/socioprophet-web/src/pages/WorkstationDevSecOps.vue` — route page wiring both components

Both `orchestration-fixtures` and `validate` jobs fail on #1428 because of these missing files.

## Fix

Restore all three files verbatim from `main`. No logic changes — the components are byte-for-byte identical to what was on main before the revendor.

## Test plan

- [ ] `orchestration-fixtures` (Workroom runtime parity UI wiring step) passes
- [ ] `validate` (`test_tritfabric_ui_component_contract_projection`) passes
- [ ] No other regressions

Stacks on #1428 — merge this first, then #1428 can land clean.