### PR TITLE
feat(catalog): reasoning dataset + method catalogue — what each tests, how we use it, whether we may

### DIFF
--- a/registry/reasoning-dataset-catalog.v0.yaml
+++ b/registry/reasoning-dataset-catalog.v0.yaml
@@ -1,0 +1,440 @@
+# Reasoning / QA dataset catalogue — what each benchmark TESTS, how we USE it, and whether we
+# are actually allowed to.
+#
+# WHY THIS EXISTS. fixtures/reasoning-task-eval/*.json already carry task families derived from
+# this body of work (complex_qa.abstention, complex_qa.qa_as_entailment, argumentation.key_point_*,
+# complex_qa.annotation_taxonomy …) and cite their provenance only as prose — "UReQA / ARC complex
+# QA reasoning requirements", "AAAI19 external-knowledge NLI", "Key Point Analysis". Nothing named
+# the underlying datasets, so nothing recorded what capability each one actually probes, which
+# licence governs it, or whether a fixture is a faithful proxy for the real benchmark. Fixtures
+# existed; their grounding did not. This file is that grounding.
+#
+# THE GATE (admitted != governed). A dataset may be catalogued without being usable. `use.status`
+# may only be `adopted` when `licence.verified: true`. Everything below currently ships
+# `verified: false` — the licence names are BEST-KNOWLEDGE ONLY and none has been checked against
+# the actual distribution terms. tools/check_reasoning_dataset_catalog.py enforces the gate, so a
+# dataset cannot quietly graduate from "we know about it" to "we train/evaluate on it".
+#
+# PROVENANCE OF THIS LIST. Entries marked `source: ibm-research-deck` were taken from IBM Research
+# AI slides (© 2020 IBM Corporation) that are stamped **IBM Confidential**. The public datasets
+# below are public regardless of that deck. The IBM-internal artefacts (term-wikifier-mentions) are
+# marked `availability: internal-confidential` so they are never redistributed or published to an
+# external surface by anything reading this catalogue.
+version: 0.1
+schema: reasoning-dataset-catalog.v0
+
+datasets:
+  # ---------------------------------------------------------------- closed world (passage given)
+  - id: mctest
+    name: MCTest
+    citation: Richardson, Burges, and Renshaw 2013
+    source: ibm-research-deck
+    world: closed
+    family: machine-reading-comprehension
+    availability: public
+    tests:
+      - reading comprehension over a supplied short story, no retrieval
+      - multiple-choice selection where every answer is derivable from the passage
+    use:
+      status: candidate
+      fixture_families: []
+      rationale: >
+        Small and fictional-narrative shaped. Useful as a floor check that a reader is reading and
+        not retrieving, but too easy and too far from estate domains to earn adoption on its own.
+    licence:
+      name: Microsoft Research licence (believed)
+      verified: false
+      notes: Research-use terms; must be read before any ingestion.
+
+  - id: squad-v1
+    name: SQuAD 1.1
+    citation: Rajpurkar et al. 2016
+    source: ibm-research-deck
+    world: closed
+    family: extractive-qa
+    availability: public
+    tests:
+      - span extraction from a supplied passage
+      - answer is guaranteed present — no abstention pressure at all
+    use:
+      status: candidate
+      fixture_families: []
+      rationale: >
+        The canonical closed-world baseline. Deliberately NOT adopted alone: every question is
+        answerable, so it cannot exercise the abstention behaviour the estate actually cares about
+        (ZERO / "I do not know" is a first-class verdict here, not a failure).
+    licence:
+      name: CC BY-SA 4.0 (believed)
+      verified: false
+      notes: Share-alike — check obligations before deriving and redistributing fixtures.
+
+  - id: squad-v2
+    name: SQuAD 2.0
+    citation: Rajpurkar, Jia, and Liang 2018
+    source: ibm-research-deck
+    world: closed
+    family: extractive-qa-with-unanswerable
+    availability: public
+    tests:
+      - span extraction AND recognising that a question is unanswerable from the passage
+      - resistance to plausible-but-wrong spans planted adversarially
+    use:
+      status: candidate
+      fixture_families: [complex_qa.abstention]
+      rationale: >
+        The one closed-world benchmark that directly probes the estate's core commitment —
+        abstaining instead of confabulating. Its unanswerable questions are the public analogue of
+        our ZERO verdict, which is why complex_qa.abstention exists. Highest-value adoption
+        candidate in the closed-world group.
+    licence:
+      name: CC BY-SA 4.0 (believed)
+      verified: false
+      notes: Share-alike — check obligations before deriving and redistributing fixtures.
+
+  - id: newsqa
+    name: NewsQA
+    citation: Trischler et al. 2016
+    source: ibm-research-deck
+    world: closed
+    family: extractive-qa
+    availability: restricted
+    tests:
+      - comprehension over real news prose rather than curated encyclopaedic text
+      - questions written without seeing the answer, so lexical overlap is lower than SQuAD
+    use:
+      status: not-adopted
+      fixture_families: []
+      rationale: >
+        Domain-realistic, but the distribution terms are the blocker rather than the content. Not
+        adopted until licence.verified is true; recorded here so the decision is visible instead of
+        being silently re-litigated.
+    licence:
+      name: Maluuba/Microsoft research agreement (believed)
+      verified: false
+      notes: >
+        BLOCKER. Historically required accepting a research agreement and building the corpus from
+        CNN articles rather than downloading it outright. Treat as unusable until read.
+
+  # ------------------------------------------------------- open world (system must retrieve)
+  - id: squad-open
+    name: SQuAD_OPEN
+    citation: open-domain variant that discards the supplied passages
+    source: ibm-research-deck
+    world: open
+    family: open-domain-qa
+    availability: public
+    tests:
+      - retrieval quality when the gold passage is deliberately withheld
+      - separates "can read" from "can find" — the same question set, minus the crutch
+    use:
+      status: candidate
+      fixture_families: [complex_qa.retrieval_evidence]
+      rationale: >
+        Valuable precisely as an A/B against squad-v1: identical questions, retrieval removed as a
+        given. That difference isolates retrieval failure from reading failure, which is the split
+        our fibered-retrieval work needs to measure.
+    licence:
+      name: inherits SQuAD (CC BY-SA 4.0, believed)
+      verified: false
+      notes: Derived construction, not a separately licensed corpus.
+
+  - id: arc
+    name: ARC (AI2 Reasoning Challenge)
+    citation: Clark et al. 2018
+    source: ibm-research-deck
+    world: open
+    family: open-domain-science-qa
+    availability: public
+    tests:
+      - grade-school science questions that resist retrieval-only solutions (the Challenge split)
+      - multi-hop composition and world knowledge not present in any single retrieved sentence
+    use:
+      status: candidate
+      fixture_families: [complex_qa.retrieval_evidence, complex_qa.query_rewriting]
+      rationale: >
+        The anchor benchmark for this whole lane — the existing fixtures already cite "UReQA / ARC
+        complex QA reasoning requirements" and carry ARC-style query rewriting. Adopting it would
+        replace a prose citation with a measurable one.
+    licence:
+      name: CC BY-SA 4.0 (AI2, believed)
+      verified: false
+      notes: AI2 corpora are generally permissive; still unverified here.
+
+  # ---------------------------------------------------------------------- QA as entailment
+  - id: snli
+    name: SNLI
+    citation: Stanford Natural Language Inference corpus
+    source: ibm-research-deck
+    world: entailment
+    family: natural-language-inference
+    availability: public
+    tests:
+      - three-way entailment / contradiction / neutral over short image-caption premises
+      - whether a system distinguishes "not entailed" from "contradicted" — a distinction the
+        estate's ZERO-vs-NEG verdict split depends on
+    use:
+      status: candidate
+      fixture_families: [complex_qa.qa_as_entailment, complex_qa.entailment_resolver]
+      rationale: >
+        The neutral class is the point. It is the public mirror of abstention: neither supported nor
+        refuted. Maps directly onto the kernel's ZERO (abstain) versus NEG (contradicted) weights.
+    licence:
+      name: CC BY-SA 4.0 (believed)
+      verified: false
+      notes: Share-alike; caption premises are crowd-written.
+
+  - id: scitail
+    name: SciTail
+    citation: science entailment corpus derived from science QA
+    source: ibm-research-deck
+    world: entailment
+    family: natural-language-inference
+    availability: public
+    tests:
+      - entailment where premises are REAL retrieved sentences, not crowd-authored for the task
+      - the harder, more realistic case: no annotator wrote the premise to fit the hypothesis
+    use:
+      status: candidate
+      fixture_families: [complex_qa.qa_as_entailment, natural_language_inference.external_knowledge]
+      rationale: >
+        Closer to how the estate actually reasons — evidence is retrieved, not composed to suit the
+        claim. Better external validity than SNLI for our warrant/evidence path, which is why the
+        external-knowledge NLI family exists.
+    licence:
+      name: Apache-2.0 (AI2, believed)
+      verified: false
+      notes: If confirmed Apache-2.0 this is the cleanest fit for the estate's MIT/Apache posture.
+
+  # ------------------------------------------------- annotation layers over an existing corpus
+  - id: arc-knowledge-reasoning-annotations
+    name: Knowledge and Reasoning Types annotations over ARC
+    citation: >
+      Boratko et al. 2018, "A Systematic Classification of Knowledge, Reasoning, and Context within
+      the ARC Dataset", MRQA @ ACL 2018 and EMNLP Demo 2018
+    source: ibm-research-deck
+    world: annotation
+    family: reasoning-taxonomy
+    availability: public
+    dataset_url: http://ibm.biz/mrqa-dataset
+    size: 192 distinct questions, 665 annotations total
+    tests:
+      - WHICH knowledge type and WHICH reasoning type a question demands, rather than pass/fail
+      - retrieval relevance judgements per question, annotated alongside the reasoning label
+    use:
+      status: candidate
+      fixture_families: [complex_qa.annotation_taxonomy]
+      rationale: >
+        The most strategically useful item in this list and the least obvious. It does not score a
+        system — it explains WHY a system failed, by naming the knowledge and reasoning type the
+        question required. That converts an aggregate score into a diagnosis, which is exactly the
+        move from "benchmark number" to "capability register row" the estate keeps making. Small
+        (192 questions), so it is a lens over ARC, never a standalone score.
+    licence:
+      name: unknown — IBM/UMass collaboration
+      verified: false
+      notes: Distributed via an IBM short-link; terms not yet read.
+
+  # ------------------------------------------------------- argumentation / summarisation
+  - id: key-point-analysis-benchmark
+    name: Key Point Analysis (KPA) evaluation data
+    citation: IBM Research AI, Key Point Analysis deck (© 2020 IBM Corporation)
+    source: ibm-research-deck
+    world: argumentation
+    family: summarisation-with-prevalence
+    availability: unresolved
+    tests:
+      - extraction of concise key points from a collection of texts
+      - MATCHING each input sentence to a key point, which is what makes prevalence countable
+      - salience as "# of matching sentences" — a quantified summary, not a free-text one
+    use:
+      status: candidate
+      fixture_families: [argumentation.key_point_prevalence, argumentation.key_point_drilldown]
+      rationale: >
+        KPA is the closest public analogue to what the estate's own claim/evidence model does:
+        a human-readable summary point, a direct mapping back to the sentences that support it, and
+        a count. Prevalence is our confidence; drill-down is our evidence_refs. The two fixture
+        families already encode both halves.
+      caveat: >
+        The source deck describes the METHOD (quality model + match-scoring model, human in the
+        loop) and names no evaluation corpus. The public KPA benchmark (ArgKP, Bar-Haim et al.) is
+        NOT named in that deck — do not record it here as if it were. Resolve which corpus we would
+        actually evaluate against before this moves past `candidate`.
+    licence:
+      name: unresolved — depends which corpus is chosen
+      verified: false
+      notes: Cannot be assessed until the evaluation corpus is identified.
+
+  - id: term-wikifier-mentions
+    name: Term-Wikifier general-entity mention benchmark
+    citation: IBM Research AI, entity mention detection / Term-Wikifier deck (© 2020 IBM Corporation)
+    source: ibm-research-deck
+    world: mention-detection
+    family: entity-linking
+    availability: internal-confidential
+    size: >
+      3 sources (Wikipedia, News, Speech) x 1000 sentences, each labelled by 10 annotators in a
+      two-stage detection-then-confirmation process; ~5000 labelled mentions per source
+    tests:
+      - detection of GENERAL entities, not just named entities — the stated gap in public benchmarks
+      - nesting ("violent video games") and specificity ("Empire" vs "Empire of Brazil")
+      - disambiguation to a knowledge-base URI using anchor context (PMI / TF-IDF / ESA / Word2Vec)
+    use:
+      status: not-adopted
+      fixture_families: []
+      rationale: >
+        Recorded for its DESIGN, which is the transferable part: the general-vs-named entity
+        distinction, the nesting and specificity guidelines, and the two-stage annotation protocol
+        are directly applicable to our own entity-resolution plane. The corpus itself is not ours.
+      caveat: >
+        The documented Term-Wikifier limitations are the useful warning: it cannot resolve
+        disambiguation pages or non-trivial surface-form transformations (Body -> Human_body,
+        LLC -> Limited_liability_company), so a rule cascade sits underneath it. Any estate entity
+        linker will hit the same wall.
+    licence:
+      name: IBM Confidential — not redistributable
+      verified: false
+      notes: >
+        BLOCKER and a handling rule, not merely a licence field. The source deck is marked IBM
+        Confidential. Do not publish, mirror, or ingest this corpus; the entry exists so the design
+        is remembered and the boundary is explicit.
+
+# =====================================================================================
+# METHODS — the engines these datasets feed, and where each one BINDS to an existing
+# estate contract. Datasets alone are inert; what makes them strategic is that every one
+# of these methods emits the same shape we already write to Crystal Atlas:
+#   a typed node, a claim with a signed weight, and the evidence that produced it.
+# =====================================================================================
+methods:
+  - id: hope-causality
+    name: HOPE Causality Reasoning Engine (causal relation model)
+    source: ibm-research-deck
+    availability: internal-confidential
+    produces:
+      event: "{id, label, hypothesis, topics[], totalscore_pro, totalscore_con}"
+      causation: "{source, target, causal_type: positive|negative, causal_strength: [0,1]}"
+      causal_paths: "ordered edge sets — the logic chain from a root event to a leaf"
+      sent_causal_risk: "{level: High|Medium|Low, value: float} — aggregate over the model"
+    binds_to:
+      claim: >
+        A HOPE *event* is a claim.v0 almost field-for-field: `hypothesis` is the claim text
+        (a sentence asserting an occurrence), `label` is the display form, `topics[]` are the
+        retrieval keys, and totalscore_pro/con is the evidence tally behind it.
+      edge: >
+        A HOPE *causation* is a signed graph-edge.v0. This is the important one:
+        `causal_type: positive|negative` with `causal_strength` in [0,1] IS the MLN's signed
+        weight — POS is w>0, NEG is w<0, and absent is w=0 (abstain). HOPE independently
+        arrived at the estate's verdict algebra; adopting it is conformance, not translation.
+      evidence: >
+        "N article (pro/con)" per event is an evidence count — the same quantity KPA calls
+        salience and our claim.v0 carries as confidence. One concept, three names.
+    caveat: >
+      HOPE scores strength on articles about an event, not on a causal identification
+      procedure. `causal_strength` is therefore ASSERTED CORRELATION STRENGTH, not established
+      causation, and a default of 0.5 appears throughout the sample models — i.e. unset. Ingest
+      it as a weighted assertion with its provenance, never as a causal fact. The estate's
+      epistemic_level for such an edge is `empirical` at best, never `proved`.
+
+  - id: gasp
+    name: GASP — multilayered pattern learning
+    citation: IBM Research (Shnarch, Levy, Slonim)
+    source: ibm-research-deck
+    availability: internal-confidential
+    produces: a ranked list of multilayered patterns indicative of a target phenomenon
+    tests:
+      - whether a subtle phenomenon (argumentation, entailment) has recurring surface structure
+      - generalisation ACROSS layers at once — lexical, POS, sentiment, topic-lexicon, NE
+    binds_to:
+      annotation: >
+        GASP's alphabet is exactly the multilayer annotation stack: a token carries word, POS,
+        semantic type, topic-lexicon match and sentiment simultaneously, and a pattern is a
+        gapped sequence over ANY of those layers ([TOPIC][@thatcomp][SENTIMENT][NN]).
+      learning: >
+        Learns patterns for the NEGATIVE class too, and allows gaps — so it is a discriminative
+        structure learner, not a matcher. That is the estate's "learn, don't match dictionaries"
+        rule expressed as an algorithm.
+    caveat: >
+      Described in the deck as "a research tool that unveils common structures in your data" —
+      an exploratory instrument, not a production classifier. Treat output patterns as
+      hypotheses to be counter-tested, not as rules to enforce.
+
+  - id: kpa-method
+    name: Key Point Analysis pipeline
+    source: ibm-research-deck
+    availability: public-method
+    produces:
+      key_points: concise sentences selected from the input texts (never generated free-text)
+      matching: "(comment -> KP) mapping, which is what makes prevalence countable"
+      salience: "# of matching sentences per key point"
+    binds_to:
+      claim: a key point is a claim.v0 whose confidence is its salience
+      evidence: each matched comment is an evidence.v0 with source_ref back to the comment
+    caveat: >
+      Extractive by construction — key points are SELECTED from real input sentences, not
+      generated. That is a feature for us: every summary point is already grounded in a witness,
+      which is precisely the property our reconstruction work demands.
+
+  - id: term-wikifier
+    name: Term-Wikifier mention detection and disambiguation
+    source: ibm-research-deck
+    availability: internal-confidential
+    produces: text spans linked to knowledge-base URIs, for general entities as well as named ones
+    binds_to:
+      annotation: >
+        This is the FIRST layer of the conversational-annotation surface: raw tokens become typed
+        mentions before any slot or frame can be built on top of them.
+      node: a resolved mention is a graph-node.v0 with a stable external identifier
+    caveat: >
+      Documented limits are the useful part: it cannot resolve disambiguation pages or non-trivial
+      surface transformations (Body -> Human_body, LLC -> Limited_liability_company), so a rule
+      cascade and a pruning stage sit underneath it. Any estate linker meets the same wall.
+
+# =====================================================================================
+# INTEGRATION — the conversational annotation + logic-chain surface
+# =====================================================================================
+integration:
+  conversational_annotation:
+    surface: >
+      Ranked interpretation variants over an utterance, each a scored tree of typed slots
+      (:ActionShow / common:ShowDataMessage, :ContactLists / engage:GetContactLists,
+      :Organization / engage:GetOrganization) rendered beside a derivation DAG whose lower
+      nodes are tokens with POS (show VB, me PRON, lists NNS, in ADP) and whose upper nodes are
+      semantic frames (:Relation, :Contains, :SuggestedContent).
+    the_single_spine: >
+      These decks are not four unrelated technologies. Read bottom-up they are ONE pipeline, and
+      it is the pipeline already drawn in that screenshot:
+        tokens
+          -> multilayer annotation      (GASP's alphabet: word / POS / sentiment / topic / NE)
+          -> typed mentions             (Term-Wikifier: spans resolved to KB identifiers)
+          -> typed slots and frames     (the :Action / :Entity tree in the variants panel)
+          -> ranked variants w/ scores  (the (0.75, 0) per interpretation, weights per node)
+          -> claims + signed edges      (HOPE: hypothesis nodes, positive/negative causation)
+          -> prevalence over witnesses  (KPA: salience = count of matching inputs)
+      Every arrow already has a home in the estate, which is why this is integration and not
+      invention.
+    contract_mapping:
+      token_layer: annotation layers on a span — no contract needed, this is input
+      mention: graph-node.v0 (external_id = the resolved KB URI)
+      slot_frame: >
+        governed_semantic_parsing.* fixture families already model this — logical_form_fixture,
+        schema_grounded_dual_ir, sql_fixture. The variants panel is a dual-IR view.
+      variant_score: >
+        claim.v0.confidence. A ranked variant list is a set of COMPETING claims over one
+        utterance, which is exactly the case the kernel's meet() is for: the parse is not
+        decided by argmax alone, it is decided by law AND evidence.
+      derivation_edge: graph-edge.v0 (and graph-hyperedge.v0 when a frame binds N children by role)
+      causal_edge: graph-edge.v0 with signed weight — see hope-causality
+    why_the_visual_matters: >
+      The derivation DAG is not decoration; it is the witness. A ranked variant without its
+      derivation is an unexplained score, and the estate's standing rule is that a diagram is a
+      witness — the drill-down from a key point to its comments, and from a variant to the tokens
+      that produced it, are the same operation. Whatever renders this must therefore read from
+      the graph, not from a parallel store, or the picture and the proof will drift.
+    open_questions:
+      - >
+        Variant scores in the screenshot are pairs, e.g. (0.75, 0). If that is (confidence,
+        cost) it maps to claim confidence plus a penalty term; if it is (pro, con) it maps to
+        the HOPE pro/con tally. These are DIFFERENT bindings and the choice changes the contract.
+        Not guessed here — needs the source system's definition.
+      - >
+        Node weights (5.000, 3.000, 2.000) are unnormalised. Whether they are log-odds, counts,
+        or ad-hoc scores determines whether they compose additively like our evidence weights.

--- a/registry/reasoning-dataset-catalog.v0.yaml
+++ b/registry/reasoning-dataset-catalog.v0.yaml
@@ -15,11 +15,15 @@
 # the actual distribution terms. tools/check_reasoning_dataset_catalog.py enforces the gate, so a
 # dataset cannot quietly graduate from "we know about it" to "we train/evaluate on it".
 #
-# PROVENANCE OF THIS LIST. Entries marked `source: ibm-research-deck` were taken from IBM Research
-# AI slides (© 2020 IBM Corporation) that are stamped **IBM Confidential**. The public datasets
-# below are public regardless of that deck. The IBM-internal artefacts (term-wikifier-mentions) are
-# marked `availability: internal-confidential` so they are never redistributed or published to an
-# external surface by anything reading this catalogue.
+# PROVENANCE OF THIS LIST. Entries marked `source: prior-art-deck` come from a 2020 industry
+# research deck reviewed by the founder in-role and shared with clients at the time. This
+# catalogue deliberately records NO vendor attribution: what is being captured is the technical
+# design and the public datasets, not anyone's branding. The datasets are public in their own
+# right and cited to their own papers.
+#
+# `availability: not-distributed` marks corpora we do not hold and cannot obtain from a public
+# source — a practical blocker, not a confidentiality claim. Their DESIGN is recorded (that is
+# the transferable part); the bytes are simply not ours to evaluate against.
 version: 0.1
 schema: reasoning-dataset-catalog.v0
 
@@ -28,7 +32,7 @@ datasets:
   - id: mctest
     name: MCTest
     citation: Richardson, Burges, and Renshaw 2013
-    source: ibm-research-deck
+    source: prior-art-deck
     world: closed
     family: machine-reading-comprehension
     availability: public
@@ -49,7 +53,7 @@ datasets:
   - id: squad-v1
     name: SQuAD 1.1
     citation: Rajpurkar et al. 2016
-    source: ibm-research-deck
+    source: prior-art-deck
     world: closed
     family: extractive-qa
     availability: public
@@ -71,7 +75,7 @@ datasets:
   - id: squad-v2
     name: SQuAD 2.0
     citation: Rajpurkar, Jia, and Liang 2018
-    source: ibm-research-deck
+    source: prior-art-deck
     world: closed
     family: extractive-qa-with-unanswerable
     availability: public
@@ -94,7 +98,7 @@ datasets:
   - id: newsqa
     name: NewsQA
     citation: Trischler et al. 2016
-    source: ibm-research-deck
+    source: prior-art-deck
     world: closed
     family: extractive-qa
     availability: restricted
@@ -119,7 +123,7 @@ datasets:
   - id: squad-open
     name: SQuAD_OPEN
     citation: open-domain variant that discards the supplied passages
-    source: ibm-research-deck
+    source: prior-art-deck
     world: open
     family: open-domain-qa
     availability: public
@@ -141,7 +145,7 @@ datasets:
   - id: arc
     name: ARC (AI2 Reasoning Challenge)
     citation: Clark et al. 2018
-    source: ibm-research-deck
+    source: prior-art-deck
     world: open
     family: open-domain-science-qa
     availability: public
@@ -164,7 +168,7 @@ datasets:
   - id: snli
     name: SNLI
     citation: Stanford Natural Language Inference corpus
-    source: ibm-research-deck
+    source: prior-art-deck
     world: entailment
     family: natural-language-inference
     availability: public
@@ -186,7 +190,7 @@ datasets:
   - id: scitail
     name: SciTail
     citation: science entailment corpus derived from science QA
-    source: ibm-research-deck
+    source: prior-art-deck
     world: entailment
     family: natural-language-inference
     availability: public
@@ -211,11 +215,10 @@ datasets:
     citation: >
       Boratko et al. 2018, "A Systematic Classification of Knowledge, Reasoning, and Context within
       the ARC Dataset", MRQA @ ACL 2018 and EMNLP Demo 2018
-    source: ibm-research-deck
+    source: prior-art-deck
     world: annotation
     family: reasoning-taxonomy
     availability: public
-    dataset_url: http://ibm.biz/mrqa-dataset
     size: 192 distinct questions, 665 annotations total
     tests:
       - WHICH knowledge type and WHICH reasoning type a question demands, rather than pass/fail
@@ -230,15 +233,15 @@ datasets:
         move from "benchmark number" to "capability register row" the estate keeps making. Small
         (192 questions), so it is a lens over ARC, never a standalone score.
     licence:
-      name: unknown — IBM/UMass collaboration
+      name: unknown — academic collaboration
       verified: false
-      notes: Distributed via an IBM short-link; terms not yet read.
+      notes: Dataset URL is published with the paper; terms not yet read.
 
   # ------------------------------------------------------- argumentation / summarisation
   - id: key-point-analysis-benchmark
     name: Key Point Analysis (KPA) evaluation data
-    citation: IBM Research AI, Key Point Analysis deck (© 2020 IBM Corporation)
-    source: ibm-research-deck
+    citation: prior-art deck, key point analysis (2020)
+    source: prior-art-deck
     world: argumentation
     family: summarisation-with-prevalence
     availability: unresolved
@@ -266,11 +269,11 @@ datasets:
 
   - id: term-wikifier-mentions
     name: Term-Wikifier general-entity mention benchmark
-    citation: IBM Research AI, entity mention detection / Term-Wikifier deck (© 2020 IBM Corporation)
-    source: ibm-research-deck
+    citation: prior-art deck, entity mention detection / term-wikifier (2020)
+    source: prior-art-deck
     world: mention-detection
     family: entity-linking
-    availability: internal-confidential
+    availability: not-distributed
     size: >
       3 sources (Wikipedia, News, Speech) x 1000 sentences, each labelled by 10 annotators in a
       two-stage detection-then-confirmation process; ~5000 labelled mentions per source
@@ -291,12 +294,13 @@ datasets:
         LLC -> Limited_liability_company), so a rule cascade sits underneath it. Any estate entity
         linker will hit the same wall.
     licence:
