### PR TITLE
fix(acquire-worker): close CodeQL #175 — script/style/head end-tag bypass in stripHtml

### DIFF
--- a/apps/acquire-worker/acquire-worker/src/workspaceNote.test.ts
+++ b/apps/acquire-worker/acquire-worker/src/workspaceNote.test.ts
@@ -59,3 +59,17 @@ test('noteId is content-addressed (idempotent re-landing)', () => {
 test('WorkspaceNoteSink names itself by its inbox dir', () => {
   assert.equal(new WorkspaceNoteSink('./inbox').name, 'note:./inbox');
 });
+
+test('stripHtml strips script/style/head end tags even with trailing garbage before >', () => {
+  // Per the HTML parsing spec, `</script foo="bar">` and `</style\t\nbar>` are still recognized as
+  // the closing tag by real browsers — a stripper that only matches the exact `</script>` bytes (or
+  // only tolerates whitespace) lets the "sanitized" payload leak into bodyText (CodeQL js/bad-tag-filter).
+  const rec: LandedRecord = {
+    provenance: prov(),
+    body: '<html><body><p>safe</p><script>evil()</script foo="bar"><style>.x{}</style\t\nbar></body></html>',
+  };
+  const note = landedToNote(rec);
+  assert.ok(note.bodyText?.includes('safe'));
+  assert.ok(!note.bodyText?.includes('evil'), `script content leaked into bodyText: ${note.bodyText}`);
+  assert.ok(!note.bodyText?.includes('foo='), `stray script end-tag attribute leaked into bodyText: ${note.bodyText}`);
+});

--- a/apps/acquire-worker/acquire-worker/src/workspaceNote.ts
+++ b/apps/acquire-worker/acquire-worker/src/workspaceNote.ts
@@ -49,9 +49,12 @@ function deriveTitle(body: string, url: string): string {
 
 function looksHtml(body: string): boolean { return /<\s*(html|body|div|p|h[1-6]|article)\b/i.test(body.slice(0, 2000)); }
 function stripHtml(body: string): string {
-  // Closing tags tolerate whitespace before '>' (e.g. `</script >`) per the HTML parsing spec —
-  // matching only the exact `</script>` bytes lets that variant slip through un-stripped.
-  return body.replace(/<head[\s\S]*?<\/head\s*>/gi, ' ').replace(/<script[\s\S]*?<\/script\s*>/gi, ' ').replace(/<style[\s\S]*?<\/style\s*>/gi, ' ')
+  // Per the HTML end-tag parsing spec, a closing tag is recognized once the parser sees `</script`
+  // (case-insensitive) — everything up to the next '>' is consumed as part of the tag, including
+  // whitespace, bogus attributes, or other garbage (e.g. `</script foo="bar">`, `</script\t\nbar>`).
+  // Matching only the exact `</script>` bytes — or only tolerating whitespace before '>' — lets any
+  // of those browser-recognized variants slip through un-stripped.
+  return body.replace(/<head[\s\S]*?<\/head[^>]*>/gi, ' ').replace(/<script[\s\S]*?<\/script[^>]*>/gi, ' ').replace(/<style[\s\S]*?<\/style[^>]*>/gi, ' ')
     .replace(/<[^>]+>/g, ' ').replace(/&nbsp;/g, ' ').replace(/\s+/g, ' ').trim();
 }
 


### PR DESCRIPTION
## Why

CodeQL alert #175 (`js/bad-tag-filter`, high severity) on `apps/acquire-worker/acquire-worker/src/workspaceNote.ts`, currently open on `main`. This was the 8th instance of the same rule class as the 7 alerts already fixed on #1428 — missed there, and #1428 was merged before this one could be pushed.

## What

Per the HTML end-tag parsing spec, a closing tag is recognized as soon as the parser sees `</script` (case-insensitive) — everything up to the next `>` is consumed as part of the tag, including whitespace, bogus attributes, or other garbage (`</script foo="bar">`, `</style\t\nbar>`). The old regex only tolerated whitespace before `>`, so those browser-recognized variants slipped through un-stripped — crafted script/style content could leak into a Note's sanitized `bodyText`.

Widened `</script\s*>` → `</script[^>]*>` (same for style/head).

## Verification

New regression test asserts a payload using exactly this bypass shape doesn't leak into `bodyText`. 14/14 tests pass locally (`npm test` in `apps/acquire-worker/acquire-worker`).