### PR TITLE
feat(deploy-health): close the detect→act loop — route findings to self-closing issues

### DIFF
--- a/.github/workflows/deploy-health-detect.yml
+++ b/.github/workflows/deploy-health-detect.yml
@@ -46,8 +46,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
       - name: reconciler self-test + pytest
         run: |
+          pip install --quiet pytest
           python3 tools/deploy_health_to_issues.py --self-test
           python3 -m pytest tools/tests/test_deploy_health_to_issues.py -q
 

--- a/.github/workflows/deploy-health-detect.yml
+++ b/.github/workflows/deploy-health-detect.yml
@@ -1,0 +1,95 @@
+name: deploy-health-detect
+
+# Closes the detect->act loop for the deploy-health alerter (see the 2026-08-04
+# workspace-sync-trap postmortem). The in-cluster CronJob detects runtime gaps every
+# 10 min, but its findings only ever reached pod logs + one permanently-firing binary
+# Prometheus alert that everyone learned to ignore — so three apps sat OutOfSync for
+# ~40h, flagged every cycle, unseen. This scheduled job runs the SAME classifier
+# against the live cluster and reconciles the findings into durable GitHub issues
+# (tools/deploy_health_to_issues.py): one self-closing issue per (kind, workload) gap.
+#
+# It does NOT auto-mutate the cluster — it routes findings to a place a human or an
+# agent can act on. Wiring the sociosphere responder to remediate is a separate layer.
+#
+# Sibling of infra-drift-detect.yml (same OIDC-only auth, same "open an issue on a
+# non-empty finding" shape). Auth is Workload Identity Federation — no static kubeconfig.
+#   Secrets:   GCP_WORKLOAD_IDENTITY_PROVIDER, GCP_SERVICE_ACCOUNT  (as deploy-gitea-authority.yml)
+#   Variables: GKE_CLUSTER, GKE_LOCATION                            (as provision-secrets.yml)
+
+on:
+  schedule:
+    - cron: "0 * * * *"      # hourly — issue tracking needs freshness in ~an hour, not 10 min
+  workflow_dispatch:
+  pull_request:
+    # Exercise the reconciler's own logic before a change to it merges (no cloud access).
+    paths:
+      - ".github/workflows/deploy-health-detect.yml"
+      - "tools/deploy_health_to_issues.py"
+      - "tools/tests/test_deploy_health_to_issues.py"
+      - "infra/k8s/deploy-health-alerter/base/deploy_health_alert.py"
+
+permissions:
+  contents: read
+  id-token: write   # OIDC → GCP Workload Identity Federation
+  issues: write     # open/close the deploy-health issues
+
+concurrency:
+  # Never let two reconcilers race on the same issue set.
+  group: deploy-health-detect
+  cancel-in-progress: false
+
+jobs:
+  # Runs everywhere, including on PRs, with no cloud access — the reason the scheduled
+  # lane below can be trusted to open/close the right issues and to REFUSE on a blind scan.
+  self-test:
+    name: self-test / reconciler discriminates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: reconciler self-test + pytest
+        run: |
+          python3 tools/deploy_health_to_issues.py --self-test
+          python3 -m pytest tools/tests/test_deploy_health_to_issues.py -q
+
+  reconcile:
+    name: scan live cluster → reconcile issues
+    runs-on: ubuntu-latest
+    needs: self-test
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - uses: google-github-actions/get-gke-credentials@64bc7249bbcf78056bb92f14d3cedc2da193946c # v2.3.5
+        with:
+          cluster_name: ${{ vars.GKE_CLUSTER }}
+          location: ${{ vars.GKE_LOCATION || 'us-central1' }}
+      - name: scan + route findings to issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          # Capture the report regardless of the alerter's exit code. Its codes are
+          # 0 = clean, 1 = gaps found, 2 = could-not-observe (blind). Only 2 is a failure
+          # for us; 1 is the normal case (gaps exist and are being tracked as issues).
+          set +e
+          python3 tools/deploy_health_alert.py --namespace socioprophet --json > report.json
+          scan_rc=$?
+          set -e
+          echo "::group::deploy-health report (alerter exit=${scan_rc})"
+          cat report.json || echo "(no report captured)"
+          echo "::endgroup::"
+          # Reconcile. The tool exits 0 (clean), 1 (open gaps tracked — SUCCESS for us),
+          # or 2 (BLIND — it refused to close anything; must go red so a blind scan is loud).
+          set +e
+          python3 tools/deploy_health_to_issues.py --report report.json --repo "$GITHUB_REPOSITORY"
+          rc=$?
+          set -e
+          if [ "$rc" = "2" ]; then
+            echo "::error::deploy-health scan was BLIND (could-not-observe) — issues were NOT reconciled. A blind scan is not 'all clear'."
+            exit 1
+          fi
+          echo "reconcile ok (rc=$rc)"