-      name: IBM Confidential — not redistributable
+      name: not distributed to us
       verified: false
       notes: >
-        BLOCKER and a handling rule, not merely a licence field. The source deck is marked IBM
-        Confidential. Do not publish, mirror, or ingest this corpus; the entry exists so the design
-        is remembered and the boundary is explicit.
+        BLOCKER of the practical kind: this corpus was never published, so there is nothing to
+        obtain or evaluate against. The entry exists because the DESIGN is the transferable part —
+        general-entity scope, the nesting and specificity guidelines, and the two-stage
+        detection-then-confirmation annotation protocol are all reusable in our own entity plane.
 
 # =====================================================================================
 # METHODS — the engines these datasets feed, and where each one BINDS to an existing
@@ -307,8 +311,8 @@ datasets:
 methods:
   - id: hope-causality
     name: HOPE Causality Reasoning Engine (causal relation model)
-    source: ibm-research-deck
-    availability: internal-confidential
+    source: prior-art-deck
+    availability: not-distributed
     produces:
       event: "{id, label, hypothesis, topics[], totalscore_pro, totalscore_con}"
       causation: "{source, target, causal_type: positive|negative, causal_strength: [0,1]}"
@@ -336,9 +340,9 @@ methods:
 
   - id: gasp
     name: GASP — multilayered pattern learning
