### PR TITLE
deploy-health: catch pods stuck in ContainerCreating past a duration grace (+ track ingress-nginx as orphan)

### DIFF
--- a/infra/k8s/deploy-health-alerter/base/deploy_health_alert.py
+++ b/infra/k8s/deploy-health-alerter/base/deploy_health_alert.py
@@ -14,7 +14,10 @@ any condition that would otherwise sit unnoticed:
 
   * ArgoCD applications that are Degraded / Missing / Unknown, or OutOfSync.
   * Pods stuck in a waiting reason (CrashLoopBackOff, CreateContainerConfigError,
-    ImagePullBackOff, …) or restarting above a threshold.
+    ImagePullBackOff, …) or restarting above a threshold. A pod sitting in an
+    otherwise-benign startup reason (ContainerCreating, PodInitializing) past
+    --stuck-startup-grace (default 15m) is flagged too — the ingress-nginx
+    case, stuck ContainerCreating for 38h because nothing had a duration check.
   * Job receipts (see --receipts) that are STALE (a scheduled job silently
     stopped running) or record a non-zero exit (it ran but failed) or are
     MISSING (it never ran at all) — the generalized form of the backup that
@@ -114,6 +117,22 @@ STUCK_WAITING = frozenset({
     "ImagePullBackOff", "ErrImagePull", "InvalidImageName", "RunContainerError",
     "ImageInspectError", "ErrImageNeverPull",
 })
+# Waiting reasons that are normal for the first moments of a pod's life and
+# self-clear on their own — UNLESS they persist past STUCK_STARTUP_GRACE_S
+# (see classify_pod). That "unless" is the ingress-nginx lesson: its
+# admission-webhook pod sat in ContainerCreating for 38 HOURS because its
+# bootstrap Job failed and was never retried, and this classifier waved it
+# through as benign the entire time — a duration-blind exclusion list is a gap
+# of its own. A pod ten seconds into starting and a pod stuck for 38 hours
+# report the identical waiting reason; only elapsed time tells them apart.
+BENIGN_STARTUP_WAITING = frozenset({"ContainerCreating", "PodInitializing"})
+# How long a container may sit in a BENIGN_STARTUP_WAITING reason before it
+# flips from "still starting" to "stuck". Picked well above any normal start
+# (image pulls and node provisioning essentially never take this long even on
+# a slow/scaling-up node) and far below the 38h this is meant to catch —
+# there is a lot of room on both sides of this number, it does not need to be
+# precise. Overridable via --stuck-startup-grace.
+STUCK_STARTUP_GRACE_S = 900  # 15 minutes
 # ArgoCD Application health states that are not "the desired state is running".
 UNHEALTHY_APP_HEALTH = frozenset({"Degraded", "Missing", "Unknown"})
 
@@ -184,8 +203,15 @@ def _sync_failing(status: dict) -> bool:
     return False
 
 
-def classify_pod(pod: dict, *, restart_threshold: int) -> list[str]:
-    """Return the list of gap reasons for one Pod (empty = healthy / benign)."""
+def classify_pod(pod: dict, *, restart_threshold: int,
+                 stuck_startup_grace_s: int = STUCK_STARTUP_GRACE_S,
+                 now_epoch: float | None = None) -> list[str]:
+    """Return the list of gap reasons for one Pod (empty = healthy / benign).
+
+    ``now_epoch`` defaults to the real current time; tests pass an explicit
+    value so age-based checks stay deterministic (see classify_receipt for
+    the same pattern).
+    """
     meta = pod.get("metadata") or {}
     status = pod.get("status") or {}
     # A pod being torn down or already finished is not a gap.
@@ -193,6 +219,8 @@ def classify_pod(pod: dict, *, restart_threshold: int) -> list[str]:
         return []
     if (status.get("phase") or "") in ("Succeeded", "Completed"):
         return []
+    now = time.time() if now_epoch is None else now_epoch
+    age_s = _pod_age_seconds(pod, now_epoch=now)
     reasons: list[str] = []
     for cs in (status.get("containerStatuses") or []):
         name = cs.get("name", "?")
