### PR TITLE
feat(mesh): serve half + twin attestation + 2-node federation (recovers fail-closed admit)

### DIFF
--- a/tools/hyper_feed/attestation.py
+++ b/tools/hyper_feed/attestation.py
@@ -1,0 +1,62 @@
+"""Wire the mesh's fail-closed admission (tools.hyper_feed.fetch.admit) to the identity-twin (#1325).
+
+A hyper-feed entry's `attestation_ref` encodes a twin VerifiableReference — the context, the Ed25519
+`proof`, and the `verify_key` (procyber.semantic.vrf). The twin answers "is this provenance genuine?"
+via `POST /verify {context, proof, verify_key} -> {verified}` (fail-closed: a forged proof verifies
+false). `twin_attestation_verifier` returns exactly the `attestation_ref -> bool` callable admit expects,
+so a fetched object is admitted only if BOTH its content content-addresses to the digest AND the twin
+attests its reference.
+
+Fail-closed throughout: an unparseable attestation, or an unreachable/erroring twin, verifies FALSE —
+never admitted. encode/decode are pure (testable without a service); only `verify` touches HTTP.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import urllib.request
+from typing import Callable, Optional
+
+__all__ = ["encode_attestation", "decode_attestation", "twin_attestation_verifier"]
+
+_PREFIX = "att:"
+_FIELDS = ("context", "proof", "verify_key")
+
+
+def encode_attestation(context: str, proof: str, verify_key: str) -> str:
+    """Pack a twin VerifiableReference into a manifest `attestation_ref` string (url-safe base64 JSON)."""
+    payload = json.dumps({"context": context, "proof": proof, "verify_key": verify_key})
+    return _PREFIX + base64.urlsafe_b64encode(payload.encode()).decode()
+
+
+def decode_attestation(attestation_ref: str) -> Optional[dict]:
+    """Recover the {context, proof, verify_key} a manifest `attestation_ref` carries, or None if it is
+    not a well-formed twin attestation."""
+    if not attestation_ref.startswith(_PREFIX):
+        return None
+    try:
+        ref = json.loads(base64.urlsafe_b64decode(attestation_ref[len(_PREFIX):].encode()))
+    except (ValueError, base64.binascii.Error):  # type: ignore[attr-defined]
+        return None
+    return ref if isinstance(ref, dict) and all(k in ref for k in _FIELDS) else None
+
+
+def twin_attestation_verifier(twin_url: str, *, timeout: float = 10.0) -> Callable[[str], bool]:
+    """An `attestation_ref -> bool` verifier backed by the identity-twin's POST /verify. Fail-closed."""
+    base = twin_url.rstrip("/")
+
+    def verify(attestation_ref: str) -> bool:
+        ref = decode_attestation(attestation_ref)
+        if ref is None:
+            return False  # not a parseable twin attestation ⇒ not genuine
+        try:
+            req = urllib.request.Request(
+                base + "/verify", method="POST",
+                data=json.dumps({k: ref[k] for k in _FIELDS}).encode("utf-8"),
+                headers={"content-type": "application/json"})
+            with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - fixed internal URL
+                return bool(json.loads(resp.read()).get("verified"))
+        except Exception:  # noqa: BLE001 — an unreachable/erroring twin never attests (fail-closed)
+            return False
+
+    return verify

--- a/tools/hyper_feed/fetch.py
+++ b/tools/hyper_feed/fetch.py
@@ -28,22 +28,40 @@ class AdmitResult:
 
 
 def admit(entry: Mapping, content: bytes, *,
-          attestation_verifier: Optional[AttestationVerifier] = None) -> AdmitResult:
-    """Admit a fetched object iff its digest matches AND — when it carries an attestation_ref and a
-    verifier is supplied — its provenance verifies. Fail-closed."""
+          attestation_verifier: Optional[AttestationVerifier] = None,
+          require_attestation: bool = False) -> AdmitResult:
+    """Admit a fetched object ONLY if its digest matches AND its provenance verifies. Fail-closed: the
+    peer supplies BOTH the manifest digest and the bytes, so the digest only proves "the peer's bytes
+    match the peer's own claim" — the attestation is the sole external trust anchor. So an attestation_ref
+    that cannot be checked is REJECTED, never admitted:
+      - no verifier supplied  -> reject (attestation-unverifiable)   [was: silently admitted]
+      - verifier raises        -> reject (attestation-error)          [was: crashed the caller]
+      - verifier returns False  -> reject (attestation-invalid)
+    With `require_attestation`, an entry carrying NO attestation_ref is rejected too (strict mesh)."""
     if not verify_digest(entry, content):
         return AdmitResult(entry["ref_id"], False, "digest-mismatch")
     att = entry.get("attestation_ref")
