### PR TITLE
fix(kyverno): mutateDigest=false under Audit (unblock cloudshell-fog-policy sync)

### DIFF
--- a/infra/policy/cloudshell-fog/kyverno/verify-signed-images.yaml
+++ b/infra/policy/cloudshell-fog/kyverno/verify-signed-images.yaml
@@ -32,14 +32,20 @@ spec:
         # The registries the estate ACTUALLY publishes to (GAR via the
         # build-image workflow, and the sovereign zot mirror). The previous
         # ghcr.io/* globs matched nothing this platform deploys — the policy
-        # was a no-op even where installed. The policy itself remains
-        # uninstalled (no Kyverno controller is connected in this PR); this
-        # just stops the manifest from being wrong when it does land.
+        # was a no-op even where installed. Kyverno is now installed estate-wide
+        # (Audit, 2026-08-04); this policy is live and Kyverno's OWN admission webhook
+        # validates it — which is how the mutateDigest/Audit mismatch below was caught
+        # (the cloudshell-fog-policy ArgoCD app was stuck OutOfSync, its apply rejected).
         - imageReferences:
             - "us-central1-docker.pkg.dev/socioprophet-platform/socioprophet/*"
             - "registry.socioprophet.ai/*"
           required: true
-          mutateDigest: true
+          # mutateDigest MUST be false while validationFailureAction is Audit: Kyverno rejects
+          # the policy otherwise ("mutateDigest must be set to false for 'Audit' failure action").
+          # Mutation (rewriting a verified image to its digest) is an ENFORCING action — flip this
+          # to true in the SAME PR that flips this policy to Enforce (#1344). verifyDigest below
+          # still asserts the signature covers a digest, which is valid in Audit.
+          mutateDigest: false
           verifyDigest: true
           attestors:
             - count: 1


### PR DESCRIPTION
## What
`cloudshell-verify-signed-images` is `validationFailureAction: Audit` but had `verifyImages[0].mutateDigest: true`. Kyverno forbids that combo (mutation is an *enforcing* action, invalid in Audit). Once Kyverno was installed estate-wide (Audit, 2026-08-04), its **own** admission webhook rejected every apply of the policy:
```
admission webhook "validate-policy.kyverno.svc" denied the request:
mutateDigest must be set to false for 'Audit' failure action
```
→ the `cloudshell-fog-policy` ArgoCD app was stuck **Healthy-but-OutOfSync** (a declared≠enforced sync failure, surfaced by the deploy-health alerter's `sync=OutOfSync (sync failing)`).

## Fix
`mutateDigest: false` for the Audit phase (flip back to `true` in the same PR that flips the policy to **Enforce**, #1344). `verifyDigest` stays `true` — asserting the signature covers a digest is valid in Audit. Also corrected the stale "no Kyverno controller is connected" comment (it's installed and live — which is how this surfaced).

## Verification
`kubectl apply --dry-run=server` is now **accepted** by the Kyverno webhook (`clusterpolicy ... created (server dry run)`) — no rejection. Once merged, ArgoCD reconciles `cloudshell-fog-policy` to Synced.

Part of the live deploy-health triage (2026-08-04): one of the two sync-failing apps. The other, `svc-lattice-forge`, was the RollingUpdate→Recreate SSA strategy-trap and is already fixed live (now Synced/Healthy). Manifest-only → auto-mergeable.