@@ -200,10 +228,33 @@ def classify_pod(pod: dict, *, restart_threshold: int) -> list[str]:
         reason = waiting.get("reason")
         if reason in STUCK_WAITING:
             reasons.append(f"{name}:{reason}")
+        elif reason in BENIGN_STARTUP_WAITING and age_s is not None \
+                and age_s > stuck_startup_grace_s:
+            # otherwise-benign startup reason, but it has been sitting there
+            # too long to still be "just starting" — the ingress-nginx class.
+            reasons.append(f"{name}:{reason} (stuck {int(age_s)}s > "
+                           f"{stuck_startup_grace_s}s startup grace)")
         restarts = int(cs.get("restartCount", 0) or 0)
         if restarts >= restart_threshold:
             reasons.append(f"{name}:restarts={restarts}")
     return reasons
+
+
+def _pod_age_seconds(pod: dict, *, now_epoch: float) -> float | None:
+    """Seconds since the pod started, or None if that can't be determined.
+
+    Prefers ``status.startTime`` — set once the kubelet accepts the pod and
+    begins trying to run its containers, i.e. the clock that actually matters
+    for "how long has this container been stuck starting". Falls back to
+    ``metadata.creationTimestamp`` (set at API-server admission, slightly
+    earlier) for the rare pod that has containerStatuses before startTime is
+    recorded.
+    """
+    status = pod.get("status") or {}
+    meta = pod.get("metadata") or {}
+    ts = status.get("startTime") or meta.get("creationTimestamp")
+    epoch = _to_epoch(ts)
+    return None if epoch is None else now_epoch - epoch
 
 
 def _to_epoch(ts: Any) -> float | None:
@@ -425,7 +476,8 @@ def run(args: argparse.Namespace) -> tuple[int, dict]:
         scanned["pods"] = len(pods)
         for pod in pods:
             name = (pod.get("metadata") or {}).get("name", "?")
-            for reason in classify_pod(pod, restart_threshold=args.restart_threshold):
+            for reason in classify_pod(pod, restart_threshold=args.restart_threshold,
+                                       stuck_startup_grace_s=args.stuck_startup_grace):
                 findings.append({"kind": "pod", "name": name, "reason": reason})
 
     if args.receipts:
@@ -520,6 +572,34 @@ def _self_test() -> int:
          classify_pod({"status": {"phase": "Succeeded", "containerStatuses": [
              {"name": "c", "state": {"terminated": {"reason": "Completed"}}, "restartCount": 0}]}},
              restart_threshold=5) == []),
