### PR TITLE
fix(sherlock-engine): align runtime base to trixie — glibc 2.38 crashloop

### DIFF
--- a/apps/sherlock-engine/Dockerfile
+++ b/apps/sherlock-engine/Dockerfile
@@ -4,13 +4,19 @@
 # Rust 1.83 was too old to parse a bumped transitive manifest (idna_adapter 1.2.2 via url/idna);
 # pin a newer toolchain + a committed Cargo.lock so the build is reproducible and stops resolving
 # newer, toolchain-incompatible deps on every run.
-FROM rust:1.97-slim AS build
+#
+# GLIBC ALIGNMENT: the build and runtime bases MUST share a Debian codename. When the toolchain
+# was bumped to rust:1.97-slim its base moved to Debian trixie (glibc 2.41), while the runtime
+# stayed debian:bookworm-slim (glibc 2.36) — so the dynamically-linked binary required GLIBC_2.38
+# the runtime could not provide and crashlooped ("version `GLIBC_2.38' not found"). Both stages are
+# now pinned to trixie explicitly; keep them on the same codename whenever either is bumped.
+FROM rust:1.97-slim-trixie AS build
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 RUN cargo build --release --locked && strip target/release/sherlock-engine
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 WORKDIR /app
 RUN useradd -r -u 10001 sherlock
 COPY --from=build /build/target/release/sherlock-engine /usr/local/bin/sherlock-engine


### PR DESCRIPTION
## What
`sherlock-engine` (ns `socioprophet`) has been in CrashLoopBackOff (restarts ~28) with:
```
sherlock-engine: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
```
The ArgoCD app `svc-sherlock-engine` is Synced-but-Degraded as a result.

## Cause — build/runtime glibc drift
Bumping the toolchain to `rust:1.97-slim` moved the **build** base to Debian **trixie** (glibc **2.41**), so the dynamically-linked binary requires `GLIBC_2.38`. But the **runtime** stayed `debian:bookworm-slim` (glibc **2.36**), which can't provide it. Confirmed against `sources.debian.org`: trixie = 2.41, bookworm = 2.36.

## Fix — base images only (no Rust source touched; Dockerfile base is in-lane)
Pin **both** stages to trixie so they can't drift apart again:
- build: `rust:1.97-slim` → `rust:1.97-slim-trixie`
- runtime: `debian:bookworm-slim` → `debian:trixie-slim`

Both tags verified to exist upstream. `debian:trixie-slim` (glibc 2.41) satisfies the binary's `GLIBC_2.38`.

## Deploys via the normal path
`images.yml` rebuilds `sherlock-engine` on merge → `gitops-promote` bumps the digest tag in `deploy/values/sherlock-engine.yaml` → ArgoCD rolls it out. (The gitops-promote workflow already references "the sherlock-engine incident".)

## Verification
- Diagnosis confirmed from the live pod's previous-container log.
- Fix premise proven: trixie ships glibc 2.41 ≥ 2.38 (sources.debian.org); both base tags exist.
- Full build proof happens in CI on merge (no local docker daemon here).

## Related (flagged separately)
`apps/hellgraph-service/Dockerfile` has the same class latent (rust:1-slim=trixie build → node:20-slim=bookworm runtime) — HellGraph-lane, not currently glibc-crashing (its Degraded is a canary abort). Flagged for that lane.

Dockerfile-only change → auto-mergeable.