-    if att and attestation_verifier is not None and not attestation_verifier(att):
-        return AdmitResult(entry["ref_id"], False, "attestation-invalid")
+    if att:
+        if attestation_verifier is None:
+            return AdmitResult(entry["ref_id"], False, "attestation-unverifiable")
+        try:
+            ok = attestation_verifier(att)
+        except Exception as exc:  # noqa: BLE001 — a verifier failure is a rejection, never admission
+            return AdmitResult(entry["ref_id"], False, f"attestation-error:{type(exc).__name__}")
+        if not ok:
+            return AdmitResult(entry["ref_id"], False, "attestation-invalid")
+    elif require_attestation:
+        return AdmitResult(entry["ref_id"], False, "attestation-missing")
     return AdmitResult(entry["ref_id"], True, "ok", content)
 
 
 def federate(query_code: str, peer_manifest: Mapping, *, fetcher: Fetcher, max_hamming: int,
              op_set: Optional[str] = None,
-             attestation_verifier: Optional[AttestationVerifier] = None) -> List[AdmitResult]:
+             attestation_verifier: Optional[AttestationVerifier] = None,
+             require_attestation: bool = False) -> List[AdmitResult]:
     """Discover (Hamming match) → fetch → admit (verify), nearest first. Only admitted results carry
-    content; a fetch failure is a rejection, not a crash."""
+    content; a fetch failure is a rejection, not a crash. Admission is fail-closed (see `admit`): with
+    no verifier, an attested entry is rejected as unverifiable rather than trusted on digest alone."""
     index = {e["ref_id"]: e for e in peer_manifest.get("entries", [])}
     results: List[AdmitResult] = []
     for ref_id, _ in match(query_code, peer_manifest, max_hamming=max_hamming, op_set=op_set):
@@ -53,5 +71,6 @@ def federate(query_code: str, peer_manifest: Mapping, *, fetcher: Fetcher, max_h
         except Exception as exc:  # noqa: BLE001 — any fetch failure is a rejection
             results.append(AdmitResult(ref_id, False, f"fetch-failed:{type(exc).__name__}"))
             continue
-        results.append(admit(entry, content, attestation_verifier=attestation_verifier))
+        results.append(admit(entry, content, attestation_verifier=attestation_verifier,
+                             require_attestation=require_attestation))
     return results

--- a/tools/hyper_feed/serve.py
+++ b/tools/hyper_feed/serve.py
@@ -1,0 +1,69 @@
+"""The SERVE half of the node-symmetric mesh — the other side of tools.hyper_feed.fetch's pull. A node
+HOLDS objects (each with its semantic-hash `code`, `op_set`, content, and provenance attestation),
+PUBLISHES a hyper-feed-manifest.v0 (the codes + digests peers match against, without shipping raw data),
+and SERVES content-addressed fetch for the refs a peer matched.
+
+Symmetry: every node runs BOTH halves — it `publish_manifest()` + `serve_fetch()` for peers, and uses
+`fetch.federate()` to pull from theirs. The `code` comes from ⑤ `procyber.semantic.semantic_index`
+(`codes_hex`) or `SemanticHasher` — so a node's index literally IS its federation advertisement. Nothing
+here trusts a peer: admission (digest + attestation) is the fetcher's job (fetch.admit), never the server's.
+
+Clean-room, deterministic, pure-Python. Theorems in tools/tests/test_hyper_feed_serve.py.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from tools.hyper_feed.manifest import build_manifest, content_digest
+
+__all__ = ["Holding", "MeshNode"]
+
+
+@dataclass(frozen=True)
+class Holding:
+    """One object this node holds and will serve: its ref, op_set, semantic-hash code, bytes, and the
+    provenance attestation a peer will verify before admitting it."""
+
+    ref_id: str
+    op_set: str
+    code: str  # hex semantic-hash (procyber.semantic.semantic_index.codes_hex / SemanticHasher)
+    content: bytes
+    attestation_ref: Optional[str] = None
+
+
+@dataclass
+class MeshNode:
+    """A mesh node: hold objects, publish the manifest, serve fetch. Tenant- and op_set-scoped."""
+
+    node_id: str
+    tenant_id: str
+    _holdings: Dict[str, Holding] = field(default_factory=dict, repr=False)
+
+    def hold(self, ref_id: str, code: str, content: bytes, *,
+             op_set: str = "default", attestation_ref: Optional[str] = None) -> "MeshNode":
+        """Add (or replace) an object this node advertises + serves."""
+        self._holdings[ref_id] = Holding(ref_id, op_set, code, content, attestation_ref)
+        return self
+
+    def __len__(self) -> int:
+        return len(self._holdings)
+
+    def publish_manifest(self, *, now: str = "") -> dict:
+        """This node's hyper-feed-manifest.v0 — one entry per held object (ref_id, op_set, code, content
+        digest, and attestation_ref when present). This is all a peer needs to match by Hamming; the raw
+        content never leaves until a verified fetch."""
+        entries = [
+            {"ref_id": h.ref_id, "op_set": h.op_set, "code": h.code, "digest": content_digest(h.content),
+             **({"attestation_ref": h.attestation_ref} if h.attestation_ref else {})}
+            for h in self._holdings.values()
+        ]
+        return build_manifest(self.node_id, self.tenant_id, entries, now=now)
+
+    def serve_fetch(self, ref_id: str) -> bytes:
+        """Content-addressed fetch: the raw bytes for a ref a peer matched in the manifest. Fail-closed —
+        an unknown ref raises (a peer cannot pull what this node does not hold), never returns empty."""
+        h = self._holdings.get(ref_id)
+        if h is None:
+            raise KeyError(f"ref not held by {self.node_id}: {ref_id}")
+        return h.content

