### PR TITLE
feat(hellgraph-service): tenant-enforcement rollout — audit mode + token-mint + cutover runbook

### DIFF
--- a/apps/hellgraph-service/docs/TENANT_ENFORCEMENT_ROLLOUT.md
+++ b/apps/hellgraph-service/docs/TENANT_ENFORCEMENT_ROLLOUT.md
@@ -1,0 +1,81 @@
+# Tenant / op_set enforcement rollout (hellgraph-service)
+
+The **enforcement half** of "operational sets by default" (#1423) ships **flagged off**. Turning it on
+partitions the graph by `tenant_id` (+ `op_set`) — but it also requires every graph-API caller to present
+a token, so a blind flip would `401` the whole estate. This runbook rolls it out **without an outage**,
+using the `TENANT_ENFORCE=audit` dry run to de-risk each step. **Nothing here is auto-executed — it is the
+deliberate operator/CI sequence.**
+
+## Blast radius — who reads/writes the graph API today
+`grep -rl hellgraph-service deploy/values` + the apps with a graph client. Each needs a `graph:read`
+(and, if it writes, `graph:write`) token once `AUTH_ENFORCE=on`:
+
+- `nugget-extractor`, `prophet-materializer-clickhouse`, `hellgraph-percolator`, `market-replay`,
+  `device-service` (writers/readers on the loop)
+- `agora`, `grlplus-service`, `ie-engine`, `entity-resolution`, `holmes`, `lattice-studio`,
+  `health-twin` (readers)
+- `socioprophet-web` reaches it **same-origin** through the nginx `/svc/*` proxy — confirm it forwards a token.
+
+## The three modes (`TENANT_ENFORCE`)
+| value | reads | writes | unscopable endpoints | breaks anyone? |
+|-------|-------|--------|----------------------|----------------|
+| `off` (default) | unscoped | unguarded | served | no |
+| `audit` | unscoped, **logged** | unguarded, **logged** | served, **logged** | **no** — dry run |
+| `on` | scoped to caller tenant/op_set | cross-tenant → `403` | `403` (sparql/gremlin/cypher/reason/shacl/enrich/explore) | yes, without tokens |
+
+`on` **requires** `AUTH_ENFORCE=on` or the service refuses to start (fail-closed).
+
+## Sequence
+
+### A. Observe (safe — enable anytime)
+1. Set `TENANT_ENFORCE: "audit"` in `deploy/values/hellgraph-service.yaml`, commit, let ArgoCD sync.
+2. Watch the log plane for `[tenant-audit]` lines:
+   ```
+   kubectl -n socioprophet logs deploy/hellgraph-service | grep tenant-audit | jq .
+   ```
+   Each line names the `path`, the caller's `principal_tenant` (null = no token yet), and what would be
+   denied (`tenant_required` / `cross_tenant_write` / `op_set_forbidden` / `tenant_isolation_unavailable`).
+   This is the empirical blast radius. **Nothing is blocked.**
+
+### B. Provision identity (still non-breaking)
+3. Mint the HMAC secret once (random, ≥32 bytes), if not already present:
+   ```
+   kubectl -n socioprophet create secret generic hellgraph-auth-hmac --from-literal=secret="$(openssl rand -hex 32)"
+   ```
+4. Mint one token per consumer (offline, from the secret — never a committed PAT; mint in CI):
+   ```
+   AUTH_HMAC_SECRET="$(kubectl -n socioprophet get secret hellgraph-auth-hmac -o jsonpath='{.data.secret}' | base64 -d)" \
+     node --import tsx apps/hellgraph-service/scripts/mint-graph-token.ts \
+       --id nugget-extractor --tenant <tenant> --op-sets <ingest,...> --scopes graph:read,graph:write
+   ```
+   Store each as a Secret (`hellgraph-graph-token-<consumer>`), and wire it into that consumer's
+   `deploy/values/<consumer>.yaml` as `secretEnv.GRAPH_TOKEN`. Each consumer must send
+   `Authorization: Bearer $GRAPH_TOKEN` on its graph calls (the percolator + materializer already read a
+   token env; readers with a graph client need the header added).
+
+### C. Authenticate
+5. Once **every** consumer in the blast radius carries a token (audit logs show `principal_tenant`
+   populated, no more `null` from real callers), flip `AUTH_ENFORCE: "on"` + uncomment the
+   `AUTH_HMAC_SECRET` secretEnv in `hellgraph-service.yaml`. Tokenless callers now `401` — the audit logs
+   from step 2 are your checklist that there are none left. Keep `TENANT_ENFORCE: "audit"`.
+
+### D. Enforce
+6. Flip `TENANT_ENFORCE: "on"`. Isolation is live: cross-tenant reads return nothing, cross-tenant writes
+   `403`, unscopable endpoints `403`. Verify:
+   ```
+   # a token for tenant A cannot see tenant B's nodes, and cannot write into B
+   curl -s -H "authorization: Bearer $TOKEN_A" '.../api/graph/query?label=X' | jq '.nodes | length'
+   curl -s -o /dev/null -w '%{http_code}' -H "authorization: Bearer $TOKEN_A" -X POST '.../api/graph/node' \
+     -d '{"id":"x","labels":["clause"],"properties":{"tenant_id":"B"}}'   # expect 403
+   ```
+
+## Rollback
+Any step: set `TENANT_ENFORCE` back to `audit` (or `off`) — reverts to non-blocking immediately. `on → audit`
+keeps observability without enforcement; `→ off` silences it. `AUTH_ENFORCE` back to `off` restores tokenless
+access. All flag flips, no data migration.
+
+## Known follow-ons
+- The **unscopable** endpoints (raw query languages + engine recommenders) are `403` under `on`, not scoped
+  — engine-side scoping inside the fenced engine is a separate change. Callers that need them under
+  enforcement must move to the scoped read surfaces (`query`/`subgraph`/`surface`/`resource`/`ground`/`ask`/`analytics`).
+- Durable per-consumer token rotation (re-mint + roll the Secret) is a standard secret-rotation task.

--- a/apps/hellgraph-service/scripts/mint-graph-token.ts
+++ b/apps/hellgraph-service/scripts/mint-graph-token.ts
@@ -1,0 +1,43 @@
+/**
+ * Mint a graph-API bearer token for the tenant-enforcement rollout. Operator / CI tool — graph tokens
+ * are HMAC and minted OFFLINE from AUTH_HMAC_SECRET (there is NO runtime mint endpoint), then provisioned
+ * as a k8s Secret and injected (secretEnv GRAPH_TOKEN) into each graph-API consumer. Carries the tenant
+ * and the op_sets the caller is entitled to read, plus its scopes. See docs/TENANT_ENFORCEMENT_ROLLOUT.md.
+ *
+ * Usage (never echo the secret into shell history — read it from the k8s Secret or a file):
+ *   AUTH_HMAC_SECRET="$(kubectl -n socioprophet get secret hellgraph-auth-hmac -o jsonpath='{.data.secret}' | base64 -d)" \
+ *     node --import tsx scripts/mint-graph-token.ts \
+ *       --id nugget-extractor --tenant acme --op-sets ingest,discourse --scopes graph:read,graph:write
+ *
+ * In CI, mint into a Secret (secrets minted in CI, never a committed PAT):
+ *   kubectl create secret generic hellgraph-graph-token-<consumer> --from-literal=token="$(...mint...)"
+ */
+import { mintGraphToken, type GraphScope } from '../src/auth.js'
+
+function arg(name: string, def = ''): string {
+  const i = process.argv.indexOf(`--${name}`)
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : def
+}
+
+function main(): void {
+  const secret = process.env['AUTH_HMAC_SECRET'] ?? ''
+  if (!secret) {
+    console.error('AUTH_HMAC_SECRET is required — the value of the hellgraph-auth-hmac Secret.')
+    process.exit(1)
+  }
+  const id = arg('id')
+  const tenant = arg('tenant')
+  if (!id || !tenant) {
+    console.error('--id <principal-id> and --tenant <tenant-id> are required.')
+    process.exit(1)
+  }
+  const opSets = arg('op-sets').split(',').map((s) => s.trim()).filter(Boolean)
+  const scopes = arg('scopes', 'graph:read').split(',').map((s) => s.trim()).filter(Boolean) as GraphScope[]
+  // op_sets omitted ⇒ no op_set entitlement restriction (tenant-only scoping); pass --op-sets to restrict.
+  const token = mintGraphToken(secret, {
+    id, tenant, scopes, ...(opSets.length ? { op_sets: opSets } : {}),
+  })
+  process.stdout.write(token + '\n')
+}
+
+main()

--- a/apps/hellgraph-service/src/server.ts
+++ b/apps/hellgraph-service/src/server.ts
@@ -51,8 +51,8 @@ import { askGraph, retrieveGrounding, retrieveGroundingAuto, synthesisEnabled, s
 import { pagerank, connectedComponents, bfs, sssp, cdlp, lcc, analyticsBackend, dataScope } from './analytics.js'
 import { initAuth, authorize, type AuthState } from './auth.js'
 import {
-  initTenant, tenantPrincipal, tenantScope, scopeForRead, assertWriteTenant, refuseUnscopable,
-  type TenantState,
+  initTenant, tenantActive, tenantPrincipal, tenantScope, scopeForRead, assertWriteTenant,
+  refuseUnscopable, tenantAuditLog, type TenantState,
 } from './tenant.js'
 import { assembleOrgans } from './organs.js'
 import { initMembrane, handleMembrane, membraneCheckNodeWrite, type MembraneState } from './membrane.js'
@@ -130,16 +130,25 @@ function requestHandler(req: http.IncomingMessage, res: http.ServerResponse): vo
   const authDenied = authorize(auth, req, url)
   if (authDenied) return void json(res, authDenied.code, authDenied.body)
 
-  // Tenant/op_set isolation (tenant.ts): with TENANT_ENFORCE=on — (1) refuse endpoints that run in the
-  // fenced engine and can't be scoped here; (2) resolve the caller's read scope (deny a tokenless-tenant
-  // or an unentitled op_set); (3) expose `gv`, a view of the graph filtered to the caller's tenant/op_set
-  // that every read uses instead of `g`. Off ⇒ principal=null, gv===g — behaviour identical to today.
+  // Tenant/op_set isolation (tenant.ts). TENANT_ENFORCE ∈ {off, audit, on}:
+  //   on    → refuse unscopable endpoints, deny tokenless/unentitled reads, scope every read to `gv`.
+  //   audit → compute the SAME decisions but only LOG them ("[tenant-audit] ...") and ALLOW — the dry
+  //           run that surfaces which callers would break, before enforcing. gv === g (nothing scoped).
+  //   off   → principal=null, gv===g — behaviour identical to today.
+  const principal = tenantActive(tenant) ? tenantPrincipal(auth, req) : null
   const unscopable = refuseUnscopable(tenant, url.pathname)
-  if (unscopable) return void json(res, unscopable.code, unscopable.body)
-  const principal = tenant.enforce ? tenantPrincipal(auth, req) : null
+  if (unscopable) {
+    if (tenant.enforce) return void json(res, unscopable.code, unscopable.body)
+    tenantAuditLog(req, url, principal, unscopable)
+  }
   const readScope = scopeForRead(tenant, principal, url)
-  if (readScope && 'code' in readScope) return void json(res, readScope.code, readScope.body)
-  const gv = readScope ? tenantScope(g, readScope.tenant, readScope.opSet) : g
+  if (readScope && 'code' in readScope) {
+    if (tenant.enforce) return void json(res, readScope.code, readScope.body)
+    tenantAuditLog(req, url, principal, readScope)
+  }
+  // Scope reads ONLY under enforce; in audit/off gv === g (the decision was logged, not applied).
+  const gv = (tenant.enforce && readScope && !('code' in readScope))
+    ? tenantScope(g, readScope.tenant, readScope.opSet) : g
 
   // Membrane governance surface (membrane.ts): POST /api/membrane/decide. Same port.
   if (url.pathname.startsWith('/api/membrane/')) {
@@ -353,7 +362,10 @@ function requestHandler(req: http.IncomingMessage, res: http.ServerResponse): vo
         if (!id || !Array.isArray(labels)) throw new Error('id and labels[] required')
         // Tenant guard: no cross-tenant (or unlabeled) write when TENANT_ENFORCE=on.
         const tw = assertWriteTenant(tenant, principal, properties)
-        if (tw) return json(res, tw.code, tw.body)
+        if (tw) {
+          if (tenant.enforce) return json(res, tw.code, tw.body)
+          tenantAuditLog(req, url, principal, tw)
+        }
         // Membrane B-after-A gate (membrane.ts): an ExecutionReport write REQUIRES an
         // approved EffectDecision; EffectDecision nodes mint only via /api/membrane/decide.
         const gate = membraneCheckNodeWrite(membrane, g, { id, labels, properties })
@@ -371,7 +383,10 @@ function requestHandler(req: http.IncomingMessage, res: http.ServerResponse): vo
         if (!label || !from || !to) throw new Error('label, from, to required')
         // Tenant guard: no cross-tenant (or unlabeled) write when TENANT_ENFORCE=on.
         const tw = assertWriteTenant(tenant, principal, properties)
-        if (tw) return json(res, tw.code, tw.body)
+        if (tw) {
+          if (tenant.enforce) return json(res, tw.code, tw.body)
+          tenantAuditLog(req, url, principal, tw)
+        }
         g.addEdge(label, from, to, (properties ?? {}) as Record<string, never>)
         json(res, 200, { ok: true })
       } catch (e) { json(res, 400, { error: String(e) }) }

--- a/apps/hellgraph-service/src/spine.test.ts
+++ b/apps/hellgraph-service/src/spine.test.ts
@@ -4,7 +4,7 @@
 //   19091 server.test  ·  19093 membrane.test  ·  19094 membrane-off.test
 //   19095 auth.integration  ·  19096 auth.integration spawn  ·  19097 membrane stub gateway
 //   19101 spine.test  ·  19102 spine.test mock gateway
-//   19103 tenant.integration  ·  19104 tenant.integration spawn
+//   19103 tenant.integration  ·  19104 tenant.integration spawn  ·  19105 tenant-audit.integration
 //   dead ports (nothing may ever bind these): 19108 membrane, 19109 spine
 /**
  * W1.3 receipt unification — hellgraph-service side: the sealed engine receipt is

--- a/apps/hellgraph-service/src/tenant-audit.integration.test.ts
+++ b/apps/hellgraph-service/src/tenant-audit.integration.test.ts
@@ -1,0 +1,59 @@
+/**
+ * tenant AUDIT integration — TENANT_ENFORCE=audit over real HTTP: the dry run BLOCKS NOTHING. A
+ * cross-tenant write succeeds and a read returns every tenant's nodes (unscoped) — audit only LOGS the
+ * would-be denials ("[tenant-audit] ..."). This is the safety property the rollout depends on: enabling
+ * audit can never break a caller. (Enforcement itself is proven in tenant.integration.test.ts.)
+ */
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+
+// PORT ALLOCATION (see spine.test.ts): 19105 free for this suite.
+process.env.PORT = String(19105)
+process.env.HELLGRAPH_STORE_DIR = `${process.env.TMPDIR ?? '/tmp'}/hgsvc-tenant-audit-${process.pid}`
+process.env.HELLGRAPH_SEED = 'off'
+process.env.HELLGRAPH_LOAD_KKO = 'off'
+process.env.TENANT_ENFORCE = 'audit'   // dry run — no AUTH required, nothing enforced
+delete process.env.AUTH_ENFORCE
+delete process.env.MEMBRANE_ENFORCE
+
+const BASE = `http://127.0.0.1:${process.env.PORT}`
+let srv: { close: (cb?: () => void) => void }
+let audits = 0
+const realWarn = console.warn.bind(console)
+
+before(async () => {
+  // capture [tenant-audit] lines so we can prove the dry run is actually observing, not silent
+  console.warn = (...a: unknown[]) => { if (String(a[0] ?? '').includes('[tenant-audit]')) audits++; realWarn(...a) }
+  const mod = await import('./server')
+  srv = mod.server as unknown as typeof srv
+  await new Promise((r) => setTimeout(r, 150))
+})
+after(() => { srv?.close(); console.warn = realWarn })
+
+async function req(method: string, p: string, body?: unknown) {
+  const r = await fetch(BASE + p, {
+    method,
+    headers: body !== undefined ? { 'content-type': 'application/json' } : {},
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+  return { status: r.status, json: (await r.json()) as any }
+}
+const node = (id: string, tenant: string) =>
+  ({ id, labels: ['clause'], properties: { tenant_id: tenant, op_set: 'discourse' } })
+
+test('audit blocks NOTHING: cross-tenant writes succeed and reads are unscoped', async () => {
+  assert.equal((await req('POST', '/api/graph/node', node('acme:a1', 'acme'))).status, 200)
+  assert.equal((await req('POST', '/api/graph/node', node('gx:b1', 'globex'))).status, 200)
+
+  // a plain read returns BOTH tenants (audit did not scope) — nothing broke
+  const ids = ((await req('GET', '/api/graph/query')).json.nodes as { id: string }[]).map((n) => n.id)
+  assert.ok(ids.includes('acme:a1') && ids.includes('gx:b1'), 'audit read is unscoped (allowed)')
+
+  // an "unscopable" endpoint is NOT refused under audit (it would be under enforce)
+  assert.notEqual((await req('POST', '/api/graph/sparql', { query: 'SELECT ?s WHERE { ?s ?p ?o } LIMIT 1' })).status, 403)
+})
+
+test('audit is actually OBSERVING — [tenant-audit] lines were emitted', () => {
+  // the tokenless reads/writes above each had a would-be denial (tenant_required) that audit logged
+  assert.ok(audits > 0, 'expected [tenant-audit] dry-run lines to be emitted')
+})

--- a/apps/hellgraph-service/src/tenant.test.ts
+++ b/apps/hellgraph-service/src/tenant.test.ts
@@ -7,11 +7,13 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import {
-  initTenant, tenantScope, scopeForRead, assertWriteTenant, refuseUnscopable, type TenantState,
+  initTenant, tenantActive, tenantScope, scopeForRead, assertWriteTenant, refuseUnscopable,
+  type TenantState,
 } from './tenant.js'
 
-const ENFORCING: TenantState = { enforce: true }
-const OFF: TenantState = { enforce: false }
+const ENFORCING: TenantState = { enforce: true, audit: false }
+const OFF: TenantState = { enforce: false, audit: false }
+const AUDIT: TenantState = { enforce: false, audit: true }
 
 // A fake graph: two tenants (acme/globex), two op_sets in acme (ingest/discourse), and a reified
 // hyperedge (an "argument" node + its role-edges) in acme/discourse — exactly what the writer lands.
@@ -53,7 +55,26 @@ test('initTenant: off is passthrough with one WARN', () => {
 test('initTenant: on REQUIRES AUTH_ENFORCE=on (fail-closed startup)', () => {
   assert.throws(() => initTenant({ TENANT_ENFORCE: 'on', AUTH_ENFORCE: 'off' }, () => {}),
     /requires AUTH_ENFORCE=on/)
-  assert.deepEqual(initTenant({ TENANT_ENFORCE: 'on', AUTH_ENFORCE: 'on' }, () => {}), { enforce: true })
+  assert.deepEqual(initTenant({ TENANT_ENFORCE: 'on', AUTH_ENFORCE: 'on' }, () => {}), { enforce: true, audit: false })
+})
+
+test('initTenant: audit is a safe dry-run — no AUTH requirement, enforces nothing', () => {
+  let warned = 0
+  // audit does NOT require AUTH_ENFORCE=on (it blocks nothing) — safe to enable anytime.
+  const s = initTenant({ TENANT_ENFORCE: 'audit', AUTH_ENFORCE: 'off' }, () => { warned++ })
+  assert.deepEqual(s, { enforce: false, audit: true })
+  assert.equal(warned, 1)
+})
+
+test('audit mode COMPUTES would-be decisions (so the server can log them) but is not enforcing', () => {
+  // THEOREM: under audit the gate functions still compute the denial/scope (tenantActive true), so a
+  // dry run surfaces would-be breaks; the SERVER decides to log-not-block (tested in the integration).
+  assert.equal(tenantActive(AUDIT), true)
+  const noTenant = scopeForRead(AUDIT, { id: 'ops' }, new URL('http://x/api/graph/query'))
+  assert.ok(noTenant && 'code' in noTenant && noTenant.body.reason === 'tenant_required')
+  const cross = assertWriteTenant(AUDIT, { tenant: 'acme' }, { tenant_id: 'globex' })
+  assert.ok(cross && cross.body.reason === 'cross_tenant_write')
+  assert.ok(refuseUnscopable(AUDIT, '/api/graph/sparql'))  // would-refuse computed
 })
 
 test('tenantScope: a read sees ONLY its own tenant — cross-tenant is invisible', () => {

--- a/apps/hellgraph-service/src/tenant.ts
+++ b/apps/hellgraph-service/src/tenant.ts
@@ -28,6 +28,10 @@ import type { AuthState } from './auth.js'
 
 export interface TenantState {
   enforce: boolean
+  /** audit (dry-run): compute every would-be denial/scope and LOG it, but block/scope nothing. The
+   *  de-risking step before `on` — surfaces which callers lack a tenant token or do cross-tenant access
+   *  without breaking anyone. `enforce` and `audit` are never both true. */
+  audit: boolean
 }
 
 /** The identity a graph token carries for isolation: a tenant and the op_sets it is entitled to read. */
@@ -62,24 +66,36 @@ export const UNSCOPABLE_UNDER_ENFORCE: ReadonlySet<string> = new Set([
   '/api/graph/explore',  // engine.exploreFrom — traversal over engine internals
 ])
 
-/** Read TENANT_ENFORCE. Fail-closed: enforce-on without AUTH_ENFORCE=on throws (callers refuse startup).
- *  Off = passthrough, announced by exactly one WARN (mirrors initAuth). */
+/** Read TENANT_ENFORCE ∈ {off, audit, on}. Fail-closed: `on` without AUTH_ENFORCE=on throws (callers
+ *  refuse startup). `audit` is the safe dry-run (logs would-be denials, blocks nothing). Each mode
+ *  announces itself with exactly one WARN (mirrors initAuth). */
 export function initTenant(
   env: NodeJS.ProcessEnv = process.env,
   warn: (msg: string) => void = console.warn,
 ): TenantState {
-  const enforce = (env['TENANT_ENFORCE'] ?? 'off').trim().toLowerCase() === 'on'
-  if (!enforce) {
+  const mode = (env['TENANT_ENFORCE'] ?? 'off').trim().toLowerCase()
+  if (mode === 'audit') {
+    warn('[tenant] WARN TENANT_ENFORCE=audit — DRY RUN: every would-be tenant/op_set denial is LOGGED ' +
+      '("[tenant-audit] ..."), but NOTHING is blocked or scoped. Safe to enable anytime; use it to find ' +
+      'which callers lack a tenant token or do cross-tenant access BEFORE flipping to "on".')
+    return { enforce: false, audit: true }
+  }
+  if (mode !== 'on') {
     warn('[tenant] WARN TENANT_ENFORCE=off — graph reads/writes are NOT partitioned by tenant/op_set ' +
-      '(flagged rollout; set TENANT_ENFORCE=on WITH AUTH_ENFORCE=on to isolate per tenant/op_set).')
-    return { enforce: false }
+      '(flagged rollout; TENANT_ENFORCE=audit to observe, then =on WITH AUTH_ENFORCE=on to isolate).')
+    return { enforce: false, audit: false }
   }
   const authOn = (env['AUTH_ENFORCE'] ?? 'off').trim().toLowerCase() === 'on'
   if (!authOn) {
     throw new Error('TENANT_ENFORCE=on requires AUTH_ENFORCE=on — tenant isolation needs authenticated ' +
-      'principals to scope by (fail-closed). Set AUTH_ENFORCE=on + AUTH_HMAC_SECRET, or TENANT_ENFORCE=off.')
+      'principals to scope by (fail-closed). Set AUTH_ENFORCE=on + AUTH_HMAC_SECRET, or TENANT_ENFORCE=audit/off.')
   }
-  return { enforce: true }
+  return { enforce: true, audit: false }
+}
+
+/** True when the gate functions should COMPUTE a decision — under enforce (to apply) or audit (to log). */
+export function tenantActive(state: TenantState): boolean {
+  return state.enforce || state.audit
 }
 
 /** The verified principal (tenant + entitled op_sets) behind a request, or null when the token is absent
@@ -135,7 +151,7 @@ export function scopeForRead(
   principal: TenantPrincipal | null,
   url: URL,
 ): { tenant: string; opSet?: string } | TenantDenial | null {
-  if (!state.enforce) return null
+  if (!tenantActive(state)) return null
   if (!principal?.tenant) {
     return {
       code: 403,
@@ -161,7 +177,7 @@ export function assertWriteTenant(
   principal: TenantPrincipal | null,
   properties: Record<string, unknown> | undefined | null,
 ): TenantDenial | null {
-  if (!state.enforce) return null
+  if (!tenantActive(state)) return null
   if (!principal?.tenant) {
     return {
       code: 403,
@@ -182,7 +198,7 @@ export function assertWriteTenant(
 
 /** Refuse an endpoint that cannot be tenant-scoped in this layer (fail-closed under enforcement). */
 export function refuseUnscopable(state: TenantState, pathname: string): TenantDenial | null {
-  if (!state.enforce || !UNSCOPABLE_UNDER_ENFORCE.has(pathname)) return null
+  if (!tenantActive(state) || !UNSCOPABLE_UNDER_ENFORCE.has(pathname)) return null
   return {
     code: 403,
     body: { ok: false, error: 'forbidden', reason: 'tenant_isolation_unavailable',
@@ -190,4 +206,30 @@ export function refuseUnscopable(state: TenantState, pathname: string): TenantDe
         'service layer; it is refused under TENANT_ENFORCE=on. Use the scoped read surfaces ' +
         '(query/subgraph/surface/resource/ground/ask/analytics).' },
   }
+}
+
+/** Emit one structured dry-run line for a would-be denial or scope. Under TENANT_ENFORCE=audit the
+ *  service grep-ably logs exactly which callers would break — a request with no tenant token, a
+ *  cross-tenant write, an unscopable endpoint — BEFORE anything is enforced. Tenant ids + path + reason
+ *  only (no payloads), so it is safe to ship to the estate's log plane. */
+export function tenantAuditLog(
+  req: http.IncomingMessage,
+  url: URL,
+  principal: TenantPrincipal | null,
+  result: TenantDenial | { tenant: string; opSet?: string },
+  log: (msg: string) => void = console.warn,
+): void {
+  const entry: Record<string, unknown> = {
+    at: 'tenant-audit', method: req.method ?? 'GET', path: url.pathname,
+    principal_tenant: principal?.tenant ?? null,
+  }
+  if ('code' in result) {
+    entry['would'] = 'deny'
+    entry['reason'] = result.body.reason
+  } else {
+    entry['would'] = 'scope'
+    entry['tenant'] = result.tenant
+    entry['op_set'] = result.opSet ?? null
+  }
+  log('[tenant-audit] ' + JSON.stringify(entry))
 }


### PR DESCRIPTION
## Phase 2 of the hellgraph program — make the #1423 isolation rollout *safe*, without a prod flip
Enforcement (#1423) ships flagged **off**. Turning it on partitions the graph by tenant/op_set — but it also makes every graph-API caller (**~10 services**) need a token, so a blind flip would `401` the estate. This PR de-risks the rollout and touches **no prod values** (the flip stays a gated operator step).

## `TENANT_ENFORCE` gains an `audit` mode (off | audit | on)
- **`audit`** computes every would-be tenant/op_set denial and **logs** it (`[tenant-audit]` — path, `principal_tenant`, reason) but **blocks/scopes nothing**. Enable it anytime (no AUTH requirement, can't break a caller); read the logs to find which consumers lack a tenant token or do cross-tenant access; *then* flip to `on`.
- **`on`** unchanged — fail-closed, requires `AUTH_ENFORCE=on`.

## Also
- **`scripts/mint-graph-token.ts`** — mint a per-consumer token carrying tenant + entitled op_sets + scopes (offline HMAC, provisioned as a Secret / minted in CI; no runtime mint endpoint, no committed PAT). Round-trip verified.
- **`docs/TENANT_ENFORCEMENT_ROLLOUT.md`** — the blast radius + a **non-breaking 4-phase cutover** (observe → provision → authenticate → enforce) with verification commands and one-flag rollback.

## Verification
2 audit unit theorems + a `tenant-audit` integration proving audit **blocks nothing** (cross-tenant write `200`, read unscoped, sparql not `403`) yet **observes** (`[tenant-audit]` lines emitted). **Full service suite 111/111, `tsc` clean.** Enforcement itself (`tenant.integration`) unchanged; no `deploy/values` or `.github/workflows` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)