### PR TITLE
fix(serving): mesh-vllm-xl fsGroup + pin off vllm :latest (gitea-class + moving-tag)

### DIFF
--- a/deploy/serving/mesh-xl-a100.yaml
+++ b/deploy/serving/mesh-xl-a100.yaml
@@ -48,9 +48,24 @@ spec:
         - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
+      # The model cache (/hf, the 120Gi RWO PVC below) is written by the vLLM container.
+      # Without fsGroup a rootless container can't write the root-owned volume — the class
+      # that crashlooped gitea for 26h (kyverno require-fsgroup-for-pvc-writers, Audit).
+      # OnRootMismatch chowns the volume only when its root dir's group is wrong, so a 120Gi
+      # weights cache is not recursively re-chowned on every ~2-3 min warm — just the first.
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: vllm
-          image: vllm/vllm-openai:latest
+          # Pinned off the moving :latest tag: with imagePullPolicy IfNotPresent, :latest stayed
+          # whatever each node first cached, so the running vLLM version drifted silently per node.
+          # v0.26.0 is EXACTLY what :latest resolved to on 2026-07-25 (identical digest) — this
+          # changes the running bits by zero while making them immutable. Vendoring this image to
+          # the sovereign zot registry (registry.socioprophet.ai) is a tracked follow-up.
+          image: vllm/vllm-openai:v0.26.0@sha256:ffb2d59b1c059a5bd8d781320c9f5189de8293693b7d95da54befddaa54abf52
           args:
             - --model=Qwen/Qwen3-32B-AWQ
             - --quantization=awq_marlin


### PR DESCRIPTION
## What
The last of the 6 workloads from the 2026-08-04 fsGroup/moving-tag audit triage — the serving-lane one that #1438 flagged but (correctly) didn't touch. `mesh-vllm-xl` had **three** of the classes this estate is closing at once:

| Class | Before | Fix |
|---|---|---|
| fsGroup-less PVC writer | no `securityContext.fsGroup`; vLLM writes /hf (120Gi RWO PVC) | `fsGroup: 1000` + `fsGroupChangePolicy: OnRootMismatch` |
| Moving tag | `vllm/vllm-openai:latest` + `IfNotPresent` (drifts per-node) | `v0.26.0@sha256:ffb2d59b…` (readable version + immutable digest) |
| Orphan workload | `tracking: NONE` — not ArgoCD/Helm managed | deliberate (see below); applied via kubectl, its real delivery path |

The digest `ffb2d59b…` is **exactly what `:latest` resolved to on 2026-07-25** (`:latest` and `v0.26.0` share it), so this changes the running bits by **zero** while making them immutable. `OnRootMismatch` avoids a recursive chown of the 120Gi weights cache on every warm.

## Why applied, not just declared
`mesh-vllm-xl` is a **deliberate** orphan — an operator-scaled GPU cost-control seat (Qwen3-32B-AWQ on one A100 Spot, `replicas: 0` = \$0 idle, warmed by hand per the file header runbook). It is intentionally **not** under ArgoCD (auto-sync/prune would fight the manual `kubectl scale`), so `kubectl apply` of this manifest **is** its delivery path — unlike gitea, which was an *accidental* orphan and got GitOps-ified (#1426).

I applied the corrected manifest to the live cluster with **`replicas` unchanged at 0** (no pod, no cost). Verified live:
```
image=vllm/vllm-openai:v0.26.0@sha256:ffb2d59b…
fsGroup=1000   changePolicy=OnRootMismatch   replicas=0
```
When the operator warms it (`kubectl -n serving scale deploy/mesh-vllm-xl --replicas=1`), the new pod inherits fsGroup + the pinned image.

## Verification
- `kubectl apply --dry-run=server` clean; `kubectl diff` = only the image + securityContext lines (replicas untouched).
- Live Deployment spec confirmed carrying the fix (above).

## Follow-ups (coverage gaps this surfaced — filed, not fixed here)
1. **Vendor `vllm/vllm-openai` to the sovereign zot registry** (`registry.socioprophet.ai`), like the gitea image — a tracked follow-up.
2. **Gate coverage**: `deploy/serving/` is outside the moving-tag/preflight gate scope (they scan `deploy/argocd`, `deploy/values`, `infra/k8s`), and the orphan detector defaults to ns `socioprophet`. That's why **only the live kyverno policy caught this** — the static ratchet couldn't see it. Extend both to cover the `deploy/serving/` manuals (and sanction the deliberate GPU orphans there).

Closes the 6/6 fsGroup-audit triage. Manifest-only change → auto-mergeable.