### PR TITLE
fix(zot): startupProbe — the registry could crash-loop on its own restart

### DIFF
--- a/infra/k8s/zot/base/deployment.yaml
+++ b/infra/k8s/zot/base/deployment.yaml
@@ -37,6 +37,24 @@ spec:
             - { name: htpasswd, mountPath: /etc/zot/htpasswd, subPath: htpasswd }
             - { name: cache, mountPath: /var/lib/zot }
           # zot's /v2/ returns 401 under the login-wall, so HTTP probes would fail auth — use TCP.
+          #
+          # STARTUP PROBE — without it a restart can CRASH-LOOP this registry.
+          # On boot zot runs a dedupe restore across every blob in the MinIO backend before it
+          # binds :5000. That work grows with the registry. The liveness probe alone gave it
+          # 20s + 3x20s = 80s, so once the restore exceeded ~80s the container was killed
+          # mid-restore, restarted, and began the restore again — observed live on 2026-08-04,
+          # 3 kills before it converged (each restart keeps partial boltdb progress, which is the
+          # only reason it ever came back). A registry that cannot survive its own restart is a
+          # latent outage waiting for the next node drain or config change.
+          #
+          # startupProbe suspends liveness/readiness until the first success, then hands over:
+          # 30 x 10s = up to 5 minutes to finish the restore, while STILL killing a genuinely
+          # hung boot. Liveness keeps its tight loop afterwards, so steady-state detection of a
+          # wedged process is unchanged.
+          startupProbe:
+            tcpSocket: { port: 5000 }
+            periodSeconds: 10
+            failureThreshold: 30
           readinessProbe:
             tcpSocket: { port: 5000 }
             initialDelaySeconds: 10


### PR DESCRIPTION
## Observed live, not theoretical

Restarting zot today to pick up a config change put it into a **restart loop** — 3 kills, exit code 2, `Liveness probe failed: dial tcp ...:5000: connect: connection refused` — before it converged on its own.

## Cause

On boot zot runs a **dedupe restore over every blob in the MinIO backend** before it binds `:5000`. That work grows with the registry. There was **no `startupProbe`**, so the liveness probe alone allowed `20s + 3×20s = 80s`. Once the restore exceeded that budget, the container was killed **mid-restore**, restarted, and began the restore again. It only recovered because each attempt keeps partial boltdb progress.

## Why this matters beyond today

It's latent, not cosmetic. The next **node drain, eviction, or config change** hits the same wall — and zot is the cluster's **pull-through cache**, so while it flaps, image pulls fail estate-wide. A registry that cannot survive its own restart is an outage waiting for a trigger.

## Fix

```yaml
startupProbe:
  tcpSocket: { port: 5000 }
  periodSeconds: 10
  failureThreshold: 30      # up to 5 minutes to finish the restore
```

`startupProbe` suspends liveness/readiness until its first success, then hands over. A genuinely hung boot still dies (at 5 min), and **steady-state liveness detection is unchanged** — the tight 20s loop still catches a wedged process once running.

## Verified

YAML parses; `startupProbe` budget = 300s; `livenessProbe` unchanged.

⚠️ Infra/prod config.