--- a/tools/tests/test_hyper_feed_attestation.py
+++ b/tools/tests/test_hyper_feed_attestation.py
@@ -1,0 +1,58 @@
+"""Theorems of the twin-attestation wiring (tools.hyper_feed.attestation): a manifest attestation_ref
+encodes a twin VerifiableReference, and the verifier reflects the twin's /verify verdict — fail-closed
+on an unparseable attestation or an unreachable twin."""
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from tools.hyper_feed.attestation import decode_attestation, encode_attestation, twin_attestation_verifier
+
+
+def test_encode_decode_round_trip_and_rejects_junk():
+    att = encode_attestation("ctx", "proofhex", "vkhex")
+    assert decode_attestation(att) == {"context": "ctx", "proof": "proofhex", "verify_key": "vkhex"}
+    assert decode_attestation("att:@@not-base64@@") is None
+    assert decode_attestation("plain-ref") is None            # not the att: prefix
+    assert decode_attestation("att:" + __import__("base64").urlsafe_b64encode(b'{"context":"c"}').decode()) is None  # missing fields
+
+
+def _stub_twin(verified: bool):
+    class H(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802
+            n = int(self.headers.get("content-length", 0))
+            self.rfile.read(n)
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"verified": verified}).encode())
+
+        def log_message(self, *_a) -> None:  # silence
+            return
+
+    srv = HTTPServer(("127.0.0.1", 0), H)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, f"http://127.0.0.1:{srv.server_address[1]}"
+
+
+def test_verifier_reflects_the_twin_verdict():
+    att = encode_attestation("ctx", "p", "vk")
+    srv, url = _stub_twin(True)
+    try:
+        assert twin_attestation_verifier(url)(att) is True
+    finally:
+        srv.shutdown()
+    srv, url = _stub_twin(False)
+    try:
+        assert twin_attestation_verifier(url)(att) is False   # twin says forged ⇒ reject
+    finally:
+        srv.shutdown()
+
+
+def test_verifier_is_fail_closed():
+    # an unparseable attestation ⇒ False without trusting anything
+    assert twin_attestation_verifier("http://127.0.0.1:1")("not-an-attestation") is False
+    # a well-formed attestation but an unreachable twin ⇒ False (never admit on an unverifiable proof)
+    att = encode_attestation("ctx", "p", "vk")
+    assert twin_attestation_verifier("http://127.0.0.1:1", timeout=0.5)(att) is False