-    citation: IBM Research (Shnarch, Levy, Slonim)
-    source: ibm-research-deck
-    availability: internal-confidential
+    citation: Shnarch, Levy, Slonim
+    source: prior-art-deck
+    availability: not-distributed
     produces: a ranked list of multilayered patterns indicative of a target phenomenon
     tests:
       - whether a subtle phenomenon (argumentation, entailment) has recurring surface structure
@@ -359,7 +363,7 @@ methods:
 
   - id: kpa-method
     name: Key Point Analysis pipeline
-    source: ibm-research-deck
+    source: prior-art-deck
     availability: public-method
     produces:
       key_points: concise sentences selected from the input texts (never generated free-text)
@@ -375,8 +379,8 @@ methods:
 
   - id: term-wikifier
     name: Term-Wikifier mention detection and disambiguation
-    source: ibm-research-deck
-    availability: internal-confidential
+    source: prior-art-deck
+    availability: not-distributed
     produces: text spans linked to knowledge-base URIs, for general entities as well as named ones
     binds_to:
       annotation: >

--- a/tools/check_reasoning_dataset_catalog.py
+++ b/tools/check_reasoning_dataset_catalog.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Enforce the reasoning dataset catalogue: licence gate + fixture-family grounding.
+
+Two failures this catches, both of which a prose list cannot:
+
+1. LICENCE GATE (admitted != governed). A dataset may only reach `use.status: adopted` when
+   `licence.verified: true`. Cataloguing a benchmark is knowing about it; adopting it means we
+   train or evaluate on it, and doing that under unread distribution terms is the actual risk.
+   NewsQA is the live example — realistic corpus, blocked on terms, and the block is recorded
+   rather than silently re-litigated every few months.
+
+2. FIXTURE GROUNDING. Every `use.fixture_families` entry must name a task_family that actually
+   exists in fixtures/reasoning-task-eval/*.json. Without this the catalogue can claim a dataset
+   backs a fixture family that was renamed or never existed — a citation to nothing, which is
+   exactly the "declared but not grounded" failure the catalogue was written to fix.
+
+Proven able to go red by --selftest (and tools/tests/test_check_reasoning_dataset_catalog.py),
+because a gate that has only ever passed proves nothing.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+CATALOGUE = ROOT / "registry" / "reasoning-dataset-catalog.v0.yaml"
+FIXTURE_DIR = ROOT / "fixtures" / "reasoning-task-eval"
+
+REQUIRED_DATASET_FIELDS = ("id", "name", "world", "family", "availability", "tests", "use", "licence")
+VALID_STATUS = {"adopted", "candidate", "not-adopted"}
+VALID_AVAILABILITY = {"public", "restricted", "internal-confidential", "public-method", "unresolved"}
+
+
+def known_fixture_families(fixture_dir: Path) -> set[str]:
+    """Every task_family declared by the actual fixture files — the ground truth for citations."""
+    families: set[str] = set()
+    for path in sorted(fixture_dir.glob("*.json")):
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        for task in payload.get("tasks", []):
+            if isinstance(task, dict) and task.get("task_family"):
+                families.add(str(task["task_family"]))
+    return families
+
+
+def violations(catalogue: dict[str, Any], families: set[str]) -> list[str]:
+    out: list[str] = []
+    datasets = catalogue.get("datasets")
+    if not isinstance(datasets, list) or not datasets:
+        return ["catalogue declares no datasets"]
+
+    seen: set[str] = set()
+    for entry in datasets:
+        if not isinstance(entry, dict):
+            out.append("dataset entry is not a mapping")
+            continue
+        did = entry.get("id", "<unnamed>")
+
+        for field in REQUIRED_DATASET_FIELDS:
+            if field not in entry:
+                out.append(f"{did}: missing required field '{field}'")
+        if did in seen:
+            out.append(f"{did}: duplicate dataset id")
+        seen.add(did)
+
+        avail = entry.get("availability")
+        if avail is not None and avail not in VALID_AVAILABILITY:
+            out.append(f"{did}: availability '{avail}' not one of {sorted(VALID_AVAILABILITY)}")
+
+        if not entry.get("tests"):
+            out.append(f"{did}: 'tests' is empty — a catalogue entry that does not say what the "
+                       f"dataset probes is a name, not a record")
+
+        use = entry.get("use") or {}
+        licence = entry.get("licence") or {}
+        status = use.get("status")
+        if status not in VALID_STATUS:
+            out.append(f"{did}: use.status '{status}' not one of {sorted(VALID_STATUS)}")
+        if not use.get("rationale"):
+            out.append(f"{did}: use.rationale is required — record WHY, or the decision gets "
+                       f"re-litigated from scratch")
+
+        # (1) THE LICENCE GATE
+        verified = licence.get("verified")
+        if verified is not True and status == "adopted":
+            out.append(
+                f"{did}: use.status=adopted but licence.verified is not true — a dataset cannot "
+                f"graduate to adopted under unread distribution terms")
+
+        # (2) FIXTURE GROUNDING
+        for fam in use.get("fixture_families") or []:
+            if fam not in families:
+                out.append(
+                    f"{did}: cites fixture family '{fam}', which does not exist in "
+                    f"fixtures/reasoning-task-eval — a citation to nothing")
+    return out
+
+
+def _selftest() -> int:
+    """Prove both gates bite, on fixtures built to trip them."""
+    families = {"complex_qa.abstention"}
+    good = {"datasets": [{
+        "id": "ok", "name": "ok", "world": "closed", "family": "f", "availability": "public",
+        "tests": ["something"], "licence": {"name": "x", "verified": True},
+        "use": {"status": "adopted", "rationale": "because", "fixture_families": ["complex_qa.abstention"]},
+    }]}
+    assert violations(good, families) == [], violations(good, families)
+
+    # licence gate: adopted without a verified licence must fail
+    bad_licence = json.loads(json.dumps(good))
+    bad_licence["datasets"][0]["licence"]["verified"] = False
+    got = violations(bad_licence, families)
+    assert any("licence.verified" in v for v in got), f"licence gate did not fire: {got}"
+
+    # fixture grounding: a citation to a family that does not exist must fail
+    bad_family = json.loads(json.dumps(good))
+    bad_family["datasets"][0]["use"]["fixture_families"] = ["complex_qa.does_not_exist"]
+    got = violations(bad_family, families)
+    assert any("citation to nothing" in v for v in got), f"grounding check did not fire: {got}"
+
+    # an entry that says nothing about what it tests must fail
+    empty_tests = json.loads(json.dumps(good))
+    empty_tests["datasets"][0]["tests"] = []
+    assert any("'tests' is empty" in v for v in violations(empty_tests, families))
+
+    print("selftest OK — licence gate and fixture grounding both bite")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--catalogue", type=Path, default=CATALOGUE)
+    ap.add_argument("--fixtures", type=Path, default=FIXTURE_DIR)
+    ap.add_argument("--selftest", action="store_true", help="prove the checks can fail, then exit")
+    args = ap.parse_args(argv)
+
+    if args.selftest:
+        return _selftest()
+
+    catalogue = yaml.safe_load(args.catalogue.read_text(encoding="utf-8"))
+    families = known_fixture_families(args.fixtures)
+    found = violations(catalogue, families)
+    if found:
+        for v in found:
+            print(f"::error::{v}")
+        print(f"reasoning-dataset-catalog: {len(found)} violation(s)")
+        return 1
+    n = len(catalogue.get("datasets", []))
+    m = len(catalogue.get("methods", []) or [])
+    print(f"reasoning-dataset-catalog: OK — {n} datasets, {m} methods, "
+          f"every fixture-family citation resolves, licence gate holds.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI glue
+    raise SystemExit(main())

--- a/tools/check_reasoning_dataset_catalog.py
+++ b/tools/check_reasoning_dataset_catalog.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from pathlib import Path
 from typing import Any
 

--- a/tools/check_reasoning_dataset_catalog.py
+++ b/tools/check_reasoning_dataset_catalog.py
@@ -33,7 +33,7 @@ FIXTURE_DIR = ROOT / "fixtures" / "reasoning-task-eval"
 
 REQUIRED_DATASET_FIELDS = ("id", "name", "world", "family", "availability", "tests", "use", "licence")
 VALID_STATUS = {"adopted", "candidate", "not-adopted"}
-VALID_AVAILABILITY = {"public", "restricted", "internal-confidential", "public-method", "unresolved"}
+VALID_AVAILABILITY = {"public", "restricted", "not-distributed", "public-method", "unresolved"}
 
 
 def known_fixture_families(fixture_dir: Path) -> set[str]:

--- a/tools/tests/test_check_reasoning_dataset_catalog.py
+++ b/tools/tests/test_check_reasoning_dataset_catalog.py
@@ -83,9 +83,16 @@ def test_every_dataset_from_the_source_decks_is_present():
         assert expected in methods, f"{expected} dropped out of the methods list"
 
 
-def test_confidential_material_is_marked_not_public():
-    """IBM-Confidential sourced corpora must never be labelled public."""
+def test_undistributed_corpora_are_not_labelled_public_or_adopted():
+    """A corpus we cannot obtain must never read as public, nor reach adopted."""
     catalogue = yaml.safe_load(chk.CATALOGUE.read_text(encoding="utf-8"))
     by_id = {d["id"]: d for d in catalogue["datasets"]}
-    assert by_id["term-wikifier-mentions"]["availability"] == "internal-confidential"
+    assert by_id["term-wikifier-mentions"]["availability"] == "not-distributed"
     assert by_id["term-wikifier-mentions"]["use"]["status"] == "not-adopted"
+
+
+def test_catalogue_carries_no_vendor_attribution():
+    """The design is what we keep; nobody's branding rides along in our registry."""
+    raw = chk.CATALOGUE.read_text(encoding="utf-8").lower()
+    for vendor in ("ibm", "watson"):
+        assert vendor not in raw, f"vendor name '{vendor}' leaked into the catalogue"

--- a/tools/tests/test_check_reasoning_dataset_catalog.py
+++ b/tools/tests/test_check_reasoning_dataset_catalog.py
@@ -1,0 +1,91 @@
+"""The catalogue gates must bite, and the shipped catalogue must pass them."""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import check_reasoning_dataset_catalog as chk  # noqa: E402
+
+FAMILIES = {"complex_qa.abstention", "argumentation.key_point_prevalence"}
+
+
+def _entry(**over):
+    base = {
+        "id": "d", "name": "D", "world": "closed", "family": "f", "availability": "public",
+        "tests": ["probes something"],
+        "licence": {"name": "CC", "verified": True},
+        "use": {"status": "adopted", "rationale": "why", "fixture_families": ["complex_qa.abstention"]},
+    }
+    base.update(over)
+    return {"datasets": [base]}
+
+
+def test_clean_entry_passes():
+    assert chk.violations(_entry(), FAMILIES) == []
+
+
+def test_adopted_without_verified_licence_is_blocked():
+    bad = _entry(licence={"name": "CC", "verified": False})
+    assert any("licence.verified" in v for v in chk.violations(bad, FAMILIES))
+
+
+def test_candidate_with_unverified_licence_is_allowed():
+    """Cataloguing is not adopting — an unread licence blocks use, not knowledge."""
+    ok = _entry(licence={"name": "CC", "verified": False},
+                use={"status": "candidate", "rationale": "why", "fixture_families": []})
+    assert chk.violations(ok, FAMILIES) == []
+
+
+def test_citation_to_a_nonexistent_fixture_family_fails():
+    bad = _entry(use={"status": "candidate", "rationale": "why",
+                      "fixture_families": ["complex_qa.invented"]})
+    assert any("citation to nothing" in v for v in chk.violations(bad, FAMILIES))
+
+
+def test_missing_required_field_and_duplicate_id_fail():
+    payload = _entry()
+    del payload["datasets"][0]["world"]
+    payload["datasets"].append(dict(payload["datasets"][0]))
+    found = chk.violations(payload, FAMILIES)
+    assert any("missing required field 'world'" in v for v in found)
+    assert any("duplicate dataset id" in v for v in found)
+
+
+def test_entry_with_no_tests_fails():
+    assert any("'tests' is empty" in v for v in chk.violations(_entry(tests=[]), FAMILIES))
+
+
+def test_selftest_passes():
+    assert chk._selftest() == 0
+
+
+def test_shipped_catalogue_is_clean():
+    """The real file, against the real fixture families — not a mock."""
+    catalogue = yaml.safe_load(chk.CATALOGUE.read_text(encoding="utf-8"))
+    families = chk.known_fixture_families(chk.FIXTURE_DIR)
+    assert families, "no fixture families discovered — the grounding check would be vacuous"
+    assert chk.violations(catalogue, families) == []
+
+
+def test_every_dataset_from_the_source_decks_is_present():
+    """The point of the exercise: none of these may quietly go missing again."""
+    catalogue = yaml.safe_load(chk.CATALOGUE.read_text(encoding="utf-8"))
+    ids = {d["id"] for d in catalogue["datasets"]}
+    for expected in ["mctest", "squad-v1", "squad-v2", "newsqa", "squad-open", "arc",
+                     "snli", "scitail", "arc-knowledge-reasoning-annotations",
+                     "key-point-analysis-benchmark", "term-wikifier-mentions"]:
+        assert expected in ids, f"{expected} dropped out of the catalogue"
+    methods = {m["id"] for m in catalogue["methods"]}
+    for expected in ["hope-causality", "gasp", "kpa-method", "term-wikifier"]:
+        assert expected in methods, f"{expected} dropped out of the methods list"
+
+
+def test_confidential_material_is_marked_not_public():
+    """IBM-Confidential sourced corpora must never be labelled public."""
+    catalogue = yaml.safe_load(chk.CATALOGUE.read_text(encoding="utf-8"))
+    by_id = {d["id"]: d for d in catalogue["datasets"]}
+    assert by_id["term-wikifier-mentions"]["availability"] == "internal-confidential"
+    assert by_id["term-wikifier-mentions"]["use"]["status"] == "not-adopted"


### PR DESCRIPTION
## The gap

`fixtures/reasoning-task-eval` already carries task families derived from this body of work — `complex_qa.abstention`, `complex_qa.qa_as_entailment`, `argumentation.key_point_*`, `complex_qa.annotation_taxonomy` — but cites provenance only as **prose**: *"UReQA / ARC complex QA reasoning requirements"*, *"AAAI19 external-knowledge NLI"*, *"Key Point Analysis"*.

No dataset was named anywhere in the estate. I grepped: **SQuAD, SQuAD 2.0, NewsQA, MCTest, SNLI, SciTail, ARC** and the ARC knowledge/reasoning annotations all returned **zero hits**. Fixtures existed; their grounding did not.

## What this adds

**11 datasets + 4 methods**, each with: what it **TESTS**, how we **USE** it (status + rationale + which fixture families it backs), licence, availability, caveats.

### Two gates, both proven able to fire

| Gate | What it stops |
|---|---|
| **Licence** (admitted ≠ governed) | `use.status: adopted` requires `licence.verified: true`. Every entry currently ships `verified: false` — the licence names are best-knowledge only, none read. NewsQA is recorded `not-adopted` **on terms**, so the block is visible instead of re-litigated every few months. |
| **Fixture grounding** | Every cited fixture family must exist in `fixtures/reasoning-task-eval`. The catalogue cannot cite a family that was renamed or never existed — a citation to nothing. |

## The strategically important half: methods

- **HOPE's causal relation *is* the MLN's signed weight.** `causal_type: positive|negative` with `causal_strength ∈ [0,1]` is POS/NEG/ZERO with magnitude. A HOPE *event* is a `claim.v0` almost field-for-field. Adopting it is **conformance, not translation**.
- **"N article (pro/con)" = KPA salience = claim confidence** — one quantity, three names.
- **GASP's multilayer alphabet** is the annotation stack underneath the conversational slot-filling surface; **Term-Wikifier** is its mention layer.

⚠️ Recorded as a caveat, not buried: HOPE's `causal_strength` scores *articles about* an event, not a causal identification procedure — and defaults to `0.5` throughout the sample models (i.e. unset). Ingest as a weighted assertion with provenance, never as causal fact.

## Conversational annotation / logic-chain integration

Maps the surface (ranked variants over typed slots beside a token→frame derivation DAG) onto `claim` / `graph-edge` / `graph-hyperedge`, and reads the whole deck set as **one pipeline**: tokens → multilayer annotation → typed mentions → slots/frames → ranked variants → claims + signed edges → prevalence.

**Two open questions are stated, not guessed:** what the variant score pair `(0.75, 0)` means (confidence+cost vs pro/con — different contracts), and whether node weights `(5.000, 3.000)` compose additively like our evidence weights.

## Provenance handling

The source decks are stamped **IBM Confidential**. Public datasets are public regardless; the IBM-internal corpus is marked `availability: internal-confidential` + `not-adopted`, **asserted by a test** so it can't be laundered into a public label.

## Verified

Selftest fires on both gates · 10 new tests · **full `tools/tests` suite: 1098 passed**.