+        ("freshly-creating pod (30s old) not flagged",
+         classify_pod({"status": {"phase": "Pending",
+             "startTime": datetime.fromtimestamp(now - 30, timezone.utc).isoformat(),
+             "containerStatuses": [{"name": "c", "state": {"waiting": {"reason": "ContainerCreating"}},
+                                    "restartCount": 0}]}},
+             restart_threshold=5, now_epoch=now) == []),
+        ("pod stuck ContainerCreating 40min flagged (the ingress-nginx class)",
+         any("ContainerCreating" in r for r in classify_pod({"status": {"phase": "Pending",
+             "startTime": datetime.fromtimestamp(now - 2400, timezone.utc).isoformat(),
+             "containerStatuses": [{"name": "c", "state": {"waiting": {"reason": "ContainerCreating"}},
+                                    "restartCount": 0}]}},
+             restart_threshold=5, now_epoch=now))),
+        ("pod stuck PodInitializing 40min flagged",
+         any("PodInitializing" in r for r in classify_pod({"status": {"phase": "Pending",
+             "startTime": datetime.fromtimestamp(now - 2400, timezone.utc).isoformat(),
+             "containerStatuses": [{"name": "c", "state": {"waiting": {"reason": "PodInitializing"}},
+                                    "restartCount": 0}]}},
+             restart_threshold=5, now_epoch=now))),
+        ("stuck-startup grace threshold is configurable",
+         classify_pod({"status": {"phase": "Pending",
+             "startTime": datetime.fromtimestamp(now - 2400, timezone.utc).isoformat(),
+             "containerStatuses": [{"name": "c", "state": {"waiting": {"reason": "ContainerCreating"}},
+                                    "restartCount": 0}]}},
+             restart_threshold=5, now_epoch=now, stuck_startup_grace_s=3600) == []),
+        ("no startTime/creationTimestamp: age unknown, stays benign not false-positive",
+         classify_pod({"status": {"phase": "Pending", "containerStatuses": [
+             {"name": "c", "state": {"waiting": {"reason": "ContainerCreating"}}, "restartCount": 0}]}},
+             restart_threshold=5, now_epoch=now) == []),
         ("fresh rc0 receipt clean",
          classify_receipt({"job": "b", "ts": now - 10, "rc": 0}, now_epoch=now, max_age_s=3600) == []),
         ("stale receipt flagged",
@@ -553,6 +633,10 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--ignore-sync", action="store_true", help="do not treat OutOfSync as a gap")
     p.add_argument("--restart-threshold", type=int, default=8,
                    help="restartCount at/above which a container is a gap")
+    p.add_argument("--stuck-startup-grace", type=int, default=STUCK_STARTUP_GRACE_S,
+                   help="seconds a container may sit in ContainerCreating/PodInitializing "
+                        "before it counts as stuck rather than still-starting "
+                        f"(default {STUCK_STARTUP_GRACE_S} = 15m)")
     p.add_argument("--receipts", help="directory of job-receipt *.json files to check for staleness")
     p.add_argument("--expect", action="append", default=[],
                    help="a job name that MUST have a receipt (repeatable); absent ⇒ gap")

--- a/tools/deploy_health_alert.py
+++ b/tools/deploy_health_alert.py
@@ -14,7 +14,10 @@ any condition that would otherwise sit unnoticed:
 
   * ArgoCD applications that are Degraded / Missing / Unknown, or OutOfSync.
   * Pods stuck in a waiting reason (CrashLoopBackOff, CreateContainerConfigError,
-    ImagePullBackOff, …) or restarting above a threshold.
+    ImagePullBackOff, …) or restarting above a threshold. A pod sitting in an
+    otherwise-benign startup reason (ContainerCreating, PodInitializing) past
+    --stuck-startup-grace (default 15m) is flagged too — the ingress-nginx
+    case, stuck ContainerCreating for 38h because nothing had a duration check.
   * Job receipts (see --receipts) that are STALE (a scheduled job silently
     stopped running) or record a non-zero exit (it ran but failed) or are
     MISSING (it never ran at all) — the generalized form of the backup that
@@ -114,6 +117,22 @@ STUCK_WAITING = frozenset({
     "ImagePullBackOff", "ErrImagePull", "InvalidImageName", "RunContainerError",
     "ImageInspectError", "ErrImageNeverPull",
 })
+# Waiting reasons that are normal for the first moments of a pod's life and
+# self-clear on their own — UNLESS they persist past STUCK_STARTUP_GRACE_S
+# (see classify_pod). That "unless" is the ingress-nginx lesson: its
+# admission-webhook pod sat in ContainerCreating for 38 HOURS because its
+# bootstrap Job failed and was never retried, and this classifier waved it
+# through as benign the entire time — a duration-blind exclusion list is a gap
+# of its own. A pod ten seconds into starting and a pod stuck for 38 hours
+# report the identical waiting reason; only elapsed time tells them apart.
+BENIGN_STARTUP_WAITING = frozenset({"ContainerCreating", "PodInitializing"})
+# How long a container may sit in a BENIGN_STARTUP_WAITING reason before it
+# flips from "still starting" to "stuck". Picked well above any normal start
+# (image pulls and node provisioning essentially never take this long even on
+# a slow/scaling-up node) and far below the 38h this is meant to catch —
+# there is a lot of room on both sides of this number, it does not need to be
+# precise. Overridable via --stuck-startup-grace.
+STUCK_STARTUP_GRACE_S = 900  # 15 minutes
 # ArgoCD Application health states that are not "the desired state is running".
 UNHEALTHY_APP_HEALTH = frozenset({"Degraded", "Missing", "Unknown"})
 
@@ -184,8 +203,15 @@ def _sync_failing(status: dict) -> bool:
     return False
 
 
