### PR TITLE
harden(kyverno): null-safe fsGroup precondition — fix 39 erroring evaluations

### DIFF
--- a/infra/policy/cloudshell-fog/kyverno/require-fsgroup-pvc.yaml
+++ b/infra/policy/cloudshell-fog/kyverno/require-fsgroup-pvc.yaml
@@ -29,9 +29,14 @@ spec:
           - resources:
               kinds: [Pod]
       preconditions:
-        # only Pods that actually mount a PVC (a bare emptyDir/configMap pod needs no fsGroup)
+        # Only workloads that actually mount a PVC (a bare emptyDir/configMap pod needs no fsGroup).
+        # `(volumes || `[]`)` coalesces a MISSING volumes key to an empty list BEFORE filtering:
+        # kyverno auto-generates this rule for Pod controllers (Deployment -> spec.template.spec,
+        # CronJob -> spec.jobTemplate.spec.template.spec), and a controller whose pod template has
+        # no volumes would otherwise error ("failed to resolve …volumes[?…]") — an erroring rule is
+        # a paper control (it evaluates nothing). Coalescing degrades that to a clean skip.
         any:
-          - key: "{{ request.object.spec.volumes[?persistentVolumeClaim] | length(@) || `0` }}"
+          - key: "{{ (request.object.spec.volumes || `[]`)[?persistentVolumeClaim] | length(@) }}"
             operator: GreaterThan
             value: 0
       validate:


### PR DESCRIPTION
Adversarial follow-up to #1401. `require-fsgroup-for-pvc-writers` was **erroring on 39 evaluations** estate-wide — an erroring rule evaluates nothing (a paper control).

**Root cause (confirmed from PolicyReport messages):** kyverno **autogen** generates the rule for Pod controllers (Deployment → `spec.template.spec.volumes`, CronJob → `spec.jobTemplate.spec.template.spec.volumes`); the precondition errored (`failed to resolve …volumes[?…]`) when a controller pod-template had **no `volumes` key** — JMESPath cant filter null.

**Fix:** coalesce before filtering — `(request.object.spec.volumes || ` + "`[]`" + `)[?persistentVolumeClaim] | length(@)`. Erroring cases → clean skip; real PVCs still fire.

**Adversarially verified** (offline JMESPath): OLD errors on missing/null volumes; NEW → 0 for no-volumes/null/empty/emptyDir and counts real PVCs (which always carry `claimName` → truthy), incl. multi-PVC. Kyvernos validating webhook accepts it (server-dry-run).

Known refinement (separate follow-up): pattern requires fsGroup *present*; `fsGroup:0` passes but is useless for a rootless writer — tightening to `>0` needs a CEL/deny rule.

Next: with this merged, triage the 24 workloads Layer 1 now correctly flags.