--- a/infra/k8s/deploy-health-alerter/README.md
+++ b/infra/k8s/deploy-health-alerter/README.md
@@ -26,6 +26,23 @@ A non-zero exit (**1** = gaps found, **2** = could-not-observe) fails the Job. T
   the alerter has lost its own heartbeat. (The check checks the checker — same discipline as
   `rule-liveness-guard`.)
 
+## How findings become action (the detect→act loop)
+The two alerts above were not enough on their own: `DeployHealthGapsDetected` is *binary* —
+it fires whenever ANY gap exists — and because the estate always carries some chronic gap it
+fires forever and gets ignored. The 2026-08-04 workspace sync-trap proved the cost: three
+ArgoCD apps sat OutOfSync for ~40h, flagged every single cycle, into a void.
+
+So findings are also routed to **durable, per-workload GitHub issues**:
+- [`tools/deploy_health_to_issues.py`](../../../tools/deploy_health_to_issues.py) reconciles a
+  `--json` report into one self-closing issue per `(kind, workload)` gap (label `deploy-health`).
+  A chronic gap is one standing issue (not re-fired noise); a NEW gap opens a new issue; a gap
+  that CLEARS closes its own issue — the control witnesses its own remediation. A **blind** scan
+  (could-not-observe) refuses to reconcile, so nothing is falsely marked resolved.
+- [`.github/workflows/deploy-health-detect.yml`](../../../.github/workflows/deploy-health-detect.yml)
+  runs the classifier against the live cluster hourly (OIDC/WIF, same as `infra-drift-detect`)
+  and drives the reconciler. It routes findings to issues; it does **not** auto-mutate the
+  cluster. (Wiring the sociosphere responder to *remediate* — `law_by_kind` — is the next layer.)
+
 ## Wiring
 - Deployed by [`deploy/argocd/deploy-health-alerter.yaml`](../../../deploy/argocd/deploy-health-alerter.yaml)
   (in the root-recursed `deploy/argocd/` tree; the base stays here).