-def classify_pod(pod: dict, *, restart_threshold: int) -> list[str]:
-    """Return the list of gap reasons for one Pod (empty = healthy / benign)."""
+def classify_pod(pod: dict, *, restart_threshold: int,
+                 stuck_startup_grace_s: int = STUCK_STARTUP_GRACE_S,
+                 now_epoch: float | None = None) -> list[str]:
+    """Return the list of gap reasons for one Pod (empty = healthy / benign).
+
+    ``now_epoch`` defaults to the real current time; tests pass an explicit
+    value so age-based checks stay deterministic (see classify_receipt for
+    the same pattern).
+    """
     meta = pod.get("metadata") or {}
     status = pod.get("status") or {}
     # A pod being torn down or already finished is not a gap.
@@ -193,6 +219,8 @@ def classify_pod(pod: dict, *, restart_threshold: int) -> list[str]:
         return []
     if (status.get("phase") or "") in ("Succeeded", "Completed"):
         return []
+    now = time.time() if now_epoch is None else now_epoch
+    age_s = _pod_age_seconds(pod, now_epoch=now)
     reasons: list[str] = []
     for cs in (status.get("containerStatuses") or []):
         name = cs.get("name", "?")
@@ -200,10 +228,33 @@ def classify_pod(pod: dict, *, restart_threshold: int) -> list[str]:
         reason = waiting.get("reason")
         if reason in STUCK_WAITING:
             reasons.append(f"{name}:{reason}")
+        elif reason in BENIGN_STARTUP_WAITING and age_s is not None \
+                and age_s > stuck_startup_grace_s:
+            # otherwise-benign startup reason, but it has been sitting there
+            # too long to still be "just starting" — the ingress-nginx class.
+            reasons.append(f"{name}:{reason} (stuck {int(age_s)}s > "
+                           f"{stuck_startup_grace_s}s startup grace)")
         restarts = int(cs.get("restartCount", 0) or 0)
         if restarts >= restart_threshold:
             reasons.append(f"{name}:restarts={restarts}")
     return reasons
+
+
+def _pod_age_seconds(pod: dict, *, now_epoch: float) -> float | None:
+    """Seconds since the pod started, or None if that can't be determined.
+
+    Prefers ``status.startTime`` — set once the kubelet accepts the pod and
+    begins trying to run its containers, i.e. the clock that actually matters
+    for "how long has this container been stuck starting". Falls back to
+    ``metadata.creationTimestamp`` (set at API-server admission, slightly
+    earlier) for the rare pod that has containerStatuses before startTime is
+    recorded.
+    """
+    status = pod.get("status") or {}
+    meta = pod.get("metadata") or {}
+    ts = status.get("startTime") or meta.get("creationTimestamp")
+    epoch = _to_epoch(ts)
+    return None if epoch is None else now_epoch - epoch
 
 
 def _to_epoch(ts: Any) -> float | None:
@@ -425,7 +476,8 @@ def run(args: argparse.Namespace) -> tuple[int, dict]:
         scanned["pods"] = len(pods)
         for pod in pods:
             name = (pod.get("metadata") or {}).get("name", "?")
-            for reason in classify_pod(pod, restart_threshold=args.restart_threshold):
+            for reason in classify_pod(pod, restart_threshold=args.restart_threshold,
+                                       stuck_startup_grace_s=args.stuck_startup_grace):
                 findings.append({"kind": "pod", "name": name, "reason": reason})
 
     if args.receipts:
@@ -520,6 +572,34 @@ def _self_test() -> int:
          classify_pod({"status": {"phase": "Succeeded", "containerStatuses": [
              {"name": "c", "state": {"terminated": {"reason": "Completed"}}, "restartCount": 0}]}},
              restart_threshold=5) == []),
