### PR TITLE
fix(infra/k8s): close 26 NetworkPolicy selector-vs-pod-label mismatches (3 live in production)

### DIFF
--- a/infra/k8s/agentplane/base/deployment.yaml
+++ b/infra/k8s/agentplane/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: agentplane
   labels:
     app: agentplane
+    app.kubernetes.io/name: agentplane
     bundle: mesh.execution
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: agentplane
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: agentplane
         bundle: mesh.execution
     spec:
       containers:

--- a/infra/k8s/cairnpath-mesh/base/deployment.yaml
+++ b/infra/k8s/cairnpath-mesh/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cairnpath-mesh
   labels:
     app: cairnpath-mesh
+    app.kubernetes.io/name: cairnpath-mesh
     bundle: execution.trace
   annotations:
     socioprophet.ai/tier: "Tier 4.5 — execution path/trace mesh (cairn context, line, step audit trail)"
@@ -16,6 +17,10 @@ spec:
     metadata:
       labels:
         app: cairnpath-mesh
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: cairnpath-mesh
         bundle: execution.trace
     spec:
       containers:

--- a/infra/k8s/contractforge/base/deployment.yaml
+++ b/infra/k8s/contractforge/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: contractforge
   labels:
     app: contractforge
+    app.kubernetes.io/name: contractforge
     bundle: contracts.forge
   annotations:
     socioprophet.ai/tier: "Tier 9 — contract lifecycle, settlement, and ledger-anchored execution"
@@ -16,6 +17,10 @@ spec:
     metadata:
       labels:
         app: contractforge
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: contractforge
         bundle: contracts.forge
     spec:
       containers:

--- a/infra/k8s/eval-fabric/base/deployment.yaml
+++ b/infra/k8s/eval-fabric/base/deployment.yaml
@@ -11,6 +11,10 @@ spec:
     metadata:
       labels:
         app: eval-fabric-api
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: eval-fabric-api
     spec:
       containers:
         - name: eval-fabric-api

--- a/infra/k8s/global-devsecops-intelligence/base/deployment.yaml
+++ b/infra/k8s/global-devsecops-intelligence/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: global-devsecops-intelligence
   labels:
     app: global-devsecops-intelligence
+    app.kubernetes.io/name: global-devsecops-intelligence
     bundle: intelligence.devsecops
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: global-devsecops-intelligence
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: global-devsecops-intelligence
         bundle: intelligence.devsecops
     spec:
       serviceAccountName: gdi

--- a/infra/k8s/holmes/base/deployment.yaml
+++ b/infra/k8s/holmes/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: holmes
   labels:
     app: holmes
+    app.kubernetes.io/name: holmes
     bundle: intelligence.language
   annotations:
     socioprophet.ai/tier: "Tier 8 — language intelligence fabric (NLP/semantic/knowledge graphs)"
@@ -16,6 +17,10 @@ spec:
     metadata:
       labels:
         app: holmes
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: holmes
         bundle: intelligence.language
     spec:
       containers:

--- a/infra/k8s/mcp-a2a-zero-trust/base/deployment.yaml
+++ b/infra/k8s/mcp-a2a-zero-trust/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: mcp-a2a-zero-trust
   labels:
     app: mcp-a2a-zero-trust
+    app.kubernetes.io/name: mcp-a2a-zero-trust
     bundle: security.mcp-zero-trust
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: mcp-a2a-zero-trust
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: mcp-a2a-zero-trust
         bundle: security.mcp-zero-trust
     spec:
       containers:

--- a/infra/k8s/memoryd/base/deployment.yaml
+++ b/infra/k8s/memoryd/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: memoryd
   labels:
     app: memoryd
+    app.kubernetes.io/name: memoryd
     bundle: mesh.memory
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: memoryd
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: memoryd
         bundle: mesh.memory
     spec:
       containers:
@@ -64,7 +69,7 @@ spec:
             limits:
               cpu: "500m"
               memory: "512Mi"
-                volumeMounts:
+          volumeMounts:
             - name: data
               mountPath: /app/data
       volumes:

--- a/infra/k8s/model-router/base/deployment.yaml
+++ b/infra/k8s/model-router/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: model-router
   labels:
     app: model-router
+    app.kubernetes.io/name: model-router
     bundle: mesh.routing
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: model-router
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: model-router
         bundle: mesh.routing
     spec:
       containers:

--- a/infra/k8s/model-zoo-api/base/deployment.yaml
+++ b/infra/k8s/model-zoo-api/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: model-zoo-api
   labels:
     app: model-zoo-api
+    app.kubernetes.io/name: model-zoo-api
     bundle: model.zoo
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: model-zoo-api
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: model-zoo-api
         bundle: model.zoo
     spec:
       containers:

--- a/infra/k8s/policy-fabric/base/deployment.yaml
+++ b/infra/k8s/policy-fabric/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: policy-fabric
   labels:
     app: policy-fabric
+    app.kubernetes.io/name: policy-fabric
     bundle: mesh.policy
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: policy-fabric
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: policy-fabric
         bundle: mesh.policy
     spec:
       containers:

--- a/infra/k8s/prophet-core-catalog/base/deployment.yaml
+++ b/infra/k8s/prophet-core-catalog/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: prophet-core-catalog
   labels:
     app: prophet-core-catalog
+    app.kubernetes.io/name: prophet-core-catalog
     bundle: data.catalog
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: prophet-core-catalog
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: prophet-core-catalog
         bundle: data.catalog
     spec:
       containers:

--- a/infra/k8s/prophet-core-query/base/deployment.yaml
+++ b/infra/k8s/prophet-core-query/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: prophet-core-query
   labels:
     app: prophet-core-query
+    app.kubernetes.io/name: prophet-core-query
     bundle: data.query
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: prophet-core-query
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: prophet-core-query
         bundle: data.query
     spec:
       containers:

--- a/infra/k8s/prophet-mesh/base/deployment.yaml
+++ b/infra/k8s/prophet-mesh/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: prophet-mesh
   labels:
     app: prophet-mesh
+    app.kubernetes.io/name: prophet-mesh
     bundle: mesh.conductor
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: prophet-mesh
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: prophet-mesh
         bundle: mesh.conductor
     spec:
       containers:

--- a/infra/k8s/regis-entity-graph/base/deployment.yaml
+++ b/infra/k8s/regis-entity-graph/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: regis-entity-graph
   labels:
     app: regis-entity-graph
+    app.kubernetes.io/name: regis-entity-graph
     bundle: graph.entity
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: regis-entity-graph
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: regis-entity-graph
         bundle: graph.entity
     spec:
       containers:

--- a/infra/k8s/sherlock-search/base/deployment.yaml
+++ b/infra/k8s/sherlock-search/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: sherlock-search
   labels:
     app: sherlock-search
+    app.kubernetes.io/name: sherlock-search
     bundle: search.evidence
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: sherlock-search
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: sherlock-search
         bundle: search.evidence
     spec:
       containers:

--- a/infra/k8s/sociosphere/base/deployment.yaml
+++ b/infra/k8s/sociosphere/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: sociosphere
   labels:
     app: sociosphere
+    app.kubernetes.io/name: sociosphere
     bundle: platform.controller
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: sociosphere
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: sociosphere
         bundle: platform.controller
     spec:
       containers:

--- a/infra/k8s/superconscious/base/deployment.yaml
+++ b/infra/k8s/superconscious/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: superconscious
   labels:
     app: superconscious
+    app.kubernetes.io/name: superconscious
     bundle: mesh.cognition
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: superconscious
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: superconscious
         bundle: mesh.cognition
     spec:
       containers:

--- a/infra/k8s/synapseiq-control-plane/base/deployment.yaml
+++ b/infra/k8s/synapseiq-control-plane/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: synapseiq-control-plane
   labels:
     app: synapseiq-control-plane
