### PR TITLE
fix(workspace-caldav): correct radicale fsGroup to verified 999 + OnRootMismatch

### DIFF
--- a/charts/prophet-workspace/templates/radicale.yaml
+++ b/charts/prophet-workspace/templates/radicale.yaml
@@ -10,7 +10,12 @@ spec:
   template:
     metadata: { labels: { app: workspace-caldav } }
     spec:
-      securityContext: { fsGroup: 999 }
+      # radicale runs non-root (uid/gid 999, verified via `id` in the live pod); its PVC
+      # workspace-caldav-pvc mounts root-owned, so without fsGroup the collections can't be
+      # written — the gitea-class failure Kyverno require-fsgroup-for-pvc-writers flags. fsGroup: 999
+      # matches the runtime GID; OnRootMismatch chowns the volume group only when the root dir is
+      # wrong, so a large collection store isn't re-chowned on every mount.
+      securityContext: { fsGroup: 999, fsGroupChangePolicy: OnRootMismatch }
       containers:
         - name: radicale
           image: {{ include "pw.image" (dict "root" . "name" "radicale") }}

--- a/infra/k8s/workspace-caldav/base/deployment.yaml
+++ b/infra/k8s/workspace-caldav/base/deployment.yaml
@@ -17,11 +17,15 @@ spec:
       labels:
         app: workspace-caldav
     spec:
-      # radicale writes its collections dir on the mounted PVC; fsGroup makes the volume
-      # group-writable (via supplementary group) so the non-root container can write it
-      # (kyverno require-fsgroup-pvc — same class that crashlooped gitea for 26h).
+      # radicale runs non-root, uid/gid 999 — VERIFIED via `id` in the live pod, NOT 1000 (a prior
+      # revision guessed 1000; that only works by accident via a supplementary group). Its PVC mounts
+      # root-owned, so WITHOUT fsGroup it gets "Permission denied" writing /var/lib/radicale/collections
+      # — CalDAV silently fails to persist while /healthz stays green (the gitea-class trap Kyverno
+      # require-fsgroup-for-pvc-writers flags). fsGroup: 999 chowns the volume to radicale's actual
+      # primary group; OnRootMismatch does it only when the root dir is wrong, not every mount.
       securityContext:
-        fsGroup: 1000
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
       imagePullSecrets:
         - name: zot-pull
       containers:


### PR DESCRIPTION
## Status: the persistence bug is already fixed live — this refines it
Auditing the live pods surfaced that **radicale/CalDAV had been silently failing to persist since Jul 15** (non-root gid 999, PVC `root:root 755`, writes → Permission denied, volume empty but for `lost+found`; the `1/1` was an HTTP-only probe). A concurrent session shipped `fsGroup: 1000` to the deployed kustomize base — that **deployed and fixed the write** (confirmed in-cluster: `WRITE OK`).

This PR **corrects and hardens** that fix:
- **`fsGroup: 1000` → `999`** — radicale's real uid/gid is **999**, verified via `id` in the live pod. `1000` works only by accident (fsGroup adds it as a *supplementary* group); `999` chowns the volume to radicale's actual primary group. One-time re-chown, then correct.
- **`fsGroupChangePolicy: OnRootMismatch`** — without it, fsGroup re-chowns the *entire* collection store on every pod start; this skips it unless the root dir's group is wrong. Real cost saver as the CalDAV store grows.

The deployed source is the kustomize base `infra/k8s/workspace-caldav/base/deployment.yaml` (NOT the Helm chart — the `ws-workspace-caldav` app renders `overlays/p0-lab`). `kubectl kustomize` confirms `fsGroup: 999` renders; the app is `selfHeal=true` on `main` so merge auto-rolls it.

**dovecot + minio** run as root → benign warning, deliberately left for a tested non-root migration (spawned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)