### PR TITLE
fix(gitea): Autopilot-clean resources for gitea-authority (gitea-sovereign → Synced)

### DIFF
--- a/deploy/gitea-authority/k8s/gitea-sovereign.yaml
+++ b/deploy/gitea-authority/k8s/gitea-sovereign.yaml
@@ -22,7 +22,11 @@ spec:
             - name: AUTHORITY_CALLER_TOKEN
               valueFrom: { secretKeyRef: { name: authority-caller-token, key: token } }
           readinessProbe: { httpGet: { path: /healthz, port: 8081 }, initialDelaySeconds: 3 }
-          resources: { requests: { cpu: 25m, memory: 64Mi }, limits: { cpu: 250m, memory: 128Mi } }
+          # Values declared to MATCH GKE Autopilot's normalization so its resource mutator
+          # doesn't rewrite them (cpu 25m→50m, +ephemeral-storage 1Gi) — that rewrite kept the
+          # gitea-sovereign ArgoCD app perpetually OutOfSync after adoption (#1426). The gitea
+          # server container below already declares Autopilot-clean values and stays Synced.
+          resources: { requests: { cpu: 50m, memory: 64Mi, ephemeral-storage: 1Gi }, limits: { cpu: 250m, memory: 128Mi, ephemeral-storage: 1Gi } }
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## What
Finishes #1426's clean adoption. After the gitea pair came under ArgoCD, `gitea-sovereign` adopted the resources and rolled gitea to the base (Healthy) — but stayed **perpetually OutOfSync** on `Deployment/gitea-authority`, with `op=Succeeded` (a benign diff, not a sync failure).

**Cause:** GKE Autopilot's `autopilot-default-resources-mutator` normalizes the authority container — bumps `requests.cpu` 25m→50m and injects `ephemeral-storage: 1Gi` — so live never equals git and `selfHeal` churns every cycle.

## Fix
Declare the resources to match Autopilot's normalized values so no mutation occurs — the same pattern the gitea **server** container already uses (it stays Synced):
```
requests: { cpu: 50m, memory: 64Mi, ephemeral-storage: 1Gi }
limits:   { cpu: 250m, memory: 128Mi, ephemeral-storage: 1Gi }
```

## Verification
`kubectl diff -k deploy/gitea-authority/k8s` against the live cluster now shows **zero diff** (only the harmless Autopilot warning line). Once merged, ArgoCD reconciles `gitea-sovereign` to **Synced** — the cutover adoption is then fully clean.

Manifest-only → auto-mergeable. Part of the GitHub→gitea sovereign-SCM cutover.