### PR TITLE
docs(workspace-mail): dovecot root is intentional (privileged ports); minio non-root plan (held)

### DIFF
--- a/infra/k8s/workspace-mail/base/deployment.yaml
+++ b/infra/k8s/workspace-mail/base/deployment.yaml
@@ -17,8 +17,13 @@ spec:
       labels:
         app: workspace-mail
     spec:
-      # dovecot/mail writes its maildir on the mounted PVC; fsGroup makes the volume group-writable
-      # (via supplementary group) so the non-root container can write it (kyverno require-fsgroup-pvc).
+      # dovecot runs as ROOT — verified via `id` in the live pod, and it MUST: it binds privileged
+      # ports (imap 143, imaps 993, lmtp 24 — all < 1024) and its master process setuids per-user for
+      # mail delivery. Do NOT "harden" it to non-root: that reintroduces the exact bind/permission
+      # failures (the mail analogue of the gitea crashloop, in reverse). fsGroup: 1000 is kept anyway —
+      # it satisfies kyverno require-fsgroup-for-pvc-writers AND is forward-compatible (a future
+      # non-root gid 1000 would already own the maildir), unlike fsGroup: 0 which would be a landmine.
+      # Root here is intentional, not an oversight.
       securityContext:
         fsGroup: 1000
       imagePullSecrets:


### PR DESCRIPTION
Follow-up to the workspace fsGroup audit. **The require-fsgroup audit is already satisfied** — a concurrent session added `fsGroup: 1000` to both mail and minio, so their warnings (the events still visible are stale, from superseded replicasets) are resolved.

## dovecot (this PR) — document, don't break
Verified via `id`: dovecot runs as **root**, and **must** — it binds **143/993/24** (privileged) and its master setuids per user. The base comment wrongly called it 'the non-root container'; corrected to warn against a non-root migration that would reintroduce the exact bind/permission failures. `fsGroup: 1000` stays (compliant + forward-compatible; not the `fsGroup: 0` landmine). No functional change.

## minio — the migratable one, HELD for your go
minio *can* run non-root (arbitrary UID, non-privileged 9000/9001), and its comment already *claims* uid 1000 — but it actually runs as **root** (no `runAsUser`). Completing it safely needs:
1. `runAsNonRoot: true, runAsUser: 1000, runAsGroup: 1000` (+ keep `fsGroup: 1000`, add `OnRootMismatch`).
2. A one-time **initContainer** `chown -R 1000:1000 /data` (guarded on the /data owner so restarts skip it) — because existing objects were written as root and must become uid-1000-owned for minio to overwrite/delete them.

**Why held, not shipped:** it's a **30G live object store on an RWO PVC**. I could not satisfy the task's own rule — verify existing-data read/write in a non-prod test before merging — because there's no test env with the data, no `setpriv`/`su` in the image to drop-test in place, and the RWO PVC blocks a parallel test pod. The initContainer makes it correct-by-construction, but the `chown -R` + single-replica `Recreate` means **brief object-store downtime**. That's a maintenance-window decision, not an autonomous auto-roll (the `ws-workspace-minio` app is `selfHeal`, so a merge would apply it immediately). Say go + a window and I'll ship it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)