+    app.kubernetes.io/name: synapseiq-control-plane
     bundle: enrichment.control
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: synapseiq-control-plane
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: synapseiq-control-plane
         bundle: enrichment.control
     spec:
       containers:

--- a/infra/k8s/synapseiq-enrichment-api/base/deployment.yaml
+++ b/infra/k8s/synapseiq-enrichment-api/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: synapseiq-enrichment-api
   labels:
     app: synapseiq-enrichment-api
+    app.kubernetes.io/name: synapseiq-enrichment-api
     bundle: enrichment.api
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: synapseiq-enrichment-api
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: synapseiq-enrichment-api
         bundle: enrichment.api
     spec:
       containers:

--- a/infra/k8s/synapseiq-enrichment-collector/base/deployment.yaml
+++ b/infra/k8s/synapseiq-enrichment-collector/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: synapseiq-enrichment-collector
   labels:
     app: synapseiq-enrichment-collector
+    app.kubernetes.io/name: synapseiq-enrichment-collector
     bundle: enrichment.collector
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: synapseiq-enrichment-collector
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: synapseiq-enrichment-collector
         bundle: enrichment.collector
     spec:
       containers:

--- a/infra/k8s/synapseiq-reasoning-api/base/deployment.yaml
+++ b/infra/k8s/synapseiq-reasoning-api/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: synapseiq-reasoning-api
   labels:
     app: synapseiq-reasoning-api
+    app.kubernetes.io/name: synapseiq-reasoning-api
     bundle: enrichment.reasoning
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: synapseiq-reasoning-api
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: synapseiq-reasoning-api
         bundle: enrichment.reasoning
     spec:
       containers:

--- a/infra/k8s/synapseiq-tabular-alpha/base/deployment.yaml
+++ b/infra/k8s/synapseiq-tabular-alpha/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: synapseiq-tabular-alpha
   labels:
     app: synapseiq-tabular-alpha
+    app.kubernetes.io/name: synapseiq-tabular-alpha
     bundle: enrichment.tabular
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: synapseiq-tabular-alpha
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: synapseiq-tabular-alpha
         bundle: enrichment.tabular
     spec:
       containers:

--- a/infra/k8s/tritfabric/base/deployment.yaml
+++ b/infra/k8s/tritfabric/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: tritfabric
   labels:
     app: tritfabric
+    app.kubernetes.io/name: tritfabric
     bundle: mesh.ml
 spec:
   replicas: 1
@@ -14,6 +15,10 @@ spec:
     metadata:
       labels:
         app: tritfabric
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: tritfabric
         bundle: mesh.ml
     spec:
       containers:

--- a/infra/k8s/workspace-caldav/base/deployment.yaml
+++ b/infra/k8s/workspace-caldav/base/deployment.yaml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
         app: workspace-caldav
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: workspace-caldav
     spec:
       # radicale runs non-root, uid/gid 999 — VERIFIED via `id` in the live pod, NOT 1000 (a prior
       # revision guessed 1000; that only works by accident via a supplementary group). Its PVC mounts

--- a/infra/k8s/workspace-mail/base/deployment.yaml
+++ b/infra/k8s/workspace-mail/base/deployment.yaml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
         app: workspace-mail
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: workspace-mail
     spec:
       # dovecot/mail writes its maildir on the mounted PVC; fsGroup makes the volume group-writable
       # (via supplementary group) so the non-root container can write it (kyverno require-fsgroup-pvc).

--- a/infra/k8s/workspace-minio/base/deployment.yaml
+++ b/infra/k8s/workspace-minio/base/deployment.yaml
@@ -16,6 +16,10 @@ spec:
     metadata:
       labels:
         app: workspace-minio
+        # NetworkPolicy's podSelector matches app.kubernetes.io/name, not app — without this label
+        # the policy silently selects zero pods and enforces nothing (same root cause found and fixed
+        # for acquire-worker/noetica-agent-machine; this is the repo-wide follow-up audit).
+        app.kubernetes.io/name: workspace-minio
     spec:
       # minio writes its data dir on the mounted PVC as UID/GID 1000; without fsGroup the
       # root-owned volume is unwritable → the gitea-class crashloop (kyverno require-fsgroup-pvc).