+        ("freshly-creating pod (30s old) not flagged",
+         classify_pod({"status": {"phase": "Pending",
+             "startTime": datetime.fromtimestamp(now - 30, timezone.utc).isoformat(),
+             "containerStatuses": [{"name": "c", "state": {"waiting": {"reason": "ContainerCreating"}},
+                                    "restartCount": 0}]}},
+             restart_threshold=5, now_epoch=now) == []),
+        ("pod stuck ContainerCreating 40min flagged (the ingress-nginx class)",
+         any("ContainerCreating" in r for r in classify_pod({"status": {"phase": "Pending",
+             "startTime": datetime.fromtimestamp(now - 2400, timezone.utc).isoformat(),
+             "containerStatuses": [{"name": "c", "state": {"waiting": {"reason": "ContainerCreating"}},
+                                    "restartCount": 0}]}},
+             restart_threshold=5, now_epoch=now))),
+        ("pod stuck PodInitializing 40min flagged",
+         any("PodInitializing" in r for r in classify_pod({"status": {"phase": "Pending",
+             "startTime": datetime.fromtimestamp(now - 2400, timezone.utc).isoformat(),
+             "containerStatuses": [{"name": "c", "state": {"waiting": {"reason": "PodInitializing"}},
+                                    "restartCount": 0}]}},
+             restart_threshold=5, now_epoch=now))),
+        ("stuck-startup grace threshold is configurable",
+         classify_pod({"status": {"phase": "Pending",
+             "startTime": datetime.fromtimestamp(now - 2400, timezone.utc).isoformat(),
+             "containerStatuses": [{"name": "c", "state": {"waiting": {"reason": "ContainerCreating"}},
+                                    "restartCount": 0}]}},
+             restart_threshold=5, now_epoch=now, stuck_startup_grace_s=3600) == []),
+        ("no startTime/creationTimestamp: age unknown, stays benign not false-positive",
+         classify_pod({"status": {"phase": "Pending", "containerStatuses": [
+             {"name": "c", "state": {"waiting": {"reason": "ContainerCreating"}}, "restartCount": 0}]}},
+             restart_threshold=5, now_epoch=now) == []),
         ("fresh rc0 receipt clean",
          classify_receipt({"job": "b", "ts": now - 10, "rc": 0}, now_epoch=now, max_age_s=3600) == []),
         ("stale receipt flagged",
@@ -553,6 +633,10 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--ignore-sync", action="store_true", help="do not treat OutOfSync as a gap")
     p.add_argument("--restart-threshold", type=int, default=8,
                    help="restartCount at/above which a container is a gap")
+    p.add_argument("--stuck-startup-grace", type=int, default=STUCK_STARTUP_GRACE_S,
+                   help="seconds a container may sit in ContainerCreating/PodInitializing "
+                        "before it counts as stuck rather than still-starting "
+                        f"(default {STUCK_STARTUP_GRACE_S} = 15m)")
     p.add_argument("--receipts", help="directory of job-receipt *.json files to check for staleness")
     p.add_argument("--expect", action="append", default=[],
                    help="a job name that MUST have a receipt (repeatable); absent ⇒ gap")

--- a/tools/tests/test_deploy_health_alert.py
+++ b/tools/tests/test_deploy_health_alert.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "tools"))
 import deploy_health_alert as dha  # noqa: E402
@@ -195,6 +197,92 @@ def test_benign_waiting_reason_not_flagged():
         assert dha.classify_pod(pod, restart_threshold=5) == []
 
 