--- a/tools/deploy_health_to_issues.py
+++ b/tools/deploy_health_to_issues.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""deploy_health_to_issues — route deploy-health findings to durable GitHub issues.
+
+The deploy-health alerter (``deploy_health_alert.py``) detects live runtime gaps every
+10 minutes, but until now its findings reached only two dead ends:
+
+  * the Job's pod logs (ephemeral — gone on the next rotation), and
+  * one *binary* Prometheus alert, ``DeployHealthGapsDetected``, that fires whenever
+    ANY gap exists. Because the estate always carries some chronic gap, that alert is
+    permanently firing and therefore ignored — so a NEW gap is invisible in the noise.
+
+The 2026-08-04 workspace sync-trap is the receipt: three ArgoCD apps sat OutOfSync for
+~40h while the alerter flagged them *every single cycle* into a void. Detection had
+teeth; nothing consumed the bite. That is the detect≠heal gap this closes.
+
+This reconciles the alerter's findings into GitHub issues, WITHOUT auto-mutating prod:
+
+  * one open issue per (kind, workload) gap, de-duplicated (a crashlooping pod with two
+    reasons is ONE issue, not two);
+  * a chronic gap is a single standing issue — not re-fired noise;
+  * a NEW gap opens a new issue immediately (it stands out because the others are old);
+  * a gap that CLEARS closes its own issue (the control witnesses its own remediation).
+
+Routing to issues — not to an auto-fixer — is deliberate: it makes every finding visible,
+assignable and durable, and leaves the act to a human or an agent. Wiring the sociosphere
+responder to *remediate* (law_by_kind) is the riskier next layer, tracked separately.
+
+Honesty invariant (mirrors the alerter's own, and infra-drift-detect's exit-code map):
+a BLIND report — exit 2 / could-not-observe (no cluster access, wrong context, API down) —
+must NEVER close issues. "We couldn't look" is not "all clear"; closing on blind input
+would silently resolve real, still-broken gaps. On blind input this refuses to reconcile
+and exits non-zero, so the CI job goes RED instead of quietly marking everything fixed.
+
+Pure reconciliation (``reconcile``) is I/O-free and self-tested (``--self-test`` / the
+pytest beside it). GitHub I/O is a thin ``gh`` CLI layer, kept out of the tested core.
+
+  deploy_health_alert.py --json | deploy_health_to_issues.py            # reconcile (writes)
+  deploy_health_alert.py --json | deploy_health_to_issues.py --dry-run  # print the plan
+  deploy_health_to_issues.py --self-test                                # prove it discriminates
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+# The label every issue this tool owns carries. Reconciliation is scoped to issues with
+# this label: the tool must never touch an issue a human filed by hand, and must be able
+# to enumerate exactly the set it is responsible for closing.
+ISSUE_LABEL = "deploy-health"
+TITLE_PREFIX = "[deploy-health]"
+
+# Exit codes, aligned with deploy_health_alert.py: 0 clean, 1 reconciled-with-open-gaps,
+# 2 blind (refused to reconcile — could-not-observe dominates, same fail-closed precedence).
+EXIT_CLEAN, EXIT_ACTED, EXIT_BLIND = 0, 1, 2
+
+
+# ── pure reconciliation (no I/O; this is what the self-test pins) ──────────────
+def gap_key(kind: str, name: str) -> str:
+    """Stable identity for a gap: the (kind, workload) pair, independent of the reason.
+
+    Two findings on the same workload (e.g. a pod's ``CrashLoopBackOff`` and its
+    ``restarts=10``) share a key so they collapse to ONE issue, not two.
+    """
+    return f"{kind}/{name}"
+
+
+def title_for(key: str) -> str:
+    """The issue title for a gap key — stable, so re-runs match the same issue."""
+    return f"{TITLE_PREFIX} {key}"
+
+
+def key_from_title(title: str) -> str | None:
+    """Recover the gap key from an issue title, or None if it is not one of ours.
+
+    Defensive: only titles with our exact prefix are treated as owned, so a human
+    issue that merely contains 'deploy-health' in prose is never matched for closing.
+    """
+    if not title.startswith(TITLE_PREFIX + " "):
+        return None
+    return title[len(TITLE_PREFIX) + 1:].strip() or None
+
+
+def group_findings(findings: list[dict]) -> dict[str, list[str]]:
+    """Collapse the alerter's per-reason findings into {gap_key: [reasons...]}."""
+    grouped: dict[str, list[str]] = {}
+    for f in findings:
+        key = gap_key(f.get("kind", "?"), f.get("name", "?"))
+        grouped.setdefault(key, []).append(f.get("reason", ""))
+    return grouped
+
+
+def reconcile(
+    findings: list[dict],
+    open_issues: list[dict],
+    *,
+    blind: bool,
+) -> dict:
+    """Compute the issue actions for one scan. Pure: no network, no clock beyond caller's.
+
+    Returns a plan ``{"blind": bool, "create": [{key,title,reasons}], "close": [{number,
+    key,title}], "keep": [{number,key}]}``.
+
+    * ``create`` — a current gap with no matching open issue.
+    * ``close``  — an open issue we own whose gap is NOT in the current findings
+                   (i.e. it cleared) — SUPPRESSED ENTIRELY when ``blind`` is True.
+    * ``keep``   — a current gap that already has an open issue (left untouched — no spam).
+
+    When ``blind`` is True we cannot prove any gap resolved, so nothing is closed and the
+    caller is expected to fail loudly. New gaps could still be created, but a blind scan
+    has no findings to create from, so in practice the plan is empty + blind.
+    """
+    grouped = group_findings(findings)
+    owned_open: dict[str, dict] = {}
+    for issue in open_issues:
+        key = key_from_title(issue.get("title", ""))
+        if key is not None:
+            owned_open[key] = issue
+
+    create = [
+        {"key": key, "title": title_for(key), "reasons": reasons}
+        for key, reasons in sorted(grouped.items())
+        if key not in owned_open
+    ]
+    keep = [
+        {"number": owned_open[key]["number"], "key": key}
+        for key in sorted(grouped)
+        if key in owned_open
+    ]
+    close: list[dict] = []
+    if not blind:
+        for key in sorted(owned_open):
+            if key not in grouped:
+                close.append({"number": owned_open[key]["number"],
+                              "key": key, "title": owned_open[key].get("title", "")})
+    return {"blind": blind, "create": create, "close": close, "keep": keep}
+
+
+def issue_body(key: str, reasons: list[str], *, now_iso: str) -> str:
+    """Render the issue body for a gap: what/why/how-to-clear, machine-greppable header."""
+    kind, _, name = key.partition("/")
+    reason_lines = "\n".join(f"- {r}" for r in reasons) or "- (no reason recorded)"
+    return (
+        f"**Live deploy-health gap** detected by `deploy_health_alert.py` and routed here "
+        f"so it does not rot in a pod log.\n\n"
+        f"- **kind:** `{kind}`\n"
+        f"- **workload:** `{name}`\n"
+        f"- **first surfaced:** {now_iso}\n\n"
+        f"**Reason(s):**\n{reason_lines}\n\n"
+        f"This issue is managed by `tools/deploy_health_to_issues.py`: it will **close "
+        f"itself automatically** on the next scan in which the gap is gone. Do not close "
+        f"it by hand to 'silence' a still-broken workload — fix the workload, or (for an "
+        f"intentional state) declare a `socioprophet.io/deploy-health-hold` on the app.\n\n"
+        f"Runbook: `infra/k8s/deploy-health-alerter/README.md`\n"
+        f"<!-- deploy-health-key: {key} -->"
+    )
+
+
+# ── thin GitHub I/O via the gh CLI (kept out of the tested core) ───────────────
+def _gh(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(["gh", *args], capture_output=True, text=True, check=check)
+
+
+def ensure_label(repo: str) -> None:
+    """Create the deploy-health label if missing (idempotent; --force won't error if it exists)."""
+    _gh(["label", "create", ISSUE_LABEL, "--repo", repo, "--color", "B60205",
+         "--description", "Live runtime gap routed by deploy_health_to_issues.py",
+         "--force"], check=False)
+
+
+def list_open_issues(repo: str) -> list[dict]:
+    """Open issues carrying our label, as [{number, title}]."""
+    r = _gh(["issue", "list", "--repo", repo, "--label", ISSUE_LABEL, "--state", "open",
+             "--limit", "500", "--json", "number,title"])
+    return json.loads(r.stdout or "[]")
+
+
+def apply_plan(plan: dict, repo: str, *, now_iso: str) -> None:
+    """Execute a reconcile plan against GitHub. Never called on blind input."""
+    for item in plan["create"]:
+        body = issue_body(item["key"], item["reasons"], now_iso=now_iso)
+        _gh(["issue", "create", "--repo", repo, "--title", item["title"],
+             "--label", ISSUE_LABEL, "--body", body])
+        print(f"  opened: {item['title']}")
+    for item in plan["close"]:
+        _gh(["issue", "close", str(item["number"]), "--repo", repo, "--reason", "completed",
+             "--comment", f"Resolved: no longer detected by deploy-health at {now_iso}. "
+                          f"Auto-closed by deploy_health_to_issues.py."])
+        print(f"  closed #{item['number']}: {item['title']}")
+
+
+def _utc_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+# ── negative control: prove the reconciler discriminates ──────────────────────
+def _self_test() -> int:
+    F = [{"kind": "argocd-app", "name": "ws-workspace-caldav", "reason": "sync=OutOfSync (sync failing)"}]
+    POD2 = [
+        {"kind": "pod", "name": "sherlock-x", "reason": "svc:CrashLoopBackOff"},
+        {"kind": "pod", "name": "sherlock-x", "reason": "svc:restarts=10"},
+    ]
+    ISSUE = {"number": 42, "title": "[deploy-health] argocd-app/ws-workspace-caldav"}
+    OTHER = {"number": 7, "title": "[deploy-health] pod/gone-away"}
+    HUMAN = {"number": 9, "title": "investigate deploy-health flakiness"}  # not ours
+
+    checks = [
+        ("new gap → create",
+         [c["key"] for c in reconcile(F, [], blind=False)["create"]] == ["argocd-app/ws-workspace-caldav"]),
+        ("existing gap → keep, not re-create",
+         reconcile(F, [ISSUE], blind=False)["create"] == []
+         and [k["number"] for k in reconcile(F, [ISSUE], blind=False)["keep"]] == [42]),
+        ("cleared gap → close",
+         [c["number"] for c in reconcile([], [ISSUE], blind=False)["close"]] == [42]),
+        ("two reasons, one workload → ONE issue",
+         len(reconcile(POD2, [], blind=False)["create"]) == 1
+         and len(reconcile(POD2, [], blind=False)["create"][0]["reasons"]) == 2),
+        ("blind scan NEVER closes (could-not-observe ≠ all-clear)",
+         reconcile([], [ISSUE, OTHER], blind=True)["close"] == []),
+        ("human-filed issue is never closed by us",
+         reconcile([], [HUMAN], blind=False)["close"] == []),
+        ("mixed: one clears, one persists",
+         sorted(c["number"] for c in reconcile(F, [ISSUE, OTHER], blind=False)["close"]) == [7]
+         and [k["number"] for k in reconcile(F, [ISSUE, OTHER], blind=False)["keep"]] == [42]),
+        ("title round-trips to key",
+         key_from_title(title_for("pod/foo")) == "pod/foo"),
+        ("non-owned title → no key",
+         key_from_title("investigate deploy-health") is None),
+    ]
+    failed = [name for name, ok in checks if not ok]
+    for name, ok in checks:
+        print(f"  {'✓' if ok else '✗ FAIL'} {name}")
+    if failed:
+        print(f"self-test FAILED: {failed}")
+        return 1
+    print(f"self-test OK ({len(checks)} reconciliation checks)")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Route deploy-health findings to GitHub issues (fail-closed).")
+    p.add_argument("--report", help="deploy-health --json report file (default: stdin)")
+    p.add_argument("--repo", default="SocioProphet/prophet-platform", help="owner/repo for issues")
+    p.add_argument("--dry-run", action="store_true", help="print the plan; make no changes")
+    p.add_argument("--self-test", action="store_true", help="run the reconciliation checks and exit")
+    args = p.parse_args(argv)
+
+    if args.self_test:
+        return _self_test()
+
+    raw = open(args.report, encoding="utf-8").read() if args.report else sys.stdin.read()
+    try:
+        report = json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"[to-issues] report is not JSON: {e}\n")
+        return EXIT_BLIND  # could not even read the scan → treat as blind, never as clean
+
+    findings = report.get("findings") or []
+    # Blind = the alerter told us it could not observe something (exit 2 or a non-empty blind list).
+    blind = int(report.get("exit", 0)) == EXIT_BLIND or bool(report.get("blind"))
+    now_iso = _utc_iso()
+
+    if args.dry_run:
+        # No network at all in dry-run: reconcile against an EMPTY open-issue set so the plan
+        # is derivable offline (self-test covers the open-issue matching logic).
+        plan = reconcile(findings, [], blind=blind)
+        print(json.dumps({"now": now_iso, **plan}, indent=2))
+        return EXIT_BLIND if blind else (EXIT_ACTED if findings else EXIT_CLEAN)
+
+    if blind:
+        # Fail-closed: refuse to reconcile, so no issue is wrongly closed and CI goes red.
+        sys.stderr.write(
+            "[to-issues] BLIND report (could-not-observe) — refusing to reconcile: "
+            "not closing any issue, exiting non-zero.\n")
+        return EXIT_BLIND
+
+    ensure_label(args.repo)
+    open_issues = list_open_issues(args.repo)
+    plan = reconcile(findings, open_issues, blind=False)
+    print(f"deploy-health → issues @ {now_iso}: "
+          f"{len(plan['create'])} to open, {len(plan['close'])} to close, "
+          f"{len(plan['keep'])} unchanged")
+    apply_plan(plan, args.repo, now_iso=now_iso)
+    return EXIT_ACTED if (plan["create"] or plan["keep"]) else EXIT_CLEAN
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/tests/test_deploy_health_to_issues.py
+++ b/tools/tests/test_deploy_health_to_issues.py
@@ -1,0 +1,106 @@
+"""Tests for deploy_health_to_issues — the deploy-health → GitHub-issue reconciler.
+
+The reconciler's whole value is that it discriminates: a new gap opens an issue, a
+cleared gap closes ITS issue, a chronic gap stays as one issue (no spam), a human's
+issue is never touched, and — the load-bearing safety property — a BLIND scan closes
+nothing. These tests pin exactly those distinctions.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import deploy_health_to_issues as m  # noqa: E402
+
+
+CALDAV = {"kind": "argocd-app", "name": "ws-workspace-caldav", "reason": "sync=OutOfSync (sync failing)"}
+CALDAV_ISSUE = {"number": 42, "title": "[deploy-health] argocd-app/ws-workspace-caldav"}
+STALE_ISSUE = {"number": 7, "title": "[deploy-health] pod/gone-away"}
+HUMAN_ISSUE = {"number": 9, "title": "please look at deploy-health someday"}
+
+
+def test_new_gap_creates():
+    plan = m.reconcile([CALDAV], [], blind=False)
+    assert [c["key"] for c in plan["create"]] == ["argocd-app/ws-workspace-caldav"]
+    assert plan["close"] == [] and plan["keep"] == []
+
+
+def test_existing_gap_is_kept_not_recreated():
+    plan = m.reconcile([CALDAV], [CALDAV_ISSUE], blind=False)
+    assert plan["create"] == []
+    assert [k["number"] for k in plan["keep"]] == [42]
+
+
+def test_cleared_gap_closes_its_issue():
+    plan = m.reconcile([], [CALDAV_ISSUE], blind=False)
+    assert [c["number"] for c in plan["close"]] == [42]
+
+
+def test_two_reasons_one_workload_is_one_issue():
+    pod = [
+        {"kind": "pod", "name": "sherlock-x", "reason": "svc:CrashLoopBackOff"},
+        {"kind": "pod", "name": "sherlock-x", "reason": "svc:restarts=10"},
+    ]
+    plan = m.reconcile(pod, [], blind=False)
+    assert len(plan["create"]) == 1
+    assert sorted(plan["create"][0]["reasons"]) == ["svc:CrashLoopBackOff", "svc:restarts=10"]
+
+
+def test_blind_never_closes():
+    # The invariant that would have prevented silently "resolving" the 40h workspace trap
+    # had the scan gone blind: could-not-observe must not be read as all-clear.
+    plan = m.reconcile([], [CALDAV_ISSUE, STALE_ISSUE], blind=True)
+    assert plan["close"] == []
+
+
+def test_human_issue_is_never_closed():
+    plan = m.reconcile([], [HUMAN_ISSUE], blind=False)
+    assert plan["close"] == []
+
+
+def test_mixed_one_clears_one_persists():
+    plan = m.reconcile([CALDAV], [CALDAV_ISSUE, STALE_ISSUE], blind=False)
+    assert [c["number"] for c in plan["close"]] == [7]
+    assert [k["number"] for k in plan["keep"]] == [42]
+
+
+def test_title_key_roundtrip():
+    assert m.key_from_title(m.title_for("pod/foo")) == "pod/foo"
+    assert m.key_from_title("investigate deploy-health") is None
+    assert m.key_from_title("[deploy-health] ") is None  # empty key is not owned
+
+
+def test_body_is_greppable_and_names_the_workload():
+    body = m.issue_body("argocd-app/ws-workspace-caldav", ["sync failing"], now_iso="2026-08-04T00:00:00Z")
+    assert "deploy-health-key: argocd-app/ws-workspace-caldav" in body
+    assert "ws-workspace-caldav" in body
+
+
+def test_self_test_passes():
+    assert m._self_test() == 0
+
+
+def test_cli_blind_report_refuses(tmp_path):
+    """A blind report through the CLI exits 2 (refuse) and closes nothing."""
+    rep = tmp_path / "r.json"
+    rep.write_text(json.dumps({"exit": 2, "blind": ["pods in ns/x"], "findings": []}))
+    r = subprocess.run([sys.executable, str(Path(m.__file__)), "--report", str(rep), "--dry-run"],
+                       capture_output=True, text=True)
+    assert r.returncode == m.EXIT_BLIND
+    assert json.loads(r.stdout)["blind"] is True
+
+
+def test_cli_non_json_is_blind_not_clean(tmp_path):
+    """Garbage input must be treated as blind (exit 2), never as a clean 'no findings'."""
+    rep = tmp_path / "r.json"
+    rep.write_text("not json at all")
+    r = subprocess.run([sys.executable, str(Path(m.__file__)), "--report", str(rep)],
+                       capture_output=True, text=True)
+    assert r.returncode == m.EXIT_BLIND
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## ⚠️ Needs human review — adds a workflow
This PR adds `.github/workflows/**`, which is **excluded from agent auto-merge** (needs human review). The tool + tests would be auto-mergeable alone, but they're inert without the workflow, so they ship together to actually close the loop.

## The defect this closes
The deploy-health alerter detects live runtime gaps every 10 min — but until now its findings reached only two dead ends: the Job's **pod logs** (ephemeral) and one **binary** Prometheus alert (`DeployHealthGapsDetected`) that fires whenever *any* gap exists. Because the estate always carries some chronic gap, that alert fires **forever and is ignored** — so a new gap is invisible in the noise.

The 2026-08-04 workspace sync-trap is the receipt: three ArgoCD apps sat `OutOfSync` for **~40h**, flagged every single cycle, into a void. Detection had teeth; **nothing consumed the bite**. That's the `detect≠heal` gap.

## What this adds
| Piece | Role |
|---|---|
| `tools/deploy_health_to_issues.py` | Reconciles a deploy-health `--json` report into durable GitHub issues — one **self-closing** issue per `(kind, workload)` gap (label `deploy-health`), de-duplicated. Pure reconcile core + `--self-test`; thin `gh` I/O. |
| `.github/workflows/deploy-health-detect.yml` | Hourly (OIDC/WIF, sibling of `infra-drift-detect`): runs the classifier against the live cluster and drives the reconciler. |
| `tools/tests/test_deploy_health_to_issues.py` | 12 tests, auto-run by `make test-tools` (globs `tools/tests`). |

**Behaviour:** chronic gap → one standing issue (not re-fired noise); NEW gap → new issue (stands out); CLEARED gap → closes its own issue (the control witnesses its own remediation).

**Honesty invariant** (mirrors the alerter + `infra-drift-detect`'s exit-code map): a **BLIND** report (could-not-observe — no cluster access, wrong context, API down) **refuses to reconcile and exits non-zero**. "We couldn't look" is never "all clear" — so a blind scan goes red instead of silently closing real, still-broken issues.

## It does not auto-mutate prod
Routing to **issues**, not to an auto-fixer, is deliberate — it makes every finding visible, assignable, and durable, and leaves the *act* to a human or an agent. Wiring the sociosphere responder to *remediate* (`law_by_kind`) is the riskier next layer, tracked separately.

## Verification
- `--self-test` (9 checks) + `pytest` (12 tests) green.
- Deploy-honesty gate confirms the workflow swallows no mutation.
- **Proven on the real live report**: 11 findings → **10 per-workload issues** (the sherlock-engine pod's `CrashLoopBackOff` + `restarts=26` collapse to one), `blind=False`.

## Reviewer notes
- Auth reuses `secrets.GCP_WORKLOAD_IDENTITY_PROVIDER` / `GCP_SERVICE_ACCOUNT` + `vars.GKE_CLUSTER` / `GKE_LOCATION` (same as `deploy-gitea-authority` / `provision-secrets`). That SA is the deploy SA — over-privileged for a read-only scan; a dedicated read-only SA would be tighter (optional follow-up).
- Needs a one-time `deploy-health` label (the tool creates it via `gh label create --force`).