### PR DESCRIPTION
## Summary

Repo-wide follow-up to the acquire-worker/noetica-agent-machine NetworkPolicy fix (found while wiring those two into ArgoCD, PR #1428): in that fix, each service's `base/networkpolicy.yaml` selected pods via `app.kubernetes.io/name`, but the Deployment's pod template never carried that label — so the NetworkPolicy matched **zero pods** and silently enforced nothing. Fail-open, not fail-closed, while still reading as active isolation.

This PR audits **every** `infra/k8s/<service>/base/networkpolicy.yaml` in the repo (37 NetworkPolicy files) against its paired workload's actual pod template labels, cross-checks the result against live cluster state, and fixes every confirmed real mismatch the same way acquire-worker/noetica-agent-machine were fixed.

## 🚨 Active production exposure — read this part first

**Three of the 26 fixed services are live production workloads running right now with this exact ineffective NetworkPolicy:**

| Service | Namespace | Live NetworkPolicy | podSelector | Live pod's actual labels | `kubectl get pods -l <selector>` |
|---|---|---|---|---|---|
| `workspace-mail` | socioprophet | `workspace-mail-baseline` (Ingress+Egress, ports 143/8080/25/465/587/993 scoped to specific namespaces) | `app.kubernetes.io/name: workspace-mail` | `app: workspace-mail` only | **No resources found** |
| `workspace-caldav` | socioprophet | `workspace-caldav-baseline` (Ingress+Egress, port 5232/8080 scoped) | `app.kubernetes.io/name: workspace-caldav` | `app: workspace-caldav` only | **No resources found** |
| `workspace-minio` | socioprophet | `workspace-minio-baseline` (Ingress+Egress, port 9000/9001/8080 scoped) | `app.kubernetes.io/name: workspace-minio` | `app: workspace-minio` only | **No resources found** |

These are exactly the three suspects flagged going into this audit. Each has a real, currently-Synced/Healthy ArgoCD Application (`ws-workspace-mail`, `ws-workspace-caldav`, `ws-workspace-minio`) deploying via `infra/k8s/workspace-*/overlays/p0-lab`, each has a live NetworkPolicy object in the cluster that *looks* like it's restricting traffic to specific ports/namespaces, and each policy has selected **zero pods since the day it was deployed** — meaning the mail server, the CalDAV server, and the MinIO/S3 store have had **unrestricted ingress and egress** the entire time, not the scoped access the manifests describe. Merging this PR closes that gap.

## Full inventory

37 `networkpolicy.yaml` files audited (paired against `deployment.yaml`/`statefulset.yaml` in the same or composed kustomize tree, verified via `kubectl kustomize` on the real deployable path — not always `base/` alone — and cross-checked against live cluster state: `kubectl get networkpolicy/deployment/statefulset --all-namespaces`, plus per-service `kubectl get pods -n <ns> -l <selector> --show-labels`).

**Counts: 26 real-mismatch (fixed) · 8 correctly-matched (no action) · 2 not-applicable (see below) · 1 not-applicable, out of scope (KServe)**

### Real mismatch — fixed in this PR (26)

Same root cause and same fix as acquire-worker/noetica-agent-machine: add `app.kubernetes.io/name: <service>` to `spec.template.metadata.labels` (mirrored into the top-level `metadata.labels` where that block already existed). Purely additive — every paired `Service` selects on `app:` alone, which is untouched, so nothing is orphaned from its own Service. Verified `kubectl kustomize` builds clean for `base` and the live overlay (`overlays/p0-lab`, or `overlays/dev` for eval-fabric) for all 27 touched paths, and `tools/preflight_deploy_contract.py` still passes.

| Service | Live via this manifest? | Notes |
|---|---|---|
| `workspace-mail` | **YES — live, mismatched, unprotected** | see above |
| `workspace-caldav` | **YES — live, mismatched, unprotected** | see above |
| `workspace-minio` | **YES — live, mismatched, unprotected** | see above |
| `agentplane` | No | not wired into any ArgoCD Application (legacy `infra/k8s/argo-cd/appsets/socioprophet-appset.yaml` lists it, but that tree is outside `deploy/argocd/`, the only path the root Application recurses — same orphaned-registration situation acquire-worker/noetica-agent-machine were in before #1428) |
| `cairnpath-mesh` | No | same — not wired anywhere live |
| `contractforge` | No | same |
| `eval-fabric` (workload: `eval-fabric-api`) | No | live `eval-fabric-api` is a **different** deployment — the `charts/socioprophet-service` Helm chart via `svc-eval-fabric-api` (see issue below); this kustomize path is unused |
| `global-devsecops-intelligence` | No | not wired anywhere live |
| `holmes` | No | live `holmes` is Helm-chart-deployed (`svc-holmes`), pod labels `app.kubernetes.io/name: socioprophet-service` — this kustomize path is unused |
| `mcp-a2a-zero-trust` | No | not wired anywhere live |
| `memoryd` | No | live `memoryd` is Helm-chart-deployed (`svc-memoryd`); this kustomize path is unused. **Also had a pre-existing, unrelated broken-YAML bug** (`volumeMounts` mis-indented three levels too deep, under `limits.memory` — `kubectl kustomize` failed outright before this PR) — fixed as a minimal drive-by since verifying the label fix required the file to parse at all |
| `model-router` | No | not wired anywhere live |
| `model-zoo-api` | No | not wired anywhere live |
| `policy-fabric` | No | not wired anywhere live |
| `prophet-core-catalog` | No | not wired anywhere live |
| `prophet-core-query` | No | not wired anywhere live |
| `prophet-mesh` | No (see issue #1447) | not wired anywhere live via *this* manifest — but a same-named Deployment runs live in the `serving` namespace, applied by hand outside GitOps, with **zero** NetworkPolicy in that namespace at all. Separate, real finding — filed as #1447, not folded into this fix |
| `regis-entity-graph` | No | not wired anywhere live |
| `sherlock-search` | No | not wired anywhere live (distinct from `sherlock-engine`, which is live via the Helm chart) |
| `sociosphere` | No | not wired anywhere live |
| `superconscious` | No | not wired anywhere live |
| `synapseiq-control-plane` | No | not wired anywhere live |
| `synapseiq-enrichment-api` | No | not wired anywhere live |
| `synapseiq-enrichment-collector` | No | not wired anywhere live |
| `synapseiq-reasoning-api` | No | not wired anywhere live |
| `synapseiq-tabular-alpha` | No | not wired anywhere live |
| `tritfabric` | No | not wired anywhere live (distinct from `tritfabric-consumption-api`, which is live via the Helm chart) |

Fixing all 26 now (not just the 3 live ones) is a one-line, zero-risk change per file, and prevents this exact bug from resurfacing the next time one of the 23 currently-dead ones gets wired up for real — which is literally how the original acquire-worker/noetica-agent-machine instance of this bug was found.

### Correctly matched — no action needed (8)

Audited, selector genuinely matches the pod template. Several of these only match once composed through the real overlay/`commonLabels` chain, not `base/` in isolation — called out where that's the case so the "no action" verdict isn't mistaken for a shallow check:

- `zot` — live, correct (`app: zot` both sides)
- `mesh-qdrant` — live, correct (`app: mesh-qdrant` both sides, StatefulSet)
- `sovereign-runtime` (6 NetworkPolicy objects: `default-deny-all`, `allow-dns`, `allow-egress-governed-services`, `allow-intra-namespace`, `allow-ingress-from-platform`, `allow-gke-lb-to-jupyterlab`) — live, correct (empty selectors match-all by design; `allow-gke-lb-to-jupyterlab`'s `app: jupyterlab` selector matches `jupyterlab.yaml`'s Deployment)
- `mesh` (NetworkPolicy name `hellgraph-allow`) — live via `progressive-delivery-mesh` (`infra/k8s/mesh/overlays/gcp-gke-autopilot`). Its selector (`app: hellgraph-service`) intentionally targets a **different** service's pods (the graph kernel `mesh` fronts) — confirmed against the live `hellgraph-service` Rollout pod, which does carry `app: hellgraph-service`. Correct by design, not a mismatch.
- `search-orchestrator` — not live via this path (live `search-orchestrator` is the Helm chart), but the manifest itself is correct: `base/kustomization.yaml` composes `base-support/networkpolicy.yaml` + `deployment.yaml` together (my first pass checked `base-support/` in isolation and missed this — corrected after re-reading `base/kustomization.yaml`'s composition comment)
- `cloudshell-fog` — not live anywhere, but correct once composed: `overlays/runtime-default` (and `runtime-federal`, `runtime-v2-*`) combine `../../base` (NetworkPolicy) with `../../runtime-base` (Deployment) via a shared `commonLabels: app.kubernetes.io/name: cloudshell-fog`, which kustomize's commonLabels transformer applies to the pod template automatically
- `osm-map-api` — manifest is internally correct (both sides use `app.kubernetes.io/name: osm-map-api`), but this is moot: live `osm-map-api` is Helm-chart-deployed with completely different labels, so this manifest governs nothing live either way
- `sovereign-broker`, `hellgraph`, `hellgraph-superpeer` — correct in-manifest (consistent `app:` label both sides), not live anywhere currently

### Not applicable (2)

- **`kserve-inferenceservice`** — the NetworkPolicy selects `app.kubernetes.io/name: kserve-inferenceservice`, but the workload is a KServe `InferenceService` CRD (`community-truth-demo-candidate`), whose controller generates the actual Deployment/pods using KServe's own label convention (e.g. `serving.kserve.io/inferenceservice`), not this one. This needs KServe-specific research to pick the right selector, not a plain label add, so I left it alone. Zero current urgency: the KServe CRD isn't even installed in this cluster (`inferenceservices.serving.kserve.io` not found), so nothing is live either way.
- Everything else with no `networkpolicy.yaml` under `infra/k8s/<service>/base` was out of scope by construction (nothing to compare).

## Filed separately (found during this audit, larger/riskier than a label fix, need human triage — not fixed here)

- **#1447** — `prophet-mesh` has a live Deployment in the `serving` namespace, applied by hand outside GitOps entirely, with **zero** NetworkPolicy in that namespace (not mismatched — entirely absent). Distinct from, and arguably more urgent than, the manifest-level mismatch this PR fixes for the (unused) `infra/k8s/prophet-mesh/base` path.
- **#1448** — `charts/socioprophet-service`, the generic Helm chart backing ~50 live services (`holmes`, `memoryd`, `search-orchestrator`, `osm-map-api`, `eval-fabric-api`, `api`, `gateway`, `evidence-receipts`, `entity-resolution`, `agent-activity-ledger`, `compute-gateway`, ...), has **no NetworkPolicy template at all**. Confirmed against the live cluster: only 14 NetworkPolicy objects exist total, none for any chart-deployed service. A much bigger, architecturally different gap than the 26 fixed here — flagged for whoever owns the chart to decide whether/how to close it, not attempted in this PR.

## Test plan

- [x] `kubectl kustomize <path>` builds clean for `base` and the live overlay of all 27 touched services (54 builds total, all exit 0)
- [x] `python3 tools/preflight_deploy_contract.py` passes after the changes
- [x] Confirmed every touched service's `Service` selects on `app:` alone (unchanged), so the added `app.kubernetes.io/name` label can't orphan pods from their own Service
- [x] Confirmed the 3 live-mismatched services against the running cluster (`kubectl get networkpolicy -n socioprophet <name>-baseline -o yaml`, `kubectl get pods -n socioprophet -l app.kubernetes.io/name=<name>` returning nothing, `kubectl get pods -n socioprophet -l app=<name> --show-labels` showing the real running pod)
- [ ] Human review + merge (I did not merge this myself)