--- a/tools/tests/test_hyper_feed_fetch.py
+++ b/tools/tests/test_hyper_feed_fetch.py
@@ -29,6 +29,30 @@ def test_admit_rejects_invalid_attestation():
     assert not r.admitted and r.reason == "attestation-invalid"
 
 
+def test_admit_rejects_attested_entry_when_no_verifier():
+    # THEOREM (fail-closed): an entry that CLAIMS an attestation but cannot be verified — no verifier —
+    # must be REJECTED, never admitted on the peer's own digest alone. (Regression guard: this path
+    # previously returned reason="ok" — the fail-OPEN admit that shipped when #1404's hardening orphaned.)
+    e = _entry("r1", "ff00", b"data", att="att:present")
+    r = ff.admit(e, b"data")  # no verifier
+    assert not r.admitted and r.reason == "attestation-unverifiable" and r.content is None
+
+
+def test_admit_treats_a_throwing_verifier_as_rejection():
+    def boom(_):
+        raise RuntimeError("verifier down")
+    e = _entry("r1", "ff00", b"data", att="att:boom")
+    r = ff.admit(e, b"data", attestation_verifier=boom)
+    assert not r.admitted and r.reason.startswith("attestation-error")
+
+
+def test_require_attestation_rejects_unattested_entry():
+    e = _entry("r1", "ff00", b"data")  # no att
+    assert ff.admit(e, b"data").admitted  # lax default still admits on digest
+    r = ff.admit(e, b"data", require_attestation=True)
+    assert not r.admitted and r.reason == "attestation-missing"
+
+
 def test_federate_pulls_and_admits_only_verified():
     m = hf.build_manifest("peer", "t1", [
         _entry("r_near", "ff01", b"near-content", att="att:near"),

--- a/tools/tests/test_hyper_feed_serve.py
+++ b/tools/tests/test_hyper_feed_serve.py
@@ -1,0 +1,68 @@
+"""Theorems of the mesh SERVE half (tools.hyper_feed.serve) and the FULL 2-node federation: a node
+publishes a manifest + serves content-addressed fetch, and a peer discovers-by-Hamming → fetches →
+admits (digest + attestation), fail-closed. This is the node-symmetric mesh, end to end."""
+from __future__ import annotations
+
+from tools.hyper_feed import fetch as ff
+from tools.hyper_feed.attestation import encode_attestation
+from tools.hyper_feed.manifest import content_digest
+from tools.hyper_feed.serve import MeshNode
+
+
+def test_publish_manifest_advertises_every_holding():
+    node = MeshNode("cloud-A", "t1")
+    node.hold("r1", "ff00", b"alpha", op_set="discourse", attestation_ref="att:x")
+    node.hold("r2", "00ff", b"beta", op_set="finance")
+    m = node.publish_manifest(now="T")
+    assert m["node_id"] == "cloud-A" and len(m["entries"]) == 2
+    e1 = next(e for e in m["entries"] if e["ref_id"] == "r1")
+    assert e1["code"] == "ff00" and e1["op_set"] == "discourse"
+    assert e1["digest"] == content_digest(b"alpha") and e1["attestation_ref"] == "att:x"
+
+
+def test_serve_fetch_is_content_addressed_and_fail_closed():
+    node = MeshNode("cloud-A", "t1").hold("r1", "ff00", b"alpha")
+    assert node.serve_fetch("r1") == b"alpha"
+    assert content_digest(node.serve_fetch("r1")) == content_digest(b"alpha")
+    try:
+        node.serve_fetch("missing")
+        assert False, "unknown ref must raise, never return empty"
+    except KeyError:
+        pass
+
+
+# ── The full 2-node mesh: cloud A holds objects; edge B federates against A's manifest ──
+def _cloud_A():
+    att = encode_attestation("ctx:near", "proofhex", "vkhex")
+    return (MeshNode("cloud-A", "t1")
+            .hold("r_near", "ff01", b"near-content", op_set="discourse", attestation_ref=att)
+            .hold("r_far", "0000", b"far-content", op_set="discourse", attestation_ref=att))
+
+
+def test_two_node_federation_admits_only_the_near_verified_object():
+    # THEOREM: edge B queries A by code, pulls only the Hamming-near ref, and admits it iff the twin
+    # attests it — raw content moves only after a verified match. No node trusts the other.
+    A = _cloud_A()
+    res = ff.federate("ff00", A.publish_manifest(now="T"), fetcher=A.serve_fetch, max_hamming=4,
+                      op_set="discourse", attestation_verifier=lambda a: True)
+    assert [(r.ref_id, r.admitted) for r in res] == [("r_near", True)]   # r_far (Hamming 8) excluded
+    assert res[0].content == b"near-content"
+
+
+def test_federation_rejects_a_tampering_server():
+    # THEOREM: if A serves bytes that don't match the manifest digest, B rejects (content-addressed).
+    A = _cloud_A()
+    res = ff.federate("ff00", A.publish_manifest(now="T"), fetcher=lambda rid: b"SWAPPED",
+                      max_hamming=4, attestation_verifier=lambda a: True)
+    assert res[0].reason == "digest-mismatch" and not res[0].admitted
+
+
+def test_federation_is_fail_closed_on_provenance():
+    # THEOREM: an attested object is rejected when the twin does NOT attest it, and (the #1404 hardening)
+    # when no verifier is supplied at all — never admitted on the peer's digest alone.
+    A = _cloud_A()
+    no_attest = ff.federate("ff00", A.publish_manifest(now="T"), fetcher=A.serve_fetch,
+                            max_hamming=4, attestation_verifier=lambda a: False)
+    assert no_attest[0].reason == "attestation-invalid" and not no_attest[0].admitted
+    no_verifier = ff.federate("ff00", A.publish_manifest(now="T"), fetcher=A.serve_fetch, max_hamming=4)
+    assert no_verifier[0].reason == "attestation-unverifiable" and not no_verifier[0].admitted


### PR DESCRIPTION
## Phase 4 — completes the node-symmetric mesh
#1404 built the **pull half** (`manifest` match-by-Hamming + `fetch`). This lands the **serve half** and the **attestation**, and proves the whole thing with a **2-node federation demo**.

- **`serve.py` — `MeshNode`**: hold objects, `publish_manifest()` (the codes + digests peers match by Hamming, no raw data moves), `serve_fetch()` (content-addressed, fail-closed on an unknown ref). The `code` is ⑤ `semantic_index.codes_hex` — **a node's index IS its federation advertisement**.
- **`attestation.py` — `twin_attestation_verifier`**: an `attestation_ref` encodes a twin `VerifiableReference` (context + Ed25519 proof + verify_key); the verifier calls **identity-twin (#1325) `POST /verify`**, fail-closed (unparseable attestation / unreachable twin ⇒ never attests). This is `admit`'s external trust anchor.
- **2-node demo** (`test_hyper_feed_serve.py`): cloud A publishes → edge B federates — matches by Hamming, pulls **only** the near ref, admits it **iff the twin attests**; rejects a tampering server (digest-mismatch), a forged proof (attestation-invalid), and an attested object with **no verifier** (attestation-unverifiable).

## ⚠️ Security recovery
main's `fetch.admit` was **fail-OPEN** — an attested entry with **no verifier** was admitted `"ok"`, trusted on the peer's own digest alone. #1404's hardening had been **orphaned by an early auto-merge** (same pattern as #1400 → #1425). **Restored here**: no-verifier / throwing-verifier / false ⇒ rejected, plus `require_attestation`. The 2-node demo would not pass without it.

## Verification
**22 hyper_feed theorems** — serve (publish/fetch), attestation (encode/decode + a stub-twin `/verify` round-trip + fail-closed), fetch (fail-closed + anti-regression guards), manifest. Pure-Python, deterministic, clean-room.

Follow-on (as with the percolator): a thin `apps/hyper-feed-node` FastAPI shell exposing `/hyperfeed/manifest` + `/hyperfeed/fetch` for k8s deploy — the library + demo prove the protocol; packaging is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)