### PR TITLE
fix(k8s): fsGroup for the PVC-writing workspace workloads (gitea-class)

### DIFF
--- a/infra/k8s/workspace-caldav/base/deployment.yaml
+++ b/infra/k8s/workspace-caldav/base/deployment.yaml
@@ -17,6 +17,11 @@ spec:
       labels:
         app: workspace-caldav
     spec:
+      # radicale writes its collections dir on the mounted PVC; fsGroup makes the volume
+      # group-writable (via supplementary group) so the non-root container can write it
+      # (kyverno require-fsgroup-pvc — same class that crashlooped gitea for 26h).
+      securityContext:
+        fsGroup: 1000
       imagePullSecrets:
         - name: zot-pull
       containers:

--- a/infra/k8s/workspace-mail/base/backup-cronjob.yaml
+++ b/infra/k8s/workspace-mail/base/backup-cronjob.yaml
@@ -22,6 +22,9 @@ spec:
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
+            # writes the backup tarball onto the mounted PVC; fsGroup makes the volume
+            # group-writable for this rootless (UID 1000) job (kyverno require-fsgroup-pvc).
+            fsGroup: 1000
             seccompProfile:
               type: RuntimeDefault
           containers:

--- a/infra/k8s/workspace-mail/base/deployment.yaml
+++ b/infra/k8s/workspace-mail/base/deployment.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app: workspace-mail
     spec:
+      # dovecot/mail writes its maildir on the mounted PVC; fsGroup makes the volume group-writable
+      # (via supplementary group) so the non-root container can write it (kyverno require-fsgroup-pvc).
+      securityContext:
+        fsGroup: 1000
       imagePullSecrets:
         - name: zot-pull
       containers:

--- a/infra/k8s/workspace-minio/base/deployment.yaml
+++ b/infra/k8s/workspace-minio/base/deployment.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app: workspace-minio
     spec:
+      # minio writes its data dir on the mounted PVC as UID/GID 1000; without fsGroup the
+      # root-owned volume is unwritable → the gitea-class crashloop (kyverno require-fsgroup-pvc).
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: minio
           # Pinned to an immutable digest (was minio/minio:latest — a moving tag that re-pulls


### PR DESCRIPTION
## What

Layer-1 kyverno audit `require-fsgroup-for-pvc-writers` (from the 2026-08-04 orphan-gitea postmortem) flagged PVC-mounting pods across the estate that declare **no `spec.securityContext.fsGroup`** — the exact defect that crashlooped `gitea` for 26h: a rootless container cannot write a root-owned volume → `CrashLoopBackOff`.

This PR fixes the **workspace stack** (all synced from `overlays/p0-lab → ../../base`):

| Workload | Kind | Fix |
|---|---|---|
| `workspace-caldav` | Deployment | `fsGroup: 1000` **(newly found — see correction below)** |
| `workspace-minio` | Deployment | `fsGroup: 1000` |
| `workspace-mail` | Deployment | `fsGroup: 1000` |
| `mail-backup` | CronJob | `fsGroup: 1000` |

`fsGroup` grants write via **supplementary-group ownership** of the mount, so it works regardless of the image's primary GID. (`minio-sync` CronJob in the same base already declared `fsGroup:1000`, corroborating the value — it was never flagged.)

## ⚠️ Correction + the sync-trap that was hiding all of this (#1350)

Initial triage assumed `workspace-caldav` "already had `fsGroup:999`" and only needed a sync fix. **That was wrong** — its deployed source (base + overlay) had *no* securityContext at all. The reason it looked fine: the three `ws-workspace-*` ArgoCD apps were stuck `OutOfSync`, so nothing new had deployed for ~40h.

Root cause of the stuck sync (a class of its own): the **live** Deployments were `type: RollingUpdate` (k8s auto-populates a `rollingUpdate` block) while git declares `type: Recreate`. ServerSideApply can't prune the defaulted `rollingUpdate` field it doesn't own, so every sync failed validation:
```
Deployment.apps "workspace-caldav" is invalid: spec.strategy.rollingUpdate:
Forbidden: may not be specified when strategy `type` is 'Recreate'
```
**Fixed live** with a one-time atomic JSON-patch (`replace type→Recreate` + `remove rollingUpdate`, in one op — zero-downtime, no rollout since the pod template didn't change). All three apps are now **Synced / Healthy**. The git bases were already correct (`type: Recreate`, no `rollingUpdate`), so no manifest change was needed for the strategy — **this PR only adds the missing fsGroup, which now actually deploys.**

## Verification
- `kubectl kustomize` renders all three **overlays** (the deployed source): `fsGroup: 1000` present, `type: Recreate` present, `rollingUpdate` absent.
- Live ArgoCD after the patch: `ws-workspace-{caldav,mail,minio}` = `SYNC=Synced HEALTH=Healthy` (fresh reconcile; prior `Failed` op was pre-patch/stale).

## Not fixed here (reported)
- **`serving/mesh-vllm-xl`** — fsGroup-less AND `vllm/vllm-openai:latest` (moving tag); serving lane, flagged there.
- **`gitea` / `gitea-authority`** — already fixed (#1401) and moved under ArgoCD (#1426).

## Follow-up (new class surfaced)
The RollingUpdate→Recreate SSA trap silently wedged three apps for ~40h with `OutOfSync` + a `Failed` sync op — a "declared ≠ enforced" sibling of the orphan-gitea class. Worth a detector: **flag any ArgoCD app whose `operationState.phase=Failed` persists > N minutes** (the deploy-health alerter is the natural home).

Part of closing "declared ≠ enforced": the audit that *would have caught* the gitea crashloop is now driving real remediation, and the sync-trap that would have hidden the fix is cleared.