+# ── stuck-duration: the ingress-nginx class (benign reason, 38h stuck) ────────
+# ContainerCreating/PodInitializing are excluded above as benign startup — correct
+# for a pod ten seconds old, wrong for one that has sat there for 38 hours, which
+# is exactly what happened to ingress-nginx's admission-webhook pod: its bootstrap
+# Job failed at install time, was never retried, and nothing had a duration check
+# to tell "just starting" apart from "stuck". These pin that discrimination.
+def _pod_in_benign_wait(reason: str, age_s: float, *, use_creation_ts: bool = False) -> dict:
+    from datetime import datetime, timezone
+    ts = datetime.fromtimestamp(NOW - age_s, timezone.utc).isoformat()
+    status: dict = {"phase": "Pending", "containerStatuses": [
+        {"name": "c", "state": {"waiting": {"reason": reason}}, "restartCount": 0}]}
+    if use_creation_ts:
+        return {"metadata": {"creationTimestamp": ts}, "status": status}
+    status["startTime"] = ts
+    return {"status": status}
+
+
+def test_freshly_creating_pod_stays_clean():
+    # 30s into ContainerCreating — completely normal, must not fire
+    pod = _pod_in_benign_wait("ContainerCreating", 30)
+    assert dha.classify_pod(pod, restart_threshold=5, now_epoch=NOW) == []
+
+
+def test_long_stuck_container_creating_pod_is_flagged():
+    # 40 minutes in ContainerCreating — this is the ingress-nginx shape
+    pod = _pod_in_benign_wait("ContainerCreating", 40 * 60)
+    out = dha.classify_pod(pod, restart_threshold=5, now_epoch=NOW)
+    assert any("ContainerCreating" in r for r in out)
+
+
+def test_long_stuck_pod_initializing_is_flagged():
+    pod = _pod_in_benign_wait("PodInitializing", 40 * 60)
+    out = dha.classify_pod(pod, restart_threshold=5, now_epoch=NOW)
+    assert any("PodInitializing" in r for r in out)
+
+
+def test_stuck_duration_right_at_the_grace_boundary():
+    just_under = _pod_in_benign_wait("ContainerCreating", dha.STUCK_STARTUP_GRACE_S - 1)
+    just_over = _pod_in_benign_wait("ContainerCreating", dha.STUCK_STARTUP_GRACE_S + 1)
+    assert dha.classify_pod(just_under, restart_threshold=5, now_epoch=NOW) == []
+    assert dha.classify_pod(just_over, restart_threshold=5, now_epoch=NOW) != []
+
+
+def test_stuck_startup_grace_is_configurable():
+    pod = _pod_in_benign_wait("ContainerCreating", 40 * 60)
+    # raise the grace above the pod's actual age -> no longer a gap
+    assert dha.classify_pod(pod, restart_threshold=5, now_epoch=NOW,
+                            stuck_startup_grace_s=3600) == []
+
+
+def test_stuck_duration_falls_back_to_creation_timestamp():
+    # a pod with no startTime yet (rare) still gets an age from creationTimestamp
+    pod = _pod_in_benign_wait("ContainerCreating", 40 * 60, use_creation_ts=True)
+    out = dha.classify_pod(pod, restart_threshold=5, now_epoch=NOW)
+    assert any("ContainerCreating" in r for r in out)
+
+
+def test_stuck_duration_unknown_age_does_not_false_positive():
+    # no startTime and no creationTimestamp at all -> age is unknowable, stay benign
+    pod = {"status": {"phase": "Pending", "containerStatuses": [
+        {"name": "c", "state": {"waiting": {"reason": "ContainerCreating"}}, "restartCount": 0}]}}
+    assert dha.classify_pod(pod, restart_threshold=5, now_epoch=NOW) == []
+
+
+def test_stuck_waiting_reasons_ignore_duration_entirely():
+    # STUCK_WAITING reasons (CrashLoopBackOff etc) fire immediately regardless of
+    # age -- the duration check only widens the benign-startup set, never narrows
+    # the reasons that were already always-a-gap.
+    pod = _pod_in_benign_wait("CrashLoopBackOff", 5)
+    assert dha.classify_pod(pod, restart_threshold=5, now_epoch=NOW) == ["c:CrashLoopBackOff"]
+
+
+def test_pod_age_seconds_prefers_start_time_over_creation_timestamp():
+    from datetime import datetime, timezone
+    start = datetime.fromtimestamp(NOW - 100, timezone.utc).isoformat()
+    created = datetime.fromtimestamp(NOW - 999, timezone.utc).isoformat()
+    pod = {"metadata": {"creationTimestamp": created},
+           "status": {"startTime": start}}
+    age = dha._pod_age_seconds(pod, now_epoch=NOW)
+    assert age == pytest.approx(100, abs=1)
+
+
+def test_pod_age_seconds_none_when_unset():
+    assert dha._pod_age_seconds({"status": {}}, now_epoch=NOW) is None
+
+
 def test_high_restarts_flagged_at_threshold():
     pod = {"status": {"phase": "Running", "containerStatuses": [
         {"name": "c", "state": {"running": {}}, "restartCount": 5}]}}
@@ -249,7 +337,8 @@ def test_iso_and_epoch_timestamps_both_parse():
 def _args(**kw):
     import argparse
     base = dict(namespace="x", argocd_namespace="argocd", no_pods=False, no_argocd=False,
-                ignore_sync=False, restart_threshold=8, receipts=None, expect=[],
+                ignore_sync=False, restart_threshold=8, stuck_startup_grace=dha.STUCK_STARTUP_GRACE_S,
+                receipts=None, expect=[],
                 max_receipt_age=93600, allow_blind=False, json=False, self_test=False)
     base.update(kw)
     return argparse.Namespace(**base)

--- a/tools/tests/test_verify_no_orphan_workloads.py
+++ b/tools/tests/test_verify_no_orphan_workloads.py
@@ -92,6 +92,29 @@ def test_sanctioned_out_of_band_allowed():
     assert problems == []
 
 
+def test_ingress_nginx_controller_is_sanctioned():
+    # the 2026-08-04 38h outage (#1446): out-of-band (workflow_dispatch kubectl apply,
+    # not ArgoCD) is why nothing tracked it going wedged. Tracked here pending #1453
+    # (full GitOps adoption) so the gap is visible instead of silently unscanned.
+    problems = find_problems(
+        [_deploy("ingress-nginx-controller", namespace="ingress-nginx")],
+        allowlist=SANCTIONED,
+    )
+    assert problems == []
+    assert "ingress-nginx/ingress-nginx-controller" in SANCTIONED
+
+
+def test_ingress_nginx_controller_not_conflated_across_namespace():
+    """The sanctioned ingress-nginx-controller entry must not accidentally sanction a
+    same-named Deployment in a different namespace (same discipline as the gitea case)."""
+    problems = find_problems(
+        [_deploy("ingress-nginx-controller", namespace="other-ns")],
+        allowlist=SANCTIONED,
+    )
+    assert len(problems) == 1
+    assert "ORPHAN" in problems[0]
+
+
 def test_empty_cluster_clean():
     problems = find_problems([], allowlist=frozenset())
     assert problems == []

--- a/tools/verify_no_orphan_workloads.py
+++ b/tools/verify_no_orphan_workloads.py
@@ -50,6 +50,13 @@ SANCTIONED_OUT_OF_BAND: frozenset[str] = frozenset({
                                       # ArgoCD by deploy/argocd/gitea-scm-sovereign.yaml in this same change; kept
                                       # sanctioned only until that Application is confirmed synced (mirrors the
                                       # socioprophet/* entries' own disposition) — remove once verified GitOps-managed.
+    "ingress-nginx/ingress-nginx-controller",  # the cluster's only ingress controller; installed by an
+                                      # imperative `kubectl apply -f <upstream-URL>` one-shot workflow_dispatch
+                                      # (.github/workflows/gitea-ingress-sovereign.yml), not ArgoCD. This
+                                      # out-of-band status is exactly why its Aug-2026 admission-secret bootstrap
+                                      # failure went undetected for 38h — no GitOps drift/health signal was
+                                      # watching it at all (see #1446 for the incident, #1453 for the tracked
+                                      # GitOps-adoption follow-up). Check with `make orphan-check NS=ingress-nginx`.
 })
 
 


### PR DESCRIPTION
## Summary

Two follow-ups from tonight's ingress-nginx 38h outage (#1446 — controller pod
wedged in `ContainerCreating` because its bootstrap admission-secret Jobs
failed at install time and were never retried).

**1. `tools/deploy_health_alert.py` — stuck-duration check (the real gap this PR closes)**

`STUCK_WAITING` deliberately excludes `ContainerCreating`/`PodInitializing` as
benign startup — correct for a pod 10 seconds in, wrong for one stuck there for
38 hours, and there was no duration check anywhere in `classify_pod()` to tell
the two apart.

- New `BENIGN_STARTUP_WAITING = {"ContainerCreating", "PodInitializing"}` +
  `STUCK_STARTUP_GRACE_S = 900` (15m, overridable via `--stuck-startup-grace`).
- New `_pod_age_seconds()`: reads `status.startTime` (falls back to
  `metadata.creationTimestamp`) vs. now. Neither waiting-state carries a
  timestamp directly, so age has to come from the pod, not the container state.
- `classify_pod()` now flips a benign-startup reason to flagged once the pod
  has outlived the grace period. No timestamp available → stays benign (no
  false positive on old/minimal fixtures or synthetic data).
- 9 new pytest cases (`tools/tests/test_deploy_health_alert.py`): fresh (30s)
  stays clean, stuck (40m) fires for both reasons, the grace boundary itself,
  the configurable override, the creationTimestamp fallback, the
  unknown-age-stays-benign case, and that `STUCK_WAITING` reasons still fire
  immediately regardless of age (duration only *widens* what's flagged, never
  narrows it).
- 5 new `--self-test` discrimination checks, same pattern as the rest of the
  file's embedded self-test.
- Re-copied `tools/deploy_health_alert.py` → its CronJob-mirror at
  `infra/k8s/deploy-health-alerter/base/deploy_health_alert.py` (byte-identical
  copy the in-cluster CronJob actually runs — `verify_cronjob_script_mirrors.py`
  enforces this and correctly failed until I did).

**Why 15 minutes:** comfortably above any normal start (image pulls / node
provisioning essentially never take this long) and far below the 38h this is
meant to catch — there's a lot of slack on both sides, so it doesn't need to
be precise.

**2. `tools/verify_no_orphan_workloads.py` — track ingress-nginx as a sanctioned orphan**

`ingress-nginx` (the cluster's only ingress controller) is installed by an
imperative, one-shot `workflow_dispatch` GitHub Actions workflow
(`.github/workflows/gitea-ingress-sovereign.yml`, `kubectl apply -f <upstream
URL>`) — not ArgoCD, and wasn't in `SANCTIONED_OUT_OF_BAND` at all. Same
out-of-band-workload class the 2026-08-04 orphan-gitea postmortem named, and
part of why the outage went undetected for 38h.

Added `ingress-nginx-controller` to `SANCTIONED_OUT_OF_BAND` with a comment
explaining why, plus a teeth test. **Did not** attempt full GitOps adoption
(ArgoCD Application + committed manifest, mirroring PR #1441's `scm/gitea`
treatment) inline — filed as **#1453** instead. Rationale: this is the
cluster's sole ingress controller, and a first ArgoCD sync adopting live
resources deserves a human-reviewed dry-run diff, not a drive-by change,
especially right after this exact component caused a real outage.

Note for whoever reviews: **PR #1441** (open, `scm/gitea` GitOps adoption)
independently reworks this same file to namespace-qualify
`SANCTIONED_OUT_OF_BAND` entries (`"<namespace>/<name>"`) and scan multiple
namespaces by default. Whichever of these two PRs merges second will need a
one-line rename of the `ingress-nginx-controller` entry to match. Flagging
now so it isn't a surprise at merge time.

## Also done this session (no code change, reporting for context)

- Verified live (read-only, before a local kubectl-tunnel hiccup dropped
  mid-session — unrelated to cluster health) that the ingress-nginx fix from
  earlier tonight is holding: controller pod `1/1 Running`, both admission
  bootstrap Jobs `Completed`, Service has real Endpoints.
- Added a comment to #1446 with that verification + the resolution steps
  (delete the two failed Jobs, re-apply the upstream manifest, rollout
  restart) for a human to close.

## Test plan

- [x] `pytest -q tools/tests` → 1099 passed (full tools suite, not just the
      two files touched)
- [x] `python3 tools/deploy_health_alert.py --self-test` → OK (23 checks)
- [x] `python3 tools/verify_no_orphan_workloads.py --self-test` → OK (6 checks)
- [x] `python3 tools/verify_cronjob_script_mirrors.py` → OK (mirror re-synced)
- [ ] Live `make orphan-check NS=ingress-nginx` (blocked locally by the
      kubectl-tunnel hiccup mentioned above — the `--namespace` default is
      still `socioprophet`, so this needs an explicit `NS=ingress-nginx` to
      actually observe the new allowlist entry; noted in the code comment)

No `kubectl apply`/`delete`/`edit`/`patch` was run against the cluster at any
point in this session — read-only investigation only. `ingress-nginx`'s live
resources were not touched (already fixed earlier tonight, out of scope here).